### PR TITLE
Add opencode reader + CLI wrapper; track reasoning tokens

### DIFF
--- a/packages/analyze/src/cost.test.ts
+++ b/packages/analyze/src/cost.test.ts
@@ -18,6 +18,7 @@ function turn(model: string, u: Partial<TurnRecord['usage']> = {}): TurnRecord {
     usage: {
       input: 0,
       output: 0,
+      reasoning: 0,
       cacheRead: 0,
       cacheCreate5m: 0,
       cacheCreate1h: 0,
@@ -54,6 +55,7 @@ describe('cost', () => {
       {
         input: 0,
         output: 0,
+        reasoning: 0,
         cacheRead: 0,
         cacheCreate5m: 500_000,
         cacheCreate1h: 500_000,

--- a/packages/analyze/src/cost.test.ts
+++ b/packages/analyze/src/cost.test.ts
@@ -67,6 +67,19 @@ describe('cost', () => {
     assert.equal(c.cacheCreate, p['claude-opus-4-7']!.cacheWrite);
   });
 
+  it('bills reasoning tokens at the output rate and reports them separately', async () => {
+    const p = await loadBuiltinPricing();
+    const c = costForTurn(
+      turn('claude-sonnet-4-6', { output: 1_000_000, reasoning: 1_000_000 }),
+      p,
+    );
+    assert.ok(c);
+    const rate = p['claude-sonnet-4-6']!;
+    assert.equal(c.output, rate.output);
+    assert.equal(c.reasoning, rate.output);
+    assert.equal(c.total, rate.output * 2);
+  });
+
   it('returns null for unknown model', async () => {
     const p = await loadBuiltinPricing();
     const c = costForTurn(turn('definitely-not-a-model', { input: 100 }), p);

--- a/packages/analyze/src/cost.ts
+++ b/packages/analyze/src/cost.ts
@@ -7,6 +7,7 @@ export interface CostBreakdown {
   total: number;
   input: number;
   output: number;
+  reasoning: number;
   cacheRead: number;
   cacheCreate: number;
 }
@@ -21,15 +22,17 @@ export function costForUsage(
   const rate = lookup(model, pricing);
   if (!rate) return null;
   const input = (usage.input / PER_MILLION) * rate.input;
-  const output = ((usage.output + usage.reasoning) / PER_MILLION) * rate.output;
+  const output = (usage.output / PER_MILLION) * rate.output;
+  const reasoning = (usage.reasoning / PER_MILLION) * rate.output;
   const cacheRead = (usage.cacheRead / PER_MILLION) * rate.cacheRead;
   const cacheCreate =
     ((usage.cacheCreate5m + usage.cacheCreate1h) / PER_MILLION) * rate.cacheWrite;
   return {
     model,
-    total: input + output + cacheRead + cacheCreate,
+    total: input + output + reasoning + cacheRead + cacheCreate,
     input,
     output,
+    reasoning,
     cacheRead,
     cacheCreate,
   };
@@ -62,10 +65,19 @@ export function sumCosts(costs: CostBreakdown[]): CostBreakdown {
       total: a.total + c.total,
       input: a.input + c.input,
       output: a.output + c.output,
+      reasoning: a.reasoning + c.reasoning,
       cacheRead: a.cacheRead + c.cacheRead,
       cacheCreate: a.cacheCreate + c.cacheCreate,
     }),
-    { model: 'aggregate', total: 0, input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
+    {
+      model: 'aggregate',
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheCreate: 0,
+    },
   );
   return total;
 }

--- a/packages/analyze/src/cost.ts
+++ b/packages/analyze/src/cost.ts
@@ -21,7 +21,7 @@ export function costForUsage(
   const rate = lookup(model, pricing);
   if (!rate) return null;
   const input = (usage.input / PER_MILLION) * rate.input;
-  const output = (usage.output / PER_MILLION) * rate.output;
+  const output = ((usage.output + usage.reasoning) / PER_MILLION) * rate.output;
   const cacheRead = (usage.cacheRead / PER_MILLION) * rate.cacheRead;
   const cacheCreate =
     ((usage.cacheCreate5m + usage.cacheCreate1h) / PER_MILLION) * rate.cacheWrite;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,19 +2,22 @@
 import { parseArgs } from './args.js';
 import { runByTool } from './commands/by-tool.js';
 import { runClaudeWrapper } from './commands/claude.js';
+import { runOpencodeWrapper } from './commands/opencode.js';
 import { runSummary } from './commands/summary.js';
 
 const HELP = `burn — token usage & cost attribution for agent CLIs
 
 Usage:
-  burn summary [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>]
-  burn by-tool [--since 7d] [--project <path>] [--session <id>]
-  burn claude  [--tag k=v ...] [-- <claude args>]
+  burn summary  [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>]
+  burn by-tool  [--since 7d] [--project <path>] [--session <id>]
+  burn claude   [--tag k=v ...] [-- <claude args>]
+  burn opencode [--tag k=v ...] [-- <opencode args>]
 
 Examples:
   burn summary --since 24h
   burn by-tool --since 7d
-  burn claude --tag workflow=refactor -- --resume
+  burn claude   --tag workflow=refactor -- --resume
+  burn opencode --tag workflow=refactor
 `;
 
 async function main(): Promise<number> {
@@ -31,8 +34,9 @@ async function main(): Promise<number> {
       return runByTool(args);
     case 'claude':
       return runClaudeWrapper(args);
-    case 'codex':
     case 'opencode':
+      return runOpencodeWrapper(args);
+    case 'codex':
       process.stderr.write(`${cmd}: reader not implemented yet in v0\n`);
       return 2;
     default:

--- a/packages/cli/src/commands/by-tool.ts
+++ b/packages/cli/src/commands/by-tool.ts
@@ -2,7 +2,7 @@ import { loadPricing, costForTurn } from '@relayburn/analyze';
 import { queryAll, type Query } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
 
-import { ingestClaudeProjects } from '../ingest.js';
+import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
@@ -12,7 +12,7 @@ export async function runByTool(args: ParsedArgs): Promise<number> {
   if (typeof args.flags['project'] === 'string') q.project = args.flags['project'];
   if (typeof args.flags['session'] === 'string') q.sessionId = args.flags['session'];
 
-  await ingestClaudeProjects();
+  await ingestAll();
   const pricing = await loadPricing();
   const turns = await queryAll(q);
 

--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -1,0 +1,93 @@
+import { spawn } from 'node:child_process';
+import { readdir, stat } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+
+import { parseOpencodeSession } from '@relayburn/reader';
+import { appendTurns, stamp } from '@relayburn/ledger';
+import type { Enrichment } from '@relayburn/ledger';
+
+import type { ParsedArgs } from '../args.js';
+
+const OPENCODE_STORAGE = path.join(homedir(), '.local', 'share', 'opencode', 'storage');
+const OPENCODE_SESSION_ROOT = path.join(OPENCODE_STORAGE, 'session');
+
+export async function runOpencodeWrapper(args: ParsedArgs): Promise<number> {
+  const tags: Enrichment = { ...args.tags };
+  tags['harness'] = 'opencode';
+  tags['burnSpawn'] = '1';
+  const spawnStartTs = Date.now();
+  tags['burnSpawnTs'] = new Date(spawnStartTs).toISOString();
+
+  const preSnapshot = await snapshotSessionFiles();
+  process.stderr.write(`[burn] opencode spawn: tracking ${preSnapshot.size} existing sessions\n`);
+
+  const child = spawn('opencode', args.passthrough, { stdio: 'inherit', env: process.env });
+  const code: number = await new Promise((resolve) => {
+    child.on('exit', (c) => resolve(c ?? 0));
+    child.on('error', (err) => {
+      process.stderr.write(`[burn] failed to spawn opencode: ${err.message}\n`);
+      resolve(127);
+    });
+  });
+
+  const newFiles = await findNewSessionFiles(preSnapshot, spawnStartTs);
+  if (newFiles.length === 0) {
+    process.stderr.write(`[burn] no new opencode session files found under ${OPENCODE_SESSION_ROOT}\n`);
+    return code;
+  }
+
+  for (const file of newFiles) {
+    const turns = await parseOpencodeSession(file, { sessionPath: file });
+    if (turns.length === 0) continue;
+    await appendTurns(turns);
+    const sessionId = turns[0]!.sessionId;
+    if (sessionId) await stamp({ sessionId }, tags);
+    process.stderr.write(`[burn] ingested ${turns.length} turns from ${file}\n`);
+  }
+
+  return code;
+}
+
+async function snapshotSessionFiles(): Promise<Set<string>> {
+  const out = new Set<string>();
+  for (const file of await walkSessionJson(OPENCODE_SESSION_ROOT)) out.add(file);
+  return out;
+}
+
+async function findNewSessionFiles(pre: Set<string>, spawnStartTs: number): Promise<string[]> {
+  const now = await walkSessionJson(OPENCODE_SESSION_ROOT);
+  const candidates: string[] = [];
+  for (const file of now) {
+    if (pre.has(file)) continue;
+    try {
+      const st = await stat(file);
+      if (st.mtimeMs + 1 < spawnStartTs) continue;
+      candidates.push(file);
+    } catch {
+      continue;
+    }
+  }
+  return candidates;
+}
+
+async function walkSessionJson(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.startsWith('ses_') && e.name.endsWith('.json')) out.push(full);
+    }
+  }
+  return out;
+}

--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process';
-import { readdir, stat } from 'node:fs/promises';
-import type { Dirent } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
@@ -9,6 +8,7 @@ import { appendTurns, stamp } from '@relayburn/ledger';
 import type { Enrichment } from '@relayburn/ledger';
 
 import type { ParsedArgs } from '../args.js';
+import { walkOpencodeSessions } from '../walk.js';
 
 const OPENCODE_STORAGE = path.join(homedir(), '.local', 'share', 'opencode', 'storage');
 const OPENCODE_SESSION_ROOT = path.join(OPENCODE_STORAGE, 'session');
@@ -52,12 +52,12 @@ export async function runOpencodeWrapper(args: ParsedArgs): Promise<number> {
 
 async function snapshotSessionFiles(): Promise<Set<string>> {
   const out = new Set<string>();
-  for (const file of await walkSessionJson(OPENCODE_SESSION_ROOT)) out.add(file);
+  for (const file of await walkOpencodeSessions(OPENCODE_SESSION_ROOT)) out.add(file);
   return out;
 }
 
 async function findNewSessionFiles(pre: Set<string>, spawnStartTs: number): Promise<string[]> {
-  const now = await walkSessionJson(OPENCODE_SESSION_ROOT);
+  const now = await walkOpencodeSessions(OPENCODE_SESSION_ROOT);
   const candidates: string[] = [];
   for (const file of now) {
     if (pre.has(file)) continue;
@@ -70,24 +70,4 @@ async function findNewSessionFiles(pre: Set<string>, spawnStartTs: number): Prom
     }
   }
   return candidates;
-}
-
-async function walkSessionJson(root: string): Promise<string[]> {
-  const out: string[] = [];
-  const stack: string[] = [root];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries: Dirent[];
-    try {
-      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
-    } catch {
-      continue;
-    }
-    for (const e of entries) {
-      const full = path.join(dir, e.name);
-      if (e.isDirectory()) stack.push(full);
-      else if (e.isFile() && e.name.startsWith('ses_') && e.name.endsWith('.json')) out.push(full);
-    }
-  }
-  return out;
 }

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -38,7 +38,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  const header = ['model', 'turns', 'input', 'output', 'cacheRead', 'cacheCreate', 'cost'];
+  const header = ['model', 'turns', 'input', 'output', 'reasoning', 'cacheRead', 'cacheCreate', 'cost'];
   const dataRows: string[][] = [header];
   for (const r of rowsByModel) {
     dataRows.push([
@@ -46,6 +46,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
       formatInt(r.turns),
       formatInt(r.usage.input),
       formatInt(r.usage.output),
+      formatInt(r.usage.reasoning),
       formatInt(r.usage.cacheRead),
       formatInt(r.usage.cacheCreate5m + r.usage.cacheCreate1h),
       formatUsd(r.cost.total),
@@ -55,7 +56,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   lines.push('');
   lines.push(`total cost: ${formatUsd(totalCost.total)}`);
   lines.push(
-    `  input ${formatUsd(totalCost.input)} / output ${formatUsd(totalCost.output)} / cacheRead ${formatUsd(totalCost.cacheRead)} / cacheCreate ${formatUsd(totalCost.cacheCreate)}`,
+    `  input ${formatUsd(totalCost.input)} / output ${formatUsd(totalCost.output)} / reasoning ${formatUsd(totalCost.reasoning)} / cacheRead ${formatUsd(totalCost.cacheRead)} / cacheCreate ${formatUsd(totalCost.cacheCreate)}`,
   );
   lines.push('');
 
@@ -80,7 +81,7 @@ function aggregateByModel(turns: EnrichedTurn[], pricing: Parameters<typeof cost
         model: key,
         turns: 0,
         usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
-        cost: { model: key, total: 0, input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
+        cost: { model: key, total: 0, input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheCreate: 0 },
       };
       byModel.set(key, row);
     }
@@ -96,6 +97,7 @@ function aggregateByModel(turns: EnrichedTurn[], pricing: Parameters<typeof cost
       row.cost.total += c.total;
       row.cost.input += c.input;
       row.cost.output += c.output;
+      row.cost.reasoning += c.reasoning;
       row.cost.cacheRead += c.cacheRead;
       row.cost.cacheCreate += c.cacheCreate;
     }

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -4,7 +4,7 @@ import type { CostBreakdown } from '@relayburn/analyze';
 import { queryAll, type Query } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
 
-import { ingestClaudeProjects } from '../ingest.js';
+import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
@@ -16,7 +16,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   if (typeof args.flags['workflow'] === 'string') q.enrichment = { workflowId: args.flags['workflow'] };
   if (typeof args.flags['agent'] === 'string') q.enrichment = { ...(q.enrichment ?? {}), agentId: args.flags['agent'] };
 
-  const ingestReport = await ingestClaudeProjects();
+  const ingestReport = await ingestAll();
   const pricing = await loadPricing();
   const turns = await queryAll(q);
 
@@ -79,7 +79,7 @@ function aggregateByModel(turns: EnrichedTurn[], pricing: Parameters<typeof cost
       row = {
         model: key,
         turns: 0,
-        usage: { input: 0, output: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
+        usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
         cost: { model: key, total: 0, input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
       };
       byModel.set(key, row);
@@ -87,6 +87,7 @@ function aggregateByModel(turns: EnrichedTurn[], pricing: Parameters<typeof cost
     row.turns++;
     row.usage.input += t.usage.input;
     row.usage.output += t.usage.output;
+    row.usage.reasoning += t.usage.reasoning;
     row.usage.cacheRead += t.usage.cacheRead;
     row.usage.cacheCreate5m += t.usage.cacheCreate5m;
     row.usage.cacheCreate1h += t.usage.cacheCreate1h;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,4 +2,5 @@ export { runSummary } from './commands/summary.js';
 export { runByTool } from './commands/by-tool.js';
 export { runClaudeWrapper } from './commands/claude.js';
 export { parseArgs } from './args.js';
-export { ingestClaudeProjects } from './ingest.js';
+export { ingestClaudeProjects, ingestOpencodeSessions, ingestAll } from './ingest.js';
+export { runOpencodeWrapper } from './commands/opencode.js';

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -1,11 +1,15 @@
 import { readdir, stat } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
-import { parseClaudeSession } from '@relayburn/reader';
+import { parseClaudeSession, parseOpencodeSession } from '@relayburn/reader';
 import { appendTurns, loadHwm, saveHwm, type HwmMap } from '@relayburn/ledger';
 
 const CLAUDE_PROJECTS = path.join(homedir(), '.claude', 'projects');
+const OPENCODE_STORAGE = path.join(homedir(), '.local', 'share', 'opencode', 'storage');
+const OPENCODE_SESSION_ROOT = path.join(OPENCODE_STORAGE, 'session');
+const OPENCODE_MESSAGE_ROOT = path.join(OPENCODE_STORAGE, 'message');
 
 export interface IngestReport {
   scannedSessions: number;
@@ -54,6 +58,57 @@ export async function ingestClaudeProjects(): Promise<IngestReport> {
   return { scannedSessions: scanned, ingestedSessions: ingested, appendedTurns: appended };
 }
 
+export async function ingestOpencodeSessions(): Promise<IngestReport> {
+  const hwm = await loadHwm();
+  let scanned = 0;
+  let ingested = 0;
+  let appended = 0;
+
+  for (const file of await walkOpencodeSessions(OPENCODE_SESSION_ROOT)) {
+    scanned++;
+    const sessionId = path.basename(file, '.json');
+    const messageDir = path.join(OPENCODE_MESSAGE_ROOT, sessionId);
+    const messageMtime = await getDirMtime(messageDir);
+    if (messageMtime === null) continue;
+
+    const prior = hwm[file];
+    if (prior && prior.mtimeMs >= messageMtime) continue;
+
+    const turns = await parseOpencodeSession(file, { sessionPath: file });
+    if (turns.length === 0) continue;
+
+    const newTurns = prior
+      ? turns.filter((t) => t.ts > prior.lastTs || (t.ts === prior.lastTs && t.messageId !== prior.lastMessageId))
+      : turns;
+
+    if (newTurns.length > 0) {
+      await appendTurns(newTurns);
+      appended += newTurns.length;
+      ingested++;
+    }
+
+    const last = turns[turns.length - 1]!;
+    hwm[file] = {
+      lastMessageId: last.messageId,
+      lastTs: last.ts,
+      mtimeMs: messageMtime,
+    };
+  }
+
+  await saveHwm(hwm);
+  return { scannedSessions: scanned, ingestedSessions: ingested, appendedTurns: appended };
+}
+
+export async function ingestAll(): Promise<IngestReport> {
+  const a = await ingestClaudeProjects();
+  const b = await ingestOpencodeSessions();
+  return {
+    scannedSessions: a.scannedSessions + b.scannedSessions,
+    ingestedSessions: a.ingestedSessions + b.ingestedSessions,
+    appendedTurns: a.appendedTurns + b.appendedTurns,
+  };
+}
+
 async function listDirs(parent: string): Promise<string[]> {
   try {
     const entries = await readdir(parent, { withFileTypes: true });
@@ -71,6 +126,35 @@ async function listJsonlFiles(dir: string): Promise<string[]> {
       .map((e) => path.join(dir, e.name));
   } catch {
     return [];
+  }
+}
+
+async function walkOpencodeSessions(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.startsWith('ses_') && e.name.endsWith('.json')) out.push(full);
+    }
+  }
+  return out;
+}
+
+async function getDirMtime(dir: string): Promise<number | null> {
+  try {
+    const st = await stat(dir);
+    return st.mtimeMs;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -1,5 +1,4 @@
 import { readdir, stat } from 'node:fs/promises';
-import type { Dirent } from 'node:fs';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
@@ -11,7 +10,7 @@ import {
 } from '@relayburn/reader';
 import { appendTurns, loadHwm, saveHwm, type HwmMap } from '@relayburn/ledger';
 
-import { walkJsonl } from './walk.js';
+import { walkJsonl, walkOpencodeSessions } from './walk.js';
 
 const CLAUDE_PROJECTS = path.join(homedir(), '.claude', 'projects');
 const CODEX_SESSIONS = path.join(homedir(), '.codex', 'sessions');
@@ -178,26 +177,6 @@ async function listJsonlFiles(dir: string): Promise<string[]> {
   } catch {
     return [];
   }
-}
-
-async function walkOpencodeSessions(root: string): Promise<string[]> {
-  const out: string[] = [];
-  const stack: string[] = [root];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries: Dirent[];
-    try {
-      entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
-    } catch {
-      continue;
-    }
-    for (const e of entries) {
-      const full = path.join(dir, e.name);
-      if (e.isDirectory()) stack.push(full);
-      else if (e.isFile() && e.name.startsWith('ses_') && e.name.endsWith('.json')) out.push(full);
-    }
-  }
-  return out;
 }
 
 async function getDirMtime(dir: string): Promise<number | null> {

--- a/packages/cli/src/walk.ts
+++ b/packages/cli/src/walk.ts
@@ -3,6 +3,14 @@ import type { Dirent } from 'node:fs';
 import * as path from 'node:path';
 
 export async function walkJsonl(root: string): Promise<string[]> {
+  return walkFiles(root, (e) => e.name.endsWith('.jsonl'));
+}
+
+export async function walkOpencodeSessions(root: string): Promise<string[]> {
+  return walkFiles(root, (e) => e.name.startsWith('ses_') && e.name.endsWith('.json'));
+}
+
+async function walkFiles(root: string, accept: (e: Dirent) => boolean): Promise<string[]> {
   const out: string[] = [];
   const stack: string[] = [root];
   while (stack.length > 0) {
@@ -16,7 +24,7 @@ export async function walkJsonl(root: string): Promise<string[]> {
     for (const e of entries) {
       const full = path.join(dir, e.name);
       if (e.isDirectory()) stack.push(full);
-      else if (e.isFile() && e.name.endsWith('.jsonl')) out.push(full);
+      else if (e.isFile() && accept(e)) out.push(full);
     }
   }
   return out;

--- a/packages/ledger/src/ledger.test.ts
+++ b/packages/ledger/src/ledger.test.ts
@@ -19,7 +19,7 @@ function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
     turnIndex: 0,
     ts: '2026-04-20T00:00:00.000Z',
     model: 'claude-sonnet-4-6',
-    usage: { input: 100, output: 50, cacheRead: 1000, cacheCreate5m: 0, cacheCreate1h: 0 },
+    usage: { input: 100, output: 50, reasoning: 0, cacheRead: 1000, cacheCreate5m: 0, cacheCreate1h: 0 },
     toolCalls: [],
     project: '/tmp/project',
     ...overrides,

--- a/packages/reader/src/claude.test.ts
+++ b/packages/reader/src/claude.test.ts
@@ -22,6 +22,7 @@ describe('parseClaudeSession', () => {
     assert.deepEqual(t.usage, {
       input: 10,
       output: 5,
+      reasoning: 0,
       cacheRead: 500,
       cacheCreate5m: 80,
       cacheCreate1h: 20,
@@ -38,6 +39,7 @@ describe('parseClaudeSession', () => {
     assert.deepEqual(t.usage, {
       input: 3,
       output: 43,
+      reasoning: 0,
       cacheRead: 11496,
       cacheCreate5m: 0,
       cacheCreate1h: 4773,

--- a/packages/reader/src/claude.ts
+++ b/packages/reader/src/claude.ts
@@ -205,9 +205,9 @@ function toUsage(u: ClaudeUsage | undefined): Usage {
   const create1h = u?.cache_creation?.ephemeral_1h_input_tokens ?? 0;
   const totalCreate = u?.cache_creation_input_tokens ?? 0;
   if (create5m === 0 && create1h === 0 && totalCreate > 0) {
-    return { input, output, cacheRead, cacheCreate5m: totalCreate, cacheCreate1h: 0 };
+    return { input, output, reasoning: 0, cacheRead, cacheCreate5m: totalCreate, cacheCreate1h: 0 };
   }
-  return { input, output, cacheRead, cacheCreate5m: create5m, cacheCreate1h: create1h };
+  return { input, output, reasoning: 0, cacheRead, cacheCreate5m: create5m, cacheCreate1h: create1h };
 }
 
 function extractToolCalls(blocks: ContentBlock[]): ToolCall[] {

--- a/packages/reader/src/codex.test.ts
+++ b/packages/reader/src/codex.test.ts
@@ -24,6 +24,7 @@ describe('parseCodexSession', () => {
     assert.deepEqual(t.usage, {
       input: 600,
       output: 120,
+      reasoning: 30,
       cacheRead: 400,
       cacheCreate5m: 0,
       cacheCreate1h: 0,
@@ -40,6 +41,7 @@ describe('parseCodexSession', () => {
     assert.deepEqual(t.usage, {
       input: 3000,
       output: 800,
+      reasoning: 200,
       cacheRead: 2000,
       cacheCreate5m: 0,
       cacheCreate1h: 0,
@@ -73,6 +75,7 @@ describe('parseCodexSession', () => {
     assert.deepEqual(t1!.usage, {
       input: 2000,
       output: 200,
+      reasoning: 50,
       cacheRead: 1000,
       cacheCreate5m: 0,
       cacheCreate1h: 0,
@@ -84,6 +87,7 @@ describe('parseCodexSession', () => {
     assert.deepEqual(t2!.usage, {
       input: 2500,
       output: 500,
+      reasoning: 50,
       cacheRead: 2500,
       cacheCreate5m: 0,
       cacheCreate1h: 0,

--- a/packages/reader/src/codex.ts
+++ b/packages/reader/src/codex.ts
@@ -71,6 +71,7 @@ interface CumulativeUsage {
   input: number;
   output: number;
   cacheRead: number;
+  reasoning: number;
 }
 
 interface OpenTurn {
@@ -101,7 +102,7 @@ export async function parseCodexSession(
   let sessionId = '';
   let sessionCwd: string | undefined;
   const turnContexts = new Map<string, TurnContextPayload>();
-  const cumulative: CumulativeUsage = { input: 0, output: 0, cacheRead: 0 };
+  const cumulative: CumulativeUsage = { input: 0, output: 0, cacheRead: 0, reasoning: 0 };
   let openTurn: OpenTurn | null = null;
   const finalized: FinalizedTurn[] = [];
 
@@ -158,6 +159,7 @@ export async function parseCodexSession(
             cumulative.input = inputTotal - cached;
             cumulative.cacheRead = cached;
             cumulative.output = total.output_tokens ?? 0;
+            cumulative.reasoning = total.reasoning_output_tokens ?? 0;
           }
           continue;
         }
@@ -274,6 +276,7 @@ function finalizeTurn(open: OpenTurn, cumulative: CumulativeUsage): FinalizedTur
   const usage: Usage = {
     input: Math.max(0, cumulative.input - open.startCumulative.input),
     output: Math.max(0, cumulative.output - open.startCumulative.output),
+    reasoning: Math.max(0, cumulative.reasoning - open.startCumulative.reasoning),
     cacheRead: Math.max(0, cumulative.cacheRead - open.startCumulative.cacheRead),
     cacheCreate5m: 0,
     cacheCreate1h: 0,

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -7,3 +7,5 @@ export type {
 } from './types.js';
 export { parseClaudeSession } from './claude.js';
 export type { ParseOptions } from './claude.js';
+export { parseOpencodeSession } from './opencode.js';
+export type { ParseOpencodeOptions } from './opencode.js';

--- a/packages/reader/src/opencode.test.ts
+++ b/packages/reader/src/opencode.test.ts
@@ -1,0 +1,112 @@
+import { strict as assert } from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { parseOpencodeSession } from './opencode.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.resolve(__dirname, '..', '..', '..', 'tests', 'fixtures', 'opencode');
+
+function sessionFile(fixture: string, sessionId: string): string {
+  return path.join(FIXTURES, fixture, 'storage', 'session', 'global', `${sessionId}.json`);
+}
+
+describe('parseOpencodeSession', () => {
+  it('parses a simple one-turn session', async () => {
+    const turns = await parseOpencodeSession(sessionFile('simple', 'ses_simple'));
+    assert.equal(turns.length, 1);
+    const t = turns[0]!;
+    assert.equal(t.v, 1);
+    assert.equal(t.source, 'opencode');
+    assert.equal(t.sessionId, 'ses_simple');
+    assert.equal(t.messageId, 'msg_simple_asst');
+    assert.equal(t.turnIndex, 0);
+    assert.equal(t.model, 'anthropic/claude-sonnet-4-5');
+    assert.equal(t.project, '/tmp/project');
+    assert.equal(t.ts, '2026-04-24T00:00:02.000Z');
+    assert.equal(t.stopReason, 'end_turn');
+    assert.deepEqual(t.usage, {
+      input: 10,
+      output: 5,
+      reasoning: 0,
+      cacheRead: 500,
+      cacheCreate5m: 80,
+      cacheCreate1h: 0,
+    });
+    assert.equal(t.toolCalls.length, 0);
+    assert.equal(t.filesTouched, undefined);
+    assert.equal(t.subagent, undefined);
+  });
+
+  it('extracts tool calls and filesTouched only for file tools', async () => {
+    const turns = await parseOpencodeSession(sessionFile('with-tool', 'ses_tool'));
+    assert.equal(turns.length, 1);
+    const t = turns[0]!;
+    assert.equal(t.toolCalls.length, 3);
+    const [read, edit, bash] = t.toolCalls;
+    assert.equal(read!.name, 'read');
+    assert.equal(read!.target, '/src/a.ts');
+    assert.equal(edit!.name, 'edit');
+    assert.equal(edit!.target, '/src/b.ts');
+    assert.equal(bash!.name, 'bash');
+    assert.equal(bash!.target, 'ls -la');
+    assert.deepEqual(t.filesTouched?.sort(), ['/src/a.ts', '/src/b.ts']);
+    assert.equal(t.stopReason, 'tool-calls');
+  });
+
+  it('emits per-turn (not cumulative) usage across multiple turns', async () => {
+    const turns = await parseOpencodeSession(sessionFile('multi-turn', 'ses_multi'));
+    assert.equal(turns.length, 2);
+    const [t1, t2] = turns;
+    assert.equal(t1!.messageId, 'msg_multi_a1');
+    assert.equal(t1!.turnIndex, 0);
+    assert.equal(t1!.model, 'anthropic/claude-sonnet-4-5');
+    assert.deepEqual(t1!.usage, {
+      input: 5,
+      output: 100,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheCreate5m: 15000,
+      cacheCreate1h: 0,
+    });
+    assert.equal(t1!.subagent, undefined);
+
+    assert.equal(t2!.messageId, 'msg_multi_a2');
+    assert.equal(t2!.turnIndex, 1);
+    assert.equal(t2!.model, 'anthropic/claude-opus-4-5');
+    assert.deepEqual(t2!.usage, {
+      input: 5,
+      output: 200,
+      reasoning: 50,
+      cacheRead: 15000,
+      cacheCreate5m: 3000,
+      cacheCreate1h: 0,
+    });
+    assert.equal(t2!.toolCalls.length, 1);
+    assert.equal(t2!.toolCalls[0]!.name, 'bash');
+    assert.equal(t2!.toolCalls[0]!.target, 'git status');
+  });
+
+  it('marks turns in a session with parentID as sidechain', async () => {
+    const turns = await parseOpencodeSession(sessionFile('multi-turn', 'ses_child'));
+    assert.equal(turns.length, 1);
+    const t = turns[0]!;
+    assert.ok(t.subagent);
+    assert.equal(t.subagent!.isSidechain, true);
+    assert.equal(t.model, 'anthropic/claude-haiku-4-5');
+  });
+
+  it('produces stable argsHash for identical tool inputs', async () => {
+    const a = await parseOpencodeSession(sessionFile('with-tool', 'ses_tool'));
+    const b = await parseOpencodeSession(sessionFile('with-tool', 'ses_tool'));
+    assert.equal(a[0]!.toolCalls[0]!.argsHash, b[0]!.toolCalls[0]!.argsHash);
+    assert.notEqual(a[0]!.toolCalls[0]!.argsHash, a[0]!.toolCalls[1]!.argsHash);
+  });
+
+  it('respects sessionPath option', async () => {
+    const file = sessionFile('simple', 'ses_simple');
+    const turns = await parseOpencodeSession(file, { sessionPath: file });
+    assert.equal(turns[0]!.sessionPath, file);
+  });
+});

--- a/packages/reader/src/opencode.ts
+++ b/packages/reader/src/opencode.ts
@@ -65,7 +65,7 @@ export async function parseOpencodeSession(
 
   const storageRoot = path.resolve(sessionFilePath, '..', '..', '..');
   const messages = await readMessages(storageRoot, session.id);
-  const assistants = messages.filter((m): m is AssistantMessage => m.role === 'assistant');
+  const assistants = messages.filter(isCompleteAssistant);
   assistants.sort((a, b) => a.time.created - b.time.created);
 
   const isSidechain = typeof session.parentID === 'string' && session.parentID.length > 0;
@@ -78,7 +78,7 @@ export async function parseOpencodeSession(
     const stopReason = lastStepFinishReason(parts);
 
     const model = buildModel(m.providerID, m.modelID);
-    const project = m.path?.cwd;
+    const project = m.path?.cwd ?? session.directory;
     const usage = toUsage(m.tokens);
 
     const record: TurnRecord = {
@@ -168,7 +168,7 @@ async function readParts(storageRoot: string, messageId: string): Promise<Part[]
       continue;
     }
   }
-  // prt_* ids are time-ordered base36 suffixes; filename sort keeps chronological order
+  // prt_* ids have time-ordered base36 suffixes, so sorting by part.id keeps chronological order
   parts.sort((a, b) => ((a.id ?? '') < (b.id ?? '') ? -1 : (a.id ?? '') > (b.id ?? '') ? 1 : 0));
   return parts;
 }
@@ -259,4 +259,14 @@ function toUsage(t: MessageTokens | undefined): Usage {
 function buildModel(providerID: string | undefined, modelID: string | undefined): string {
   if (providerID && modelID) return `${providerID}/${modelID}`;
   return modelID ?? providerID ?? '';
+}
+
+function isCompleteAssistant(m: { role: string; id: string }): m is AssistantMessage {
+  if (m.role !== 'assistant') return false;
+  const a = m as Partial<AssistantMessage>;
+  return (
+    typeof a.sessionID === 'string' &&
+    typeof a.time?.created === 'number' &&
+    Number.isFinite(a.time.created)
+  );
 }

--- a/packages/reader/src/opencode.ts
+++ b/packages/reader/src/opencode.ts
@@ -1,0 +1,262 @@
+import { readFile, readdir } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { argsHash } from './hash.js';
+import type { Subagent, ToolCall, TurnRecord, Usage } from './types.js';
+
+export interface ParseOpencodeOptions {
+  sessionPath?: string;
+}
+
+interface SessionInfo {
+  id: string;
+  parentID?: string;
+  directory?: string;
+}
+
+interface MessageTokens {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cache?: {
+    read?: number;
+    write?: number;
+  };
+}
+
+interface AssistantMessage {
+  id: string;
+  sessionID: string;
+  role: 'assistant';
+  time: { created: number };
+  providerID?: string;
+  modelID?: string;
+  path?: { cwd?: string };
+  tokens?: MessageTokens;
+}
+
+interface ToolPart {
+  type: 'tool';
+  callID?: string;
+  tool?: string;
+  state?: {
+    input?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+}
+
+interface StepFinishPart {
+  type: 'step-finish';
+  reason?: string;
+  tokens?: MessageTokens;
+}
+
+type Part =
+  | ToolPart
+  | StepFinishPart
+  | { type: string; [k: string]: unknown };
+
+export async function parseOpencodeSession(
+  sessionFilePath: string,
+  options: ParseOpencodeOptions = {},
+): Promise<TurnRecord[]> {
+  const session = await readSession(sessionFilePath);
+  if (!session) return [];
+
+  const storageRoot = path.resolve(sessionFilePath, '..', '..', '..');
+  const messages = await readMessages(storageRoot, session.id);
+  const assistants = messages.filter((m): m is AssistantMessage => m.role === 'assistant');
+  assistants.sort((a, b) => a.time.created - b.time.created);
+
+  const isSidechain = typeof session.parentID === 'string' && session.parentID.length > 0;
+  const turns: TurnRecord[] = [];
+
+  for (let i = 0; i < assistants.length; i++) {
+    const m = assistants[i]!;
+    const parts = await readParts(storageRoot, m.id);
+    const { toolCalls, filesTouched } = extractToolsAndFiles(parts);
+    const stopReason = lastStepFinishReason(parts);
+
+    const model = buildModel(m.providerID, m.modelID);
+    const project = m.path?.cwd;
+    const usage = toUsage(m.tokens);
+
+    const record: TurnRecord = {
+      v: 1,
+      source: 'opencode',
+      sessionId: m.sessionID,
+      messageId: m.id,
+      turnIndex: i,
+      ts: new Date(m.time.created).toISOString(),
+      model,
+      usage,
+      toolCalls,
+    };
+    if (options.sessionPath !== undefined) record.sessionPath = options.sessionPath;
+    if (project !== undefined) record.project = project;
+    if (filesTouched.length > 0) record.filesTouched = filesTouched;
+    if (isSidechain) {
+      const sub: Subagent = { isSidechain: true };
+      record.subagent = sub;
+    }
+    if (stopReason !== undefined) record.stopReason = stopReason;
+    turns.push(record);
+  }
+
+  return turns;
+}
+
+async function readSession(sessionFilePath: string): Promise<SessionInfo | null> {
+  try {
+    const raw = await readFile(sessionFilePath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof parsed.id !== 'string') return null;
+    const out: SessionInfo = { id: parsed.id };
+    if (typeof parsed.parentID === 'string') out.parentID = parsed.parentID;
+    if (typeof parsed.directory === 'string') out.directory = parsed.directory;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+async function readMessages(
+  storageRoot: string,
+  sessionId: string,
+): Promise<Array<AssistantMessage | { role: string; id: string }>> {
+  const dir = path.join(storageRoot, 'message', sessionId);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: Array<AssistantMessage | { role: string; id: string }> = [];
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    const full = path.join(dir, name);
+    try {
+      const raw = await readFile(full, 'utf8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const role = parsed.role;
+      const id = parsed.id;
+      if (typeof role !== 'string' || typeof id !== 'string') continue;
+      out.push(parsed as unknown as AssistantMessage | { role: string; id: string });
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+async function readParts(storageRoot: string, messageId: string): Promise<Part[]> {
+  const dir = path.join(storageRoot, 'part', messageId);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const parts: Array<Part & { id?: string }> = [];
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    try {
+      const raw = await readFile(path.join(dir, name), 'utf8');
+      const parsed = JSON.parse(raw) as Part & { id?: string };
+      parts.push(parsed);
+    } catch {
+      continue;
+    }
+  }
+  // prt_* ids are time-ordered base36 suffixes; filename sort keeps chronological order
+  parts.sort((a, b) => ((a.id ?? '') < (b.id ?? '') ? -1 : (a.id ?? '') > (b.id ?? '') ? 1 : 0));
+  return parts;
+}
+
+function extractToolsAndFiles(parts: Part[]): {
+  toolCalls: ToolCall[];
+  filesTouched: string[];
+} {
+  const toolCalls: ToolCall[] = [];
+  const seen = new Set<string>();
+  const files = new Set<string>();
+  for (const p of parts) {
+    if (p.type !== 'tool') continue;
+    const tp = p as ToolPart;
+    if (typeof tp.callID !== 'string' || typeof tp.tool !== 'string') continue;
+    if (seen.has(tp.callID)) continue;
+    seen.add(tp.callID);
+    const input = tp.state?.input ?? {};
+    const call: ToolCall = {
+      id: tp.callID,
+      name: tp.tool,
+      argsHash: argsHash(input),
+    };
+    const target = pickTarget(tp.tool, input);
+    if (target !== undefined) call.target = target;
+    toolCalls.push(call);
+    if (target !== undefined && isFileTool(tp.tool)) files.add(target);
+  }
+  return { toolCalls, filesTouched: [...files] };
+}
+
+function pickTarget(name: string, input: Record<string, unknown>): string | undefined {
+  const s = (k: string): string | undefined => {
+    const v = input[k];
+    return typeof v === 'string' ? v : undefined;
+  };
+  switch (name) {
+    case 'read':
+    case 'write':
+    case 'edit':
+      return s('filePath') ?? s('file_path') ?? s('path');
+    case 'bash':
+      return s('command');
+    case 'grep':
+      return s('pattern');
+    case 'glob':
+      return s('pattern');
+    case 'webfetch':
+      return s('url');
+    case 'task':
+      return s('subagent_type') ?? s('description') ?? s('prompt');
+    default:
+      return s('filePath') ?? s('file_path') ?? s('path') ?? s('url') ?? s('command');
+  }
+}
+
+function isFileTool(name: string): boolean {
+  return name === 'read' || name === 'write' || name === 'edit';
+}
+
+function lastStepFinishReason(parts: Part[]): string | undefined {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const p = parts[i]!;
+    if (p.type === 'step-finish') {
+      const sf = p as StepFinishPart;
+      if (typeof sf.reason === 'string') return sf.reason;
+    }
+  }
+  return undefined;
+}
+
+function toUsage(t: MessageTokens | undefined): Usage {
+  const input = t?.input ?? 0;
+  const output = t?.output ?? 0;
+  const reasoning = t?.reasoning ?? 0;
+  const cacheRead = t?.cache?.read ?? 0;
+  const cacheWrite = t?.cache?.write ?? 0;
+  return {
+    input,
+    output,
+    reasoning,
+    cacheRead,
+    cacheCreate5m: cacheWrite,
+    cacheCreate1h: 0,
+  };
+}
+
+function buildModel(providerID: string | undefined, modelID: string | undefined): string {
+  if (providerID && modelID) return `${providerID}/${modelID}`;
+  return modelID ?? providerID ?? '';
+}

--- a/packages/reader/src/types.ts
+++ b/packages/reader/src/types.ts
@@ -9,6 +9,7 @@ export type SourceKind =
 export interface Usage {
   input: number;
   output: number;
+  reasoning: number;
   cacheRead: number;
   cacheCreate5m: number;
   cacheCreate1h: number;

--- a/tests/fixtures/opencode/multi-turn/storage/message/ses_child/msg_child_asst.json
+++ b/tests/fixtures/opencode/multi-turn/storage/message/ses_child/msg_child_asst.json
@@ -1,0 +1,17 @@
+{
+  "id": "msg_child_asst",
+  "sessionID": "ses_child",
+  "role": "assistant",
+  "time": { "created": 1776988823500 },
+  "parentID": "msg_child_user",
+  "providerID": "anthropic",
+  "modelID": "claude-haiku-4-5",
+  "path": { "cwd": "/tmp/project", "root": "/tmp/project" },
+  "cost": 0,
+  "tokens": {
+    "input": 3,
+    "output": 50,
+    "reasoning": 0,
+    "cache": { "read": 0, "write": 2000 }
+  }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/message/ses_child/msg_child_user.json
+++ b/tests/fixtures/opencode/multi-turn/storage/message/ses_child/msg_child_user.json
@@ -1,0 +1,6 @@
+{
+  "id": "msg_child_user",
+  "sessionID": "ses_child",
+  "role": "user",
+  "time": { "created": 1776988823000 }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_a1.json
+++ b/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_a1.json
@@ -1,0 +1,17 @@
+{
+  "id": "msg_multi_a1",
+  "sessionID": "ses_multi",
+  "role": "assistant",
+  "time": { "created": 1776988822000 },
+  "parentID": "msg_multi_u1",
+  "providerID": "anthropic",
+  "modelID": "claude-sonnet-4-5",
+  "path": { "cwd": "/tmp/project", "root": "/tmp/project" },
+  "cost": 0,
+  "tokens": {
+    "input": 5,
+    "output": 100,
+    "reasoning": 0,
+    "cache": { "read": 0, "write": 15000 }
+  }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_a2.json
+++ b/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_a2.json
@@ -1,0 +1,17 @@
+{
+  "id": "msg_multi_a2",
+  "sessionID": "ses_multi",
+  "role": "assistant",
+  "time": { "created": 1776988824000 },
+  "parentID": "msg_multi_u2",
+  "providerID": "anthropic",
+  "modelID": "claude-opus-4-5",
+  "path": { "cwd": "/tmp/project", "root": "/tmp/project" },
+  "cost": 0,
+  "tokens": {
+    "input": 5,
+    "output": 200,
+    "reasoning": 50,
+    "cache": { "read": 15000, "write": 3000 }
+  }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_u1.json
+++ b/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_u1.json
@@ -1,0 +1,6 @@
+{
+  "id": "msg_multi_u1",
+  "sessionID": "ses_multi",
+  "role": "user",
+  "time": { "created": 1776988821000 }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_u2.json
+++ b/tests/fixtures/opencode/multi-turn/storage/message/ses_multi/msg_multi_u2.json
@@ -1,0 +1,6 @@
+{
+  "id": "msg_multi_u2",
+  "sessionID": "ses_multi",
+  "role": "user",
+  "time": { "created": 1776988823000 }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/part/msg_child_asst/prt_child_1.json
+++ b/tests/fixtures/opencode/multi-turn/storage/part/msg_child_asst/prt_child_1.json
@@ -1,0 +1,13 @@
+{
+  "id": "prt_child_1",
+  "sessionID": "ses_child",
+  "messageID": "msg_child_asst",
+  "type": "step-finish",
+  "reason": "end_turn",
+  "tokens": {
+    "input": 3,
+    "output": 50,
+    "reasoning": 0,
+    "cache": { "read": 0, "write": 2000 }
+  }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/part/msg_multi_a1/prt_a1_1.json
+++ b/tests/fixtures/opencode/multi-turn/storage/part/msg_multi_a1/prt_a1_1.json
@@ -1,0 +1,13 @@
+{
+  "id": "prt_a1_1",
+  "sessionID": "ses_multi",
+  "messageID": "msg_multi_a1",
+  "type": "step-finish",
+  "reason": "end_turn",
+  "tokens": {
+    "input": 5,
+    "output": 100,
+    "reasoning": 0,
+    "cache": { "read": 0, "write": 15000 }
+  }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/part/msg_multi_a2/prt_a2_1.json
+++ b/tests/fixtures/opencode/multi-turn/storage/part/msg_multi_a2/prt_a2_1.json
@@ -1,0 +1,13 @@
+{
+  "id": "prt_a2_1",
+  "sessionID": "ses_multi",
+  "messageID": "msg_multi_a2",
+  "type": "tool",
+  "callID": "toolu_bash_multi",
+  "tool": "bash",
+  "state": {
+    "status": "completed",
+    "input": { "command": "git status" },
+    "output": "clean"
+  }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/part/msg_multi_a2/prt_a2_2.json
+++ b/tests/fixtures/opencode/multi-turn/storage/part/msg_multi_a2/prt_a2_2.json
@@ -1,0 +1,13 @@
+{
+  "id": "prt_a2_2",
+  "sessionID": "ses_multi",
+  "messageID": "msg_multi_a2",
+  "type": "step-finish",
+  "reason": "tool-calls",
+  "tokens": {
+    "input": 5,
+    "output": 200,
+    "reasoning": 50,
+    "cache": { "read": 15000, "write": 3000 }
+  }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/session/global/ses_child.json
+++ b/tests/fixtures/opencode/multi-turn/storage/session/global/ses_child.json
@@ -1,0 +1,9 @@
+{
+  "id": "ses_child",
+  "version": "1.0.0",
+  "projectID": "global",
+  "parentID": "ses_multi",
+  "directory": "/tmp/project",
+  "title": "subagent child",
+  "time": { "created": 1776988822500, "updated": 1776988823700 }
+}

--- a/tests/fixtures/opencode/multi-turn/storage/session/global/ses_multi.json
+++ b/tests/fixtures/opencode/multi-turn/storage/session/global/ses_multi.json
@@ -1,0 +1,8 @@
+{
+  "id": "ses_multi",
+  "version": "1.0.0",
+  "projectID": "global",
+  "directory": "/tmp/project",
+  "title": "multi turn",
+  "time": { "created": 1776988820000, "updated": 1776988825000 }
+}

--- a/tests/fixtures/opencode/simple/storage/message/ses_simple/msg_simple_asst.json
+++ b/tests/fixtures/opencode/simple/storage/message/ses_simple/msg_simple_asst.json
@@ -1,0 +1,17 @@
+{
+  "id": "msg_simple_asst",
+  "sessionID": "ses_simple",
+  "role": "assistant",
+  "time": { "created": 1776988802000 },
+  "parentID": "msg_simple_user",
+  "providerID": "anthropic",
+  "modelID": "claude-sonnet-4-5",
+  "path": { "cwd": "/tmp/project", "root": "/tmp/project" },
+  "cost": 0,
+  "tokens": {
+    "input": 10,
+    "output": 5,
+    "reasoning": 0,
+    "cache": { "read": 500, "write": 80 }
+  }
+}

--- a/tests/fixtures/opencode/simple/storage/message/ses_simple/msg_simple_user.json
+++ b/tests/fixtures/opencode/simple/storage/message/ses_simple/msg_simple_user.json
@@ -1,0 +1,6 @@
+{
+  "id": "msg_simple_user",
+  "sessionID": "ses_simple",
+  "role": "user",
+  "time": { "created": 1776988801000 }
+}

--- a/tests/fixtures/opencode/simple/storage/part/msg_simple_asst/prt_simple_1.json
+++ b/tests/fixtures/opencode/simple/storage/part/msg_simple_asst/prt_simple_1.json
@@ -1,0 +1,7 @@
+{
+  "id": "prt_simple_1",
+  "sessionID": "ses_simple",
+  "messageID": "msg_simple_asst",
+  "type": "step-start",
+  "snapshot": "abc"
+}

--- a/tests/fixtures/opencode/simple/storage/part/msg_simple_asst/prt_simple_2.json
+++ b/tests/fixtures/opencode/simple/storage/part/msg_simple_asst/prt_simple_2.json
@@ -1,0 +1,7 @@
+{
+  "id": "prt_simple_2",
+  "sessionID": "ses_simple",
+  "messageID": "msg_simple_asst",
+  "type": "text",
+  "text": "Hello."
+}

--- a/tests/fixtures/opencode/simple/storage/part/msg_simple_asst/prt_simple_3.json
+++ b/tests/fixtures/opencode/simple/storage/part/msg_simple_asst/prt_simple_3.json
@@ -1,0 +1,13 @@
+{
+  "id": "prt_simple_3",
+  "sessionID": "ses_simple",
+  "messageID": "msg_simple_asst",
+  "type": "step-finish",
+  "reason": "end_turn",
+  "tokens": {
+    "input": 10,
+    "output": 5,
+    "reasoning": 0,
+    "cache": { "read": 500, "write": 80 }
+  }
+}

--- a/tests/fixtures/opencode/simple/storage/session/global/ses_simple.json
+++ b/tests/fixtures/opencode/simple/storage/session/global/ses_simple.json
@@ -1,0 +1,9 @@
+{
+  "id": "ses_simple",
+  "version": "1.0.0",
+  "projectID": "global",
+  "directory": "/tmp/project",
+  "title": "simple turn",
+  "time": { "created": 1776988800000, "updated": 1776988803000 },
+  "summary": { "additions": 0, "deletions": 0, "files": 0 }
+}

--- a/tests/fixtures/opencode/with-tool/storage/message/ses_tool/msg_tool_asst.json
+++ b/tests/fixtures/opencode/with-tool/storage/message/ses_tool/msg_tool_asst.json
@@ -1,0 +1,17 @@
+{
+  "id": "msg_tool_asst",
+  "sessionID": "ses_tool",
+  "role": "assistant",
+  "time": { "created": 1776988812000 },
+  "parentID": "msg_tool_user",
+  "providerID": "anthropic",
+  "modelID": "claude-opus-4-5",
+  "path": { "cwd": "/tmp/project", "root": "/tmp/project" },
+  "cost": 0,
+  "tokens": {
+    "input": 6,
+    "output": 100,
+    "reasoning": 0,
+    "cache": { "read": 0, "write": 20000 }
+  }
+}

--- a/tests/fixtures/opencode/with-tool/storage/message/ses_tool/msg_tool_user.json
+++ b/tests/fixtures/opencode/with-tool/storage/message/ses_tool/msg_tool_user.json
@@ -1,0 +1,6 @@
+{
+  "id": "msg_tool_user",
+  "sessionID": "ses_tool",
+  "role": "user",
+  "time": { "created": 1776988811000 }
+}

--- a/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_1.json
+++ b/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_1.json
@@ -1,0 +1,7 @@
+{
+  "id": "prt_tool_1",
+  "sessionID": "ses_tool",
+  "messageID": "msg_tool_asst",
+  "type": "step-start",
+  "snapshot": "xyz"
+}

--- a/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_2_read.json
+++ b/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_2_read.json
@@ -1,0 +1,14 @@
+{
+  "id": "prt_tool_2_read",
+  "sessionID": "ses_tool",
+  "messageID": "msg_tool_asst",
+  "type": "tool",
+  "callID": "toolu_read_1",
+  "tool": "read",
+  "state": {
+    "status": "completed",
+    "input": { "filePath": "/src/a.ts" },
+    "output": "...",
+    "title": "src/a.ts"
+  }
+}

--- a/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_3_edit.json
+++ b/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_3_edit.json
@@ -1,0 +1,14 @@
+{
+  "id": "prt_tool_3_edit",
+  "sessionID": "ses_tool",
+  "messageID": "msg_tool_asst",
+  "type": "tool",
+  "callID": "toolu_edit_1",
+  "tool": "edit",
+  "state": {
+    "status": "completed",
+    "input": { "filePath": "/src/b.ts", "oldString": "a", "newString": "b" },
+    "output": "edited",
+    "title": "src/b.ts"
+  }
+}

--- a/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_4_bash.json
+++ b/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_4_bash.json
@@ -1,0 +1,13 @@
+{
+  "id": "prt_tool_4_bash",
+  "sessionID": "ses_tool",
+  "messageID": "msg_tool_asst",
+  "type": "tool",
+  "callID": "toolu_bash_1",
+  "tool": "bash",
+  "state": {
+    "status": "completed",
+    "input": { "command": "ls -la" },
+    "output": "file listing"
+  }
+}

--- a/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_5.json
+++ b/tests/fixtures/opencode/with-tool/storage/part/msg_tool_asst/prt_tool_5.json
@@ -1,0 +1,13 @@
+{
+  "id": "prt_tool_5",
+  "sessionID": "ses_tool",
+  "messageID": "msg_tool_asst",
+  "type": "step-finish",
+  "reason": "tool-calls",
+  "tokens": {
+    "input": 6,
+    "output": 100,
+    "reasoning": 0,
+    "cache": { "read": 0, "write": 20000 }
+  }
+}

--- a/tests/fixtures/opencode/with-tool/storage/session/global/ses_tool.json
+++ b/tests/fixtures/opencode/with-tool/storage/session/global/ses_tool.json
@@ -1,0 +1,8 @@
+{
+  "id": "ses_tool",
+  "version": "1.0.0",
+  "projectID": "global",
+  "directory": "/tmp/project",
+  "title": "tool call turn",
+  "time": { "created": 1776988810000, "updated": 1776988813000 }
+}


### PR DESCRIPTION
## Summary

- New `@relayburn/reader` parser for opencode's tree-structured storage (`~/.local/share/opencode/storage/{session,message,part}/`). Emits one `TurnRecord` per assistant message; sidechain from session-level `parentID`; per-turn (not cumulative) usage.
- `burn opencode` spawn wrapper (snapshot-diff — opencode has no pre-supplied session-id flag, unlike `claude --session-id`) + `ingestOpencodeSessions()` shared-walker integration.
- `Usage.reasoning: number` added to the shared shape (claude parser backfills `0`, opencode fills from `tokens.reasoning`); `cost.ts` folds reasoning into output billing. Stored separately so we can split later if providers diverge on how they bill it.

## Known pricing gap

`google/gemini-3-pro-high` is absent from the vendored models.dev snapshot — shows \$0.00 in summaries. Flagged, not hand-patched.

## Merge note

Branched off \`main\`, not \`v0.1-codex\`. When \`v0.1-codex\` lands, its \`codex.ts::toUsage\` needs a one-line \`reasoning: 0\` added to satisfy the new \`Usage\` shape.

## Test plan

- [x] \`npx tsc --build\` clean
- [x] \`node --test 'packages/*/dist/**/*.test.js'\` — 30/30 pass (5 new opencode tests + all existing)
- [x] Smoke test: \`RELAYBURN_HOME=\$(mktemp -d) burn summary --since 365d\` ingested 39,783 opencode sessions / 60,105 turns, priced across \`anthropic/*\`, \`opencode/*\`, \`google/*\` model strings
- [x] Ingestion idempotent (second run: 0 new sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)