### PR TITLE
Add Codex session reader and CLI integration

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from './args.js';
 import { runByTool } from './commands/by-tool.js';
 import { runClaudeWrapper } from './commands/claude.js';
+import { runCodexWrapper } from './commands/codex.js';
 import { runSummary } from './commands/summary.js';
 
 const HELP = `burn — token usage & cost attribution for agent CLIs
@@ -10,11 +11,13 @@ Usage:
   burn summary [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>]
   burn by-tool [--since 7d] [--project <path>] [--session <id>]
   burn claude  [--tag k=v ...] [-- <claude args>]
+  burn codex   [--tag k=v ...] [-- <codex args>]
 
 Examples:
   burn summary --since 24h
   burn by-tool --since 7d
   burn claude --tag workflow=refactor -- --resume
+  burn codex  --tag workflow=refactor
 `;
 
 async function main(): Promise<number> {
@@ -32,6 +35,7 @@ async function main(): Promise<number> {
     case 'claude':
       return runClaudeWrapper(args);
     case 'codex':
+      return runCodexWrapper(args);
     case 'opencode':
       process.stderr.write(`${cmd}: reader not implemented yet in v0\n`);
       return 2;

--- a/packages/cli/src/commands/by-tool.ts
+++ b/packages/cli/src/commands/by-tool.ts
@@ -2,7 +2,7 @@ import { loadPricing, costForTurn } from '@relayburn/analyze';
 import { queryAll, type Query } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
 
-import { ingestClaudeProjects } from '../ingest.js';
+import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
@@ -12,7 +12,7 @@ export async function runByTool(args: ParsedArgs): Promise<number> {
   if (typeof args.flags['project'] === 'string') q.project = args.flags['project'];
   if (typeof args.flags['session'] === 'string') q.sessionId = args.flags['session'];
 
-  await ingestClaudeProjects();
+  await ingestAll();
   const pricing = await loadPricing();
   const turns = await queryAll(q);
 

--- a/packages/cli/src/commands/codex.ts
+++ b/packages/cli/src/commands/codex.ts
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+import { readdir, stat } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+
+import { parseCodexSession } from '@relayburn/reader';
+import { appendTurns, stamp } from '@relayburn/ledger';
+import type { Enrichment } from '@relayburn/ledger';
+
+import type { ParsedArgs } from '../args.js';
+
+const CODEX_SESSIONS = path.join(homedir(), '.codex', 'sessions');
+
+export async function runCodexWrapper(args: ParsedArgs): Promise<number> {
+  const tags: Enrichment = { ...args.tags };
+  tags['harness'] = 'codex';
+  tags['burnSpawn'] = '1';
+  const spawnStartTs = Date.now();
+  tags['burnSpawnTs'] = new Date(spawnStartTs).toISOString();
+
+  const preSnapshot = await snapshotSessions();
+  process.stderr.write(`[burn] codex spawn: tracking ${preSnapshot.size} existing sessions\n`);
+
+  const child = spawn('codex', args.passthrough, { stdio: 'inherit', env: process.env });
+  const code: number = await new Promise((resolve) => {
+    child.on('exit', (c) => resolve(c ?? 0));
+    child.on('error', (err) => {
+      process.stderr.write(`[burn] failed to spawn codex: ${err.message}\n`);
+      resolve(127);
+    });
+  });
+
+  const newFiles = await findNewSessions(preSnapshot, spawnStartTs);
+  if (newFiles.length === 0) {
+    process.stderr.write(`[burn] no new codex session files found under ${CODEX_SESSIONS}\n`);
+    return code;
+  }
+
+  for (const file of newFiles) {
+    const turns = await parseCodexSession(file, { sessionPath: file });
+    if (turns.length === 0) continue;
+    await appendTurns(turns);
+    const sessionId = turns[0]!.sessionId;
+    if (sessionId) await stamp({ sessionId }, tags);
+    process.stderr.write(`[burn] ingested ${turns.length} turns from ${file}\n`);
+  }
+
+  return code;
+}
+
+async function snapshotSessions(): Promise<Set<string>> {
+  const out = new Set<string>();
+  for (const file of await walkJsonl(CODEX_SESSIONS)) out.add(file);
+  return out;
+}
+
+async function findNewSessions(pre: Set<string>, spawnStartTs: number): Promise<string[]> {
+  const now = await walkJsonl(CODEX_SESSIONS);
+  const candidates: string[] = [];
+  for (const file of now) {
+    if (pre.has(file)) continue;
+    try {
+      const st = await stat(file);
+      if (st.mtimeMs + 1 < spawnStartTs) continue;
+      candidates.push(file);
+    } catch {
+      continue;
+    }
+  }
+  return candidates;
+}
+
+async function walkJsonl(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.endsWith('.jsonl')) out.push(full);
+    }
+  }
+  return out;
+}

