### PR TITLE
Add 'burn limits' Claude quota tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -408,12 +408,108 @@ jobs:
             node /tmp/gen-changelog.mjs "$pkg" "$version" "$TODAY"
           done
 
+      # Root CHANGELOG.md gets the same Unreleased→[x.y.z] promotion the
+      # per-package files just got, but driven by the highest version bumped
+      # in this release (packages move in lockstep today; using max also
+      # handles future drift). No git-log fallback — the root file is a
+      # hand-curated cross-package narrative, so an empty [Unreleased] means
+      # "no narrative-worthy changes this release" and we leave the file
+      # alone rather than inventing bullets.
+      - name: Generate root changelog
+        if: ${{ github.event.inputs.version != 'none' || github.event.inputs.custom_version != '' }}
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          cat > /tmp/gen-root-changelog.mjs << 'GENEOF'
+          import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+          const [,, versionsRaw, today] = process.argv;
+          const path = 'CHANGELOG.md';
+
+          const entries = versionsRaw.trim().split(/\s+/).filter(Boolean).map((e) => {
+            const [pkg, ver] = e.split(':');
+            return { pkg, ver };
+          });
+          if (entries.length === 0) {
+            console.log('root changelog: no versions bumped, skipping');
+            process.exit(0);
+          }
+          if (entries.some((e) => e.ver.includes('-'))) {
+            console.log('root changelog: prerelease bump, skipping');
+            process.exit(0);
+          }
+
+          // Pick the highest version across packages bumped in this release.
+          const cmp = (a, b) => {
+            const pa = a.split('.').map(Number);
+            const pb = b.split('.').map(Number);
+            for (let i = 0; i < 3; i++) {
+              const da = pa[i] || 0;
+              const db = pb[i] || 0;
+              if (da !== db) return da - db;
+            }
+            return 0;
+          };
+          const newVersion = entries.map((e) => e.ver).sort(cmp).slice(-1)[0];
+
+          if (!existsSync(path)) {
+            console.log(`root changelog: ${path} not found, skipping`);
+            process.exit(0);
+          }
+          const existing = readFileSync(path, 'utf-8');
+          if (existing.includes(`## [${newVersion}]`)) {
+            console.log(`root changelog: already has ${newVersion}, skipping`);
+            process.exit(0);
+          }
+
+          // Same slicer as the per-package generator: header → body → next ##.
+          function splitAtUnreleased(raw) {
+            const headerRe = /^## \[Unreleased\][^\n]*\n/m;
+            const headerMatch = raw.match(headerRe);
+            if (!headerMatch) return null;
+            const headerStart = headerMatch.index;
+            const afterHeader = headerStart + headerMatch[0].length;
+            const tail = raw.slice(afterHeader);
+            const nextMatch = tail.match(/^## \[/m);
+            const bodyEnd = nextMatch ? afterHeader + nextMatch.index : raw.length;
+            return {
+              before: raw.slice(0, headerStart),
+              headerLine: headerMatch[0],
+              body: raw.slice(afterHeader, bodyEnd),
+              after: raw.slice(bodyEnd),
+            };
+          }
+
+          const parts = splitAtUnreleased(existing);
+          if (!parts) {
+            console.log('root changelog: no [Unreleased] header, skipping');
+            process.exit(0);
+          }
+          const body = parts.body.trim();
+          if (body.length === 0) {
+            console.log(`root changelog: [Unreleased] is empty, skipping ${newVersion} stamp`);
+            process.exit(0);
+          }
+
+          const newEntry = `## [${newVersion}] - ${today}\n\n${body}\n`;
+          const rebuilt =
+            parts.before +
+            parts.headerLine +
+            '\n' +
+            newEntry +
+            (parts.after.startsWith('\n') ? '' : '\n') +
+            parts.after;
+          writeFileSync(path, rebuilt);
+          console.log(`root changelog: promoted [Unreleased] into ${newVersion}`);
+          GENEOF
+
+          node /tmp/gen-root-changelog.mjs "${{ steps.bump.outputs.versions }}" "$TODAY"
+
       - name: Commit version bumps
         if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.version != 'none' || github.event.inputs.custom_version != '') }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packages/*/package.json packages/*/CHANGELOG.md
+          git add packages/*/package.json packages/*/CHANGELOG.md CHANGELOG.md
           if git diff --cached --quiet; then
             echo "No version changes to commit."
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The root `CHANGELOG.md` is the cross-package narrative. Packages release in lock
 
 The publish workflow promotes the root `[Unreleased]` block the same way it does per-package files: at release time it stamps `## [x.y.z] - DATE` (using `max` of the versions bumped in the run) and resets `[Unreleased]` to empty. **No git-log fallback for the root file** — an empty `[Unreleased]` at release time means "no narrative-worthy changes this release" and the file is left alone. So if you want the root to record a release, write the bullet under `[Unreleased]` *before* the publish run.
 
-**Fallback — git-log inference.** If `[Unreleased]` is empty at release time, the workflow reconstructs an entry from `git log` subjects since the last `<pkg>-v*` tag. This is only a safety net; prefer hand-curated entries. The inference buckets by leading verb:
+**Fallback — git-log inference (per-package CHANGELOGs only).** If a package's `[Unreleased]` block is empty at release time, the workflow reconstructs an entry for `packages/<pkg>/CHANGELOG.md` from `git log` subjects since the last `<pkg>-v*` tag. This is only a safety net; prefer hand-curated entries. **The root `CHANGELOG.md` does not get this fallback** — see the previous paragraph. The inference buckets by leading verb:
 
 | Subject starts with… | Lands in section |
 |---|---|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@ Tests run from `dist/` so a stale build will lie. If a test fails unexpectedly, 
 
 Curate `[Unreleased]` in the relevant per-package `packages/*/CHANGELOG.md` as you land PRs — write the entry the way you'd want it to read in a release note. At publish time, the workflow (`.github/workflows/publish.yml`) **promotes** your `[Unreleased]` block verbatim into `## [x.y.z] - DATE` and resets `[Unreleased]` to empty. No double-writing, no post-release hand-editing.
 
-The root `CHANGELOG.md` is the cross-package narrative — update it under `[Unreleased]` when the work spans packages or warrants a top-level summary.
+The root `CHANGELOG.md` is the cross-package narrative. Packages release in lockstep, so each release in the root file is a single `## [x.y.z] - YYYY-MM-DD` header that applies to all four packages — no `**Versions:** ...` lines, no per-bullet `[reader, cli]` tags. Update `[Unreleased]` only when the work spans packages or warrants a top-level summary; single-package work belongs only in that package's CHANGELOG.
+
+The publish workflow promotes the root `[Unreleased]` block the same way it does per-package files: at release time it stamps `## [x.y.z] - DATE` (using `max` of the versions bumped in the run) and resets `[Unreleased]` to empty. **No git-log fallback for the root file** — an empty `[Unreleased]` at release time means "no narrative-worthy changes this release" and the file is left alone. So if you want the root to record a release, write the bullet under `[Unreleased]` *before* the publish run.
 
 **Fallback — git-log inference.** If `[Unreleased]` is empty at release time, the workflow reconstructs an entry from `git log` subjects since the last `<pkg>-v*` tag. This is only a safety net; prefer hand-curated entries. The inference buckets by leading verb:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,130 +1,88 @@
 # Changelog
 
-All notable changes across the relayburn monorepo, rolled up across the four published packages. The per-package CHANGELOGs at `packages/*/CHANGELOG.md` remain the authoritative source for what shipped where; this file is a unified view organized by release date.
+Cross-package narrative for the relayburn monorepo. The per-package CHANGELOGs at `packages/*/CHANGELOG.md` are authoritative for exactly what shipped in each package; this file is the unified view.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the workspace adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each package versions independently — the version line under each release lists every package that bumped on that date.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the workspace adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Packages are released in lockstep, so each version below applies to all four (`reader`, `ledger`, `analyze`, `cli`).
 
 ## [Unreleased]
 
