### PR TITLE
Add content capture for Codex and OpenCode parsers (#33 follow-up)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`burn summary --quality`** — appends a quality rollup to the summary output: outcome counts (completed / abandoned / errored / unknown) plus the weighted one-shot edit rate across the matched sessions. Closes [#6](https://github.com/AgentWorkforce/burn/issues/6).
   - Opportunistically loads per-session content sidecars (when available) so give-up phrase detection can downgrade assistant-ended confidence. Sidecar reads run with a concurrency cap of 8 so large ledgers don't serialize I/O.
+- **`burn rebuild --content`** — re-parses source session files to populate missing content sidecars. Skips sessions that already have content on disk, leaves cursors and ledger rows untouched. Primary use: backfill content for historical Codex and OpenCode sessions ingested before content capture was implemented for those adapters (#33 follow-up), or to restore a sidecar that was pruned.
 
 ## [0.6.0] - 2026-04-24
 

--- a/packages/cli/src/commands/rebuild.ts
+++ b/packages/cli/src/commands/rebuild.ts
@@ -18,11 +18,8 @@ Flags:
   --force       with --reclassify, overwrite activity even if already set
   --content     re-parse source session files to populate missing content
                 sidecars. Skips sessions that already have content on disk.
-                Does not touch cursors or existing ledger rows. Only adapters
-                whose parser emits content records benefit — today that is
-                Claude sessions only; codex and opencode parsers have content
-                capture marked TODO(#33-followup) and will not produce
-                records from this command until that lands.
+                Does not touch cursors or existing ledger rows.
+
 `;
 
 export async function runRebuild(args: ParsedArgs): Promise<number> {

--- a/packages/cli/src/commands/rebuild.ts
+++ b/packages/cli/src/commands/rebuild.ts
@@ -1,5 +1,6 @@
 import { rebuildIndex, reclassifyLedger } from '@relayburn/ledger';
 
+import { reingestMissingContent } from '../ingest.js';
 import { formatInt } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
@@ -8,20 +9,29 @@ const REBUILD_HELP = `burn rebuild — rebuild derived ledger artifacts
 Usage:
   burn rebuild --index
   burn rebuild --reclassify [--force]
+  burn rebuild --content
   burn rebuild --index --reclassify [--force]
 
 Flags:
   --index       rebuild the sidecar index (equivalent to 'burn rebuild-index')
   --reclassify  re-run the activity classifier on every ledger turn
   --force       with --reclassify, overwrite activity even if already set
+  --content     re-parse source session files to populate missing content
+                sidecars. Skips sessions that already have content on disk.
+                Does not touch cursors or existing ledger rows. Only adapters
+                whose parser emits content records benefit — today that is
+                Claude sessions only; codex and opencode parsers have content
+                capture marked TODO(#33-followup) and will not produce
+                records from this command until that lands.
 `;
 
 export async function runRebuild(args: ParsedArgs): Promise<number> {
   const doIndex = args.flags['index'] === true;
   const doReclassify = args.flags['reclassify'] === true;
+  const doContent = args.flags['content'] === true;
   const force = args.flags['force'] === true;
 
-  if (!doIndex && !doReclassify) {
+  if (!doIndex && !doReclassify && !doContent) {
     process.stdout.write(REBUILD_HELP);
     return 0;
   }
@@ -45,6 +55,17 @@ export async function runRebuild(args: ParsedArgs): Promise<number> {
         lines.push(`    → ${cat}: ${formatInt(n)}`);
       }
     }
+  }
+
+  if (doContent) {
+    const r = await reingestMissingContent();
+    lines.push(
+      `reingested content for ${formatInt(r.reingestedSessions)} sessions` +
+        ` (${formatInt(r.scannedFiles)} files scanned,` +
+        ` ${formatInt(r.skippedExisting)} already had content,` +
+        ` ${formatInt(r.appendedContent)} records appended,` +
+        ` ${formatInt(r.failed)} failed)`,
+    );
   }
 
   // Rebuild index after reclassify — ids/fingerprints are unchanged by

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -12,6 +12,7 @@ import {
   appendCompactions,
   appendContent,
   appendTurns,
+  listContentSessionIds,
   loadConfig,
   loadCursors,
   saveCursors,
@@ -263,6 +264,145 @@ async function ingestOpencodeInto(
 
 function emptyReport(): IngestReport {
   return { scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 };
+}
+
+export interface ReingestContentReport {
+  scannedFiles: number;
+  skippedExisting: number;
+  reingestedSessions: number;
+  appendedContent: number;
+  failed: number;
+}
+
+// Re-parse source session files to populate missing content sidecars. Used by
+// `burn rebuild --content` to fix up historical sessions ingested before the
+// sidecar was written (or where the sidecar was pruned). Does NOT touch
+// cursors, ledger turns, or compactions — only writes content records for
+// sessions that currently have no sidecar on disk.
+export async function reingestMissingContent(): Promise<ReingestContentReport> {
+  const existing = await listContentSessionIds();
+  const report: ReingestContentReport = {
+    scannedFiles: 0,
+    skippedExisting: 0,
+    reingestedSessions: 0,
+    appendedContent: 0,
+    failed: 0,
+  };
+  await reingestClaudeContent(existing, report);
+  await reingestCodexContent(existing, report);
+  await reingestOpencodeContent(existing, report);
+  return report;
+}
+
+async function reingestClaudeContent(
+  existing: Set<string>,
+  report: ReingestContentReport,
+): Promise<void> {
+  const projects = await listDirs(CLAUDE_PROJECTS);
+  for (const projectDir of projects) {
+    const files = await listJsonlFiles(projectDir);
+    for (const file of files) {
+      report.scannedFiles++;
+      const sessionId = path.basename(file, '.jsonl');
+      if (existing.has(sessionId)) {
+        report.skippedExisting++;
+        continue;
+      }
+      try {
+        const { content } = await parseClaudeSessionIncremental(file, {
+          startOffset: 0,
+          sessionPath: file,
+          contentMode: 'full',
+        });
+        const filtered = content.filter((c) => !existing.has(c.sessionId));
+        if (filtered.length > 0) {
+          await appendContent(filtered);
+          report.appendedContent += filtered.length;
+          report.reingestedSessions++;
+          for (const c of filtered) existing.add(c.sessionId);
+        }
+      } catch (err) {
+        report.failed++;
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[burn] reingest skipped ${file}: ${msg}\n`);
+      }
+    }
+  }
+}
+
+async function reingestCodexContent(
+  existing: Set<string>,
+  report: ReingestContentReport,
+): Promise<void> {
+  for (const file of await walkJsonl(CODEX_SESSIONS)) {
+    report.scannedFiles++;
+    const derived = deriveCodexSessionId(file);
+    if (derived && existing.has(derived)) {
+      report.skippedExisting++;
+      continue;
+    }
+    try {
+      const { content } = await parseCodexSessionIncremental(file, {
+        startOffset: 0,
+        sessionPath: file,
+        contentMode: 'full',
+      });
+      const filtered = content.filter((c) => !existing.has(c.sessionId));
+      if (filtered.length > 0) {
+        await appendContent(filtered);
+        report.appendedContent += filtered.length;
+        report.reingestedSessions++;
+        for (const c of filtered) existing.add(c.sessionId);
+      }
+    } catch (err) {
+      report.failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[burn] reingest skipped ${file}: ${msg}\n`);
+    }
+  }
+}
+
+async function reingestOpencodeContent(
+  existing: Set<string>,
+  report: ReingestContentReport,
+): Promise<void> {
+  for (const file of await walkOpencodeSessions(OPENCODE_SESSION_ROOT)) {
+    report.scannedFiles++;
+    const sessionId = path.basename(file, '.json');
+    if (existing.has(sessionId)) {
+      report.skippedExisting++;
+      continue;
+    }
+    try {
+      const { content } = await parseOpencodeSessionIncremental(file, {
+        sessionPath: file,
+        seenMessageIds: new Set<string>(),
+        contentMode: 'full',
+      });
+      const filtered = content.filter((c) => !existing.has(c.sessionId));
+      if (filtered.length > 0) {
+        await appendContent(filtered);
+        report.appendedContent += filtered.length;
+        report.reingestedSessions++;
+        for (const c of filtered) existing.add(c.sessionId);
+      }
+    } catch (err) {
+      report.failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[burn] reingest skipped ${file}: ${msg}\n`);
+    }
+  }
+}
+
+// Codex filenames are `rollout-<timestamp>-<uuid>.jsonl` where the UUID is the
+// session id. Extract it for a cheap skip check before parsing. If the pattern
+// doesn't match, return null and fall back to post-filtering.
+function deriveCodexSessionId(file: string): string | null {
+  const base = path.basename(file, '.jsonl');
+  const m = base.match(
+    /([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/,
+  );
+  return m ? m[1]! : null;
 }
 
 async function listDirs(parent: string): Promise<string[]> {

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `listContentSessionIds()` — enumerate sessionIds that have a non-empty content sidecar on disk. Used by `burn rebuild --content` to skip sessions whose content is already populated.
+
 ## [0.6.0] - 2026-04-24
 
 ### Added

--- a/packages/ledger/src/content.ts
+++ b/packages/ledger/src/content.ts
@@ -144,6 +144,32 @@ export async function pruneContent(options: PruneOptions): Promise<PruneResult> 
   return { filesDeleted, bytesFreed };
 }
 
+export async function listContentSessionIds(): Promise<Set<string>> {
+  const dir = contentDir();
+  const out = new Set<string>();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return out;
+    throw err;
+  }
+  for (const name of entries) {
+    if (!name.endsWith('.jsonl')) continue;
+    const sessionId = name.slice(0, -'.jsonl'.length);
+    if (!isValidSessionId(sessionId)) continue;
+    // An empty sidecar signals "attempted but nothing written" and should be
+    // re-parsed rather than treated as already-populated.
+    try {
+      const st = await stat(path.join(dir, name));
+      if (st.size > 0) out.add(sessionId);
+    } catch {
+      // raced with deletion; ignore
+    }
+  }
+  return out;
+}
+
 // Test helper: set the mtime/atime on a session's content file.
 export async function __setContentFileMtimeForTesting(
   sessionId: string,

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -15,7 +15,12 @@ export {
   contentFilePath,
   isValidSessionId,
 } from './paths.js';
-export { appendContent, readContent, pruneContent } from './content.js';
+export {
+  appendContent,
+  listContentSessionIds,
+  pruneContent,
+  readContent,
+} from './content.js';
 export type { PruneOptions, PruneResult, ReadContentSelector } from './content.js';
 export { loadConfig, retentionMs, DEFAULT_CONFIG } from './config.js';
 export type { BurnConfig, ContentConfig } from './config.js';

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Content capture for Codex and OpenCode parsers** (#33 follow-up). Both parsers now emit `ContentRecord` entries when `contentMode === 'full'`, matching the shape the Claude parser already produced. Covers `text` (user/assistant), `thinking` (codex reasoning), `tool_use`, and — most importantly for `burn waste` attribution — `tool_result` keyed by the same `call_id` / `callID` the tool call carries. In codex, content only emits for turns that commit at `task_complete`; uncommitted content is dropped and will be re-emitted once the turn commits. Removes the `TODO(#33-followup)` markers in `codex.ts` and `opencode.ts`.
+
 ## [0.6.0] - 2026-04-24
 
 ### Added

--- a/packages/reader/src/codex.test.ts
+++ b/packages/reader/src/codex.test.ts
@@ -351,3 +351,199 @@ describe('parseCodexSessionIncremental', () => {
     }
   });
 });
