### PR TITLE
Bump CI actions to Node 24 runtimes + pin pnpm version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,15 +66,15 @@ jobs:
       versions: ${{ steps.bump.outputs.versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
@@ -400,7 +400,7 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.published == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Need the tag that the publish job just pushed.
           ref: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
@@ -432,7 +432,7 @@ jobs:
 
       - name: Create GitHub Release (stable, with changelog)
         if: steps.check.outputs.published == 'true' && steps.check.outputs.prerelease != 'true' && steps.notes.outputs.has_notes == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
           name: "@relayburn/${{ matrix.package }}@${{ steps.check.outputs.version }}"
@@ -440,7 +440,7 @@ jobs:
 
       - name: Create GitHub Release (stable, auto notes)
         if: steps.check.outputs.published == 'true' && steps.check.outputs.prerelease != 'true' && steps.notes.outputs.has_notes != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
           name: "@relayburn/${{ matrix.package }}@${{ steps.check.outputs.version }}"
@@ -448,7 +448,7 @@ jobs:
 
       - name: Create GitHub Release (prerelease)
         if: steps.check.outputs.published == 'true' && steps.check.outputs.prerelease == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
           name: "@relayburn/${{ matrix.package }}@${{ steps.check.outputs.version }} (prerelease)"

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "engines": {
     "node": ">=22"
   },
+  "packageManager": "pnpm@10.17.1",
   "scripts": {
     "build": "tsc --build",
     "dev": "tsc --build --watch --preserveWatchOutput",


### PR DESCRIPTION
Fixes the **Publish Package** workflow which failed on `pnpm/action-setup@v4` with:

> Error: No pnpm version is specified.
> Please specify it by one of the following ways:
>   - in the GitHub Action config with the key "version"
>   - in the package.json with the key "packageManager"

Neither was set. Adding `"packageManager": "pnpm@10.17.1"` to the root `package.json` resolves it — both `pnpm/action-setup` and `actions/setup-node`'s cache detection read that field directly, which is the path both actions now recommend.

Also clears the **"Node.js 20 actions are deprecated"** annotation by moving all four JS actions to their Node 24 runtime releases:

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | |
| `actions/setup-node` | v4 | v6 | `cache: 'pnpm'` still supported explicitly (v6 made npm auto-cache the default for repos with `packageManager`, but explicit `cache:` still wins) |
| `pnpm/action-setup` | v4 | v5 | Reads `packageManager` from package.json by default — no `version:` input needed |
| `softprops/action-gh-release` | v2 | v3 | Explicit Node 24 runtime bump per the v3 release notes |

## What's not changed
- `node-version: '22.14.0'` in the workflow is unchanged — that's the Node version installed for *build/test* runs, independent of the JS action runtime. Engines still says `>=22`; bumping the test matrix to Node 24 is a separable decision.
- No code changes. Only the root `package.json` packageManager field + workflow `uses:` bumps.

## Test plan
- [ ] Re-run `Publish Package` with `dry_run: true` after merge — should pass the `Setup pnpm` step that previously failed.
- [ ] Confirm the deprecation annotation no longer appears on the workflow run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
