### PR TITLE
Backfill 0.1.0 and 0.2.0 changelog entries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,10 +136,16 @@ jobs:
           echo "versions=${VERSIONS# }" >> "$GITHUB_OUTPUT"
 
       # Per-package CHANGELOG.md generation. For each package being published,
-      # finds the last `<pkg>-v*` tag, collects Conventional Commits since then
-      # that touched `packages/<pkg>/**`, buckets them, and prepends a new
+      # finds the last `<pkg>-v*` tag, collects commits since then that
+      # touched `packages/<pkg>/**`, buckets them, and prepends a new
       # versioned block. Skips silently for prereleases (version contains `-`)
       # and for first publishes (no prior tag).
+      #
+      # Bucketing prefers Conventional Commits prefixes (feat:/fix:/refactor:
+      # etc.) but also infers from imperative-style subjects ("Add X" → feat,
+      # "Fix Y" → fix, "Refactor Z" → changed). Anything still unclassified
+      # goes into the Changed section as a fallback so commits never get
+      # silently dropped from the changelog.
       - name: Generate changelogs
         if: ${{ github.event.inputs.version != 'none' || github.event.inputs.custom_version != '' }}
         run: |
@@ -206,31 +212,47 @@ jobs:
 
           const getType = (subject) => {
             const m = subject.match(/^(feat|fix|refactor|perf|chore|test|ci|docs|build|style)(\([^)]+\))?(!)?:/i);
-            if (!m) return 'other';
-            const type = m[1].toLowerCase();
-            const scope = (m[2] || '').replace(/[()]/g, '');
-            if (m[3] === '!') return 'breaking';
-            if (type === 'feat') return 'feat';
-            if (type === 'fix') return 'fix';
-            if (type === 'refactor' || type === 'perf' || type === 'build') return 'changed';
-            if (type === 'test' || type === 'ci') return 'reliability';
-            if (type === 'chore' && scope === 'release') return 'release';
-            if (type === 'chore') return 'deps';
+            if (m) {
+              const type = m[1].toLowerCase();
+              const scope = (m[2] || '').replace(/[()]/g, '');
+              if (m[3] === '!') return 'breaking';
+              if (type === 'feat') return 'feat';
+              if (type === 'fix') return 'fix';
+              if (type === 'refactor' || type === 'perf' || type === 'build') return 'changed';
+              if (type === 'test' || type === 'ci') return 'reliability';
+              if (type === 'chore' && scope === 'release') return 'release';
+              if (type === 'chore') return 'deps';
+              return 'other';
+            }
+            // Imperative-verb inference for commits that don't follow
+            // Conventional Commits. Order matters — more specific verbs first.
+            const trimmed = subject.trim();
+            if (/^(add|implement|introduce|create|support|enable|expose|wire|allow)\b/i.test(trimmed)) return 'feat';
+            if (/^(fix|resolve|correct|patch|prevent|guard|stop)\b/i.test(trimmed)) return 'fix';
+            if (
+              /^(refactor|rename|extract|reorganize|restructure|simplify|move|split|consolidate|rewrite|replace)\b/i.test(trimmed) ||
+              /^(update|bump|upgrade|migrate|switch|tighten|loosen|tweak|adjust|improve|clarify|polish|cleanup|clean\s+up|harden)\b/i.test(trimmed)
+            ) return 'changed';
+            if (/^(test|cover|verify)\b/i.test(trimmed)) return 'reliability';
+            if (/^(document|docs?\b|readme)\b/i.test(trimmed)) return 'docs';
             return 'other';
           };
 
-          const cats = { breaking: [], feat: [], fix: [], changed: [], reliability: [], deps: [], release: [], other: [] };
+          const cats = { breaking: [], feat: [], fix: [], changed: [], reliability: [], deps: [], release: [], docs: [], other: [] };
           for (const c of commits) {
             const type = getType(c.subject);
             cats[type].push({ title: formatTitle(c.subject), pr: extractPR(c.subject, c.body) });
           }
 