+
+describe('parseCodexSession content capture', () => {
+  async function withFixture<T>(body: (file: string) => Promise<T>): Promise<T> {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-codex-content-'));
+    try {
+      const file = path.join(tmp, 'session.jsonl');
+      const lines = [
+        {
+          timestamp: '2026-04-20T01:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'sess_content_1', cwd: '/tmp/project', timestamp: '2026-04-20T01:00:00.000Z' },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.050Z',
+          type: 'turn_context',
+          payload: { turn_id: 'turn_content_1', cwd: '/tmp/project', model: 'gpt-5.3-codex' },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.100Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'list files' }],
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.200Z',
+          type: 'event_msg',
+          payload: { type: 'task_started', turn_id: 'turn_content_1' },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.300Z',
+          type: 'response_item',
+          payload: {
+            type: 'reasoning',
+            summary: [{ type: 'summary_text', text: 'planning the ls' }],
+            content: null,
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.400Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'shell',
+            arguments: '{"cmd":"ls"}',
+            call_id: 'call_fc_1',
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.500Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call_output',
+            call_id: 'call_fc_1',
+            output: 'README.md\npackage.json\n',
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.600Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'apply_patch',
+            input: '*** Begin Patch\n*** Add File: /tmp/project/X\n',
+            call_id: 'call_ct_1',
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.700Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_ct_1',
+            output: '{"success":true}',
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.800Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'done.' }],
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.900Z',
+          type: 'event_msg',
+          payload: {
+            type: 'token_count',
+            info: { total_token_usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 20, reasoning_output_tokens: 10 } },
+          },
+        },
+        {
+          timestamp: '2026-04-20T01:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_complete', turn_id: 'turn_content_1' },
+        },
+      ];
+      await writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+      return await body(file);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }
+
+  it('returns empty content when contentMode is off (default)', async () => {
+    await withFixture(async (file) => {
+      const { content } = await parseCodexSession(file);
+      assert.deepEqual(content, []);
+    });
+  });
+
+  it('returns empty content when contentMode is hash-only', async () => {
+    await withFixture(async (file) => {
+      const { content } = await parseCodexSession(file, { contentMode: 'hash-only' });
+      assert.deepEqual(content, []);
+    });
+  });
+
+  it('emits tool_result for function_call_output with matching toolUseId', async () => {
+    await withFixture(async (file) => {
+      const { turns, content } = await parseCodexSession(file, { contentMode: 'full' });
+      assert.equal(turns.length, 1);
+      const tr = content.find((c) => c.kind === 'tool_result' && c.toolResult?.toolUseId === 'call_fc_1');
+      assert.ok(tr, 'tool_result for function_call_output is emitted');
+      assert.equal(tr!.source, 'codex');
+      assert.equal(tr!.toolResult!.content, 'README.md\npackage.json\n');
+      const toolIds = new Set(turns[0]!.toolCalls.map((tc) => tc.id));
+      assert.ok(toolIds.has('call_fc_1'), 'attributor can join tool_result to a toolCall');
+    });
+  });
+
+  it('emits tool_result for custom_tool_call_output', async () => {
+    await withFixture(async (file) => {
+      const { content } = await parseCodexSession(file, { contentMode: 'full' });
+      const tr = content.find((c) => c.kind === 'tool_result' && c.toolResult?.toolUseId === 'call_ct_1');
+      assert.ok(tr);
+      assert.equal(tr!.toolResult!.content, '{"success":true}');
+    });
+  });
+
+  it('captures user/assistant text, reasoning, and tool_use blocks', async () => {
+    await withFixture(async (file) => {
+      const { content } = await parseCodexSession(file, { contentMode: 'full' });
+      const user = content.find((c) => c.role === 'user' && c.kind === 'text');
+      assert.equal(user!.text, 'list files');
+      assert.equal(user!.messageId, 'turn_content_1', 'pre-turn user content re-anchors to the turn it opens');
+      const asst = content.find((c) => c.role === 'assistant' && c.kind === 'text');
+      assert.equal(asst!.text, 'done.');
+      const thinking = content.find((c) => c.kind === 'thinking');
+      assert.equal(thinking!.text, 'planning the ls');
+      const toolUses = content.filter((c) => c.kind === 'tool_use');
+      assert.equal(toolUses.length, 2);
+      assert.deepEqual(
+        toolUses.map((t) => t.toolUse!.name).sort(),
+        ['apply_patch', 'shell'],
+      );
+    });
+  });
+
+  it('drops content when the enclosing turn never commits', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-codex-uncommitted-'));
+    try {
+      const file = path.join(tmp, 'session.jsonl');
+      const lines = [
+        { timestamp: '2026-04-20T01:00:00.000Z', type: 'session_meta', payload: { id: 'sess_u', cwd: '/tmp', timestamp: '2026-04-20T01:00:00.000Z' } },
+        { timestamp: '2026-04-20T01:00:00.050Z', type: 'turn_context', payload: { turn_id: 'turn_u', cwd: '/tmp', model: 'gpt-5.4' } },
+        { timestamp: '2026-04-20T01:00:00.200Z', type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn_u' } },
+        {
+          timestamp: '2026-04-20T01:00:00.400Z',
+          type: 'response_item',
+          payload: { type: 'function_call', name: 'shell', arguments: '{"cmd":"ls"}', call_id: 'call_u_1' },
+        },
+        {
+          timestamp: '2026-04-20T01:00:00.500Z',
+          type: 'response_item',
+          payload: { type: 'function_call_output', call_id: 'call_u_1', output: 'should-be-dropped' },
+        },
+        // no task_complete — turn is still open
+      ];
+      await writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+      const { turns, content } = await parseCodexSession(file, { contentMode: 'full' });
+      assert.equal(turns.length, 0);
+      assert.equal(content.length, 0, 'uncommitted content is not emitted');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/reader/src/codex.ts
+++ b/packages/reader/src/codex.ts
@@ -108,6 +108,24 @@ interface MessagePayload {
   content?: Array<{ type?: string; text?: string }>;
 }
 
+interface ReasoningPayload {
+  type: 'reasoning';
+  summary?: Array<{ type?: string; text?: string }>;
+  content?: Array<{ type?: string; text?: string }> | null;
+}
+
+interface FunctionCallOutputPayload {
+  type: 'function_call_output';
+  call_id?: string;
+  output?: unknown;
+}
+
+interface CustomToolCallOutputPayload {
+  type: 'custom_tool_call_output';
+  call_id?: string;
+  output?: unknown;
+}
+
 interface CumulativeUsage {
   input: number;
   output: number;
@@ -127,6 +145,9 @@ interface OpenTurn {
   userText: string;
   assistantText: string;
   erroredCallIds: Set<string>;
+  // Captured only when contentMode === 'full'. Emitted alongside the turn
+  // once task_complete commits it; dropped if the turn never commits.
+  content: ContentRecord[];
 }
 
 interface FinalizedTurn
@@ -181,6 +202,8 @@ export async function parseCodexSessionIncremental(
     await handle.close();
   }
 
+  const captureContent = options.contentMode === 'full';
+
   let sessionId = options.resume?.sessionId ?? '';
   let sessionCwd: string | undefined = options.resume?.sessionCwd;
   const turnContexts = new Map<string, TurnContextPayload>();
@@ -195,6 +218,10 @@ export async function parseCodexSessionIncremental(
   };
   let openTurn: OpenTurn | null = null;
   let pendingUserText = '';
+  // User content (and any stray records) that arrive before the next
+  // task_started. Attached to the turn on open, so they only flush if the
+  // turn itself eventually commits.
+  let pendingContent: ContentRecord[] = [];
   const finalized: FinalizedTurn[] = [];
 
   // Commit snapshot — only advanced at task_complete boundaries.
@@ -288,8 +315,17 @@ export async function parseCodexSessionIncremental(
           userText: pendingUserText,
           assistantText: '',
           erroredCallIds: new Set(),
+          content: [],
         };
         pendingUserText = '';
+        if (captureContent && pendingContent.length > 0) {
+          // Re-stamp pre-turn content with this turn's id so sidecar records
+          // group under the turn that absorbed them, matching how
+          // `pendingUserText` folds into `openTurn.userText`.
+          for (const c of pendingContent) c.messageId = turnId;
+          openTurn.content.push(...pendingContent);
+          pendingContent = [];
+        }
         if (project !== undefined) openTurn.project = project;
         continue;
       }
@@ -335,6 +371,7 @@ export async function parseCodexSessionIncremental(
     }
 
     if (rec.type === 'response_item') {
+      const itemTs = rec.timestamp ?? '';
       if (pl.type === 'message') {
         const msg = payload as MessagePayload;
         const text = collectMessageText(msg);
@@ -344,9 +381,70 @@ export async function parseCodexSessionIncremental(
           // next task_started picks them up as that turn's prompt text.
           if (openTurn) openTurn.userText = appendText(openTurn.userText, text);
           else pendingUserText = appendText(pendingUserText, text);
+          if (captureContent) {
+            pushContent(openTurn, pendingContent, {
+              v: 1,
+              source: 'codex',
+              sessionId,
+              messageId: openTurn?.turnId ?? '',
+              ts: itemTs,
+              role: 'user',
+              kind: 'text',
+              text,
+            });
+          }
         } else if (msg.role === 'assistant' && openTurn) {
           openTurn.assistantText = appendText(openTurn.assistantText, text);
+          if (captureContent) {
+            openTurn.content.push({
+              v: 1,
+              source: 'codex',
+              sessionId,
+              messageId: openTurn.turnId,
+              ts: itemTs,
+              role: 'assistant',
+              kind: 'text',
+              text,
+            });
+          }
         }
+        continue;
+      }
+      if (pl.type === 'reasoning' && openTurn && captureContent) {
+        const rp = payload as ReasoningPayload;
+        const text = collectReasoningText(rp);
+        if (text.length > 0) {
+          openTurn.content.push({
+            v: 1,
+            source: 'codex',
+            sessionId,
+            messageId: openTurn.turnId,
+            ts: itemTs,
+            role: 'assistant',
+            kind: 'thinking',
+            text,
+          });
+        }
+        continue;
+      }
+      if (pl.type === 'function_call_output' || pl.type === 'custom_tool_call_output') {
+        // Tool outputs can appear outside an open turn if codex streams them
+        // after task_complete. Attribution only requires the call_id linkage,
+        // which is preserved either way; we attach to the open turn when we
+        // have one, or buffer as pre-turn content otherwise.
+        if (!captureContent) continue;
+        const out = payload as FunctionCallOutputPayload | CustomToolCallOutputPayload;
+        if (typeof out.call_id !== 'string') continue;
+        pushContent(openTurn, pendingContent, {
+          v: 1,
+          source: 'codex',
+          sessionId,
+          messageId: openTurn?.turnId ?? '',
+          ts: itemTs,
+          role: 'tool_result',
+          kind: 'tool_result',
+          toolResult: { toolUseId: out.call_id, content: out.output ?? '' },
+        });
         continue;
       }
       if (!openTurn) continue;
@@ -364,6 +462,18 @@ export async function parseCodexSessionIncremental(
         const target = pickFunctionCallTarget(fc.name, parsedArgs);
         if (target !== undefined) call.target = target;
         openTurn.toolCalls.push(call);
+        if (captureContent) {
+          openTurn.content.push({
+            v: 1,
+            source: 'codex',
+            sessionId,
+            messageId: openTurn.turnId,
+            ts: itemTs,
+            role: 'assistant',
+            kind: 'tool_use',
+            toolUse: { id: fc.call_id, name: fc.name, input: parsedArgs ?? {} },
+          });
+        }
       } else if (pl.type === 'custom_tool_call') {
         const ct = payload as CustomToolCallPayload;
         if (typeof ct.name !== 'string' || typeof ct.call_id !== 'string') continue;
@@ -378,6 +488,18 @@ export async function parseCodexSessionIncremental(
         const target = pickCustomToolTarget(ct.name, input);
         if (target !== undefined) call.target = target;
         openTurn.toolCalls.push(call);
+        if (captureContent) {
+          openTurn.content.push({
+            v: 1,
+            source: 'codex',
+            sessionId,
+            messageId: openTurn.turnId,
+            ts: itemTs,
+            role: 'assistant',
+            kind: 'tool_use',
+            toolUse: { id: ct.call_id, name: ct.name, input: { input } },
+          });
+        }
       }
     }
   }
@@ -385,6 +507,7 @@ export async function parseCodexSessionIncremental(
   // Only emit turns committed up to the last task_complete boundary.
   const committed = finalized.slice(0, committedFinalizedCount);
   const turns: TurnRecord[] = [];
+  const content: ContentRecord[] = [];
   for (let i = 0; i < committed.length; i++) {
     const f = committed[i]!;
     const record: TurnRecord = {
@@ -417,6 +540,7 @@ export async function parseCodexSessionIncremental(
     record.retries = classified.retries;
     record.hasEdits = classified.hasEdits;
     turns.push(record);
+    if (captureContent) content.push(...f.content);
   }
 
   const resume: CodexResumeState = {
@@ -426,10 +550,31 @@ export async function parseCodexSessionIncremental(
   };
   if (committedSessionCwd !== undefined) resume.sessionCwd = committedSessionCwd;
 
-  // TODO(#33-followup): content capture for Codex sessions. The incremental
-  // result preserves the { turns, content } shape so that wiring the reader
-  // output into appendContent is a no-op when full content arrives.
-  return { turns, content: [], endOffset: committedEndOffset, resume };
+  return { turns, content, endOffset: committedEndOffset, resume };
+}
+
+function pushContent(
+  openTurn: OpenTurn | null,
+  pending: ContentRecord[],
+  record: ContentRecord,
+): void {
+  if (openTurn) openTurn.content.push(record);
+  else pending.push(record);
+}
+
+function collectReasoningText(rp: ReasoningPayload): string {
+  const parts: string[] = [];
+  if (Array.isArray(rp.summary)) {
+    for (const s of rp.summary) {
+      if (s && typeof s.text === 'string' && s.text.length > 0) parts.push(s.text);
+    }
+  }
+  if (Array.isArray(rp.content)) {
+    for (const c of rp.content) {
+      if (c && typeof c.text === 'string' && c.text.length > 0) parts.push(c.text);
+    }
+  }
+  return parts.join('\n');
 }
 
 function cloneResume(r: CodexResumeState | undefined): CodexResumeState {
@@ -468,6 +613,7 @@ function finalizeTurn(open: OpenTurn, cumulative: CumulativeUsage): FinalizedTur
     userText: open.userText,
     assistantText: open.assistantText,
     erroredCallIds: open.erroredCallIds,
+    content: open.content,
   };
   if (open.project !== undefined) out.project = open.project;
   return out;

--- a/packages/reader/src/opencode.test.ts
+++ b/packages/reader/src/opencode.test.ts
@@ -225,3 +225,161 @@ describe('parseOpencodeSessionIncremental', () => {
     assert.equal(r.turns.length, 0);
   });
 });
+
+describe('parseOpencodeSession content capture', () => {
+  async function withFixture<T>(body: (file: string) => Promise<T>): Promise<T> {
+    const { mkdtemp, mkdir, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-oc-content-'));
+    try {
+      const storage = path.join(tmp, 'storage');
+      const sessionDir = path.join(storage, 'session', 'global');
+      const msgDir = path.join(storage, 'message', 'ses_content');
+      const partAsstDir = path.join(storage, 'part', 'msg_content_asst');
+      const partUserDir = path.join(storage, 'part', 'msg_content_user');
+      await mkdir(sessionDir, { recursive: true });
+      await mkdir(msgDir, { recursive: true });
+      await mkdir(partAsstDir, { recursive: true });
+      await mkdir(partUserDir, { recursive: true });
+      await writeFile(
+        path.join(sessionDir, 'ses_content.json'),
+        JSON.stringify({ id: 'ses_content', directory: '/tmp/proj' }),
+      );
+      await writeFile(
+        path.join(msgDir, 'msg_content_user.json'),
+        JSON.stringify({
+          id: 'msg_content_user',
+          sessionID: 'ses_content',
+          role: 'user',
+          time: { created: 1_776_988_000_000 },
+        }),
+      );
+      await writeFile(
+        path.join(partUserDir, 'prt_user_a.json'),
+        JSON.stringify({
+          id: 'prt_user_a',
+          sessionID: 'ses_content',
+          messageID: 'msg_content_user',
+          type: 'text',
+          text: 'run tests',
+        }),
+      );
+      // Synthetic user prompts (agent-mode nudges) must not appear in content.
+      await writeFile(
+        path.join(partUserDir, 'prt_user_b.json'),
+        JSON.stringify({
+          id: 'prt_user_b',
+          sessionID: 'ses_content',
+          messageID: 'msg_content_user',
+          type: 'text',
+          text: '<synthetic nudge>',
+          synthetic: true,
+        }),
+      );
+      await writeFile(
+        path.join(msgDir, 'msg_content_asst.json'),
+        JSON.stringify({
+          id: 'msg_content_asst',
+          sessionID: 'ses_content',
+          role: 'assistant',
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4-6',
+          time: { created: 1_776_988_001_000 },
+          path: { cwd: '/tmp/proj' },
+          tokens: { input: 100, output: 20, cache: { read: 0, write: 0 } },
+        }),
+      );
+      await writeFile(
+        path.join(partAsstDir, 'prt_asst_a.json'),
+        JSON.stringify({
+          id: 'prt_asst_a',
+          sessionID: 'ses_content',
+          messageID: 'msg_content_asst',
+          type: 'text',
+          text: 'running now.',
+        }),
+      );
+      await writeFile(
+        path.join(partAsstDir, 'prt_asst_b.json'),
+        JSON.stringify({
+          id: 'prt_asst_b',
+          sessionID: 'ses_content',
+          messageID: 'msg_content_asst',
+          type: 'tool',
+          callID: 'call_oc_bash',
+          tool: 'bash',
+          state: {
+            status: 'completed',
+            input: { command: 'npm test' },
+            output: '10 passed',
+            metadata: { exit: 0 },
+          },
+        }),
+      );
+      await writeFile(
+        path.join(partAsstDir, 'prt_asst_c.json'),
+        JSON.stringify({
+          id: 'prt_asst_c',
+          sessionID: 'ses_content',
+          messageID: 'msg_content_asst',
+          type: 'tool',
+          callID: 'call_oc_fail',
+          tool: 'bash',
+          state: {
+            status: 'completed',
+            input: { command: 'lint' },
+            output: 'ERR',
+            metadata: { exit: 2 },
+          },
+        }),
+      );
+      const file = path.join(sessionDir, 'ses_content.json');
+      return await body(file);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }
+
+  it('returns empty content when contentMode is off (default)', async () => {
+    await withFixture(async (file) => {
+      const { content } = await parseOpencodeSession(file);
+      assert.deepEqual(content, []);
+    });
+  });
+
+  it('returns empty content when contentMode is hash-only', async () => {
+    await withFixture(async (file) => {
+      const { content } = await parseOpencodeSession(file, { contentMode: 'hash-only' });
+      assert.deepEqual(content, []);
+    });
+  });
+
+  it('emits tool_result for each tool part, keyed by callID', async () => {
+    await withFixture(async (file) => {
+      const { turns, content } = await parseOpencodeSession(file, { contentMode: 'full' });
+      assert.equal(turns.length, 1);
+      const toolResults = content.filter((c) => c.kind === 'tool_result');
+      assert.equal(toolResults.length, 2);
+      const byId = new Map(toolResults.map((t) => [t.toolResult!.toolUseId, t]));
+      assert.equal(byId.get('call_oc_bash')!.toolResult!.content, '10 passed');
+      assert.equal(byId.get('call_oc_fail')!.toolResult!.content, 'ERR');
+      assert.equal(byId.get('call_oc_fail')!.toolResult!.isError, true, 'exit!=0 flags isError');
+      assert.equal(byId.get('call_oc_bash')!.toolResult!.isError, undefined);
+      const turnToolIds = new Set(turns[0]!.toolCalls.map((tc) => tc.id));
+      assert.ok(turnToolIds.has('call_oc_bash'));
+      assert.ok(turnToolIds.has('call_oc_fail'));
+    });
+  });
+
+  it('captures user text (skipping synthetic) and assistant text + tool_use', async () => {
+    await withFixture(async (file) => {
+      const { content } = await parseOpencodeSession(file, { contentMode: 'full' });
+      const userTexts = content.filter((c) => c.role === 'user' && c.kind === 'text').map((c) => c.text);
+      assert.deepEqual(userTexts, ['run tests']);
+      const asstText = content.find((c) => c.role === 'assistant' && c.kind === 'text');
+      assert.equal(asstText!.text, 'running now.');
+      const toolUses = content.filter((c) => c.kind === 'tool_use');
+      assert.equal(toolUses.length, 2);
+    });
+  });
+});

--- a/packages/reader/src/opencode.ts
+++ b/packages/reader/src/opencode.ts
@@ -53,6 +53,10 @@ interface ToolPart {
     input?: Record<string, unknown>;
     status?: string;
     metadata?: { exit?: number; [k: string]: unknown };
+    // Tool output, written by opencode once the tool completes. Typically a
+    // string but can be structured for some tools; we pass it through to the
+    // sidecar unchanged and let downstream stringify as needed.
+    output?: unknown;
     [k: string]: unknown;
   };
 }
@@ -121,9 +125,11 @@ export async function parseOpencodeSessionIncremental(
   assistants.sort((a, b) => a.time.created - b.time.created);
   users.sort((a, b) => a.time.created - b.time.created);
 
+  const captureContent = options.contentMode === 'full';
   const isSidechain = typeof session.parentID === 'string' && session.parentID.length > 0;
   const seen = new Set<string>(options.seenMessageIds ?? []);
   const turns: TurnRecord[] = [];
+  const content: ContentRecord[] = [];
 
   for (let i = 0; i < assistants.length; i++) {
     const m = assistants[i]!;
@@ -177,12 +183,106 @@ export async function parseOpencodeSessionIncremental(
 
     turns.push(record);
     seen.add(m.id);
+
+    if (captureContent) {
+      const assistantTs = new Date(m.time.created).toISOString();
+      if (userMessage) {
+        const userTs = new Date(userMessage.time.created).toISOString();
+        for (const t of await readUserTextParts(storageRoot, userMessage.id)) {
+          content.push({
+            v: 1,
+            source: 'opencode',
+            sessionId: m.sessionID,
+            messageId: userMessage.id,
+            ts: userTs,
+            role: 'user',
+            kind: 'text',
+            text: t,
+          });
+        }
+      }
+      for (const rec of extractAssistantContent(parts, m.sessionID, m.id, assistantTs)) {
+        content.push(rec);
+      }
+    }
   }
 
-  // TODO(#33-followup): content capture for OpenCode sessions. The result
-  // shape carries a `content` array so appendContent wiring in the CLI stays
-  // a no-op once capture lands.
-  return { turns, content: [], seenMessageIds: seen };
+  return { turns, content, seenMessageIds: seen };
+}
+
+function extractAssistantContent(
+  parts: Part[],
+  sessionId: string,
+  messageId: string,
+  ts: string,
+): ContentRecord[] {
+  const out: ContentRecord[] = [];
+  for (const p of parts) {
+    if (p.type === 'text') {
+      const tp = p as TextPart;
+      if (tp.synthetic === true) continue;
+      if (typeof tp.text === 'string' && tp.text.length > 0) {
+        out.push({
+          v: 1,
+          source: 'opencode',
+          sessionId,
+          messageId,
+          ts,
+          role: 'assistant',
+          kind: 'text',
+          text: tp.text,
+        });
+      }
+      continue;
+    }
+    if (p.type === 'tool') {
+      const tp = p as ToolPart;
+      if (typeof tp.callID !== 'string' || typeof tp.tool !== 'string') continue;
+      const input = tp.state?.input ?? {};
+      out.push({
+        v: 1,
+        source: 'opencode',
+        sessionId,
+        messageId,
+        ts,
+        role: 'assistant',
+        kind: 'tool_use',
+        toolUse: { id: tp.callID, name: tp.tool, input },
+      });
+      const state = tp.state;
+      if (state && Object.prototype.hasOwnProperty.call(state, 'output')) {
+        const result: ContentRecord = {
+          v: 1,
+          source: 'opencode',
+          sessionId,
+          messageId,
+          ts,
+          role: 'tool_result',
+          kind: 'tool_result',
+          toolResult: { toolUseId: tp.callID, content: state.output ?? '' },
+        };
+        if (state.status === 'error') result.toolResult!.isError = true;
+        else {
+          const exit = state.metadata?.exit;
+          if (typeof exit === 'number' && exit !== 0) result.toolResult!.isError = true;
+        }
+        out.push(result);
+      }
+    }
+  }
+  return out;
+}
+
+async function readUserTextParts(storageRoot: string, userMessageId: string): Promise<string[]> {
+  const parts = await readParts(storageRoot, userMessageId);
+  const out: string[] = [];
+  for (const p of parts) {
+    if (p.type !== 'text') continue;
+    const tp = p as TextPart;
+    if (tp.synthetic === true) continue;
+    if (typeof tp.text === 'string' && tp.text.length > 0) out.push(tp.text);
+  }
+  return out;
 }
 
 async function readSession(sessionFilePath: string): Promise<SessionInfo | null> {


### PR DESCRIPTION
## Summary

- Codex and OpenCode parsers now emit `ContentRecord` entries when `contentMode === 'full'` — matching the Claude parser's shape. Removes the `TODO(#33-followup)` markers in both files.
- The critical record for `burn waste` is `tool_result`, keyed by `call_id` (codex) / `callID` (opencode). This lets the waste attributor switch those sessions from even-split to sized.
- Ships `burn rebuild --content`: re-parses source files to backfill missing sidecars. Safe to rerun — skips sessions whose sidecar is already present, and touches neither cursors nor existing ledger rows.

## Impact on a real local ledger

Before: `note: 39486/39587 sessions used even-split (no content sidecar).`
After running the new `burn rebuild --content`: `note: 27536/39588 sessions used even-split.` — 12,000 historical sessions flipped from even-split to sized. The remaining even-splits are mostly codex sessions that never hit a `task_complete` (no committed turns to attach content to) and any opencode sessions without tool outputs.

Attributed total went from $645.94 → $451.14 because sized mode stops over-attributing non-tool-result context that even-split bakes into initial cost. More precise, lower absolute number — expected.

## Design notes

- **Codex commit semantics preserved.** Content for an open turn accumulates on the `OpenTurn` object and only flushes to the output array when the turn commits at `task_complete`. Uncommitted content is dropped; on resume from the cursor, the same lines re-parse and re-emit once the enclosing turn commits. Mirrors how `finalized` turns already worked.
- **Codex pre-turn user messages.** When a user message arrives before `task_started` (codex pattern), it's buffered into `pendingContent` and re-stamped with the new turn's id on open, mirroring the existing `pendingUserText` behavior.
- **Codex reasoning.** Text is collected from `reasoning.summary[*].text` and `reasoning.content[*].text`. In practice most reasoning items are `encrypted_content` with empty summaries — we emit nothing and that's fine.
- **OpenCode tool_result.** Emitted only when the tool part's `state` actually has an `output` key (some tools are in-progress and have no output yet). `isError` is set when `state.status === 'error'` or `state.metadata.exit !== 0`, matching `isFailedTool` logic used for turn classification.
- **OpenCode synthetic user prompts** (agent-mode nudges with `synthetic: true`) are skipped in content, same as they're skipped in text extraction for classification.

## Test plan

- [x] 10 new tests added (5 codex content capture + 4 opencode content capture + uncommitted-turn-drops-content); 251 total pass
- [x] Built clean (`pnpm -r build`)
- [x] End-to-end: ran `burn rebuild --content` against a local ~40k-session ledger; 30,358 sessions reingested, 332,089 records appended, 0 failed, run took 100s.
- [x] Ran `burn waste` before/after; confirmed even-split count dropped by ~12,000 sessions and sized attribution numbers look sensible (lower than even-split, as expected — sized excludes non-tool-result context from attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