-### Added
-
-- **Hook-based Claude Code ingest.** Spawners can now install burn's ingest hooks per-invocation via Claude Code's `--settings` flag, removing any need to mutate `~/.claude/settings.json` globally. Closes [#7](https://github.com/AgentWorkforce/burn/issues/7). [cli, ledger]
-  - `@relayburn/ledger` — new `buildClaudeHookSettings({ burnBin? })` returns `{ sessionId, settings }`: a fresh UUID plus a JSON string wiring every Claude Code hook event (`PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Notification`, `Stop`, `SubagentStop`, `SessionEnd`) to `burn ingest --runtime claude --quiet`. Sits alongside `stamp` so spawners get both primitives from one package.
-  - `burn ingest --runtime claude [--quiet]` — new CLI command that reads a hook payload JSON on stdin, extracts `session_id` + `transcript_path`, and incrementally parses the transcript via the existing cursor + dedup machinery. Safe to fire on every hook event; hook failures never propagate a non-zero exit back to Claude Code.
-  - Tool-call failures ride in the regular `PostToolUse` payload (surfaced as `ToolCall.isError` on the resulting `TurnRecord`); no phantom `PostToolUseFailure` event is registered.
-- **Subagent tree as first-class primitive.** Replaces the flat `subagent.isSidechain` boolean with a proper parent→child→grandchild tree reconstructed from historical Claude JSONL alone. Answers questions like "which subagent invocation cost the most?" and "what did the Explore subagent cost us cumulatively across the week?" Closes [#8](https://github.com/AgentWorkforce/burn/issues/8). [reader, analyze, cli]
-  - `@relayburn/reader` — `TurnRecord.subagent` gains `agentId`, `parentAgentId`, `parentToolUseId`, `subagentType`, and `description`. The Claude parser walks `parentUuid` chains to locate each invocation's root user message, distinguishes spawn boundaries from tool_result continuations via `tool_use_id` matching, and memoizes per-uuid walks so deeply nested chains stay linear. `isSidechain` is kept unchanged — all existing consumers keep working.
-  - `@relayburn/analyze` — new `buildSubagentTree(turns, { pricing })` returns per-session `SubagentTreeNode` hierarchies with `selfCost` / `selfTurns` per node and `cumulativeCost` / `cumulativeTurns` rolled up from leaves. New `aggregateSubagentTypeStats(turns, { pricing })` reports per-`subagentType` invocations, total / median / p95 / mean cost across sessions (counted once per unique invocation, not per turn). New exported types: `SubagentTreeNode`, `SubagentTypeStats`, `BuildSubagentTreeOptions`.
-  - `burn summary --subagent-tree <session-id>` — renders a single session's subagent tree with rolled-up cost. `burn summary --by-subagent-type` — aggregates invocations across sessions (respects `--since` / `--project` / `--workflow` / `--agent`). Both support `--json`.
-
-## 2026-04-24 — Content capture everywhere + `burn rebuild --content`
-
-**Versions:** `@relayburn/reader@0.7.0`, `@relayburn/ledger@0.7.0`, `@relayburn/analyze@0.7.0`, `@relayburn/cli@0.7.0`
+## [0.9.0] - 2026-04-24
 
 ### Added
 
-- **Content capture for Codex and OpenCode parsers** (#33 follow-up). Both parsers now emit `ContentRecord` entries when `contentMode === 'full'`, matching the shape the Claude parser already produced. Covers `text` (user/assistant), `thinking` (Codex reasoning), `tool_use`, and — most importantly for `burn waste` attribution — `tool_result` keyed by the same `call_id` / `callID` the tool call carries. In Codex, content only emits for turns that commit at `task_complete`; uncommitted content is dropped and will be re-emitted once the turn commits. [reader]
-- **`burn rebuild --content`** — re-parses source session files to populate missing content sidecars. Skips sessions that already have content on disk, leaves cursors and ledger rows untouched. Primary use: backfill content for historical Codex and OpenCode sessions ingested before content capture was implemented for those adapters, or to restore a sidecar that was pruned. [cli]
-- **`listContentSessionIds()`** — ledger helper enumerating sessionIds with a non-empty content sidecar on disk. Drives `burn rebuild --content`'s skip path. [ledger]
+- **Subagent tree as a first-class primitive** (#8). Replaces the flat `subagent.isSidechain` boolean with a parent→child tree reconstructed from Claude JSONL. `TurnRecord.subagent` gains `agentId`, `parentAgentId`, `parentToolUseId`, `subagentType`, `description`. New `buildSubagentTree(turns, { pricing })` and `aggregateSubagentTypeStats` in analyze. New `burn summary --subagent-tree <session-id>` and `burn summary --by-subagent-type` (both `--json`-able).
 
-## 2026-04-24 — Quality signals + waste-pattern detectors
-
-**Versions:** `@relayburn/reader@0.6.0`, `@relayburn/ledger@0.6.0`, `@relayburn/analyze@0.6.0`, `@relayburn/cli@0.6.0`
+## [0.8.0] - 2026-04-24
 
 ### Added
 
-- **Quality signals: outcome inference + one-shot rate.** Two orthogonal per-session signals for the "was this work good enough that a cheaper model could have done it" question. Closes [#6](https://github.com/AgentWorkforce/burn/issues/6). [cli, analyze]
-  - `@relayburn/analyze` — new `computeQuality(turns, opts)` returning `SessionOutcome[]` (classifies sessions as `completed` / `abandoned` / `errored` / `unknown` with explicit confidence and a reason code) and `OneShotMetrics[]` (edit turns / one-shot edit turns / retry volume, excluding sidechain subagent turns). Give-up phrase detection on the last assistant text downgrades confidence when the content sidecar is available, but is never required.
-  - `burn summary --quality` — appends a quality rollup (outcome counts + weighted one-shot rate) to summary output. Content sidecar reads run with a concurrency cap of 8 so large ledgers don't serialize I/O.
-  - Both signals are computed lazily at query time (never persisted) so future rule changes don't require a rebuild.
-  - Sources that don't record `stopReason` (e.g. Codex) are classified `completed/low` with reason `unknown-ending` rather than being swept into `abandoned`.
-- **Waste-pattern detectors** — retry loops, failure runs, compaction loss, edit-revert. Closes [#11](https://github.com/AgentWorkforce/burn/issues/11). [analyze, reader]
+- **Hook-based Claude Code ingest** (#7). Spawners install burn's ingest hooks per-invocation via Claude Code's `--settings` flag — no global `~/.claude/settings.json` mutation. New `buildClaudeHookSettings({ burnBin? })` in ledger. New `burn ingest --runtime claude [--quiet]` reads hook payloads on stdin; safe to fire on every event, hook failures never propagate non-zero back to Claude Code.
 
-### PRs in this release
-
-- [#53](https://github.com/AgentWorkforce/burn/pull/53) — Add quality signals (outcome inference + one-shot rate)
-
-## 2026-04-24 — Changelog hygiene
-
-**Versions:** `@relayburn/reader@0.5.0`, `@relayburn/ledger@0.5.0`, `@relayburn/analyze@0.5.0`, `@relayburn/cli@0.5.0`
-
-Housekeeping bump only — folds prior `[Unreleased]` content into the correct historical release sections. No functional changes in any package.
-
-## 2026-04-23 — `burn waste`: per-tool-call cost attribution
-
-**Versions:** `@relayburn/reader@0.4.0`, `@relayburn/ledger@0.4.0`, `@relayburn/analyze@0.4.0`, `@relayburn/cli@0.4.0`
-
-> `reader` and `ledger` had no functional changes — bumped for version parity across the workspace.
+## [0.7.0] - 2026-04-24
 
 ### Added
 
-- **`burn waste`** — per-tool-call and per-file cost attribution. Ranks the most expensive tool calls, files, Bash commands, and subagent calls by attributed cost: **initial** (turn after the tool call, where the result enters context as fresh `input`/`cacheCreate`) plus **persistence** (every subsequent turn it rides along in `cacheRead` until evicted). Closes [#3](https://github.com/AgentWorkforce/burn/issues/3). [cli, analyze]
-  - `burn waste [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--all] [--json]` — top-N rankings by file, Bash command (collapsed by `argsHash`), and subagent (`subagent_type`). `--all` shows full lists; `--json` emits raw aggregations.
-  - Sized attribution from the content sidecar when available (text length / 4 as a token estimate); even-split fallback (initial only) when it isn't, with a printed note.
-  - Per-paying-turn model rates so cross-model sessions are priced correctly. Sibling normalization across simultaneously-entering tool_results so attributed cost never exceeds what was actually paid.
+- **Content capture for Codex and OpenCode parsers** (#33 follow-up). Both parsers now emit `ContentRecord` entries when `contentMode === 'full'`, matching the Claude shape — `text`, `thinking` (Codex reasoning), `tool_use`, and `tool_result` keyed by the same `call_id` / `callID` the tool call carries. Codex commits content only at `task_complete`; uncommitted content re-emits when the turn commits.
+- **`burn rebuild --content`** — re-parses source session files to populate missing content sidecars. Skips sessions with content on disk; leaves cursors and ledger rows untouched.
+- **`listContentSessionIds()`** — ledger helper enumerating sessionIds with non-empty content sidecars on disk.
 
-### PRs in this release
-
-- [#50](https://github.com/AgentWorkforce/burn/pull/50) — Add `burn waste` plus the per-paying-turn pricing / sibling-normalization refactor
-
-## 2026-04-23 — `burn context`: agent context-file cost attribution
-
-**Versions:** `@relayburn/reader@0.3.0`, `@relayburn/ledger@0.3.0`, `@relayburn/analyze@0.3.0`, `@relayburn/cli@0.3.0`
-
-> `reader` and `ledger` had no functional changes — bumped for version parity across the workspace.
+## [0.6.0] - 2026-04-24
 
 ### Added
 
-- **`burn context`** — cost attribution for agent context files across every agent `burn` ingests: `CLAUDE.md`, `.claude/CLAUDE.md`, and `AGENTS.md`. Answers "how much are my rules files costing me per session, and which sections are the most expensive?" Closes [#10](https://github.com/AgentWorkforce/burn/issues/10). [cli, analyze]
-  - `burn context [--project <path>] [--since 7d] [--kind <k>] [--json]` — reports file size, per-session avg / p95 cost, window total across N sessions, and sections ranked by cost, per file. `--kind claude-md` / `--kind agents-md` narrows to one file kind.
-  - `burn context advise [--top <n>]` — emits read-only unified-diff TRIM hunks for the most expensive sections across every discovered file. POSIX-relative paths so hunks apply with `git apply` / `patch`. No `--apply` flag: burn never mutates your context files.
-  - Each file is attributed against only the turns whose harness actually reads it (Claude Code for CLAUDE.md; Codex and OpenCode for AGENTS.md) — a Codex session never pays for CLAUDE.md, a Claude Code session never pays for AGENTS.md.
-  - Attribution math is direct: `file_tokens × cacheReadPrice` per turn whose `cacheRead` is large enough to hold the file (conservative eviction signal that skips the first turn, where the file lives in `cacheCreate`, and any turn where it's been compacted away).
-  - Uses the git-canonical `projectKey` for ledger queries when available, so multiple worktrees of the same repo roll up together.
-  - Section parser groups at H2 (with H1 fallback), treats top-level content as preamble, and skips headings inside fenced code blocks with strict CommonMark close matching. CRLF → LF normalization and trailing-newline handling so line numbers match what an editor shows.
+- **Quality signals: outcome inference + one-shot rate** (#6). New `computeQuality(turns, opts)` returns `SessionOutcome[]` (`completed` / `abandoned` / `errored` / `unknown` with confidence + reason code) and `OneShotMetrics[]` (edit turns / one-shot edit turns / retry volume, sidechain-excluded). `burn summary --quality` appends outcome counts and weighted one-shot rate. Lazy at query time. Sources without `stopReason` (Codex) classify `completed/low` rather than `abandoned`.
+- **Waste-pattern detectors** (#11) — retry loops, failure runs, compaction loss, edit-revert.
 
-### Fixed
-
-- `attributeContext` deduplicates per-session `totalRidingTurns` using max-per-session rather than summing across files, so a session that reads multiple context files isn't double-counted.
-
-## 2026-04-23 — `burn compare` and cross-harness classifier
-
-**Versions:** `@relayburn/reader@0.2.0`, `@relayburn/ledger@0.2.0`, `@relayburn/analyze@0.2.0`, `@relayburn/cli@0.2.0`
-
-### Added
-
-- **`burn compare`** — observed-data comparison of cost-per-turn, one-shot rate, and turn count by `(model, activity)`. The headline query for the meta-goal: "looking at the work I actually did, which model handled each activity category best?" Closes [#38](https://github.com/AgentWorkforce/burn/issues/38). [cli, analyze]
-  - Flags: `--models a,b`, `--since 7d`, `--project <path>`, `--session <id>`, `--workflow <id>`, `--agent <id>`, `--min-sample <n>`, `--json`, `--csv`, `--help`.
-  - Grouped TTY table with coverage notes; missing-data cells render `—` (never `$0.00` or `0%`).
-  - JSON and CSV output expose `noData` / `insufficientSample` / `pricedTurns` so consumers can distinguish "no data" from "low sample" and "free model" from "unknown pricing."
-- **`burn rebuild --reclassify [--force]`** — backfills activity labels on existing ledger turns by re-running `classifyActivity`. Default skips already-classified turns; `--force` reclassifies everything. Reports per-category change counts. `burn rebuild --index` rebuilds the sidecar; both can run together. `burn rebuild-index` retained as alias. [cli, ledger]
-- **Activity classifier now runs for Codex and OpenCode turns** — previously only Claude Code turns received an `activity` label, which left every Codex/OpenCode turn in `unclassified` and made cross-harness comparison impossible. [reader]
-- **`TOOL_ALIASES` map + `normalizeToolName(name)`** in the classifier normalizes harness-specific tool names (`apply_patch`, `exec_command`, `shell`, lowercase OpenCode names, codex agent tools) onto canonical Claude names so the rule tables stay single-source. [reader]
-- **Six new activity categories** (taxonomy expanded from 12 → 18): `reasoning`, `docs`, `deps`, `format`, `review`, `verification`. [reader]
-- **`buildCompareTable(turns, opts)`** — pure aggregator in `@relayburn/analyze` so scripts can consume the same shape the CLI renders. [analyze]
-
-### Fixed
-
-- **Race between `appendTurns` and `reclassifyLedger`.** `appendLines` in the writer now acquires the same `withLock('ledger', …)` that `reclassifyLedger` holds for its read-modify-write pass. Previously an `appendFile` landing between reclassify's `readFile` and `rename` would write to the soon-orphaned old inode and silently disappear when rename swapped the new file in. Reported by Devin's review on [#48](https://github.com/AgentWorkforce/burn/pull/48). [ledger]
+## [0.5.0] - 2026-04-24
 
 ### Changed
 
-- `BUILD_DEPLOY_PATTERNS` tightened — the catch-all `/\bdeploy\b/` is replaced with explicit verbs per-tool (`vercel/netlify/flyctl/railway/sst deploy|up`, `kubectl apply/rollout/set`, `helm install/upgrade`, `terraform apply/plan/destroy`, `make build|release|dist|package|deploy`). [reader]
-- Top-level `burn` help and the README list every `burn compare` filter (`--session`, `--agent`) instead of just the most common ones. [cli]
-- `burn compare` now rejects `--json` + `--csv` together with exit 2 instead of silently picking JSON. [cli]
-- `--models` filter pre-seeds requested models so a model the user explicitly asked about stays visible (as an all-empty column with a coverage note) even when zero turns matched. [analyze]
+- Housekeeping bump only — folds prior `[Unreleased]` content into the correct historical release sections. No functional changes in any package.
 
-### PRs in this release
-
-- [#48](https://github.com/AgentWorkforce/burn/pull/48) — Add burn compare, classifier wiring, reclassify, race fix, taxonomy expansion
-
-## 2026-04-22 — Initial release
-
-**Versions:** `@relayburn/reader@0.1.0`, `@relayburn/ledger@0.1.0`, `@relayburn/analyze@0.1.0`, `@relayburn/cli@0.1.0`
+## [0.4.0] - 2026-04-23
 
 ### Added
 
-- **`@relayburn/reader`** — pure parsers turning agent session logs into `TurnRecord[]` and `ContentRecord[]`. Claude Code (`parseClaudeSession`), Codex (`parseCodexSession` with cumulative-token-delta accounting), OpenCode (`parseOpencodeSession` reading the per-session/message/part storage layout). All three have `*SessionIncremental` variants for cursor-based ingest. Deterministic activity classifier with 12 categories (Claude Code only at this release). Git-canonical project resolution (`resolveProject`) so `projectKey` survives across worktrees.
-- **`@relayburn/ledger`** — append-only JSONL ledger at `~/.relayburn/ledger.jsonl` (override via `RELAYBURN_HOME`). `appendTurns`, `stamp`, `query`, `queryAll`. Stamping for spawn-time enrichment with `{sessionId}` / `{messageId}` / `{sessionId, range}` selectors; last-write-wins per key, folded at query time. **Content sidecar** at `~/.relayburn/content/<sessionId>.jsonl` with `full` / `hash-only` / `off` modes via `RELAYBURN_CONTENT_STORE`; default 90-day retention. **Index sidecar** for fast dedup with `rebuildIndex()`. Per-process file lock (`withLock`) with stale-lock recovery. Per-source cursors for incremental ingest.
-- **`@relayburn/analyze`** — pricing loader (vendored models.dev snapshot with optional override at `$RELAYBURN_HOME/models.dev.json`) and per-record cost derivation (`costForTurn`, `costForUsage`, `sumCosts`). Reasoning tokens billed at the output rate and reported separately. Provider-prefix fallback in lookup so `anthropic/claude-sonnet-4-6` resolves to the `claude-sonnet-4-6` rate.
-- **`@relayburn/cli`** — `burn` binary with `summary`, `by-tool`, `claude` / `codex` / `opencode` spawn-wrappers (pre-assigned session UUIDs, stamps before spawn, ingest on exit), `content prune`, `rebuild-index`. Opportunistic content-sidecar prune on every non-`content` invocation.
+- **`burn waste`** (#3) — per-tool-call and per-file cost attribution. Ranks tool calls / files / Bash commands / subagents by attributed cost: **initial** (turn after the call, where the result enters context as fresh `input` / `cacheCreate`) plus **persistence** (every subsequent turn it rides along in `cacheRead` until evicted). Sized attribution from the content sidecar when available; even-split fallback (initial only) when not, with a printed note. Per-paying-turn model rates so cross-model sessions price correctly. Sibling normalization across simultaneously-entering tool_results so attributed cost never exceeds what was actually paid.
+
+## [0.3.0] - 2026-04-23
+
+### Added
+
+- **`burn context`** (#10) — cost attribution for agent context files (`CLAUDE.md`, `.claude/CLAUDE.md`, `AGENTS.md`). Per-file ranked section tables plus a grand total across all discovered files. `--kind claude-md|agents-md` narrows by file kind. Each file is attributed only against turns whose harness reads it (Claude Code for CLAUDE.md; Codex / OpenCode for AGENTS.md). Section parser groups at H2 (H1 fallback), treats top-level content as preamble, skips headings inside fenced code blocks.
+- **`burn context advise`** — emits read-only unified-diff TRIM hunks for the most expensive sections across every discovered file. POSIX-relative paths apply with `git apply` / `patch`. No `--apply` flag — burn never mutates your context files.
+
+### Fixed
+
+- `attributeContext` deduplicates `totalRidingTurns` per session via max-per-session rather than summing across files, so a session that reads multiple context files isn't double-counted.
+
+## [0.2.0] - 2026-04-23
+
+### Added
+
+- **`burn compare`** (#38) — observed-data comparison of cost-per-turn, one-shot rate, and turn count by `(model, activity)`. The headline meta-goal query: "which model handled each activity category best in the work I actually did?" Flags: `--models a,b`, `--since 7d`, `--project`, `--session`, `--workflow`, `--agent`, `--min-sample <n>`, `--json`, `--csv`. Grouped TTY table; missing-data cells render `—` (never `$0.00` or `0%`). JSON / CSV expose `noData` / `insufficientSample` / `pricedTurns`.
+- **`burn rebuild --reclassify [--force]`** — backfills `activity` labels on existing ledger turns by re-running `classifyActivity`. Default skips already-classified; `--force` reclassifies everything. `--index` rebuilds the sidecar; both can run together. `burn rebuild-index` retained as alias.
+- **Activity classifier runs for Codex and OpenCode turns** — previously Claude-only, which left every other harness in `unclassified` and made cross-harness comparison impossible.
+- **`TOOL_ALIASES` + `normalizeToolName(name)`** — collapses harness-specific tool names (`apply_patch`, `exec_command`, `shell`, codex agent tools, lowercased OpenCode names) onto canonical Claude names so the rule tables stay single-source.
+- **Six new activity categories** (taxonomy 12 → 18): `reasoning`, `docs`, `deps`, `format`, `review`, `verification`.
+- **`buildCompareTable(turns, opts)`** — pure aggregator in analyze so scripts can consume the same shape the CLI renders.
+
+### Fixed
+
+- **Race between `appendTurns` and `reclassifyLedger`** (#48). `appendLines` now acquires the same `withLock('ledger', …)` that reclassify holds; previously an `appendFile` landing between reclassify's `readFile` and `rename` would write to a soon-orphaned inode and silently disappear when rename swapped the new file in.
+
+### Changed
+
+- `BUILD_DEPLOY_PATTERNS` tightened — replaces catch-all `/\bdeploy\b/` with explicit verbs per-tool (`vercel/netlify/flyctl/railway/sst deploy|up`, `kubectl apply/rollout/set`, `helm install/upgrade`, `terraform apply/plan/destroy`, `make build|release|dist|package|deploy`).
+- `burn compare` rejects `--json` + `--csv` together with exit 2 instead of silently picking JSON.
+- `--models` filter pre-seeds requested models so a model explicitly asked about stays visible (all-empty column with coverage note) when zero turns matched.
+
+## [0.1.0] - 2026-04-22
+
+### Added
+
+- **Initial release.** Four packages.
+  - **`@relayburn/reader`** — pure parsers turning agent session logs into `TurnRecord[]` and `ContentRecord[]`. Claude Code, Codex (with cumulative-token-delta accounting), OpenCode (per-session/message/part storage layout). All three have `*SessionIncremental` variants for cursor-based ingest. Activity classifier with 12 categories (Claude Code only at this release). Git-canonical project resolution (`resolveProject`) so `projectKey` survives across worktrees.
+  - **`@relayburn/ledger`** — append-only JSONL ledger at `~/.relayburn/ledger.jsonl` (override via `RELAYBURN_HOME`). `appendTurns`, `stamp`, `query`, `queryAll`. Stamping with `{sessionId}` / `{messageId}` / `{sessionId, range}` selectors; last-write-wins per key, folded at query time. Content sidecar at `~/.relayburn/content/<sessionId>.jsonl` with `full` / `hash-only` / `off` modes (default 90-day retention). Index sidecar with `rebuildIndex()`. Per-process file lock with stale-lock recovery. Per-source cursors for incremental ingest.
+  - **`@relayburn/analyze`** — pricing loader (vendored models.dev snapshot, override at `$RELAYBURN_HOME/models.dev.json`) and per-record cost derivation (`costForTurn`, `costForUsage`, `sumCosts`). Reasoning tokens billed at the output rate and reported separately. Provider-prefix fallback so `anthropic/claude-sonnet-4-6` resolves to the `claude-sonnet-4-6` rate.
+  - **`@relayburn/cli`** — `burn` binary with `summary`, `by-tool`, `claude` / `codex` / `opencode` spawn-wrappers (pre-assigned session UUIDs, stamp before spawn, ingest on exit), `content prune`, `rebuild-index`. Opportunistic content-sidecar prune on every non-`content` invocation.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`burn limits`** — Claude quota-window tracker. Pairs the OAuth `usage` endpoint snapshot (`five_hour`, `seven_day`, `seven_day_opus`, `extra_usage`) with a local-ledger forecast (burn rate + linearly-extrapolated projected % at reset). Supports `--watch [5s]`, `--json`, `--no-api` (offline), `--no-forecast`. Reads the OAuth token from `CLAUDE_CODE_OAUTH_TOKEN`, `~/.claude/.credentials.json`, or macOS Keychain without persisting it; responses cached ≤30s in-process. Token-missing exits 2 with a one-line message. (#5)
+
 ## [0.9.0] - 2026-04-24
 
 ### Added

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,7 @@ import { runContent, opportunisticPrune } from './commands/content.js';
 import { runContext } from './commands/context.js';
 import { runDiagnose } from './commands/diagnose.js';
 import { runIngest } from './commands/ingest.js';
+import { runLimits } from './commands/limits.js';
 import { runOpencodeWrapper } from './commands/opencode.js';
 import { runRebuild } from './commands/rebuild.js';
 import { runRebuildIndex } from './commands/rebuild-index.js';
@@ -23,6 +24,7 @@ Usage:
   burn waste         [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--all] [--json]
                      [--patterns[=retries,failures,compaction,reverts]]
   burn diagnose      <session-id> [--json]
+  burn limits        [--watch [5s]] [--json] [--no-api] [--no-forecast]
   burn context       [advise] [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]
   burn compare       [--models a,b] [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--json|--csv]
   burn claude        [--tag k=v ...] [-- <claude args>]
@@ -41,6 +43,9 @@ Examples:
   burn waste --since 7d
   burn waste --patterns --since 7d
   burn diagnose <session-id>
+  burn limits
+  burn limits --watch
+  burn limits --no-api
   burn context --since 30d
   burn context --kind claude-md
   burn context advise --top 3
@@ -73,6 +78,8 @@ async function main(): Promise<number> {
       return runWaste(args);
     case 'diagnose':
       return runDiagnose(args);
+    case 'limits':
+      return runLimits(args);
     case 'context':
       return runContext(args);
     case 'compare':

--- a/packages/cli/src/commands/limits.test.ts
+++ b/packages/cli/src/commands/limits.test.ts
@@ -1,33 +1,37 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { runLimits, type ForecastInput, type LimitsDeps, type UsageResponse } from './limits.js';
+import {
+  makeCachingFetcher,
+  runLimits,
+  type ForecastInput,
+  type LimitsDeps,
+  type UsageResponse,
+} from './limits.js';
 import type { ParsedArgs } from '../args.js';
 
-function captureStdout<T>(fn: () => Promise<T>): Promise<{ result: T; stdout: string; stderr: string }> {
-  return new Promise(async (resolve, reject) => {
-    let stdout = '';
-    let stderr = '';
-    const origOut = process.stdout.write.bind(process.stdout);
-    const origErr = process.stderr.write.bind(process.stderr);
-    process.stdout.write = ((c: string | Uint8Array) => {
-      stdout += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
-      return true;
-    }) as typeof process.stdout.write;
-    process.stderr.write = ((c: string | Uint8Array) => {
-      stderr += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
-      return true;
-    }) as typeof process.stderr.write;
-    try {
-      const result = await fn();
-      resolve({ result, stdout, stderr });
-    } catch (e) {
-      reject(e);
-    } finally {
-      process.stdout.write = origOut;
-      process.stderr.write = origErr;
-    }
-  });
+async function captureStdout<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; stdout: string; stderr: string }> {
+  let stdout = '';
+  let stderr = '';
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((c: string | Uint8Array) => {
+    stdout += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: string | Uint8Array) => {
+    stderr += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await fn();
+    return { result, stdout, stderr };
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
 }
 
 function args(flags: Record<string, string | true> = {}): ParsedArgs {
@@ -59,12 +63,15 @@ function tokenDeps(usage: UsageResponse, forecast: ForecastInput | null = null):
 }
 
 describe('burn limits', () => {
-  it('exits 2 with one-line guidance when token missing', async () => {
-    const { result, stdout } = await captureStdout(() => runLimits(args(), noTokenDeps()));
+  it('exits 2 with one-line guidance on stderr when token missing', async () => {
+    const { result, stdout, stderr } = await captureStdout(() =>
+      runLimits(args(), noTokenDeps()),
+    );
     assert.equal(result, 2);
-    assert.equal(stdout.split('\n').filter(Boolean).length, 1);
-    assert.match(stdout, /no Claude OAuth token found/);
-    assert.match(stdout, /CLAUDE_CODE_OAUTH_TOKEN/);
+    assert.equal(stdout, '');
+    assert.equal(stderr.split('\n').filter(Boolean).length, 1);
+    assert.match(stderr, /no Claude OAuth token found/);
+    assert.match(stderr, /CLAUDE_CODE_OAUTH_TOKEN/);
   });
 
   it('renders five_hour, seven_day, seven_day_opus, extra_usage with reset countdowns', async () => {
@@ -183,27 +190,80 @@ describe('burn limits', () => {
     assert.match(stderr, /invalid --watch value/);
   });
 
-  it('caches the OAuth response for repeated fetches within TTL', async () => {
+  it('renders very-low projected % without double-normalizing back to 0..1', async () => {
+    // Regression: projectFromOauth returns a value already on the 0..100 scale
+    // (and capped at 100). If the renderer pipes that through the same
+    // formatter that auto-detects 0..1 fractions, a 1.01% projection becomes
+    // "101%". Pin down the rendered string here.
     const usage: UsageResponse = {
-      five_hour: { percent_used: 10, reset_at: '2026-04-24T13:00:00.000Z' },
+      // 0.01% used after ~99% of the window elapsed → projected ~1%.
+      five_hour: { percent_used: 0.01, reset_at: '2026-04-24T12:01:48.000Z' },
     };
-    let fetchCount = 0;
-    const deps: LimitsDeps = {
-      loadToken: async () => 'tok',
-      fetchUsage: async () => {
-        fetchCount++;
-        return usage;
+    const forecast: ForecastInput = {
+      tokensSoFar: 1,
+      elapsedMs: (5 * 60 * 60 - 108) * 1000, // window minus the 108s till reset
+      remainingMs: 108 * 1000,
+    };
+    const { stdout } = await captureStdout(() =>
+      runLimits(args(), tokenDeps(usage, forecast)),
+    );
+    assert.match(stdout, /projected 1% at reset/);
+    assert.doesNotMatch(stdout, /projected (10|100|101)% at reset/);
+  });
+});
+
+describe('makeCachingFetcher', () => {
+  const baseTime = Date.parse('2026-04-24T12:00:00.000Z');
+
+  it('returns the cached value within the TTL without re-invoking the fetcher', async () => {
+    let calls = 0;
+    let clock = baseTime;
+    const fetcher = makeCachingFetcher(
+      async () => {
+        calls++;
+        return { five_hour: { percent_used: 10, reset_at: '2026-04-24T13:00:00.000Z' } };
       },
-      now: fakeNow,
-      loadForecast: async () => null,
-    };
-    // First invocation: a separate process state, so cache is fresh per call.
-    // We test the cache through two back-to-back JSON renders inside a single
-    // runLimits call by running with --json twice via separate calls — each
-    // runLimits constructs its own fetcher, so the in-process cache is per
-    // command invocation. Verify that *within one invocation* a watch loop
-    // would dedupe; here we just confirm a single invocation does one fetch.
-    await captureStdout(() => runLimits(args({ json: true }), deps));
-    assert.equal(fetchCount, 1);
+      30_000,
+      () => new Date(clock),
+    );
+    await fetcher('tok');
+    clock += 10_000;
+    await fetcher('tok');
+    clock += 10_000;
+    await fetcher('tok');
+    assert.equal(calls, 1);
+  });
+
+  it('re-fetches once the TTL elapses', async () => {
+    let calls = 0;
+    let clock = baseTime;
+    const fetcher = makeCachingFetcher(
+      async () => {
+        calls++;
+        return {};
+      },
+      30_000,
+      () => new Date(clock),
+    );
+    await fetcher('tok');
+    clock += 31_000;
+    await fetcher('tok');
+    assert.equal(calls, 2);
+  });
+
+  it('does not serve cache across distinct tokens', async () => {
+    let calls = 0;
+    const fetcher = makeCachingFetcher(
+      async () => {
+        calls++;
+        return {};
+      },
+      30_000,
+      () => new Date(baseTime),
+    );
+    await fetcher('tok-a');
+    await fetcher('tok-b');
+    await fetcher('tok-a'); // cache is single-slot, so token-a now misses too
+    assert.equal(calls, 3);
   });
 });

--- a/packages/cli/src/commands/limits.test.ts
+++ b/packages/cli/src/commands/limits.test.ts
@@ -1,0 +1,209 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { runLimits, type ForecastInput, type LimitsDeps, type UsageResponse } from './limits.js';
+import type { ParsedArgs } from '../args.js';
+
+function captureStdout<T>(fn: () => Promise<T>): Promise<{ result: T; stdout: string; stderr: string }> {
+  return new Promise(async (resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stdout.write = ((c: string | Uint8Array) => {
+      stdout += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((c: string | Uint8Array) => {
+      stderr += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const result = await fn();
+      resolve({ result, stdout, stderr });
+    } catch (e) {
+      reject(e);
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    }
+  });
+}
+
+function args(flags: Record<string, string | true> = {}): ParsedArgs {
+  return { flags, tags: {}, positional: [], passthrough: [] };
+}
+
+const FIXED_NOW = new Date('2026-04-24T12:00:00.000Z');
+
+function fakeNow(): Date {
+  return new Date(FIXED_NOW);
+}
+
+function noTokenDeps(): LimitsDeps {
+  return {
+    loadToken: async () => null,
+    fetchUsage: async () => ({}),
+    now: fakeNow,
+    loadForecast: async () => null,
+  };
+}
+
+function tokenDeps(usage: UsageResponse, forecast: ForecastInput | null = null): LimitsDeps {
+  return {
+    loadToken: async () => 'fake-token',
+    fetchUsage: async () => usage,
+    now: fakeNow,
+    loadForecast: async () => forecast,
+  };
+}
+
+describe('burn limits', () => {
+  it('exits 2 with one-line guidance when token missing', async () => {
+    const { result, stdout } = await captureStdout(() => runLimits(args(), noTokenDeps()));
+    assert.equal(result, 2);
+    assert.equal(stdout.split('\n').filter(Boolean).length, 1);
+    assert.match(stdout, /no Claude OAuth token found/);
+    assert.match(stdout, /CLAUDE_CODE_OAUTH_TOKEN/);
+  });
+
+  it('renders five_hour, seven_day, seven_day_opus, extra_usage with reset countdowns', async () => {
+    const usage: UsageResponse = {
+      five_hour: { percent_used: 34, reset_at: '2026-04-24T14:14:00.000Z' },
+      seven_day: { percent_used: 12, reset_at: '2026-04-28T18:00:00.000Z' },
+      seven_day_opus: { percent_used: 8, reset_at: '2026-04-28T18:00:00.000Z' },
+      extra_usage: { percent_used: 0, reset_at: '2026-04-28T18:00:00.000Z' },
+    };
+    const { result, stdout } = await captureStdout(() => runLimits(args(), tokenDeps(usage)));
+    assert.equal(result, 0);
+    // 5-hour: reset 2h 14m from FIXED_NOW
+    assert.match(stdout, /5-hour\s+34% used\s+resets in 2h 14m/);
+    assert.match(stdout, /7-day\s+12% used\s+resets in 4d 6h/);
+    assert.match(stdout, /7-day Opus\s+8% used\s+resets in 4d 6h/);
+    assert.match(stdout, /extra\s+0% used/);
+  });
+
+  it('handles fractional percent_used (0..1) by scaling to 0..100', async () => {
+    const usage: UsageResponse = {
+      five_hour: { percent_used: 0.42, reset_at: '2026-04-24T13:00:00.000Z' },
+    };
+    const { stdout } = await captureStdout(() => runLimits(args(), tokenDeps(usage)));
+    assert.match(stdout, /5-hour\s+42% used/);
+  });
+
+  it('emits JSON with --json including usage and forecast', async () => {
+    const usage: UsageResponse = {
+      five_hour: { percent_used: 40, reset_at: '2026-04-24T14:00:00.000Z' },
+    };
+    const forecast: ForecastInput = {
+      tokensSoFar: 600_000,
+      elapsedMs: 2 * 60 * 60 * 1000, // 2h
+      remainingMs: 2 * 60 * 60 * 1000, // 2h
+    };
+    const { result, stdout } = await captureStdout(() =>
+      runLimits(args({ json: true }), tokenDeps(usage, forecast)),
+    );
+    assert.equal(result, 0);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.usage.five_hour.percent_used, 40);
+    assert.equal(parsed.forecast.tokensSoFar, 600_000);
+    // 600k tokens / 120 minutes = 5000 tok/min
+    assert.equal(parsed.forecast.burnRateTokensPerMinute, 5000);
+    // 40% at 2h elapsed of 4h total → projected 80% at reset
+    assert.equal(parsed.forecast.projectedPercentAtReset, 80);
+  });
+
+  it('reports api errors without crashing and exits non-zero', async () => {
+    const deps: LimitsDeps = {
+      loadToken: async () => 'tok',
+      fetchUsage: async () => {
+        throw new Error('usage endpoint 401: unauthorized');
+      },
+      now: fakeNow,
+      loadForecast: async () => null,
+    };
+    const { result, stdout } = await captureStdout(() => runLimits(args(), deps));
+    assert.equal(result, 1);
+    assert.match(stdout, /api error: usage endpoint 401/);
+  });
+
+  it('--no-api skips OAuth and renders local-only forecast', async () => {
+    const forecast: ForecastInput = {
+      tokensSoFar: 60_000,
+      elapsedMs: 60 * 60 * 1000, // 1h
+      remainingMs: 4 * 60 * 60 * 1000, // 4h
+    };
+    const deps: LimitsDeps = {
+      loadToken: async () => {
+        throw new Error('should not be called when --no-api');
+      },
+      fetchUsage: async () => {
+        throw new Error('should not be called when --no-api');
+      },
+      now: fakeNow,
+      loadForecast: async () => forecast,
+    };
+    const { result, stdout } = await captureStdout(() =>
+      runLimits(args({ 'no-api': true }), deps),
+    );
+    assert.equal(result, 0);
+    // 60k / 60min = 1000 tok/min
+    assert.match(stdout, /burn rate 1\.0k tok\/min/);
+    // No projected % without OAuth baseline
+    assert.doesNotMatch(stdout, /projected/);
+  });
+
+  it('--no-forecast skips ledger read', async () => {
+    const usage: UsageResponse = {
+      five_hour: { percent_used: 50, reset_at: '2026-04-24T13:00:00.000Z' },
+    };
+    let forecastCalled = false;
+    const deps: LimitsDeps = {
+      loadToken: async () => 'tok',
+      fetchUsage: async () => usage,
+      now: fakeNow,
+      loadForecast: async () => {
+        forecastCalled = true;
+        return null;
+      },
+    };
+    const { result, stdout } = await captureStdout(() =>
+      runLimits(args({ 'no-forecast': true }), deps),
+    );
+    assert.equal(result, 0);
+    assert.equal(forecastCalled, false);
+    assert.doesNotMatch(stdout, /Forecast/);
+  });
+
+  it('--watch with non-numeric value exits 2', async () => {
+    const { result, stderr } = await captureStdout(() =>
+      runLimits(args({ watch: 'abc' }), tokenDeps({})),
+    );
+    assert.equal(result, 2);
+    assert.match(stderr, /invalid --watch value/);
+  });
+
+  it('caches the OAuth response for repeated fetches within TTL', async () => {
+    const usage: UsageResponse = {
+      five_hour: { percent_used: 10, reset_at: '2026-04-24T13:00:00.000Z' },
+    };
+    let fetchCount = 0;
+    const deps: LimitsDeps = {
+      loadToken: async () => 'tok',
+      fetchUsage: async () => {
+        fetchCount++;
+        return usage;
+      },
+      now: fakeNow,
+      loadForecast: async () => null,
+    };
+    // First invocation: a separate process state, so cache is fresh per call.
+    // We test the cache through two back-to-back JSON renders inside a single
+    // runLimits call by running with --json twice via separate calls — each
+    // runLimits constructs its own fetcher, so the in-process cache is per
+    // command invocation. Verify that *within one invocation* a watch loop
+    // would dedupe; here we just confirm a single invocation does one fetch.
+    await captureStdout(() => runLimits(args({ json: true }), deps));
+    assert.equal(fetchCount, 1);
+  });
+});

--- a/packages/cli/src/commands/limits.ts
+++ b/packages/cli/src/commands/limits.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { queryAll } from '@relayburn/ledger';
 
 import type { ParsedArgs } from '../args.js';
+import { ingestAll } from '../ingest.js';
 
 const USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage';
 const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20';
@@ -52,21 +53,27 @@ export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promis
   const now = deps.now ?? (() => new Date());
   const loadForecast = deps.loadForecast ?? loadForecastFromLedger;
 
+  // Resolve the OAuth token once per invocation, not per render. The macOS
+  // Keychain path spawns `security`, which is expensive enough that calling
+  // it on every --watch tick (every 5s by default) would dominate the loop.
+  let token: string | null = null;
+  if (!noApi) {
+    token = await loadToken();
+    if (!token) {
+      process.stderr.write(
+        'burn limits: no Claude OAuth token found. Run `claude /login` to authenticate, ' +
+          'or set CLAUDE_CODE_OAUTH_TOKEN.\n',
+      );
+      return 2;
+    }
+  }
+
   const fetchOnce = makeCachingFetcher(fetchUsage, CACHE_TTL_MS, now);
 
   const renderOnce = async (): Promise<{ exitCode: number; output: string }> => {
     let usage: UsageResponse | null = null;
     let usageError: string | null = null;
-    if (!noApi) {
-      const token = await loadToken();
-      if (!token) {
-        return {
-          exitCode: 2,
-          output:
-            'burn limits: no Claude OAuth token found. Run `claude /login` to authenticate, ' +
-            'or set CLAUDE_CODE_OAUTH_TOKEN.\n',
-        };
-      }
+    if (token !== null) {
       try {
         usage = await fetchOnce(token);
       } catch (err) {
@@ -188,7 +195,10 @@ function renderTty(opts: {
     } else {
       const parts = [`burn rate ${formatTokensPerMinute(rate)}`];
       if (projectedPercent !== null) {
-        parts.push(`projected ${formatPercent(projectedPercent)} at reset`);
+        // projectedPercent is already on the 0..100 scale (projectFromOauth
+        // normalizes + caps); skip formatPercent's auto-detect heuristic so
+        // small values like 1.01 don't get re-multiplied to 101.
+        parts.push(`projected ${projectedPercent.toFixed(0)}% at reset`);
       }
       lines.push(`  ${parts.join(', ')}`);
     }
@@ -255,7 +265,7 @@ function forecastWindowStartMs(fiveHour: UsageWindow | undefined, now: Date): nu
   return now.getTime() - SESSION_DURATION_MS;
 }
 
-function makeCachingFetcher(
+export function makeCachingFetcher(
   fetchUsage: (token: string) => Promise<UsageResponse>,
   ttlMs: number,
   now: () => Date,
@@ -419,6 +429,13 @@ async function loadForecastFromLedger(
   windowStartMs: number,
   nowMs: number,
 ): Promise<ForecastInput | null> {
+  // Match the convention used by every other read-only command (summary,
+  // by-tool, diagnose, …): sweep new session logs into the ledger before
+  // querying, so the forecast reflects what just happened in the active
+  // claude session rather than whatever the last burn invocation captured.
+  // ingestAll is incremental via cursors, so the watch loop calling this
+  // every ~5s stays cheap on a steady-state ledger.
+  await ingestAll();
   const since = new Date(windowStartMs).toISOString();
   const turns = await queryAll({ since, source: 'claude-code' });
   if (turns.length === 0) return null;

--- a/packages/cli/src/commands/limits.ts
+++ b/packages/cli/src/commands/limits.ts
@@ -1,0 +1,439 @@
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+
+import { queryAll } from '@relayburn/ledger';
+
+import type { ParsedArgs } from '../args.js';
+
+const USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage';
+const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20';
+const CACHE_TTL_MS = 30_000;
+const DEFAULT_WATCH_INTERVAL_S = 5;
+const SESSION_DURATION_MS = 5 * 60 * 60 * 1000;
+
+interface UsageWindow {
+  percent_used: number;
+  reset_at: string;
+}
+
+export interface UsageResponse {
+  five_hour?: UsageWindow;
+  seven_day?: UsageWindow;
+  seven_day_opus?: UsageWindow;
+  extra_usage?: UsageWindow;
+}
+
+export interface ForecastInput {
+  // tokens consumed since the start of the 5-hour window
+  tokensSoFar: number;
+  // ms elapsed since the window start
+  elapsedMs: number;
+  // ms remaining until window end (reset)
+  remainingMs: number;
+}
+
+export interface LimitsDeps {
+  loadToken?: () => Promise<string | null>;
+  fetchUsage?: (token: string) => Promise<UsageResponse>;
+  now?: () => Date;
+  loadForecast?: (windowStartMs: number, nowMs: number) => Promise<ForecastInput | null>;
+}
+
+export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promise<number> {
+  const watchFlag = args.flags['watch'];
+  const json = args.flags['json'] === true;
+  const noApi = args.flags['no-api'] === true;
+  const noForecast = args.flags['no-forecast'] === true;
+
+  const loadToken = deps.loadToken ?? loadOauthToken;
+  const fetchUsage = deps.fetchUsage ?? fetchUsageFromApi;
+  const now = deps.now ?? (() => new Date());
+  const loadForecast = deps.loadForecast ?? loadForecastFromLedger;
+
+  const fetchOnce = makeCachingFetcher(fetchUsage, CACHE_TTL_MS, now);
+
+  const renderOnce = async (): Promise<{ exitCode: number; output: string }> => {
+    let usage: UsageResponse | null = null;
+    let usageError: string | null = null;
+    if (!noApi) {
+      const token = await loadToken();
+      if (!token) {
+        return {
+          exitCode: 2,
+          output:
+            'burn limits: no Claude OAuth token found. Run `claude /login` to authenticate, ' +
+            'or set CLAUDE_CODE_OAUTH_TOKEN.\n',
+        };
+      }
+      try {
+        usage = await fetchOnce(token);
+      } catch (err) {
+        usageError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    const nowDate = now();
+    let forecast: { window: ForecastWindow; data: ForecastInput } | null = null;
+    if (!noForecast) {
+      const windowStartMs = forecastWindowStartMs(usage?.five_hour, nowDate);
+      const data = await loadForecast(windowStartMs, nowDate.getTime());
+      if (data) {
+        forecast = { window: { startMs: windowStartMs }, data };
+      }
+    }
+
+    const projectedPercent = forecast && usage?.five_hour
+      ? projectFromOauth(usage.five_hour.percent_used, forecast.data)
+      : null;
+
+    if (json) {
+      return {
+        exitCode: usageError ? 1 : 0,
+        output: JSON.stringify(
+          {
+            fetchedAt: nowDate.toISOString(),
+            usage,
+            usageError,
+            forecast: forecast
+              ? {
+                  windowStart: new Date(forecast.window.startMs).toISOString(),
+                  tokensSoFar: forecast.data.tokensSoFar,
+                  elapsedMs: forecast.data.elapsedMs,
+                  remainingMs: forecast.data.remainingMs,
+                  burnRateTokensPerMinute: burnRatePerMinute(forecast.data),
+                  projectedPercentAtReset: projectedPercent,
+                }
+              : null,
+          },
+          null,
+          2,
+        ) + '\n',
+      };
+    }
+
+    return {
+      exitCode: usageError ? 1 : 0,
+      output: renderTty({ usage, usageError, forecast, projectedPercent, now: nowDate }),
+    };
+  };
+
+  if (watchFlag === undefined) {
+    const { exitCode, output } = await renderOnce();
+    process.stdout.write(output);
+    return exitCode;
+  }
+
+  const intervalMs = parseWatchInterval(watchFlag);
+  if (intervalMs === null) {
+    process.stderr.write(
+      `burn limits: invalid --watch value: ${JSON.stringify(watchFlag)} (expected seconds, e.g. 5 or 5s)\n`,
+    );
+    return 2;
+  }
+  return runWatch(renderOnce, intervalMs);
+}
+
+interface ForecastWindow {
+  startMs: number;
+}
+
+function renderTty(opts: {
+  usage: UsageResponse | null;
+  usageError: string | null;
+  forecast: { window: ForecastWindow; data: ForecastInput } | null;
+  projectedPercent: number | null;
+  now: Date;
+}): string {
+  const { usage, usageError, forecast, projectedPercent, now } = opts;
+  const lines: string[] = [];
+  lines.push('Claude');
+
+  if (usageError) {
+    lines.push(`  (api error: ${usageError})`);
+  } else if (usage) {
+    const rows: { label: string; window: UsageWindow | undefined }[] = [
+      { label: '5-hour', window: usage.five_hour },
+      { label: '7-day', window: usage.seven_day },
+      { label: '7-day Opus', window: usage.seven_day_opus },
+      { label: 'extra', window: usage.extra_usage },
+    ];
+    const visible = rows.filter((r) => r.window !== undefined) as {
+      label: string;
+      window: UsageWindow;
+    }[];
+    if (visible.length === 0) {
+      lines.push('  (no quota windows reported)');
+    } else {
+      const labelWidth = Math.max(...visible.map((r) => r.label.length));
+      const pctWidth = Math.max(
+        ...visible.map((r) => formatPercent(r.window.percent_used).length),
+      );
+      for (const r of visible) {
+        const label = r.label.padEnd(labelWidth);
+        const pct = formatPercent(r.window.percent_used).padStart(pctWidth);
+        const reset = formatResetIn(r.window.reset_at, now);
+        lines.push(`  ${label}  ${pct} used  resets in ${reset}`);
+      }
+    }
+  }
+
+  if (forecast) {
+    const rate = burnRatePerMinute(forecast.data);
+    lines.push('');
+    lines.push('Forecast (5-hour window, local ledger):');
+    if (rate === null) {
+      lines.push('  insufficient data');
+    } else {
+      const parts = [`burn rate ${formatTokensPerMinute(rate)}`];
+      if (projectedPercent !== null) {
+        parts.push(`projected ${formatPercent(projectedPercent)} at reset`);
+      }
+      lines.push(`  ${parts.join(', ')}`);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function formatPercent(fraction: number): string {
+  // Endpoint returns 0..100 (per issue example "34"); guard either shape by
+  // assuming >1.5 means already in percent units.
+  const pct = fraction > 1.5 ? fraction : fraction * 100;
+  return `${pct.toFixed(0)}%`;
+}
+
+function formatResetIn(resetAt: string, now: Date): string {
+  const t = Date.parse(resetAt);
+  if (!Number.isFinite(t)) return 'unknown';
+  const ms = t - now.getTime();
+  if (ms <= 0) return 'now';
+  return formatDuration(ms);
+}
+
+function formatDuration(ms: number): string {
+  const totalMin = Math.round(ms / 60_000);
+  const days = Math.floor(totalMin / (60 * 24));
+  const hours = Math.floor((totalMin % (60 * 24)) / 60);
+  const minutes = totalMin % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function formatTokensPerMinute(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k tok/min`;
+  return `${n.toFixed(0)} tok/min`;
+}
+
+function burnRatePerMinute(f: ForecastInput): number | null {
+  if (f.elapsedMs <= 0) return null;
+  return f.tokensSoFar / (f.elapsedMs / 60_000);
+}
+
+// Linear extrapolation from the OAuth-reported current % to the end of the
+// 5-hour window. We can't translate local tokens → % without knowing the
+// per-plan cap, so we lean on OAuth's authoritative %-used and assume the
+// next remainder of the window keeps the same average rate as the elapsed
+// portion. Capped at 100.
+function projectFromOauth(currentPercent: number, f: ForecastInput): number | null {
+  if (f.elapsedMs <= 0) return null;
+  const totalMs = f.elapsedMs + f.remainingMs;
+  if (totalMs <= 0) return null;
+  const elapsedFraction = f.elapsedMs / totalMs;
+  if (elapsedFraction <= 0) return null;
+  const pct = currentPercent > 1.5 ? currentPercent : currentPercent * 100;
+  return Math.min(100, pct / elapsedFraction);
+}
+
+function forecastWindowStartMs(fiveHour: UsageWindow | undefined, now: Date): number {
+  if (fiveHour) {
+    const reset = Date.parse(fiveHour.reset_at);
+    if (Number.isFinite(reset)) return reset - SESSION_DURATION_MS;
+  }
+  return now.getTime() - SESSION_DURATION_MS;
+}
+
+function makeCachingFetcher(
+  fetchUsage: (token: string) => Promise<UsageResponse>,
+  ttlMs: number,
+  now: () => Date,
+): (token: string) => Promise<UsageResponse> {
+  let cache: { token: string; at: number; value: UsageResponse } | null = null;
+  return async (token: string) => {
+    const t = now().getTime();
+    if (cache && cache.token === token && t - cache.at < ttlMs) return cache.value;
+    const value = await fetchUsage(token);
+    cache = { token, at: t, value };
+    return value;
+  };
+}
+
+function parseWatchInterval(flag: string | true): number | null {
+  if (flag === true) return DEFAULT_WATCH_INTERVAL_S * 1000;
+  const m = /^(\d+)(s)?$/.exec(flag.trim());
+  if (!m) return null;
+  const n = parseInt(m[1]!, 10);
+  if (n <= 0) return null;
+  return n * 1000;
+}
+
+async function runWatch(
+  renderOnce: () => Promise<{ exitCode: number; output: string }>,
+  intervalMs: number,
+): Promise<number> {
+  let stopped = false;
+  const stop = () => {
+    stopped = true;
+  };
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+
+  const isTty = process.stdout.isTTY === true;
+  let lastExit = 0;
+  while (!stopped) {
+    const { exitCode, output } = await renderOnce();
+    lastExit = exitCode;
+    if (isTty) {
+      process.stdout.write('\x1b[H\x1b[2J' + output);
+    } else {
+      process.stdout.write(output);
+    }
+    if (stopped) break;
+    await sleep(intervalMs, () => stopped);
+  }
+  process.off('SIGINT', stop);
+  process.off('SIGTERM', stop);
+  return lastExit;
+}
+
+function sleep(ms: number, isCancelled: () => boolean): Promise<void> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const tick = () => {
+      if (isCancelled() || Date.now() - start >= ms) return resolve();
+      setTimeout(tick, Math.min(100, ms));
+    };
+    tick();
+  });
+}
+
+export async function loadOauthToken(): Promise<string | null> {
+  const env = process.env['CLAUDE_CODE_OAUTH_TOKEN'];
+  if (env && env.length > 0) return env;
+
+  const fromFile = await readCredentialsFile();
+  if (fromFile) return fromFile;
+
+  if (process.platform === 'darwin') {
+    const fromKeychain = await readMacOsKeychain();
+    if (fromKeychain) return fromKeychain;
+  }
+  return null;
+}
+
+async function readCredentialsFile(): Promise<string | null> {
+  const candidates = [
+    path.join(homedir(), '.claude', '.credentials.json'),
+    path.join(homedir(), '.claude', 'credentials.json'),
+  ];
+  for (const p of candidates) {
+    try {
+      const raw = await readFile(p, 'utf8');
+      const parsed = JSON.parse(raw) as unknown;
+      const token = extractTokenFromCredentials(parsed);
+      if (token) return token;
+    } catch {
+      // fall through to next candidate
+    }
+  }
+  return null;
+}
+
+function extractTokenFromCredentials(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  const oauth = obj['claudeAiOauth'];
+  if (oauth && typeof oauth === 'object') {
+    const access = (oauth as Record<string, unknown>)['accessToken'];
+    if (typeof access === 'string' && access.length > 0) return access;
+  }
+  const direct = obj['accessToken'];
+  if (typeof direct === 'string' && direct.length > 0) return direct;
+  return null;
+}
+
+function readMacOsKeychain(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      'security',
+      ['find-generic-password', '-s', 'Claude Code-credentials', '-w'],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    let out = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      out += chunk.toString('utf8');
+    });
+    child.on('error', () => resolve(null));
+    child.on('exit', (code) => {
+      if (code !== 0) return resolve(null);
+      const trimmed = out.trim();
+      if (!trimmed) return resolve(null);
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        const fromJson = extractTokenFromCredentials(parsed);
+        if (fromJson) return resolve(fromJson);
+      } catch {
+        // keychain entry is the bare token, not JSON
+      }
+      resolve(trimmed);
+    });
+  });
+}
+
+async function fetchUsageFromApi(token: string): Promise<UsageResponse> {
+  const res = await fetch(USAGE_ENDPOINT, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'anthropic-beta': ANTHROPIC_OAUTH_BETA,
+      Accept: 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`usage endpoint ${res.status}: ${await safeBody(res)}`);
+  }
+  return (await res.json()) as UsageResponse;
+}
+
+async function safeBody(res: Response): Promise<string> {
+  try {
+    const t = await res.text();
+    return t.slice(0, 200);
+  } catch {
+    return '';
+  }
+}
+
+async function loadForecastFromLedger(
+  windowStartMs: number,
+  nowMs: number,
+): Promise<ForecastInput | null> {
+  const since = new Date(windowStartMs).toISOString();
+  const turns = await queryAll({ since, source: 'claude-code' });
+  if (turns.length === 0) return null;
+  let tokens = 0;
+  for (const t of turns) {
+    const u = t.usage;
+    tokens +=
+      (u.input ?? 0) +
+      (u.output ?? 0) +
+      (u.reasoning ?? 0) +
+      (u.cacheRead ?? 0) +
+      (u.cacheCreate5m ?? 0) +
+      (u.cacheCreate1h ?? 0);
+  }
+  const elapsedMs = Math.max(0, nowMs - windowStartMs);
+  const remainingMs = Math.max(0, windowStartMs + SESSION_DURATION_MS - nowMs);
+  return { tokensSoFar: tokens, elapsedMs, remainingMs };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ export { runWaste } from './commands/waste.js';
 export { runContext } from './commands/context.js';
 export { runClaudeWrapper } from './commands/claude.js';
 export { runIngest } from './commands/ingest.js';
+export { runLimits } from './commands/limits.js';
 export { parseArgs } from './args.js';
 export { ingestClaudeProjects, ingestOpencodeSessions, ingestAll } from './ingest.js';
 export { runOpencodeWrapper } from './commands/opencode.js';


### PR DESCRIPTION
## Summary

- Introduce `burn limits`: a CLI command that surfaces Claude OAuth quota windows (`five_hour`, `seven_day`, `seven_day_opus`, `extra_usage`) and pairs them with a local-ledger forecast (burn rate + linearly-extrapolated projected % at reset). Closes #5.
- Pipeline: resolve the OAuth token once per invocation (env → `~/.claude/.credentials.json` → macOS Keychain), fetch + cache (≤30s TTL), optionally compute a forecast from `queryAll({ source: 'claude-code' })` over the active 5-hour window.
- Flags: `--watch [5s]` (in-place TTY refresh, clean SIGINT exit), `--json` (programmatic), `--no-api` (offline forecast only), `--no-forecast` (OAuth only).
- Failure modes match the rest of the CLI: token-missing → exit 2 with a one-line message on **stderr**; OAuth fetch error → renders `(api error: …)` and exits 1.

## Out-of-scope cleanup also in this PR

- **Root `CHANGELOG.md` reformat** — every release now uses Keep-a-Changelog `## [x.y.z] - YYYY-MM-DD` headers (since the four packages release in lockstep), the redundant `**Versions:** ...` lines and per-bullet `[reader, cli]` tags are gone, and the stale `[Unreleased]` block is folded into 0.8.0 / 0.9.0 where it actually shipped. **The root file does NOT add a `burn limits` bullet** — this is single-package work, and `AGENTS.md` now states that single-package changes belong only in their package's CHANGELOG. The root entry for `burn limits` lives in `packages/cli/CHANGELOG.md`.
- **Publish workflow now stamps the root `CHANGELOG.md`** the same way it stamps per-package files: at release time, the root `[Unreleased]` is promoted to `## [x.y.z] - DATE` (using `max` of bumped versions). No git-log fallback for the root file — empty `[Unreleased]` is left alone. Verified with four local dry-runs (lockstep bump, empty Unreleased, prerelease, drifted versions).
- **AGENTS.md** updated to document the lockstep convention, the new auto-promotion behavior, and to scope the existing git-log fallback paragraph explicitly to per-package CHANGELOGs.

## Test plan

- [x] `pnpm run test:ts` passes (278 tests, +12 new for `burn limits` + `makeCachingFetcher`).
- [x] `node packages/cli/dist/cli.js limits --help` and `--no-api` smoke-tested locally.
- [x] Workflow root-changelog script dry-run against fixtures: non-empty Unreleased → promoted; empty → skipped; prerelease → skipped; drifted versions → picks max.
- [ ] Real publish run will exercise the new workflow step end-to-end (out-of-band; safe — workflow is purely additive: new step skips when there's nothing to promote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)