--- a/packages/cli/src/commands/codex.ts
+++ b/packages/cli/src/commands/codex.ts
@@ -1,6 +1,4 @@
 import { spawn } from 'node:child_process';
-import { readdir, stat } from 'node:fs/promises';
-import type { Dirent } from 'node:fs';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
@@ -9,6 +7,7 @@ import { appendTurns, stamp } from '@relayburn/ledger';
 import type { Enrichment } from '@relayburn/ledger';
 
 import type { ParsedArgs } from '../args.js';
+import { walkJsonl } from '../walk.js';
 
 const CODEX_SESSIONS = path.join(homedir(), '.codex', 'sessions');
 
@@ -31,7 +30,7 @@ export async function runCodexWrapper(args: ParsedArgs): Promise<number> {
     });
   });
 
-  const newFiles = await findNewSessions(preSnapshot, spawnStartTs);
+  const newFiles = await findNewSessions(preSnapshot);
   if (newFiles.length === 0) {
     process.stderr.write(`[burn] no new codex session files found under ${CODEX_SESSIONS}\n`);
     return code;
@@ -55,38 +54,7 @@ async function snapshotSessions(): Promise<Set<string>> {
   return out;
 }
 
-async function findNewSessions(pre: Set<string>, spawnStartTs: number): Promise<string[]> {
+async function findNewSessions(pre: Set<string>): Promise<string[]> {
   const now = await walkJsonl(CODEX_SESSIONS);
-  const candidates: string[] = [];
-  for (const file of now) {
-    if (pre.has(file)) continue;
-    try {
-      const st = await stat(file);
-      if (st.mtimeMs + 1 < spawnStartTs) continue;
-      candidates.push(file);
-    } catch {
-      continue;
-    }
-  }
-  return candidates;
-}
-
-async function walkJsonl(root: string): Promise<string[]> {
-  const out: string[] = [];
-  const stack: string[] = [root];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries: Dirent[];
-    try {
-      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
-    } catch {
-      continue;
-    }
-    for (const e of entries) {
-      const full = path.join(dir, e.name);
-      if (e.isDirectory()) stack.push(full);
-      else if (e.isFile() && e.name.endsWith('.jsonl')) out.push(full);
-    }
-  }
-  return out;
+  return now.filter((file) => !pre.has(file));
 }

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -4,7 +4,7 @@ import type { CostBreakdown } from '@relayburn/analyze';
 import { queryAll, type Query } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
 
-import { ingestClaudeProjects } from '../ingest.js';
+import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
@@ -16,7 +16,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   if (typeof args.flags['workflow'] === 'string') q.enrichment = { workflowId: args.flags['workflow'] };
   if (typeof args.flags['agent'] === 'string') q.enrichment = { ...(q.enrichment ?? {}), agentId: args.flags['agent'] };
 
-  const ingestReport = await ingestClaudeProjects();
+  const ingestReport = await ingestAll();
   const pricing = await loadPricing();
   const turns = await queryAll(q);
 

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -68,31 +68,37 @@ async function ingestOne(
   parse: (f: string) => Promise<TurnRecord[]>,
 ): Promise<void> {
   report.scannedSessions++;
-  const st = await stat(file);
-  const prior = hwm[file];
-  if (prior && prior.mtimeMs >= st.mtimeMs) return;
+  try {
+    const st = await stat(file);
+    const prior = hwm[file];
+    if (prior && prior.mtimeMs >= st.mtimeMs) return;
 
-  const turns = await parse(file);
-  if (turns.length === 0) return;
+    const turns = await parse(file);
+    if (turns.length === 0) return;
 
-  const newTurns = prior
-    ? turns.filter(
-        (t) => t.ts > prior.lastTs || (t.ts === prior.lastTs && t.messageId !== prior.lastMessageId),
-      )
-    : turns;
+    const newTurns = prior
+      ? turns.filter(
+          (t) =>
+            t.ts > prior.lastTs || (t.ts === prior.lastTs && t.messageId !== prior.lastMessageId),
+        )
+      : turns;
 
-  if (newTurns.length > 0) {
-    await appendTurns(newTurns);
-    report.appendedTurns += newTurns.length;
-    report.ingestedSessions++;
+    if (newTurns.length > 0) {
+      await appendTurns(newTurns);
+      report.appendedTurns += newTurns.length;
+      report.ingestedSessions++;
+    }
+
+    const last = turns[turns.length - 1]!;
+    hwm[file] = {
+      lastMessageId: last.messageId,
+      lastTs: last.ts,
+      mtimeMs: st.mtimeMs,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[burn] skipping ${file}: ${msg}\n`);
   }
-
-  const last = turns[turns.length - 1]!;
-  hwm[file] = {
-    lastMessageId: last.messageId,
-    lastTs: last.ts,
-    mtimeMs: st.mtimeMs,
-  };
 }
 
 async function listDirs(parent: string): Promise<string[]> {

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -1,10 +1,11 @@
 import { readdir, stat } from 'node:fs/promises';
-import type { Dirent } from 'node:fs';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
 import { parseClaudeSession, parseCodexSession, type TurnRecord } from '@relayburn/reader';
 import { appendTurns, loadHwm, saveHwm, type HwmMap } from '@relayburn/ledger';
+
+import { walkJsonl } from './walk.js';
 
 const CLAUDE_PROJECTS = path.join(homedir(), '.claude', 'projects');
 const CODEX_SESSIONS = path.join(homedir(), '.codex', 'sessions');
@@ -17,8 +18,30 @@ export interface IngestReport {
 
 export async function ingestClaudeProjects(): Promise<IngestReport> {
   const hwm = await loadHwm();
-  const report = { scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 };
+  const report = emptyReport();
+  await ingestClaudeInto(hwm, report);
+  await saveHwm(hwm);
+  return report;
+}
 
+export async function ingestCodexSessions(): Promise<IngestReport> {
+  const hwm = await loadHwm();
+  const report = emptyReport();
+  await ingestCodexInto(hwm, report);
+  await saveHwm(hwm);
+  return report;
+}
+
+export async function ingestAll(): Promise<IngestReport> {
+  const hwm = await loadHwm();
+  const report = emptyReport();
+  await ingestClaudeInto(hwm, report);
+  await ingestCodexInto(hwm, report);
+  await saveHwm(hwm);
+  return report;
+}
+
+async function ingestClaudeInto(hwm: HwmMap, report: IngestReport): Promise<void> {
   const projects = await listDirs(CLAUDE_PROJECTS);
   for (const projectDir of projects) {
     const files = await listJsonlFiles(projectDir);
@@ -26,31 +49,16 @@ export async function ingestClaudeProjects(): Promise<IngestReport> {
       await ingestOne(file, hwm, report, (f) => parseClaudeSession(f, { sessionPath: f }));
     }
   }
-
-  await saveHwm(hwm);
-  return report;
 }
 
-export async function ingestCodexSessions(): Promise<IngestReport> {
-  const hwm = await loadHwm();
-  const report = { scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 };
-
+async function ingestCodexInto(hwm: HwmMap, report: IngestReport): Promise<void> {
   for (const file of await walkJsonl(CODEX_SESSIONS)) {
     await ingestOne(file, hwm, report, (f) => parseCodexSession(f, { sessionPath: f }));
   }
-
-  await saveHwm(hwm);
-  return report;
 }
 
-export async function ingestAll(): Promise<IngestReport> {
-  const a = await ingestClaudeProjects();
-  const b = await ingestCodexSessions();
-  return {
-    scannedSessions: a.scannedSessions + b.scannedSessions,
-    ingestedSessions: a.ingestedSessions + b.ingestedSessions,
-    appendedTurns: a.appendedTurns + b.appendedTurns,
-  };
+function emptyReport(): IngestReport {
+  return { scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 };
 }
 
 async function ingestOne(
@@ -85,26 +93,6 @@ async function ingestOne(
     lastTs: last.ts,
     mtimeMs: st.mtimeMs,
   };
-}
-
-async function walkJsonl(root: string): Promise<string[]> {
-  const out: string[] = [];
-  const stack: string[] = [root];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries: Dirent[];
-    try {
-      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
-    } catch {
-      continue;
-    }
-    for (const e of entries) {
-      const full = path.join(dir, e.name);
-      if (e.isDirectory()) stack.push(full);
-      else if (e.isFile() && e.name.endsWith('.jsonl')) out.push(full);
-    }
-  }
-  return out;
 }
 
 async function listDirs(parent: string): Promise<string[]> {

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -1,11 +1,13 @@
 import { readdir, stat } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
-import { parseClaudeSession } from '@relayburn/reader';
+import { parseClaudeSession, parseCodexSession, type TurnRecord } from '@relayburn/reader';
 import { appendTurns, loadHwm, saveHwm, type HwmMap } from '@relayburn/ledger';
 
 const CLAUDE_PROJECTS = path.join(homedir(), '.claude', 'projects');
+const CODEX_SESSIONS = path.join(homedir(), '.codex', 'sessions');
 
 export interface IngestReport {
   scannedSessions: number;
@@ -15,43 +17,94 @@ export interface IngestReport {
 
 export async function ingestClaudeProjects(): Promise<IngestReport> {
   const hwm = await loadHwm();
-  let scanned = 0;
-  let ingested = 0;
-  let appended = 0;
+  const report = { scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 };
 
   const projects = await listDirs(CLAUDE_PROJECTS);
   for (const projectDir of projects) {
     const files = await listJsonlFiles(projectDir);
     for (const file of files) {
-      scanned++;
-      const st = await stat(file);
-      const prior = hwm[file];
-      if (prior && prior.mtimeMs >= st.mtimeMs) continue;
-
-      const turns = await parseClaudeSession(file, { sessionPath: file });
-      if (turns.length === 0) continue;
-
-      const newTurns = prior
-        ? turns.filter((t) => t.ts > prior.lastTs || (t.ts === prior.lastTs && t.messageId !== prior.lastMessageId))
-        : turns;
-
-      if (newTurns.length > 0) {
-        await appendTurns(newTurns);
-        appended += newTurns.length;
-        ingested++;
-      }
-
-      const last = turns[turns.length - 1]!;
-      hwm[file] = {
-        lastMessageId: last.messageId,
-        lastTs: last.ts,
-        mtimeMs: st.mtimeMs,
-      };
+      await ingestOne(file, hwm, report, (f) => parseClaudeSession(f, { sessionPath: f }));
     }
   }
 
   await saveHwm(hwm);
-  return { scannedSessions: scanned, ingestedSessions: ingested, appendedTurns: appended };
+  return report;
+}
+
+export async function ingestCodexSessions(): Promise<IngestReport> {
+  const hwm = await loadHwm();
+  const report = { scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 };
+
+  for (const file of await walkJsonl(CODEX_SESSIONS)) {
+    await ingestOne(file, hwm, report, (f) => parseCodexSession(f, { sessionPath: f }));
+  }
+
+  await saveHwm(hwm);
+  return report;
+}
+
+export async function ingestAll(): Promise<IngestReport> {
+  const a = await ingestClaudeProjects();
+  const b = await ingestCodexSessions();
+  return {
+    scannedSessions: a.scannedSessions + b.scannedSessions,
+    ingestedSessions: a.ingestedSessions + b.ingestedSessions,
+    appendedTurns: a.appendedTurns + b.appendedTurns,
+  };
+}
+
+async function ingestOne(
+  file: string,
+  hwm: HwmMap,
+  report: IngestReport,
+  parse: (f: string) => Promise<TurnRecord[]>,
+): Promise<void> {
+  report.scannedSessions++;
+  const st = await stat(file);
+  const prior = hwm[file];
+  if (prior && prior.mtimeMs >= st.mtimeMs) return;
+
+  const turns = await parse(file);
+  if (turns.length === 0) return;
+
+  const newTurns = prior
+    ? turns.filter(
+        (t) => t.ts > prior.lastTs || (t.ts === prior.lastTs && t.messageId !== prior.lastMessageId),
+      )
+    : turns;
+
+  if (newTurns.length > 0) {
+    await appendTurns(newTurns);
+    report.appendedTurns += newTurns.length;
+    report.ingestedSessions++;
+  }
+
+  const last = turns[turns.length - 1]!;
+  hwm[file] = {
+    lastMessageId: last.messageId,
+    lastTs: last.ts,
+    mtimeMs: st.mtimeMs,
+  };
+}
+
+async function walkJsonl(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.endsWith('.jsonl')) out.push(full);
+    }
+  }
+  return out;
 }
 
 async function listDirs(parent: string): Promise<string[]> {

--- a/packages/cli/src/walk.ts
+++ b/packages/cli/src/walk.ts
@@ -1,0 +1,23 @@
+import { readdir } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import * as path from 'node:path';
+
+export async function walkJsonl(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.endsWith('.jsonl')) out.push(full);
+    }
+  }
+  return out;
+}

--- a/packages/reader/src/codex.test.ts
+++ b/packages/reader/src/codex.test.ts
@@ -1,0 +1,108 @@
+import { strict as assert } from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { parseCodexSession } from './codex.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.resolve(__dirname, '..', '..', '..', 'tests', 'fixtures', 'codex');
+
+describe('parseCodexSession', () => {
+  it('parses a simple one-turn session', async () => {
+    const turns = await parseCodexSession(path.join(FIXTURES, 'simple-turn.jsonl'));
+    assert.equal(turns.length, 1);
+    const t = turns[0]!;
+    assert.equal(t.v, 1);
+    assert.equal(t.source, 'codex');
+    assert.equal(t.sessionId, 'sess_simple_1');
+    assert.equal(t.messageId, 'turn_simple_1');
+    assert.equal(t.turnIndex, 0);
+    assert.equal(t.model, 'gpt-5.4');
+    assert.equal(t.project, '/tmp/project');
+    assert.equal(t.ts, '2026-04-20T00:00:00.200Z');
+    assert.deepEqual(t.usage, {
+      input: 600,
+      output: 120,
+      cacheRead: 400,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    });
+    assert.equal(t.toolCalls.length, 0);
+    assert.equal(t.filesTouched, undefined);
+  });
+
+  it('extracts function and custom tool calls and maps filesTouched from patch_apply_end', async () => {
+    const turns = await parseCodexSession(path.join(FIXTURES, 'with-tool-call.jsonl'));
+    assert.equal(turns.length, 1);
+    const t = turns[0]!;
+    assert.equal(t.model, 'gpt-5.3-codex');
+    assert.deepEqual(t.usage, {
+      input: 3000,
+      output: 800,
+      cacheRead: 2000,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    });
+    assert.equal(t.toolCalls.length, 3);
+
+    const [exec, patch1, patch2] = t.toolCalls;
+    assert.equal(exec!.name, 'exec_command');
+    assert.equal(exec!.target, 'git status');
+
+    assert.equal(patch1!.name, 'apply_patch');
+    assert.equal(patch1!.target, '/tmp/project/README.md');
+
+    assert.equal(patch2!.name, 'apply_patch');
+    assert.equal(patch2!.target, '/tmp/project/NEW.md');
+
+    assert.deepEqual(t.filesTouched?.sort(), [
+      '/tmp/project/NEW.md',
+      '/tmp/project/README.md',
+    ]);
+  });
+
+  it('computes per-turn usage as delta of cumulative totals across multiple turns', async () => {
+    const turns = await parseCodexSession(path.join(FIXTURES, 'multi-turn.jsonl'));
+    assert.equal(turns.length, 2);
+
+    const [t1, t2] = turns;
+    assert.equal(t1!.messageId, 'turn_multi_1');
+    assert.equal(t1!.turnIndex, 0);
+    assert.equal(t1!.model, 'gpt-5.4');
+    assert.deepEqual(t1!.usage, {
+      input: 2000,
+      output: 200,
+      cacheRead: 1000,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    });
+
+    assert.equal(t2!.messageId, 'turn_multi_2');
+    assert.equal(t2!.turnIndex, 1);
+    assert.equal(t2!.model, 'gpt-5.3-codex');
+    assert.deepEqual(t2!.usage, {
+      input: 2500,
+      output: 500,
+      cacheRead: 2500,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    });
+    assert.equal(t2!.toolCalls.length, 1);
+    assert.equal(t2!.toolCalls[0]!.name, 'exec_command');
+    assert.equal(t2!.toolCalls[0]!.target, 'ls');
+  });
+
+  it('produces stable argsHash for identical tool inputs', async () => {
+    const a = await parseCodexSession(path.join(FIXTURES, 'with-tool-call.jsonl'));
+    const b = await parseCodexSession(path.join(FIXTURES, 'with-tool-call.jsonl'));
+    assert.equal(a[0]!.toolCalls[0]!.argsHash, b[0]!.toolCalls[0]!.argsHash);
+    assert.notEqual(a[0]!.toolCalls[0]!.argsHash, a[0]!.toolCalls[1]!.argsHash);
+  });
+
+  it('respects sessionPath option', async () => {
+    const file = path.join(FIXTURES, 'simple-turn.jsonl');
+    const turns = await parseCodexSession(file, { sessionPath: file });
+    assert.equal(turns[0]!.sessionPath, file);
+  });
+});

--- a/packages/reader/src/codex.ts
+++ b/packages/reader/src/codex.ts
@@ -1,0 +1,329 @@
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+import { argsHash } from './hash.js';
+import type { ToolCall, TurnRecord, Usage } from './types.js';
+
+export interface ParseCodexOptions {
+  sessionPath?: string;
+}
+
+interface SessionMetaPayload {
+  id?: string;
+  cwd?: string;
+  timestamp?: string;
+}
+
+interface TurnContextPayload {
+  turn_id?: string;
+  cwd?: string;
+  model?: string;
+}
+
+interface TaskStartedPayload {
+  type: 'task_started';
+  turn_id?: string;
+}
+
+interface TaskCompletePayload {
+  type: 'task_complete';
+  turn_id?: string;
+}
+
+interface TokenUsage {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+  reasoning_output_tokens?: number;
+  total_tokens?: number;
+}
+
+interface TokenCountPayload {
+  type: 'token_count';
+  info?: {
+    total_token_usage?: TokenUsage;
+    last_token_usage?: TokenUsage;
+  } | null;
+}
+
+interface FunctionCallPayload {
+  type: 'function_call';
+  name?: string;
+  arguments?: string;
+  call_id?: string;
+}
+
+interface CustomToolCallPayload {
+  type: 'custom_tool_call';
+  name?: string;
+  input?: string;
+  call_id?: string;
+}
+
+interface PatchApplyEndPayload {
+  type: 'patch_apply_end';
+  turn_id?: string;
+  success?: boolean;
+  changes?: Record<string, unknown>;
+}
+
+interface CumulativeUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+}
+
+interface OpenTurn {
+  turnId: string;
+  ts: string;
+  model: string;
+  project?: string;
+  startCumulative: CumulativeUsage;
+  toolCalls: ToolCall[];
+  seenCallIds: Set<string>;
+  filesTouched: Set<string>;
+}
+
+interface FinalizedTurn extends Omit<OpenTurn, 'startCumulative' | 'seenCallIds' | 'filesTouched'> {
+  usage: Usage;
+  filesTouched: string[];
+}
+
+export async function parseCodexSession(
+  filePath: string,
+  options: ParseCodexOptions = {},
+): Promise<TurnRecord[]> {
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  });
+
+  let sessionId = '';
+  let sessionCwd: string | undefined;
+  const turnContexts = new Map<string, TurnContextPayload>();
+  const cumulative: CumulativeUsage = { input: 0, output: 0, cacheRead: 0 };
+  let openTurn: OpenTurn | null = null;
+  const finalized: FinalizedTurn[] = [];
+
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (!parsed || typeof parsed !== 'object') continue;
+      const rec = parsed as {
+        type?: string;
+        timestamp?: string;
+        payload?: unknown;
+      };
+      const payload = rec.payload;
+      if (!payload || typeof payload !== 'object') continue;
+
+      if (rec.type === 'session_meta') {
+        const p = payload as SessionMetaPayload;
+        if (typeof p.id === 'string') sessionId = p.id;
+        if (typeof p.cwd === 'string') sessionCwd = p.cwd;
+        continue;
+      }
+
+      if (rec.type === 'turn_context') {
+        const ctx = payload as TurnContextPayload;
+        if (typeof ctx.turn_id === 'string') turnContexts.set(ctx.turn_id, ctx);
+        if (openTurn && ctx.turn_id === openTurn.turnId) {
+          if (!openTurn.model && typeof ctx.model === 'string') openTurn.model = ctx.model;
+          if (openTurn.project === undefined && typeof ctx.cwd === 'string') {
+            openTurn.project = ctx.cwd;
+          }
+        }
+        continue;
+      }
+
+      const p = payload as { type?: string };
+
+      if (rec.type === 'event_msg') {
+        if (p.type === 'token_count') {
+          const tc = payload as TokenCountPayload;
+          const total = tc.info?.total_token_usage;
+          if (total) {
+            const inputTotal = total.input_tokens ?? 0;
+            const cached = total.cached_input_tokens ?? 0;
+            cumulative.input = inputTotal - cached;
+            cumulative.cacheRead = cached;
+            cumulative.output = total.output_tokens ?? 0;
+          }
+          continue;
+        }
+
+        if (p.type === 'task_started') {
+          const ts = rec.timestamp ?? '';
+          const ev = payload as TaskStartedPayload;
+          const turnId = ev.turn_id;
+          if (typeof turnId !== 'string') continue;
+          if (openTurn) {
+            finalized.push(finalizeTurn(openTurn, cumulative));
+          }
+          const ctx = turnContexts.get(turnId);
+          const project = ctx?.cwd ?? sessionCwd;
+          openTurn = {
+            turnId,
+            ts,
+            model: ctx?.model ?? '',
+            startCumulative: { ...cumulative },
+            toolCalls: [],
+            seenCallIds: new Set(),
+            filesTouched: new Set(),
+          };
+          if (project !== undefined) openTurn.project = project;
+          continue;
+        }
+
+        if (p.type === 'task_complete') {
+          const ev = payload as TaskCompletePayload;
+          if (openTurn && ev.turn_id === openTurn.turnId) {
+            finalized.push(finalizeTurn(openTurn, cumulative));
+            openTurn = null;
+          }
+          continue;
+        }
+
+        if (p.type === 'patch_apply_end') {
+          const ev = payload as PatchApplyEndPayload;
+          if (!openTurn || ev.turn_id !== openTurn.turnId) continue;
+          if (ev.success === false) continue;
+          const changes = ev.changes;
+          if (changes && typeof changes === 'object') {
+            for (const file of Object.keys(changes)) openTurn.filesTouched.add(file);
+          }
+          continue;
+        }
+        continue;
+      }
+
+      if (rec.type === 'response_item') {
+        if (!openTurn) continue;
+        if (p.type === 'function_call') {
+          const fc = payload as FunctionCallPayload;
+          if (typeof fc.name !== 'string' || typeof fc.call_id !== 'string') continue;
+          if (openTurn.seenCallIds.has(fc.call_id)) continue;
+          openTurn.seenCallIds.add(fc.call_id);
+          const parsedArgs = safeParseJson(fc.arguments);
+          const call: ToolCall = {
+            id: fc.call_id,
+            name: fc.name,
+            argsHash: argsHash(parsedArgs ?? {}),
+          };
+          const target = pickFunctionCallTarget(fc.name, parsedArgs);
+          if (target !== undefined) call.target = target;
+          openTurn.toolCalls.push(call);
+        } else if (p.type === 'custom_tool_call') {
+          const ct = payload as CustomToolCallPayload;
+          if (typeof ct.name !== 'string' || typeof ct.call_id !== 'string') continue;
+          if (openTurn.seenCallIds.has(ct.call_id)) continue;
+          openTurn.seenCallIds.add(ct.call_id);
+          const input = ct.input ?? '';
+          const call: ToolCall = {
+            id: ct.call_id,
+            name: ct.name,
+            argsHash: argsHash({ input }),
+          };
+          const target = pickCustomToolTarget(ct.name, input);
+          if (target !== undefined) call.target = target;
+          openTurn.toolCalls.push(call);
+        }
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  if (openTurn) {
+    finalized.push(finalizeTurn(openTurn, cumulative));
+  }
+
+  const turns: TurnRecord[] = [];
+  for (let i = 0; i < finalized.length; i++) {
+    const f = finalized[i]!;
+    const record: TurnRecord = {
+      v: 1,
+      source: 'codex',
+      sessionId,
+      messageId: f.turnId,
+      turnIndex: i,
+      ts: f.ts,
+      model: f.model,
+      usage: f.usage,
+      toolCalls: f.toolCalls,
+    };
+    if (options.sessionPath !== undefined) record.sessionPath = options.sessionPath;
+    if (f.project !== undefined) record.project = f.project;
+    if (f.filesTouched.length > 0) record.filesTouched = f.filesTouched;
+    turns.push(record);
+  }
+  return turns;
+}
+
+function finalizeTurn(open: OpenTurn, cumulative: CumulativeUsage): FinalizedTurn {
+  const usage: Usage = {
+    input: Math.max(0, cumulative.input - open.startCumulative.input),
+    output: Math.max(0, cumulative.output - open.startCumulative.output),
+    cacheRead: Math.max(0, cumulative.cacheRead - open.startCumulative.cacheRead),
+    cacheCreate5m: 0,
+    cacheCreate1h: 0,
+  };
+  const out: FinalizedTurn = {
+    turnId: open.turnId,
+    ts: open.ts,
+    model: open.model,
+    toolCalls: open.toolCalls,
+    usage,
+    filesTouched: [...open.filesTouched],
+  };
+  if (open.project !== undefined) out.project = open.project;
+  return out;
+}
+
+function safeParseJson(s: string | undefined): Record<string, unknown> | undefined {
+  if (typeof s !== 'string' || s.length === 0) return undefined;
+  try {
+    const v = JSON.parse(s);
+    if (v && typeof v === 'object' && !Array.isArray(v)) return v as Record<string, unknown>;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pickFunctionCallTarget(
+  name: string,
+  args: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!args) return undefined;
+  const s = (k: string): string | undefined => {
+    const v = args[k];
+    return typeof v === 'string' ? v : undefined;
+  };
+  switch (name) {
+    case 'exec_command':
+    case 'shell':
+      return s('cmd') ?? s('command');
+    case 'read_file':
+      return s('path') ?? s('file_path');
+    case 'write_file':
+      return s('path') ?? s('file_path');
+    default:
+      return s('path') ?? s('file_path') ?? s('cmd') ?? s('command') ?? s('url');
+  }
+}
+
+function pickCustomToolTarget(name: string, input: string): string | undefined {
+  if (name === 'apply_patch') {
+    const m = input.match(/\*\*\*\s+(?:Update|Add|Delete)\s+File:\s+(\S.*?)\s*$/m);
+    if (m) return m[1];
+  }
+  return undefined;
+}

--- a/packages/reader/src/codex.ts
+++ b/packages/reader/src/codex.ts
@@ -127,7 +127,10 @@ export async function parseCodexSession(
       if (rec.type === 'session_meta') {
         const p = payload as SessionMetaPayload;
         if (typeof p.id === 'string') sessionId = p.id;
-        if (typeof p.cwd === 'string') sessionCwd = p.cwd;
+        if (typeof p.cwd === 'string') {
+          sessionCwd = p.cwd;
+          if (openTurn && openTurn.project === undefined) openTurn.project = p.cwd;
+        }
         continue;
       }
 

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -7,3 +7,5 @@ export type {
 } from './types.js';
 export { parseClaudeSession } from './claude.js';
 export type { ParseOptions } from './claude.js';
+export { parseCodexSession } from './codex.js';
+export type { ParseCodexOptions } from './codex.js';

--- a/tests/fixtures/codex/multi-turn.jsonl
+++ b/tests/fixtures/codex/multi-turn.jsonl
@@ -1,0 +1,11 @@
+{"timestamp":"2026-04-20T02:00:00.000Z","type":"session_meta","payload":{"id":"sess_multi_1","cwd":"/tmp/project","timestamp":"2026-04-20T02:00:00.000Z"}}
+{"timestamp":"2026-04-20T02:00:00.100Z","type":"turn_context","payload":{"turn_id":"turn_multi_1","cwd":"/tmp/project","model":"gpt-5.4"}}
+{"timestamp":"2026-04-20T02:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_multi_1"}}
+{"timestamp":"2026-04-20T02:00:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":3000,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":3200}}}}
+{"timestamp":"2026-04-20T02:00:02.500Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":3000,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":3200}}}}
+{"timestamp":"2026-04-20T02:00:03.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_multi_1"}}
+{"timestamp":"2026-04-20T02:00:10.000Z","type":"turn_context","payload":{"turn_id":"turn_multi_2","cwd":"/tmp/project","model":"gpt-5.3-codex"}}
+{"timestamp":"2026-04-20T02:00:10.100Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_multi_2"}}
+{"timestamp":"2026-04-20T02:00:11.000Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\"}","call_id":"call_m2_1"}}
+{"timestamp":"2026-04-20T02:00:12.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":8000,"cached_input_tokens":3500,"output_tokens":700,"reasoning_output_tokens":100,"total_tokens":8700}}}}
+{"timestamp":"2026-04-20T02:00:12.500Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_multi_2"}}

--- a/tests/fixtures/codex/simple-turn.jsonl
+++ b/tests/fixtures/codex/simple-turn.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2026-04-20T00:00:00.000Z","type":"session_meta","payload":{"id":"sess_simple_1","cwd":"/tmp/project","timestamp":"2026-04-20T00:00:00.000Z","cli_version":"0.121.0"}}
+{"timestamp":"2026-04-20T00:00:00.100Z","type":"turn_context","payload":{"turn_id":"turn_simple_1","cwd":"/tmp/project","model":"gpt-5.4"}}
+{"timestamp":"2026-04-20T00:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_simple_1"}}
+{"timestamp":"2026-04-20T00:00:00.300Z","type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":{}}}
+{"timestamp":"2026-04-20T00:00:05.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":120,"reasoning_output_tokens":30,"total_tokens":1120},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":120,"reasoning_output_tokens":30,"total_tokens":1120}}}}
+{"timestamp":"2026-04-20T00:00:05.100Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_simple_1","completed_at":1776672305,"duration_ms":4900}}

--- a/tests/fixtures/codex/with-tool-call.jsonl
+++ b/tests/fixtures/codex/with-tool-call.jsonl
@@ -1,0 +1,11 @@
+{"timestamp":"2026-04-20T01:00:00.000Z","type":"session_meta","payload":{"id":"sess_tools_1","cwd":"/tmp/project","timestamp":"2026-04-20T01:00:00.000Z"}}
+{"timestamp":"2026-04-20T01:00:00.100Z","type":"turn_context","payload":{"turn_id":"turn_tools_1","cwd":"/tmp/project","model":"gpt-5.3-codex"}}
+{"timestamp":"2026-04-20T01:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_tools_1"}}
+{"timestamp":"2026-04-20T01:00:01.000Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"git status\",\"workdir\":\"/tmp/project\"}","call_id":"call_exec_1"}}
+{"timestamp":"2026-04-20T01:00:01.500Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_exec_1","turn_id":"turn_tools_1","exit_code":0}}
+{"timestamp":"2026-04-20T01:00:02.000Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_patch_1","name":"apply_patch","input":"*** Begin Patch\n*** Update File: /tmp/project/README.md\n@@\n+banner\n*** End Patch\n"}}
+{"timestamp":"2026-04-20T01:00:02.500Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"call_patch_1","turn_id":"turn_tools_1","success":true,"changes":{"/tmp/project/README.md":{"type":"update","unified_diff":"@@\n+banner"}}}}
+{"timestamp":"2026-04-20T01:00:03.000Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_patch_2","name":"apply_patch","input":"*** Begin Patch\n*** Add File: /tmp/project/NEW.md\n+hello\n*** End Patch\n"}}
+{"timestamp":"2026-04-20T01:00:03.200Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"call_patch_2","turn_id":"turn_tools_1","success":true,"changes":{"/tmp/project/NEW.md":{"type":"add"}}}}
+{"timestamp":"2026-04-20T01:00:04.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":5000,"cached_input_tokens":2000,"output_tokens":800,"reasoning_output_tokens":200,"total_tokens":5800}}}}
+{"timestamp":"2026-04-20T01:00:04.100Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_tools_1"}}


### PR DESCRIPTION
Introduce support for Codex sessions: add a parseCodexSession reader, tests, and JSONL fixtures; export the parser from the reader package. Add a new CLI subcommand and wrapper (burn codex) that spawns the codex binary, finds new session files, parses turns, appends them to the ledger, and stamps enrichments. Refactor ingestion: consolidate ingestion logic into ingestOne/ingestAll and add ingestCodexSessions; update summary and by-tool commands to call ingestAll instead of the Claude-only ingest. The Codex parser computes per-turn usage deltas, extracts function/custom tool calls, maps filesTouched from patch_apply_end events, and preserves sessionPath when provided.