### PR TITLE
Add rule-based activity classifier for per-turn categorization (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ interface TurnRecord {
   toolCalls: ToolCall[];
   filesTouched?: string[];
   subagent?: { isSidechain: boolean };
+  activity?: ActivityCategory;  // what kind of work this turn did
+  retries?: number;              // edit→bash→edit cycles within the turn
+  hasEdits?: boolean;            // at least one Edit/Write/NotebookEdit call
 }
 ```
 
@@ -135,6 +138,36 @@ Three content modes:
 Set via `RELAYBURN_CONTENT_STORE=<mode>` or the config file.
 
 Content lives on your machine. Burn makes no outbound requests beyond optional pricing updates. If the device you run on is sensitive to conversation leak (shared dev machines, cloud-synced home directories, compliance contexts), switch to `hash-only`.
+
+## Activity classification
+
+Every turn is tagged with an `activity` label so cost can be compared like-for-like. "Sonnet cost more than Haiku last month" isn't useful on its own; "Sonnet and Haiku both attempted 43 refactoring turns, Sonnet landed them first-try 75% of the time vs. Haiku's 60%" is. That's what per-turn activity enables.
+
+Classification is deterministic and rule-based — no LLM in the loop. Every turn with the same tool calls and prompt text produces the same label.
+
+Twelve categories, from codeburn's taxonomy so cross-tool comparison stays possible:
+
+| Category | Trigger |
+|---|---|
+| `planning` | `ExitPlanMode` tool, or planning/roadmap keywords with no tool use |
+| `delegation` | `Agent` / `Task` spawn — dominates other signals |
+| `testing` | `Bash` matching `pytest`, `vitest`, `bun test`, `jest`, `go test`, `cargo test`, `npm test`, etc. |
+| `git` | `Bash` matching `git push/pull/commit/merge/rebase/checkout/cherry-pick/...` |
+| `build-deploy` | `Bash` matching `docker build`, `cargo build`, `npm run build`, `kubectl apply`, `terraform apply`, etc. |
+| `coding` | `Edit` / `Write` / `NotebookEdit` with no stronger keyword signal |
+| `debugging` | Edit turn where prompt mentions bug/error/crash/traceback, or any tool call errored this turn |
+| `refactoring` | Edit turn with keywords: `refactor`, `cleanup`, `rename`, `extract`, `restructure` |
+| `feature` | Edit turn with keywords: `add`, `create`, `implement`, `new`, `introduce` |
+| `exploration` | `Read` / `Grep` / `Glob` / `WebFetch` / `WebSearch` without edits |
+| `brainstorming` | No tool use; prompt asks *what if*, *think through*, *should we*, *design* |
+| `conversation` | No tool use, no category keywords — the fallback |
+
+Two companion fields fall out of the same pass:
+
+- `hasEdits` — true when a turn called any file-mutating tool. Lets `coding`/`refactoring`/`feature`/`debugging` share a cross-cutting filter.
+- `retries` — count of edit→bash→edit cycles *within a single turn*. Non-zero values surface reactive edits (wrote, tested, fixed) without waiting for whole-session retry analysis. Cross-turn retry loops are tracked separately.
+
+Together these make `oneShotRate = oneShotTurns / editTurns` computable directly on the ledger (a "one-shot turn" has `hasEdits && retries === 0`), which is the secondary quality signal feeding model comparison.
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   },
   "scripts": {
     "build": "tsc --build",
+    "dev": "tsc --build --watch --preserveWatchOutput",
+    "dev:cli": "node packages/cli/dist/cli.js",
     "test": "node --test --test-reporter=spec 'packages/*/dist/**/*.test.js'",
     "test:ts": "tsc --build && pnpm run test",
     "clean": "tsc --build --clean",

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -104,11 +104,17 @@ async function ingestClaudeInto(
           continue;
         }
 
-        const { turns, content, endOffset } = await parseClaudeSessionIncremental(file, {
+        const parseOpts: Parameters<typeof parseClaudeSessionIncremental>[1] = {
           startOffset,
           sessionPath: file,
           contentMode,
-        });
+        };
+        const priorUserText = rotated ? undefined : priorClaude?.lastUserText;
+        if (priorUserText) parseOpts.lastUserText = priorUserText;
+        const { turns, content, endOffset, lastUserText } = await parseClaudeSessionIncremental(
+          file,
+          parseOpts,
+        );
         if (turns.length > 0) {
           await appendTurns(turns);
           report.appendedTurns += turns.length;
@@ -123,6 +129,7 @@ async function ingestClaudeInto(
           offsetBytes: endOffset,
           mtimeMs: st.mtimeMs,
         };
+        if (lastUserText) next.lastUserText = lastUserText;
         cursors[file] = next;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/packages/ledger/src/cursors.ts
+++ b/packages/ledger/src/cursors.ts
@@ -9,6 +9,10 @@ export interface ClaudeCursor {
   inode: number;
   offsetBytes: number;
   mtimeMs: number;
+  // The last user prompt text as of `offsetBytes`. Carried across calls so
+  // the activity classifier keeps keyword context when `offsetBytes` backed
+  // up past a user message to defer an incomplete assistant turn.
+  lastUserText?: string;
 }
 
 export interface CodexCursor {

--- a/packages/reader/src/classifier.test.ts
+++ b/packages/reader/src/classifier.test.ts
@@ -116,6 +116,23 @@ describe('classifyActivity — keyword refinement', () => {
     assert.equal(r.activity, 'debugging');
   });
 
+  it('promotes failed bash test/git/build to debugging', () => {
+    // A failing pytest / git push / npm run build is the model reacting to an
+    // error, not neutrally running the command — debugging should win over the
+    // bash-pattern category.
+    const cases: Array<[string, string]> = [
+      ['pytest', 'testing'],
+      ['git push origin main', 'git'],
+      ['npm run build', 'build-deploy'],
+    ];
+    for (const [cmd] of cases) {
+      const ok = classifyActivity({ toolCalls: [tc('Bash', cmd)] });
+      const failed = classifyActivity({ toolCalls: [tc('Bash', cmd)], hasFailedTool: true });
+      assert.notEqual(ok.activity, 'debugging', `${cmd} without failure should not be debugging`);
+      assert.equal(failed.activity, 'debugging', `${cmd} with failure should be debugging`);
+    }
+  });
+
   it('promotes exploration to feature when the prompt asks to add something', () => {
     // Adversarial case from the issue: a turn that looks like exploration
     // (only Read/Grep) but the ask is clearly a feature request — keyword

--- a/packages/reader/src/classifier.test.ts
+++ b/packages/reader/src/classifier.test.ts
@@ -1,0 +1,219 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { classifyActivity, countRetries } from './classifier.js';
+import type { ToolCall } from './types.js';
+
+const tc = (name: string, target?: string, id = name): ToolCall => {
+  const call: ToolCall = { id, name, argsHash: 'h' };
+  if (target !== undefined) call.target = target;
+  return call;
+};
+
+describe('classifyActivity — tool-pattern classification', () => {
+  it('classifies turns that spawn a subagent as delegation', () => {
+    // Delegation dominates even when an Edit is also present: spawning the
+    // subagent is the headline activity and describes the work this turn did.
+    const r = classifyActivity({
+      toolCalls: [tc('Agent', 'Explore'), tc('Edit', '/a.ts')],
+    });
+    assert.equal(r.activity, 'delegation');
+  });
+
+  it('classifies ExitPlanMode turns as planning', () => {
+    const r = classifyActivity({ toolCalls: [tc('ExitPlanMode')] });
+    assert.equal(r.activity, 'planning');
+  });
+
+  it('classifies bash test runners as testing', () => {
+    const cases = ['pytest', 'vitest run', 'bun test', 'npm test', 'go test ./...', 'cargo test', 'node --test'];
+    for (const cmd of cases) {
+      const r = classifyActivity({ toolCalls: [tc('Bash', cmd)] });
+      assert.equal(r.activity, 'testing', `expected 'testing' for ${cmd}, got ${r.activity}`);
+    }
+  });
+
+  it('ignores leading env assignments when matching bash patterns', () => {
+    const r = classifyActivity({ toolCalls: [tc('Bash', 'CI=1 NODE_ENV=test pytest -q')] });
+    assert.equal(r.activity, 'testing');
+  });
+
+  it('classifies git commands as git', () => {
+    for (const cmd of ['git push origin main', 'git commit -m "x"', 'git rebase main']) {
+      const r = classifyActivity({ toolCalls: [tc('Bash', cmd)] });
+      assert.equal(r.activity, 'git', cmd);
+    }
+  });
+
+  it('classifies build and deploy commands as build-deploy', () => {
+    for (const cmd of ['npm run build', 'docker build .', 'cargo build --release', 'kubectl apply -f k8s/', 'terraform apply']) {
+      const r = classifyActivity({ toolCalls: [tc('Bash', cmd)] });
+      assert.equal(r.activity, 'build-deploy', cmd);
+    }
+  });
+
+  it('classifies plain edit turns as coding', () => {
+    const r = classifyActivity({ toolCalls: [tc('Edit', '/a.ts'), tc('Write', '/b.ts')] });
+    assert.equal(r.activity, 'coding');
+    assert.equal(r.hasEdits, true);
+  });
+
+  it('classifies read-only tool turns as exploration', () => {
+    const r = classifyActivity({ toolCalls: [tc('Read', '/a.ts'), tc('Grep', 'foo')] });
+    assert.equal(r.activity, 'exploration');
+  });
+});
+
+describe('classifyActivity — keyword refinement', () => {
+  it('refines edits into debugging when prompt mentions errors', () => {
+    const r = classifyActivity({
+      toolCalls: [tc('Edit', '/a.ts')],
+      text: 'fix the bug that crashes on null input',
+    });
+    assert.equal(r.activity, 'debugging');
+  });
+
+  it('refines edits into debugging when a tool call failed this turn', () => {
+    // A subsequent tool_result with is_error flips an otherwise plain "coding"
+    // turn into debugging — the model is reacting to a real failure.
+    const r = classifyActivity({
+      toolCalls: [tc('Edit', '/a.ts')],
+      text: 'make this work',
+      hasFailedTool: true,
+    });
+    assert.equal(r.activity, 'debugging');
+  });
+
+  it('refines edits into refactoring when prompt mentions refactor terms', () => {
+    const r = classifyActivity({
+      toolCalls: [tc('Edit', '/a.ts')],
+      text: 'please refactor this to extract the helper',
+    });
+    assert.equal(r.activity, 'refactoring');
+  });
+
+  it('refines edits into feature when prompt mentions add/implement', () => {
+    const r = classifyActivity({
+      toolCalls: [tc('Edit', '/a.ts'), tc('Write', '/b.ts')],
+      text: 'add a new endpoint for /users',
+    });
+    assert.equal(r.activity, 'feature');
+  });
+
+  it('prioritizes debugging over feature keywords when both appear', () => {
+    const r = classifyActivity({
+      toolCalls: [tc('Edit', '/a.ts')],
+      text: 'add handling to fix the bug where requests crash',
+    });
+    assert.equal(r.activity, 'debugging');
+  });
+
+  it('promotes exploration into debugging when a tool call errored', () => {
+    const r = classifyActivity({
+      toolCalls: [tc('Read', '/a.ts')],
+      hasFailedTool: true,
+    });
+    assert.equal(r.activity, 'debugging');
+  });
+
+  it('promotes exploration to feature when the prompt asks to add something', () => {
+    // Adversarial case from the issue: a turn that looks like exploration
+    // (only Read/Grep) but the ask is clearly a feature request — keyword
+    // refinement should move it off exploration.
+    const r = classifyActivity({
+      toolCalls: [tc('Read', '/a.ts'), tc('Grep', 'router')],
+      text: 'add a new route for /admin',
+    });
+    assert.equal(r.activity, 'feature');
+  });
+});
+
+describe('classifyActivity — no-tool fallback', () => {
+  it('returns brainstorming for idea-exploration prompts with no tools', () => {
+    const r = classifyActivity({ toolCalls: [], text: 'what if we tried a different approach here?' });
+    assert.equal(r.activity, 'brainstorming');
+  });
+
+  it('returns planning for planning prompts with no tools', () => {
+    const r = classifyActivity({ toolCalls: [], text: "let's outline the roadmap for Q3" });
+    assert.equal(r.activity, 'planning');
+  });
+
+  it('returns debugging when text mentions bugs even without tools', () => {
+    const r = classifyActivity({ toolCalls: [], text: 'the build is broken with a null pointer error' });
+    assert.equal(r.activity, 'debugging');
+  });
+
+  it('falls back to conversation when nothing matches', () => {
+    const r = classifyActivity({ toolCalls: [], text: 'thanks, that looks good' });
+    assert.equal(r.activity, 'conversation');
+  });
+
+  it('falls back to conversation on empty input', () => {
+    const r = classifyActivity({ toolCalls: [] });
+    assert.equal(r.activity, 'conversation');
+    assert.equal(r.retries, 0);
+    assert.equal(r.hasEdits, false);
+  });
+});
+
+describe('countRetries', () => {
+  it('counts a single edit→bash→edit cycle as one retry', () => {
+    assert.equal(
+      countRetries([tc('Edit', '/a.ts', '1'), tc('Bash', 'npm test', '2'), tc('Edit', '/a.ts', '3')]),
+      1,
+    );
+  });
+
+  it('counts two retries in edit→bash→edit→bash→edit', () => {
+    assert.equal(
+      countRetries([
+        tc('Edit', '/a.ts', '1'),
+        tc('Bash', 'npm test', '2'),
+        tc('Edit', '/a.ts', '3'),
+        tc('Bash', 'npm test', '4'),
+        tc('Edit', '/a.ts', '5'),
+      ]),
+      2,
+    );
+  });
+
+  it('counts retries across different files (edit→bash→edit of a different file)', () => {
+    // Adversarial case: the retry signal is about *rework*, not same-file.
+    // Touching b.ts after testing a.ts still indicates a reactive edit.
+    assert.equal(
+      countRetries([tc('Edit', '/a.ts', '1'), tc('Bash', 'npm test', '2'), tc('Edit', '/b.ts', '3')]),
+      1,
+    );
+  });
+
+  it('returns 0 for two consecutive edits with no bash between them', () => {
+    assert.equal(countRetries([tc('Edit', '/a.ts', '1'), tc('Edit', '/b.ts', '2')]), 0);
+  });
+
+  it('returns 0 when bash appears before any edit', () => {
+    assert.equal(countRetries([tc('Bash', 'ls', '1'), tc('Edit', '/a.ts', '2')]), 0);
+  });
+
+  it('is surfaced on ClassificationResult for edit-heavy turns', () => {
+    const r = classifyActivity({
+      toolCalls: [tc('Edit', '/a.ts', '1'), tc('Bash', 'npm test', '2'), tc('Edit', '/a.ts', '3')],
+    });
+    assert.equal(r.retries, 1);
+    assert.equal(r.hasEdits, true);
+    assert.equal(r.activity, 'coding');
+  });
+});
+
+describe('classifyActivity — hasEdits flag', () => {
+  it('is true whenever any edit tool is present', () => {
+    assert.equal(classifyActivity({ toolCalls: [tc('Edit', '/a.ts')] }).hasEdits, true);
+    assert.equal(classifyActivity({ toolCalls: [tc('Write', '/a.ts')] }).hasEdits, true);
+    assert.equal(classifyActivity({ toolCalls: [tc('NotebookEdit', '/a.ipynb')] }).hasEdits, true);
+  });
+
+  it('is false when only read-only or bash tools are present', () => {
+    assert.equal(classifyActivity({ toolCalls: [tc('Read', '/a.ts')] }).hasEdits, false);
+    assert.equal(classifyActivity({ toolCalls: [tc('Bash', 'ls')] }).hasEdits, false);
+  });
+});

--- a/packages/reader/src/classifier.ts
+++ b/packages/reader/src/classifier.ts
@@ -1,0 +1,169 @@
+import type { ActivityCategory, ToolCall } from './types.js';
+
+export interface ClassificationInput {
+  toolCalls: ToolCall[];
+  // Message text used for keyword refinement. Typically the preceding user
+  // prompt, optionally concatenated with the assistant's own text blocks.
+  text?: string;
+  // True if any tool_result block for this turn reported is_error.
+  hasFailedTool?: boolean;
+}
+
+export interface ClassificationResult {
+  activity: ActivityCategory;
+  retries: number;
+  hasEdits: boolean;
+}
+
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
+const DELEGATION_TOOLS = new Set(['Agent', 'Task']);
+const READ_ONLY_TOOLS = new Set([
+  'Read',
+  'Grep',
+  'Glob',
+  'WebFetch',
+  'WebSearch',
+  'LS',
+]);
+
+// Bash command heuristics. Match on the first non-env token after stripping
+// leading environment assignments (e.g. "CI=1 pytest" → "pytest").
+const TEST_PATTERNS: RegExp[] = [
+  /\bpytest\b/,
+  /\bpython\s+-m\s+pytest\b/,
+  /\bvitest\b/,
+  /\bbun\s+test\b/,
+  /\bjest\b/,
+  /\bmocha\b/,
+  /\brspec\b/,
+  /\bphpunit\b/,
+  /\bgo\s+test\b/,
+  /\bcargo\s+test\b/,
+  /\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?test\b/,
+  /\bnode\s+--test\b/,
+];
+
+const GIT_PATTERNS: RegExp[] = [
+  /\bgit\s+(?:push|pull|fetch|commit|merge|rebase|checkout|cherry-pick|reset|revert|switch|tag|stash)\b/,
+];
+
+const BUILD_DEPLOY_PATTERNS: RegExp[] = [
+  /\bdocker\s+(?:build|compose\s+build|push)\b/,
+  /\bcargo\s+build\b/,
+  /\bgo\s+build\b/,
+  /\bmake(?:\s|$)/,
+  /\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?build\b/,
+  /\b(?:webpack|vite|next|rollup|esbuild)\s+build\b/,
+  /\btsc\s+--build\b/,
+  /\bpm2\s+/,
+  /\bkubectl\s+(?:apply|rollout|set)\b/,
+  /\bterraform\s+(?:apply|plan)\b/,
+  /\bserverless\s+deploy\b/,
+  /\bdeploy\b/,
+];
+
+const DEBUG_RE =
+  /\b(bug|error|crash|traceback|stack\s*trace|failure|failing|broken|fix\s+the|not\s+working|throws?)\b/i;
+const REFACTOR_RE =
+  /\b(refactor|refactoring|cleanup|clean\s+up|rename|extract|restructure|move\s+this|reorganize)\b/i;
+const FEATURE_RE =
+  /\b(add|create|implement|new\s+feature|build\s+the|introduce|support\s+for)\b/i;
+const BRAINSTORM_RE =
+  /\b(brainstorm|what\s+if|think\s+through|explore(?:\s+ideas)?|design|should\s+we|approach(?:es)?)\b/i;
+const PLANNING_RE = /\b(plan(?:ning)?|outline|roadmap|strategy)\b/i;
+
+export function classifyActivity(input: ClassificationInput): ClassificationResult {
+  const toolCalls = input.toolCalls ?? [];
+  const text = input.text ?? '';
+  const hasFailedTool = input.hasFailedTool === true;
+  const hasEdits = toolCalls.some((t) => EDIT_TOOLS.has(t.name));
+  const retries = countRetries(toolCalls);
+
+  const activity = pickCategory({ toolCalls, text, hasFailedTool, hasEdits });
+  return { activity, retries, hasEdits };
+}
+
+interface PickInput {
+  toolCalls: ToolCall[];
+  text: string;
+  hasFailedTool: boolean;
+  hasEdits: boolean;
+}
+
+function pickCategory({ toolCalls, text, hasFailedTool, hasEdits }: PickInput): ActivityCategory {
+  // Priority 1: explicit plan-mode marker.
+  if (toolCalls.some((t) => t.name === 'ExitPlanMode')) return 'planning';
+
+  // Priority 2: delegation — spawning a subagent dominates whatever else happened.
+  if (toolCalls.some((t) => DELEGATION_TOOLS.has(t.name))) return 'delegation';
+
+  // Priority 3: edits present. Let keyword refinement pick a sub-category;
+  // default to coding if nothing stronger fires.
+  if (hasEdits) {
+    const refined = refineByKeywords(text, hasFailedTool);
+    return refined ?? 'coding';
+  }
+
+  // Priority 4: bash commands with recognizable patterns.
+  const bashCalls = toolCalls.filter((t) => t.name === 'Bash');
+  for (const call of bashCalls) {
+    const cmd = stripEnv(call.target ?? '');
+    if (!cmd) continue;
+    if (TEST_PATTERNS.some((re) => re.test(cmd))) return 'testing';
+    if (GIT_PATTERNS.some((re) => re.test(cmd))) return 'git';
+    if (BUILD_DEPLOY_PATTERNS.some((re) => re.test(cmd))) return 'build-deploy';
+  }
+
+  // Priority 5: any tools used at all → exploration (read-only, MCP, skills,
+  // or un-patterned bash). Keyword hints can still promote to debugging etc.
+  if (toolCalls.length > 0) {
+    if (hasFailedTool) return 'debugging';
+    const refined = refineByKeywords(text, false);
+    if (refined) return refined;
+    if (toolCalls.some((t) => READ_ONLY_TOOLS.has(t.name))) return 'exploration';
+    return 'exploration';
+  }
+
+  // Priority 6: no tools — keyword-only classification.
+  const refined = refineByKeywords(text, hasFailedTool);
+  if (refined) return refined;
+  if (BRAINSTORM_RE.test(text)) return 'brainstorming';
+  if (PLANNING_RE.test(text)) return 'planning';
+  return 'conversation';
+}
+
+function refineByKeywords(text: string, hasFailedTool: boolean): ActivityCategory | null {
+  if (hasFailedTool) return 'debugging';
+  if (!text) return null;
+  if (DEBUG_RE.test(text)) return 'debugging';
+  if (REFACTOR_RE.test(text)) return 'refactoring';
+  if (FEATURE_RE.test(text)) return 'feature';
+  return null;
+}
+
+function stripEnv(cmd: string): string {
+  // Strip leading `FOO=bar BAZ=qux` assignments so `CI=1 pytest` matches pytest.
+  return cmd.replace(/^(?:\s*[A-Z_][A-Z0-9_]*=\S+\s+)+/, '');
+}
+
+// Count edit→bash→edit cycles within a single turn. A "cycle" ends when an
+// edit tool appears after at least one bash call that followed an earlier edit.
+// Example: [Edit, Bash, Edit] → 1. [Edit, Bash, Edit, Bash, Edit] → 2.
+// [Edit, Edit] → 0 (no bash in between). [Bash, Edit, Edit] → 0.
+export function countRetries(toolCalls: ToolCall[]): number {
+  let retries = 0;
+  let seenEdit = false;
+  let seenBashAfterEdit = false;
+  for (const tc of toolCalls) {
+    if (EDIT_TOOLS.has(tc.name)) {
+      if (seenEdit && seenBashAfterEdit) {
+        retries++;
+        seenBashAfterEdit = false;
+      }
+      seenEdit = true;
+    } else if (tc.name === 'Bash' && seenEdit) {
+      seenBashAfterEdit = true;
+    }
+  }
+  return retries;
+}

--- a/packages/reader/src/classifier.ts
+++ b/packages/reader/src/classifier.ts
@@ -91,11 +91,11 @@ interface PickInput {
 }
 
 function pickCategory({ toolCalls, text, hasFailedTool, hasEdits }: PickInput): ActivityCategory {
-  // Priority 1: explicit plan-mode marker.
-  if (toolCalls.some((t) => t.name === 'ExitPlanMode')) return 'planning';
-
-  // Priority 2: delegation — spawning a subagent dominates whatever else happened.
+  // Priority 1: delegation — spawning a subagent dominates whatever else happened.
   if (toolCalls.some((t) => DELEGATION_TOOLS.has(t.name))) return 'delegation';
+
+  // Priority 2: explicit plan-mode marker.
+  if (toolCalls.some((t) => t.name === 'ExitPlanMode')) return 'planning';
 
   // Priority 3: edits present. Let keyword refinement pick a sub-category;
   // default to coding if nothing stronger fires.
@@ -104,7 +104,12 @@ function pickCategory({ toolCalls, text, hasFailedTool, hasEdits }: PickInput): 
     return refined ?? 'coding';
   }
 
-  // Priority 4: bash commands with recognizable patterns.
+  // Priority 4: a failed tool call on a non-edit turn is debugging — a failing
+  // pytest / git push / build command is the model reacting to an error, not
+  // neutrally running tests or pushing code.
+  if (hasFailedTool) return 'debugging';
+
+  // Priority 5: bash commands with recognizable patterns.
   const bashCalls = toolCalls.filter((t) => t.name === 'Bash');
   for (const call of bashCalls) {
     const cmd = stripEnv(call.target ?? '');
@@ -114,10 +119,9 @@ function pickCategory({ toolCalls, text, hasFailedTool, hasEdits }: PickInput): 
     if (BUILD_DEPLOY_PATTERNS.some((re) => re.test(cmd))) return 'build-deploy';
   }
 
-  // Priority 5: any tools used at all → exploration (read-only, MCP, skills,
-  // or un-patterned bash). Keyword hints can still promote to debugging etc.
+  // Priority 6: any tools used at all → exploration (read-only, MCP, skills,
+  // or un-patterned bash). Keyword hints can still promote the category.
   if (toolCalls.length > 0) {
-    if (hasFailedTool) return 'debugging';
     const refined = refineByKeywords(text, false);
     if (refined) return refined;
     if (toolCalls.some((t) => READ_ONLY_TOOLS.has(t.name))) return 'exploration';

--- a/packages/reader/src/claude.test.ts
+++ b/packages/reader/src/claude.test.ts
@@ -412,4 +412,86 @@ describe('parseClaudeSessionIncremental', () => {
     assert.equal(second.turns[0]!.messageId, 'msg_inprog_1');
     assert.equal(second.turns[0]!.stopReason, 'end_turn');
   });
+
+  it('preserves the user prompt across a resume so keyword refinement still applies', async () => {
+    // Regression: when an incomplete assistant message forces endOffset to
+    // back up past the user prompt, the resumed call re-reads the assistant
+    // line without seeing the prompt. We carry lastUserText forward so the
+    // classifier still has keyword context (and can reach 'debugging' instead
+    // of falling back to 'coding').
+    const working = path.join(tmp, 'session.jsonl');
+    const sessionId = '44444444-4444-4444-4444-444444444444';
+    const lines = [
+      JSON.stringify({
+        parentUuid: null,
+        isSidechain: false,
+        type: 'user',
+        message: { role: 'user', content: 'fix the bug in auth.ts' },
+        uuid: 'u-user-1',
+        timestamp: '2026-04-20T00:00:00.000Z',
+        cwd: '/tmp/project',
+        sessionId,
+      }),
+      // Incomplete assistant (no stop_reason).
+      JSON.stringify({
+        parentUuid: 'u-user-1',
+        isSidechain: false,
+        message: {
+          model: 'claude-sonnet-4-6',
+          id: 'msg_resume_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tu_edit_1', name: 'Edit', input: { file_path: '/auth.ts' } }],
+          stop_reason: null,
+          usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 } },
+        },
+        type: 'assistant',
+        uuid: 'u-asst-1',
+        timestamp: '2026-04-20T00:00:01.000Z',
+        cwd: '/tmp/project',
+        sessionId,
+      }),
+    ];
+    await writeFile(working, lines.join('\n') + '\n', 'utf8');
+
+    const first = await parseClaudeSessionIncremental(working);
+    assert.equal(first.turns.length, 0, 'incomplete turn is deferred');
+    assert.equal(first.lastUserText, 'fix the bug in auth.ts');
+
+    // Append the completion line for msg_resume_1.
+    const tail =
+      JSON.stringify({
+        parentUuid: 'u-asst-1',
+        isSidechain: false,
+        message: {
+          model: 'claude-sonnet-4-6',
+          id: 'msg_resume_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tu_edit_1', name: 'Edit', input: { file_path: '/auth.ts' } }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 } },
+        },
+        type: 'assistant',
+        uuid: 'u-asst-1',
+        timestamp: '2026-04-20T00:00:01.000Z',
+        cwd: '/tmp/project',
+        sessionId,
+      }) + '\n';
+    const prev = await readFile(working, 'utf8');
+    await writeFile(working, prev + tail, 'utf8');
+
+    const second = await parseClaudeSessionIncremental(working, {
+      startOffset: first.endOffset,
+      lastUserText: first.lastUserText,
+    });
+    assert.equal(second.turns.length, 1);
+    const t = second.turns[0]!;
+    assert.equal(t.messageId, 'msg_resume_1');
+    assert.equal(t.activity, 'debugging', 'user prompt mentions "bug" so edit turn is debugging, not coding');
+
+    // Without lastUserText the prompt is lost and the turn falls back to coding.
+    const withoutSeed = await parseClaudeSessionIncremental(working, { startOffset: first.endOffset });
+    assert.equal(withoutSeed.turns[0]!.activity, 'coding');
+  });
 });

--- a/packages/reader/src/claude.ts
+++ b/packages/reader/src/claude.ts
@@ -2,6 +2,7 @@ import { createReadStream } from 'node:fs';
 import { open } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 
+import { classifyActivity } from './classifier.js';
 import { resolveProject } from './git.js';
 import { argsHash } from './hash.js';
 import type {
@@ -111,6 +112,9 @@ export async function parseClaudeSession(
   // to the seq of its first appearance).
   const userPending: Array<{ seq: number; record: ContentRecord }> = [];
   const firstSeq = new Map<string, number>();
+  const userTextByMessageId = new Map<string, string>();
+  const erroredToolUseIds = new Set<string>();
+  let currentUserText = '';
   let seq = 0;
 
   const rl = createInterface({
@@ -137,9 +141,15 @@ export async function parseClaudeSession(
         if (captureContent && typeof mid === 'string' && !firstSeq.has(mid)) {
           firstSeq.set(mid, seq);
         }
+        if (typeof mid === 'string' && !userTextByMessageId.has(mid)) {
+          userTextByMessageId.set(mid, currentUserText);
+        }
         ingestAssistant(al, working, order);
       } else if (rec.type === 'user') {
         const ul = rec as unknown as UserLine;
+        const prompt = extractPlainUserText(ul);
+        if (prompt) currentUserText = prompt;
+        collectErroredToolUseIds(ul, erroredToolUseIds);
         captureSubagentFromToolResult(ul, subagentByToolUseId);
         if (captureContent) {
           for (const c of extractUserContent(ul)) userPending.push({ seq, record: c });
@@ -181,6 +191,7 @@ export async function parseClaudeSession(
     if (filesTouched.length > 0) record.filesTouched = filesTouched;
     if (subagent) record.subagent = subagent;
     if (w.stopReason !== undefined) record.stopReason = w.stopReason;
+    applyClassification(record, w, userTextByMessageId, erroredToolUseIds);
     turns.push(record);
 
     if (captureContent) {
@@ -455,6 +466,67 @@ function resolveSubagent(
   return undefined;
 }
 
+function extractPlainUserText(line: UserLine): string | undefined {
+  const body = line.message?.content;
+  if (typeof body === 'string') {
+    return body.length > 0 ? body : undefined;
+  }
+  if (!Array.isArray(body)) return undefined;
+  const parts: string[] = [];
+  for (const block of body) {
+    if (!block || typeof block !== 'object') continue;
+    if (block.type === 'text') {
+      const b = block as { text?: string };
+      if (typeof b.text === 'string' && b.text.length > 0) parts.push(b.text);
+    }
+  }
+  return parts.length > 0 ? parts.join('\n') : undefined;
+}
+
+function collectErroredToolUseIds(line: UserLine, into: Set<string>): void {
+  const body = line.message?.content;
+  if (!Array.isArray(body)) return;
+  for (const block of body) {
+    if (!block || typeof block !== 'object' || block.type !== 'tool_result') continue;
+    const tr = block as { tool_use_id?: string; is_error?: boolean };
+    if (tr.is_error === true && typeof tr.tool_use_id === 'string') {
+      into.add(tr.tool_use_id);
+    }
+  }
+}
+
+function applyClassification(
+  record: TurnRecord,
+  w: WorkingRecord,
+  userTextByMessageId: Map<string, string>,
+  erroredToolUseIds: Set<string>,
+): void {
+  const userText = userTextByMessageId.get(w.messageId) ?? '';
+  const assistantText = extractAssistantTextForClassification(w.blocks);
+  const text = [userText, assistantText].filter((s) => s.length > 0).join('\n');
+  const hasFailedTool = record.toolCalls.some((tc) => erroredToolUseIds.has(tc.id));
+  const result = classifyActivity({
+    toolCalls: record.toolCalls,
+    text,
+    hasFailedTool,
+  });
+  record.activity = result.activity;
+  record.retries = result.retries;
+  record.hasEdits = result.hasEdits;
+}
+
+function extractAssistantTextForClassification(blocks: ContentBlock[]): string {
+  const parts: string[] = [];
+  for (const b of blocks) {
+    if (!b || typeof b !== 'object') continue;
+    if (b.type === 'text') {
+      const tb = b as { text?: string };
+      if (typeof tb.text === 'string' && tb.text.length > 0) parts.push(tb.text);
+    }
+  }
+  return parts.join('\n');
+}
+
 export interface ParseIncrementalOptions extends ParseOptions {
   startOffset?: number;
 }
@@ -495,6 +567,9 @@ export async function parseClaudeSessionIncremental(
     { type?: string; taskDescription?: string }
   >();
   const messageIdFirstOffset = new Map<string, number>();
+  const userTextByMessageId = new Map<string, string>();
+  const erroredToolUseIds = new Set<string>();
+  let currentUserText = '';
   // User content tagged with the byte offset of its line so we can (a) drop
   // records past endOffset and (b) interleave them with assistant content by
   // source-order at emit time.
@@ -526,9 +601,15 @@ export async function parseClaudeSessionIncremental(
       if (msgId && !messageIdFirstOffset.has(msgId)) {
         messageIdFirstOffset.set(msgId, lineStartOffset);
       }
+      if (msgId && !userTextByMessageId.has(msgId)) {
+        userTextByMessageId.set(msgId, currentUserText);
+      }
       ingestAssistant(line, working, order);
     } else if (rec.type === 'user') {
       const ul = rec as unknown as UserLine;
+      const prompt = extractPlainUserText(ul);
+      if (prompt) currentUserText = prompt;
+      collectErroredToolUseIds(ul, erroredToolUseIds);
       captureSubagentFromToolResult(ul, subagentByToolUseId);
       if (captureContent) {
         for (const c of extractUserContent(ul)) {
@@ -585,6 +666,7 @@ export async function parseClaudeSessionIncremental(
     if (filesTouched.length > 0) record.filesTouched = filesTouched;
     if (subagent) record.subagent = subagent;
     record.stopReason = w.stopReason;
+    applyClassification(record, w, userTextByMessageId, erroredToolUseIds);
     turns.push(record);
     if (captureContent) {
       const msgOffset = messageIdFirstOffset.get(w.messageId) ?? 0;

--- a/packages/reader/src/claude.ts
+++ b/packages/reader/src/claude.ts
@@ -529,12 +529,19 @@ function extractAssistantTextForClassification(blocks: ContentBlock[]): string {
 
 export interface ParseIncrementalOptions extends ParseOptions {
   startOffset?: number;
+  // The most recent user prompt text seen before `startOffset`. Classification
+  // uses the user prompt for keyword refinement; when `endOffset` backs up to
+  // an incomplete assistant line, the prompt that preceded it is before the
+  // resume point and won't be re-read — so callers must carry it forward.
+  lastUserText?: string;
 }
 
 export interface ParseIncrementalResult {
   turns: TurnRecord[];
   content: ContentRecord[];
   endOffset: number;
+  // Carry forward to the next incremental call; see `lastUserText` option.
+  lastUserText: string;
 }
 
 export async function parseClaudeSessionIncremental(
@@ -551,7 +558,12 @@ export async function parseClaudeSessionIncremental(
     const st = await handle.stat();
     size = st.size;
     if (startOffset >= size) {
-      return { turns: [], content: [], endOffset: startOffset };
+      return {
+        turns: [],
+        content: [],
+        endOffset: startOffset,
+        lastUserText: options.lastUserText ?? '',
+      };
     }
     const length = size - startOffset;
     buf = Buffer.allocUnsafe(length);
@@ -569,7 +581,9 @@ export async function parseClaudeSessionIncremental(
   const messageIdFirstOffset = new Map<string, number>();
   const userTextByMessageId = new Map<string, string>();
   const erroredToolUseIds = new Set<string>();
-  let currentUserText = '';
+  // Seed from the prior call so an in-progress turn whose user prompt lives
+  // before `startOffset` still classifies against that prompt on resume.
+  let currentUserText = options.lastUserText ?? '';
   // User content tagged with the byte offset of its line so we can (a) drop
   // records past endOffset and (b) interleave them with assistant content by
   // source-order at emit time.
@@ -694,5 +708,5 @@ export async function parseClaudeSessionIncremental(
     content = merged.map((m) => m.record);
   }
 
-  return { turns, content, endOffset };
+  return { turns, content, endOffset, lastUserText: currentUserText };
 }

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -4,6 +4,7 @@ export type {
   ToolCall,
   Subagent,
   TurnRecord,
+  ActivityCategory,
   ContentRecord,
   ContentRole,
   ContentKind,
@@ -11,6 +12,8 @@ export type {
   ContentToolResult,
   ContentStoreMode,
 } from './types.js';
+export { classifyActivity, countRetries } from './classifier.js';
+export type { ClassificationInput, ClassificationResult } from './classifier.js';
 export { parseClaudeSession, parseClaudeSessionIncremental } from './claude.js';
 export type {
   ParseOptions,

--- a/packages/reader/src/types.ts
+++ b/packages/reader/src/types.ts
@@ -29,6 +29,20 @@ export interface Subagent {
   parentToolUseId?: string;
 }
 
+export type ActivityCategory =
+  | 'planning'
+  | 'delegation'
+  | 'testing'
+  | 'git'
+  | 'build-deploy'
+  | 'coding'
+  | 'debugging'
+  | 'refactoring'
+  | 'feature'
+  | 'exploration'
+  | 'brainstorming'
+  | 'conversation';
+
 export interface TurnRecord {
   v: 1;
   source: SourceKind;
@@ -45,6 +59,9 @@ export interface TurnRecord {
   filesTouched?: string[];
   subagent?: Subagent;
   stopReason?: string;
+  activity?: ActivityCategory;
+  retries?: number;
+  hasEdits?: boolean;
 }
 
 export type ContentRole = 'user' | 'assistant' | 'tool_result';


### PR DESCRIPTION
Closes #37.

## Summary
- Adds a deterministic, rule-based `classifyActivity()` that labels each turn with one of 12 activity categories (`planning`, `delegation`, `testing`, `git`, `build-deploy`, `coding`, `debugging`, `refactoring`, `feature`, `exploration`, `brainstorming`, `conversation`) — ported from codeburn's taxonomy so cross-tool comparison stays possible.
- Populates three new optional fields on every `TurnRecord` from the Claude reader: `activity`, `retries` (edit→bash→edit cycles within the turn), and `hasEdits`.
- Two-phase algorithm per the issue: (1) tool-pattern classification with priority `delegation > ExitPlanMode > edits > bash test/git/build > read-only`; (2) keyword refinement on the preceding user prompt + assistant text for edit/exploration turns, with `debugging > refactoring > feature` precedence; (3) no-tool fallback handles brainstorming/planning/conversation. Failed tool calls (tool_result with `is_error`) promote to `debugging`.
- Wired into both `parseClaudeSession` and `parseClaudeSessionIncremental`. Existing ledger and CLI commands are unaffected — the new fields are additive and optional.

## What's not in this PR
- Codex and OpenCode readers are untouched. The classifier is a pure function that can be dropped into those readers in a follow-up.
- The `burn summary --by-activity` example query from the issue lives under the separate `burn compare` issue.

## Test plan
- [x] 28 new classifier unit tests (`packages/reader/src/classifier.test.ts`) covering every category, adversarial cases (exploration→feature via keyword, retries across different files, env-prefixed bash commands, debugging-over-feature precedence), and the retry counter.
- [x] Full test suite passes: 132/132 (up from 104).
- [x] Sanity-ran the three claude fixtures through `parseClaudeSession` and confirmed sensible labels (`simple-turn → conversation`, `multi-block-turn → delegation`, `files-touched → exploration`).
- [ ] Reviewer: spot-check keyword heuristics against real session data — particularly whether the `refactoring` vs `feature` precedence feels right on your workload.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