+          // Anything that didn't match a typed bucket goes into "Changed" so
+          // commits never get silently dropped from the changelog.
           const sections = [
             ['Breaking Changes', cats.breaking, true],
             ['Added', cats.feat, true],
             ['Fixed', cats.fix, false],
-            ['Changed', cats.changed, false],
+            ['Changed', [...cats.changed, ...cats.other], false],
             ['Reliability', cats.reliability, false],
+            ['Documentation', cats.docs, false],
             ['Dependencies', cats.deps, false],
           ];
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# Agent guide for relayburn
+
+Conventions an agent (or human) needs to know to work productively in this repo.
+Pairs with [`README.md`](./README.md) — README is what burn does, this file is how to work on it.
+
+## Layout
+
+pnpm workspace, four published packages in dependency order:
+
+```
+@relayburn/reader   — pure parsers (Claude Code / Codex / OpenCode session logs → TurnRecord)
+@relayburn/ledger   — append-only JSONL ledger + content sidecar at ~/.relayburn/
+@relayburn/analyze  — pricing + per-record cost derivation + comparison aggregator
+@relayburn/cli      — `burn` binary (summary, by-tool, compare, claude/codex/opencode wrappers, …)
+```
+
+`reader → ledger → analyze → cli`. Always build the whole workspace; never touch a single package's `tsconfig.tsbuildinfo` to "skip" a dep.
+
+## Common commands
+
+```bash
+pnpm install              # frozen-lockfile install
+pnpm run build            # tsc --build across the workspace
+pnpm run test             # node --test against built dist/
+pnpm run test:ts          # build + test in one shot
+pnpm dev:cli <args>       # run the local CLI against a built dist/
+
+pnpm run pricing:update   # refresh the vendored models.dev snapshot
+```
+
+Tests run from `dist/` so a stale build will lie. If a test fails unexpectedly, rebuild before debugging.
+
+## Commit messages drive the changelog
+
+The publish workflow (`.github/workflows/publish.yml`) auto-generates per-package CHANGELOG entries by parsing `git log` since the last `<pkg>-v*` tag. **You do not need to manually edit CHANGELOG.md** — the release workflow inserts a new section under `[Unreleased]` at publish time.
+
+It buckets commits by their subject's leading verb. Use one of these to land in the right section:
+
+| Subject starts with… | Lands in section |
+|---|---|
+| `Add`, `Implement`, `Introduce`, `Create`, `Support`, `Enable`, `Expose`, `Wire`, `Allow` | **Added** |
+| `Fix`, `Resolve`, `Correct`, `Patch`, `Prevent`, `Guard`, `Stop` | **Fixed** |
+| `Refactor`, `Rename`, `Extract`, `Reorganize`, `Restructure`, `Simplify`, `Move`, `Split`, `Consolidate`, `Rewrite`, `Replace`, `Update`, `Bump`, `Upgrade`, `Migrate`, `Switch`, `Tighten`, `Loosen`, `Tweak`, `Adjust`, `Improve`, `Clarify`, `Polish`, `Cleanup`, `Harden` | **Changed** |
+| `Test`, `Cover`, `Verify` | **Reliability** |
+| `Document`, `Docs`, `Readme` | **Documentation** |
+| anything else | **Changed** (catch-all so nothing is silently dropped) |
+
+Conventional Commits (`feat:`, `fix:`, `refactor:`, `chore(release):`, etc.) also work and take precedence over verb inference. Either style is fine; mixing is fine.
+
+Breaking changes: append `!` to a Conventional Commits prefix (e.g. `feat!:`) to land under **Breaking Changes**.
+
+## Releases
+
+```bash
+# from GitHub Actions: workflow_dispatch → "Publish Package"
+#   package: all | reader | ledger | analyze | cli
+#   version: patch | minor | major | prepatch | … | none (re-publish current)
+#   custom_version: 0.3.1 (overrides version type)
+#   tag: latest | next | beta | alpha
+#   dry_run: true to skip publish + tag + git push
+```
+
+The workflow:
+1. Builds + tests the whole workspace.
+2. Bumps `package.json` versions in dep order (reader → ledger → analyze → cli).
+3. Generates changelog entries from `git log <pkg>-v<last>..HEAD -- packages/<pkg>`.
+4. Publishes via `pnpm pack` + `npm publish` using OIDC trusted-publisher auth (no `NPM_TOKEN`).
+5. Tags `<pkg>-v<version>` and creates a GitHub Release with the changelog body.
+
+A separate `Verify Publish` workflow smoke-tests installs from npm afterward.
+
+## When in doubt
+
+- **Architecture / API surface:** read `README.md` first, then the package's `src/index.ts` for exports.
+- **Activity classifier rules:** the rule tables (`TEST_PATTERNS`, `EDIT_TOOLS`, `TOOL_ALIASES`, etc.) live at `packages/reader/src/classifier.ts`. They're the source of truth for what `burn compare` buckets each turn into. Adding a new harness = adding entries to `TOOL_ALIASES`; adding a new category = updating `ActivityCategory` in `packages/reader/src/types.ts` and adding its rule + a test.
+- **Ledger schema:** `packages/reader/src/types.ts` (`TurnRecord`, `ContentRecord`) and `packages/ledger/src/schema.ts` (`LedgerLine`, `TurnLine`, `StampLine`). Bump `v` if the on-disk shape changes.
+- **Concurrency:** any read-modify-write on the ledger MUST hold `withLock('ledger', …)` from `@relayburn/ledger`. Append-only writes use the same lock to avoid racing reclassify-style rewrites.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes across the relayburn monorepo, rolled up across the four published packages. The per-package CHANGELOGs at `packages/*/CHANGELOG.md` remain the authoritative source for what shipped where; this file is a unified view organized by release date.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the workspace adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each package versions independently — the version line under each release lists every package that bumped on that date.
+
+## [Unreleased]
+
+## 2026-04-23 — `burn compare` and cross-harness classifier
+
+**Versions:** `@relayburn/reader@0.2.0`, `@relayburn/ledger@0.2.0`, `@relayburn/analyze@0.2.0`, `@relayburn/cli@0.2.0`
+
+### Added
+
+- **`burn compare`** — observed-data comparison of cost-per-turn, one-shot rate, and turn count by `(model, activity)`. The headline query for the meta-goal: "looking at the work I actually did, which model handled each activity category best?" Closes [#38](https://github.com/AgentWorkforce/burn/issues/38). [cli, analyze]
+  - Flags: `--models a,b`, `--since 7d`, `--project <path>`, `--session <id>`, `--workflow <id>`, `--agent <id>`, `--min-sample <n>`, `--json`, `--csv`, `--help`.
+  - Grouped TTY table with coverage notes; missing-data cells render `—` (never `$0.00` or `0%`).
+  - JSON and CSV output expose `noData` / `insufficientSample` / `pricedTurns` so consumers can distinguish "no data" from "low sample" and "free model" from "unknown pricing."
+- **`burn rebuild --reclassify [--force]`** — backfills activity labels on existing ledger turns by re-running `classifyActivity`. Default skips already-classified turns; `--force` reclassifies everything. Reports per-category change counts. `burn rebuild --index` rebuilds the sidecar; both can run together. `burn rebuild-index` retained as alias. [cli, ledger]
+- **Activity classifier now runs for Codex and OpenCode turns** — previously only Claude Code turns received an `activity` label, which left every Codex/OpenCode turn in `unclassified` and made cross-harness comparison impossible. [reader]
+- **`TOOL_ALIASES` map + `normalizeToolName(name)`** in the classifier normalizes harness-specific tool names (`apply_patch`, `exec_command`, `shell`, lowercase OpenCode names, codex agent tools) onto canonical Claude names so the rule tables stay single-source. [reader]
+- **Six new activity categories** (taxonomy expanded from 12 → 18): `reasoning`, `docs`, `deps`, `format`, `review`, `verification`. [reader]
+- **`buildCompareTable(turns, opts)`** — pure aggregator in `@relayburn/analyze` so scripts can consume the same shape the CLI renders. [analyze]
+
+### Fixed
+
+- **Race between `appendTurns` and `reclassifyLedger`.** `appendLines` in the writer now acquires the same `withLock('ledger', …)` that `reclassifyLedger` holds for its read-modify-write pass. Previously an `appendFile` landing between reclassify's `readFile` and `rename` would write to the soon-orphaned old inode and silently disappear when rename swapped the new file in. Reported by Devin's review on [#48](https://github.com/AgentWorkforce/burn/pull/48). [ledger]
+
+### Changed
+
+- `BUILD_DEPLOY_PATTERNS` tightened — the catch-all `/\bdeploy\b/` is replaced with explicit verbs per-tool (`vercel/netlify/flyctl/railway/sst deploy|up`, `kubectl apply/rollout/set`, `helm install/upgrade`, `terraform apply/plan/destroy`, `make build|release|dist|package|deploy`). [reader]
+- Top-level `burn` help and the README list every `burn compare` filter (`--session`, `--agent`) instead of just the most common ones. [cli]
+- `burn compare` now rejects `--json` + `--csv` together with exit 2 instead of silently picking JSON. [cli]
+- `--models` filter pre-seeds requested models so a model the user explicitly asked about stays visible (as an all-empty column with a coverage note) even when zero turns matched. [analyze]
+
+### PRs in this release
+
+- [#48](https://github.com/AgentWorkforce/burn/pull/48) — Add burn compare, classifier wiring, reclassify, race fix, taxonomy expansion
+
+## 2026-04-22 — Initial release
+
+**Versions:** `@relayburn/reader@0.1.0`, `@relayburn/ledger@0.1.0`, `@relayburn/analyze@0.1.0`, `@relayburn/cli@0.1.0`
+
+### Added
+
+- **`@relayburn/reader`** — pure parsers turning agent session logs into `TurnRecord[]` and `ContentRecord[]`. Claude Code (`parseClaudeSession`), Codex (`parseCodexSession` with cumulative-token-delta accounting), OpenCode (`parseOpencodeSession` reading the per-session/message/part storage layout). All three have `*SessionIncremental` variants for cursor-based ingest. Deterministic activity classifier with 12 categories (Claude Code only at this release). Git-canonical project resolution (`resolveProject`) so `projectKey` survives across worktrees.
+- **`@relayburn/ledger`** — append-only JSONL ledger at `~/.relayburn/ledger.jsonl` (override via `RELAYBURN_HOME`). `appendTurns`, `stamp`, `query`, `queryAll`. Stamping for spawn-time enrichment with `{sessionId}` / `{messageId}` / `{sessionId, range}` selectors; last-write-wins per key, folded at query time. **Content sidecar** at `~/.relayburn/content/<sessionId>.jsonl` with `full` / `hash-only` / `off` modes via `RELAYBURN_CONTENT_STORE`; default 90-day retention. **Index sidecar** for fast dedup with `rebuildIndex()`. Per-process file lock (`withLock`) with stale-lock recovery. Per-source cursors for incremental ingest.
+- **`@relayburn/analyze`** — pricing loader (vendored models.dev snapshot with optional override at `$RELAYBURN_HOME/models.dev.json`) and per-record cost derivation (`costForTurn`, `costForUsage`, `sumCosts`). Reasoning tokens billed at the output rate and reported separately. Provider-prefix fallback in lookup so `anthropic/claude-sonnet-4-6` resolves to the `claude-sonnet-4-6` rate.
+- **`@relayburn/cli`** — `burn` binary with `summary`, `by-tool`, `claude` / `codex` / `opencode` spawn-wrappers (pre-assigned session UUIDs, stamps before spawn, ingest on exit), `content prune`, `rebuild-index`. Opportunistic content-sidecar prune on every non-`content` invocation.

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -9,7 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-23
 
-### Released
+### Added
 
-- v0.2.0
+- **`buildCompareTable(turns, opts)`** — bucket turns by `(model, activity)` and emit a `CompareTable` with per-cell metrics: `turns`, `editTurns`, `oneShotTurns`, `pricedTurns`, `totalCost`, `costPerTurn`, `oneShotRate`, `cacheHitRate`, `medianRetries`, plus `noData` / `insufficientSample` flags. Sorts models by total cost descending, categories by total turns descending. Filters: `models[]`, `minSample`.
+- **`DEFAULT_MIN_SAMPLE`** export (defaults to 5).
+- `CompareCell.pricedTurns` distinguishes "cost is zero because the model is free" from "cost is unknown because we have no pricing for this model" — `costPerTurn` is `null` (renders as `—`) when no priced turns, never silently `$0.00`.
+- `CompareCell.noData` is mutually exclusive with `insufficientSample` so consumers can tell "we never saw this combination" apart from "we have data but the sample is small."
+- `--models` filter pre-seeds requested models so a model the user explicitly asked about stays visible (as an all-empty column with coverage notes) even when zero turns matched.
 
+## [0.1.0] - 2026-04-22
+
+### Added
+
+- **Initial release.** Pricing loader and per-record cost derivation.
+- `loadBuiltinPricing()` / `loadPricing()` — vendored models.dev snapshot with optional user override at `$RELAYBURN_HOME/models.dev.json`.
+- `costForTurn(turn, pricing)` / `costForUsage(usage, model, pricing)` — per-turn cost breakdown (`input`, `output`, `reasoning` at output rate, `cacheRead`, `cacheCreate`).
+- `sumCosts(costs[])` aggregator.
+- Provider-prefix fallback in lookup so `anthropic/claude-sonnet-4-6` resolves to the `claude-sonnet-4-6` rate.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,13 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-23
 
-### Released
+### Added
 
-- v0.2.0
+- **`burn compare`** — observed-data comparison of cost-per-turn, one-shot rate, and turn count by `(model, activity)`. The headline query for the meta-goal: "looking at the work I actually did, which model handled each activity category best?" Closes #38.
+  - Flags: `--models a,b`, `--since 7d`, `--project <path>`, `--session <id>`, `--workflow <id>`, `--agent <id>`, `--min-sample <n>`, `--json`, `--csv`, `--help` / `-h` / `help`.
+  - TTY output renders a grouped table (model name spans three sub-columns) with coverage notes for missing or low-sample cells. Notes capped at 8 with `… and N more` overflow.
+  - `--json` and `--csv` are mutually exclusive — passing both exits 2 instead of silently picking JSON.
+  - Missing-data cells render `—`, never `$0.00` or `0%`. JSON/CSV expose the underlying `noData` and `insufficientSample` flags so script consumers can distinguish them.
+- **`burn rebuild`** — backfill derived ledger artifacts.
+  - `--reclassify [--force]` re-runs `classifyActivity` across the whole ledger so old turns benefit from new classifier rules. Default mode skips turns that already have an `activity` (safe to re-run); `--force` reclassifies every turn.
+  - `--index` rebuilds the sidecar index (equivalent to `burn rebuild-index`). Both flags can run together.
+  - Reports `processed` / `changed` / `unchanged` / `skipped` counts plus per-category change breakdown.
+- **`burn rebuild-index`** retained as a backward-compat alias for `burn rebuild --index`.
+
+### Changed
+
+- Top-level `burn` help and the README now list every `burn compare` filter (`--session`, `--agent`) instead of just the most common ones.
 
 ## [0.1.0] - 2026-04-22
 
-### Released
+### Added
 
-- v0.1.0
-
+- **Initial release.** `burn` CLI binary.
+- `burn summary [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>]` — per-model token + cost breakdown. Triggers ingest from Claude Code, Codex, and OpenCode session logs before reporting.
+- `burn by-tool [--since 7d] [--project <path>] [--session <id>]` — per-tool attribution. Splits each turn's input cost across the prior turn's tool calls.
+- `burn claude [--tag k=v ...] [-- <claude args>]` — spawn-wrapper that pre-assigns a session UUID, applies stamps before spawn, and ingests the session on exit.
+- `burn codex [--tag k=v ...] [-- <codex args>]` — same wrapper pattern for Codex.
+- `burn opencode [--tag k=v ...] [-- <opencode args>]` — same wrapper pattern for OpenCode.
+- `burn content prune [--days <n>]` — apply retention to the content sidecar.
+- `burn rebuild-index` — rebuild the sidecar hash index from the ledger.
+- Opportunistic content-sidecar prune on every non-`content` invocation (best-effort, never fails the CLI).

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -9,13 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-23
 
-### Released
+### Added
 
-- v0.2.0
+- **`reclassifyLedger({ force? })`** — rewrites the ledger atomically and re-runs `classifyActivity` on every turn. Default mode skips turns that already have an `activity` set (safe to re-run, won't downgrade Claude turns whose content sidecar has since been pruned). `--force` reclassifies everything; useful after a classifier rule change.
+- Recovers user prompt text + assistant text + errored tool IDs from the content sidecar when present, falling back to tool-only signal otherwise.
+- Returns a `ReclassifyReport` with separate `scanned` / `processed` / `changed` / `skipped` counters plus per-category change breakdown.
+- Preserves stamp lines and blank lines verbatim; only rewrites turn lines whose classification actually changed.
+
+### Fixed
+
+- **Race between `appendTurns` and `reclassifyLedger`.** `appendLines` in the writer now acquires the same `withLock('ledger', ...)` that `reclassifyLedger` holds for its read-modify-write pass. Without this, an `appendFile` that landed between reclassify's `readFile` and `rename` would write to the soon-orphaned old inode and silently disappear when the rename swapped the new file in. Reported by Devin's PR review on #48.
 
 ## [0.1.0] - 2026-04-22
 
-### Released
+### Added
 
-- v0.1.0
-
+- **Initial release.** Append-only JSONL ledger at `~/.relayburn/ledger.jsonl` with override via `RELAYBURN_HOME`.
+- `appendTurns(turns)` with content-fingerprint dedup against historical turns.
+- `stamp(selector, enrichment)` — attach metadata to a session by `{sessionId}`, `{messageId}`, or `{sessionId, range: { fromTs, toTs }}`. Last-write-wins per key. Stamps fold at query time.
+- `query(q)` / `queryAll(q)` async iterables, returning `EnrichedTurn` (the turn record plus folded enrichment). Filters: `since`, `until`, `project`, `sessionId`, `source`, `enrichment`.
+- **Content sidecar** at `~/.relayburn/content/<sessionId>.jsonl`. `appendContent`, `readContent`, `pruneContent` with `full` / `hash-only` / `off` modes via `RELAYBURN_CONTENT_STORE` or config file. Default 90-day retention, configurable via `RELAYBURN_CONTENT_TTL_DAYS`.
+- **Index sidecar** for fast dedup. `rebuildIndex()` rebuilds the on-disk hash sets from the ledger; `turnIdHash`, `turnContentFingerprint` exported.
+- Per-process file lock (`withLock`) used by content writes and index updates; stale-lock recovery after 30s.
+- Cursors (`loadCursors`, `saveCursors`) for incremental ingest of Claude / Codex / OpenCode session files. Carries `lastUserText` for Claude so classification keyword refinement survives EOF resumes.
+- Schema types: `LedgerLine`, `TurnLine`, `StampLine`, `Enrichment`, `MessageIdRange`, `StampSelector` plus `isTurnLine` / `isStampLine` / `stampMatches` guards.

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -9,13 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-23
 
-### Released
+### Added
 
-- v0.2.0
+- **Activity classifier now runs for Codex and OpenCode turns.** Previously only Claude Code turns received an `activity` label; everything else fell into `unclassified` and `burn compare` could not bucket cross-harness work.
+- **`TOOL_ALIASES` map** in the classifier normalizes harness-specific tool names (`apply_patch`, `exec_command`, `shell`, lowercase `read`/`write`/`edit`/`bash`/`grep`/`glob`/`webfetch`/`task`, plus codex agent tools) onto canonical Claude names so the rule tables stay single-source. Exported as `normalizeToolName(name)`.
+- **Six new activity categories** (taxonomy expanded from 12 → 18): `reasoning`, `docs`, `deps`, `format`, `review`, `verification`.
+  - `reasoning`: tool-less turns billed reasoning tokens (extended thinking, Codex `reasoning_output_tokens`).
+  - `docs`: edit turns where every edited file is a doc (`*.md`, `*.mdx`, `*.rst`, `*.adoc`, `*.txt`, `README*`, `CHANGELOG*`, `docs/**`).
+  - `deps`: bash matching `npm/pnpm/yarn/bun install|add`, `pip install`, `uv add`, `cargo add`, `go get`, `bundle install`, `brew install`, etc.
+  - `format`: bash matching `prettier --write`, `eslint --fix`, `black`, `ruff format`, `cargo fmt`, `gofmt`, etc.
+  - `review`: read-only inspection (`git status/diff/show/log/blame`, `gh pr view/diff/checks`) or read-only turns whose prompt asks for review.
+  - `verification`: lint/typecheck/check commands (`eslint`, `tsc --noEmit`, `cargo check`, `mypy`, `ruff check`, `prettier --check`, etc.).
+- **Retries-based debugging fallback.** Edit turns with `retries >= 2` (≥2 edit→bash→edit cycles in one turn) classify as `debugging` even without an explicit error keyword.
+- **Codex reader carries user prompt text** (skipping `<environment_context>` / `<permissions>` / `# AGENTS.md` boilerplate), assistant `output_text`, and errored call IDs from `exec_command_end.exit_code !== 0` and `patch_apply_end.success === false` into the classifier.
+- **OpenCode reader reads user messages alongside assistants**, skips `synthetic: true` text parts (harness-injected nudges), and detects failed tool parts via `state.status === "error"` or `state.metadata.exit !== 0`.
+- **Reasoning tokens flow into classification.** `ClassificationInput.reasoningTokens` lets the classifier distinguish reasoning-only turns from chit-chat conversation.
+- **Expanded `TEST_PATTERNS`** to catch e2e/browser runners: `playwright`, `cypress`, `puppeteer`, `make test`, `ctest`.
+
+### Changed
+
+- `BUILD_DEPLOY_PATTERNS` tightened. The catch-all `/\bdeploy\b/` is replaced with explicit verbs per-tool (`vercel/netlify/flyctl/railway/sst deploy|up`, `kubectl apply/rollout/set`, `helm install/upgrade`, `terraform apply/plan/destroy`, `make build|release|dist|package|deploy`).
 
 ## [0.1.0] - 2026-04-22
 
-### Released
+### Added
 
-- v0.1.0
-
+- **Initial release.** Pure parsers (no I/O writes, no shared state) that turn agent session logs into `TurnRecord[]` and `ContentRecord[]`.
+- Claude Code reader (`parseClaudeSession`, `parseClaudeSessionIncremental`).
+- Codex reader (`parseCodexSession`, `parseCodexSessionIncremental`) with cumulative-token-delta accounting and resume state across `task_complete` boundaries.
+- OpenCode reader (`parseOpencodeSession`, `parseOpencodeSessionIncremental`) reading the `~/.local/share/opencode/storage` per-session/message/part layout.
+- Activity classifier (`classifyActivity`, `countRetries`) — 12 categories, deterministic and rule-based, no LLM in the loop. Runs against Claude Code turns only at this version.
+- Git-canonical project resolution (`resolveProject`, `canonicalizeRemoteUrl`, `parseGitConfig`) so projectKey survives across worktrees.
+- `argsHash` content fingerprinting for tool-call dedup.


### PR DESCRIPTION
## Why the changelogs were empty

`.github/workflows/publish.yml` generates per-package CHANGELOG entries by parsing `git log` for Conventional Commits prefixes (`feat:`, `fix:`, `refactor:`, etc.) since the last tag. Commits without a prefix bucketed as `other`, which the script never emitted in any section — so when no prefixed commits existed, `anyContent === false` and only the placeholder "Released - vX.Y.Z" was emitted.

Every commit on this repo so far has been imperative-style without the prefix (`Add X`, `Fix Y`), so every released version got the placeholder.

## What this PR does

### 1. Backfill the missing entries
Hand-written 0.1.0 and 0.2.0 entries for all four packages, derived from each package's `git log <pkg>-v0.1.0..<pkg>-v0.2.0 --no-merges -- packages/<pkg>` output:

- **@relayburn/reader** — initial parsers + classifier (0.1.0); cross-harness classifier wiring + 6 new categories + retries-debugging fallback (0.2.0).
- **@relayburn/ledger** — append-only ledger + stamping + sidecars (0.1.0); `reclassifyLedger()` + the appendLines lock fix from Devin's review (0.2.0).
- **@relayburn/analyze** — pricing + cost derivation (0.1.0); `buildCompareTable()` with the full cell shape (0.2.0).
- **@relayburn/cli** — `summary`/`by-tool`/wrappers/`content prune`/`rebuild-index` (0.1.0); `burn compare` + `burn rebuild --reclassify` (0.2.0).

### 2. Fix the generator so it doesn't happen again
`getType()` in the publish workflow now falls back to imperative-verb inference when no Conventional Commits prefix matches:

| Subject starts with… | Section |
|---|---|
| `Add`, `Implement`, `Introduce`, `Create`, `Support`, `Enable`, `Expose`, `Wire`, `Allow` | **Added** |
| `Fix`, `Resolve`, `Correct`, `Patch`, `Prevent`, `Guard`, `Stop` | **Fixed** |
| `Refactor`, `Rename`, `Update`, `Bump`, `Clarify`, `Improve`, `Simplify`, … | **Changed** |
| `Test`, `Cover`, `Verify` | **Reliability** |
| `Document`, `Docs`, `Readme` | **Documentation** |
| anything else | **Changed** (catch-all so nothing is silently dropped) |

Verified by extracting the patched generator and dry-running it against each `<pkg>-v0.1.0..<pkg>-v0.2.0` range — every package produces real Added/Fixed/Changed sections.

### 3. AGENTS.md
New top-level file capturing the conventions an agent (or contributor) needs to work productively in this repo: layout, common commands, release flow, and the commit-message verb-prefix rules that drive the auto-generated changelog sections. The intent is that the next round of work doesn't ship with empty changelogs because someone wasn't aware of the rules.

### 4. Root CHANGELOG.md
Unified rollup across all four packages, organized by release date with each section listing the package versions that bumped on that date and the Added / Fixed / Changed entries rolled up across the workspace. Per-package CHANGELOGs at `packages/*/CHANGELOG.md` remain the authoritative source; this file is a single landing place to see what shipped together.

A natural follow-up: teach the publish workflow to regenerate the root CHANGELOG from the per-package ones at release time so it doesn't drift.

## Test plan
- [x] Hand-checked each backfilled entry against `git log <pkg>-vA..<pkg>-vB` for the four packages
- [x] Extracted the patched generator and dry-ran it against each `<pkg>-v0.1.0..<pkg>-v0.2.0` range — produces the expected sections without the placeholder fallback
- [ ] No code changes outside the workflow + docs; CI tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)