### PR TITLE
Add plan-based monthly quota tracking (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **Plan-based monthly quota tracking** (#39). Complement to `burn limits`'s 5-hour OAuth window: track spend against monthly plan budgets (Claude Pro/Max, Cursor Pro, or any custom plan) and surface projected end-of-cycle spend, runway-days-at-current-rate, and over/under-budget delta. Configure with `burn plans add --provider claude --preset max`; the status flows automatically into `burn limits` output as a `Monthly plan` block alongside the 5-hour view. Projections with fewer than 7 days of cycle data are marked `(limited data)` so users don't anchor on first-week noise. Plans persist to `~/.relayburn/plans.json` and respect a custom `resetDay` 1-31 (with end-of-month clamping for short months).
+  - `@relayburn/ledger` — `Plan` / `PlansFile` / `PlanProvider` types, `loadPlans` / `savePlans`, `BUILTIN_PRESETS`, `findPreset`, `normalizePlan`, `plansPath`.
+  - `@relayburn/analyze` — `computePlanUsage(plan, turns, { pricing, now })` returning a fully-derived `PlanUsage` (spend, projection, runway, limited-data flag); `cycleBounds(resetDay, now)` exposed for callers that just need the window.
+  - `@relayburn/cli` — `burn plans` subcommand (list / add / remove / set-reset-day), plan-status block wired into `burn limits` TTY + `--json` output.
+
 ## [0.9.0] - 2026-04-24
 
 ### Added

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`computePlanUsage(plan, turns, { pricing, now })`** (#39) — aggregates spend over a plan's current cycle and returns a `PlanUsage`: `spentUsd`, `daysElapsed`, `daysInCycle`, `projectedEndOfCycleUsd` (linear extrapolation from observed rate), `overBudget`, `runwayDays` (days of budget left at the current daily rate, only populated when the projection exceeds budget), `resetAt`, and `limitedData` (true when fewer than 7 days have elapsed in the cycle, so renderers can mark projections as low-confidence per the issue's acceptance). Provider-aware filtering: `claude` plans count `claude-code` + `anthropic-api` turns, `cursor` plans count `cursor` turns (no reader emits these yet — see SourceKind), `custom` plans count every turn.
+- **`cycleBounds(resetDay, now)`** — exposed for callers that need the cycle window without a full `PlanUsage`. UTC-anchored, clamps `resetDay > 28` to the actual last-day-of-month so February with `resetDay: 31` resolves to Feb 28/29, handles year-boundary crossings, and never returns a zero-length cycle.
+
 ## [0.9.0] - 2026-04-24
 
 ### Added

--- a/packages/analyze/src/index.ts
+++ b/packages/analyze/src/index.ts
@@ -70,6 +70,8 @@ export {
   findContextFiles,
   loadContextFile,
 } from './context-md.js';
+export { computePlanUsage, cycleBounds } from './plan-usage.js';
+export type { ComputePlanUsageOptions, PlanUsage } from './plan-usage.js';
 export type {
   AttributeContextInput,
   ContextAttributionResult,

--- a/packages/analyze/src/plan-usage.test.ts
+++ b/packages/analyze/src/plan-usage.test.ts
@@ -1,0 +1,206 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { Plan } from '@relayburn/ledger';
+import type { TurnRecord } from '@relayburn/reader';
+
+import { computePlanUsage, cycleBounds } from './plan-usage.js';
+import type { PricingTable } from './pricing.js';
+
+const PRICING: PricingTable = {
+  'claude-sonnet-4-6': {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheWrite: 3.75,
+  },
+};
+
+function turn(opts: {
+  ts: string;
+  source?: TurnRecord['source'];
+  inputTokens?: number;
+  outputTokens?: number;
+  model?: string;
+  sessionId?: string;
+}): TurnRecord {
+  return {
+    v: 1,
+    source: opts.source ?? 'claude-code',
+    sessionId: opts.sessionId ?? 's1',
+    messageId: `m-${opts.ts}`,
+    turnIndex: 0,
+    ts: opts.ts,
+    model: opts.model ?? 'claude-sonnet-4-6',
+    usage: {
+      input: opts.inputTokens ?? 0,
+      output: opts.outputTokens ?? 0,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    },
+    toolCalls: [],
+  };
+}
+
+const plan: Plan = {
+  id: 'claude-pro',
+  provider: 'claude',
+  name: 'Claude Pro',
+  budgetUsd: 20,
+  resetDay: 1,
+};
+
+describe('cycleBounds', () => {
+  it('day 1 → calendar month boundary', () => {
+    const now = new Date('2026-04-15T12:00:00.000Z');
+    const { cycleStart, cycleEnd } = cycleBounds(1, now);
+    assert.equal(cycleStart.toISOString(), '2026-04-01T00:00:00.000Z');
+    assert.equal(cycleEnd.toISOString(), '2026-05-01T00:00:00.000Z');
+  });
+
+  it('day 15 mid-cycle → cycle started this month', () => {
+    const now = new Date('2026-04-20T12:00:00.000Z');
+    const { cycleStart, cycleEnd } = cycleBounds(15, now);
+    assert.equal(cycleStart.toISOString(), '2026-04-15T00:00:00.000Z');
+    assert.equal(cycleEnd.toISOString(), '2026-05-15T00:00:00.000Z');
+  });
+
+  it('day 15 before mid-month → cycle started last month', () => {
+    const now = new Date('2026-04-10T12:00:00.000Z');
+    const { cycleStart, cycleEnd } = cycleBounds(15, now);
+    assert.equal(cycleStart.toISOString(), '2026-03-15T00:00:00.000Z');
+    assert.equal(cycleEnd.toISOString(), '2026-04-15T00:00:00.000Z');
+  });
+
+  it('day 31 in February → clamps to last day of February', () => {
+    const now = new Date('2026-02-15T12:00:00.000Z');
+    const { cycleStart } = cycleBounds(31, now);
+    // 2026 is not a leap year → Feb has 28 days
+    assert.equal(cycleStart.toISOString(), '2026-01-31T00:00:00.000Z');
+  });
+
+  it('day 31 anchored end-of-month rolls forward correctly', () => {
+    // Just after Jan 31 → cycle started Jan 31, ends end-of-Feb (clamped to 28)
+    const now = new Date('2026-02-10T12:00:00.000Z');
+    const { cycleStart, cycleEnd } = cycleBounds(31, now);
+    assert.equal(cycleStart.toISOString(), '2026-01-31T00:00:00.000Z');
+    assert.equal(cycleEnd.toISOString(), '2026-02-28T00:00:00.000Z');
+  });
+
+  it('crosses year boundary cleanly', () => {
+    const now = new Date('2026-01-05T12:00:00.000Z');
+    const { cycleStart, cycleEnd } = cycleBounds(15, now);
+    assert.equal(cycleStart.toISOString(), '2025-12-15T00:00:00.000Z');
+    assert.equal(cycleEnd.toISOString(), '2026-01-15T00:00:00.000Z');
+  });
+});
+
+describe('computePlanUsage', () => {
+  const now = new Date('2026-04-15T00:00:00.000Z'); // 14 days into a calendar cycle
+
+  it('sums spend within the cycle and ignores turns outside it', () => {
+    // 1M input tokens at $3/MM = $3 per turn
+    const turns: TurnRecord[] = [
+      turn({ ts: '2026-04-05T00:00:00.000Z', inputTokens: 1_000_000 }),
+      turn({ ts: '2026-04-10T00:00:00.000Z', inputTokens: 1_000_000 }),
+      // Outside cycle: previous month
+      turn({ ts: '2026-03-25T00:00:00.000Z', inputTokens: 5_000_000 }),
+    ];
+    const u = computePlanUsage(plan, turns, { pricing: PRICING, now });
+    assert.equal(u.spentUsd, 6);
+    assert.equal(u.daysElapsed, 14);
+    assert.equal(u.daysInCycle, 30);
+  });
+
+  it('linearly projects end-of-cycle spend from observed rate', () => {
+    // 1M input tokens × $3/MM = $3 per turn; 14 turns = $42 over 14 days.
+    // Cycle = 30 days, so projected = 42 × 30/14 = $90.
+    const turns: TurnRecord[] = Array.from({ length: 14 }, (_, i) =>
+      turn({ ts: `2026-04-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`, inputTokens: 1_000_000 }),
+    );
+    const u = computePlanUsage(plan, turns, { pricing: PRICING, now });
+    assert.equal(u.spentUsd, 42);
+    assert.equal(u.projectedEndOfCycleUsd, 90);
+  });
+
+  it('flags overBudget and computes runwayDays when projection exceeds budget', () => {
+    // $30 spent over 14 days on a $20 plan → projected $64, over budget
+    const turns: TurnRecord[] = [
+      turn({ ts: '2026-04-08T00:00:00.000Z', inputTokens: 10_000_000 }),
+    ];
+    const u = computePlanUsage(plan, turns, { pricing: PRICING, now });
+    assert.equal(u.spentUsd, 30);
+    assert.ok(u.projectedEndOfCycleUsd > plan.budgetUsd);
+    assert.equal(u.overBudget, true);
+    // remaining = max(0, 20-30) = 0 → runway = 0 days (already past)
+    assert.equal(u.runwayDays, 0);
+  });
+
+  it('runwayDays is null when projection is under budget', () => {
+    const turns: TurnRecord[] = [turn({ ts: '2026-04-05T00:00:00.000Z', inputTokens: 1_000_000 })];
+    const u = computePlanUsage(plan, turns, { pricing: PRICING, now });
+    assert.equal(u.overBudget, false);
+    assert.equal(u.runwayDays, null);
+  });
+
+  it('flags limitedData when fewer than 7 days have elapsed', () => {
+    const earlyNow = new Date('2026-04-04T00:00:00.000Z'); // 3 days into cycle
+    const u = computePlanUsage(plan, [], { pricing: PRICING, now: earlyNow });
+    assert.equal(u.daysElapsed, 3);
+    assert.equal(u.limitedData, true);
+  });
+
+  it('does not collapse projection to zero when cycle just started', () => {
+    const cycleStart = new Date('2026-04-01T00:00:00.000Z');
+    const u = computePlanUsage(plan, [], { pricing: PRICING, now: cycleStart });
+    assert.equal(u.spentUsd, 0);
+    assert.equal(u.projectedEndOfCycleUsd, 0); // 0 spend → 0 projection, but no NaN
+    assert.equal(Number.isFinite(u.projectedEndOfCycleUsd), true);
+  });
+
+  it('claude provider only counts claude-code/anthropic-api turns', () => {
+    const turns: TurnRecord[] = [
+      turn({ ts: '2026-04-05T00:00:00.000Z', source: 'claude-code', inputTokens: 1_000_000 }),
+      turn({ ts: '2026-04-06T00:00:00.000Z', source: 'codex', inputTokens: 1_000_000 }),
+      turn({ ts: '2026-04-07T00:00:00.000Z', source: 'opencode', inputTokens: 1_000_000 }),
+    ];
+    const u = computePlanUsage(plan, turns, { pricing: PRICING, now });
+    assert.equal(u.spentUsd, 3); // only the claude-code turn
+  });
+
+  it('custom provider counts every turn', () => {
+    const customPlan: Plan = { ...plan, provider: 'custom' };
+    const turns: TurnRecord[] = [
+      turn({ ts: '2026-04-05T00:00:00.000Z', source: 'claude-code', inputTokens: 1_000_000 }),
+      turn({ ts: '2026-04-06T00:00:00.000Z', source: 'codex', inputTokens: 1_000_000 }),
+      turn({ ts: '2026-04-07T00:00:00.000Z', source: 'opencode', inputTokens: 1_000_000 }),
+    ];
+    const u = computePlanUsage(customPlan, turns, { pricing: PRICING, now });
+    assert.equal(u.spentUsd, 9); // all three
+  });
+
+  it('honors a custom resetDay (anniversary cycle)', () => {
+    const anniversaryPlan: Plan = { ...plan, resetDay: 15 };
+    // now = April 20, cycle started April 15, ends May 15
+    const turns: TurnRecord[] = [
+      turn({ ts: '2026-04-16T00:00:00.000Z', inputTokens: 1_000_000 }), // inside
+      turn({ ts: '2026-04-10T00:00:00.000Z', inputTokens: 5_000_000 }), // before cycle start
+    ];
+    const u = computePlanUsage(anniversaryPlan, turns, {
+      pricing: PRICING,
+      now: new Date('2026-04-20T00:00:00.000Z'),
+    });
+    assert.equal(u.spentUsd, 3);
+  });
+
+  it('skips turns with unparseable timestamps without throwing', () => {
+    const turns: TurnRecord[] = [
+      turn({ ts: 'garbage', inputTokens: 1_000_000 }),
+      turn({ ts: '2026-04-05T00:00:00.000Z', inputTokens: 1_000_000 }),
+    ];
+    const u = computePlanUsage(plan, turns, { pricing: PRICING, now });
+    assert.equal(u.spentUsd, 3);
+  });
+});

--- a/packages/analyze/src/plan-usage.ts
+++ b/packages/analyze/src/plan-usage.ts
@@ -143,8 +143,13 @@ function matchesProvider(provider: Plan['provider'], turn: TurnRecord): boolean 
     case 'claude':
       return turn.source === 'claude-code' || turn.source === 'anthropic-api';
     case 'cursor':
-      // No reader emits `cursor` turns yet (see SourceKind in @relayburn/reader);
-      // this branch will start picking up spend once a Cursor adapter lands.
+      // Cursor spend is structurally unobservable from a local-first tool:
+      // Cursor moved usage tracking server-side around 2026-01 and the
+      // `tokenCount` fields in their local SQLite went to zero. See #22 for
+      // the full investigation — the issue is closed wontfix. The cursor
+      // preset is kept so users on Cursor Pro can still register their
+      // monthly budget and reset day, but `spentUsd` will always be 0
+      // (and the projection therefore $0) until Cursor reverses course.
       return turn.source === ('cursor' as TurnRecord['source']);
     case 'custom':
       // Custom plans count every turn the ledger has — the user opts in by

--- a/packages/analyze/src/plan-usage.ts
+++ b/packages/analyze/src/plan-usage.ts
@@ -1,0 +1,154 @@
+import type { Plan } from '@relayburn/ledger';
+import type { TurnRecord } from '@relayburn/reader';
+
+import { costForTurn } from './cost.js';
+import type { PricingTable } from './pricing.js';
+
+export interface PlanUsage {
+  plan: Plan;
+  cycleStart: Date;
+  cycleEnd: Date;
+  spentUsd: number;
+  daysElapsed: number;
+  daysInCycle: number;
+  // Linear extrapolation: spent / daysElapsed × daysInCycle. Equals spentUsd
+  // when the cycle just started (daysElapsed === 0) so the projection never
+  // collapses to zero or NaN.
+  projectedEndOfCycleUsd: number;
+  overBudget: boolean;
+  // Days of budget left at the current daily-spend rate. null when daily
+  // spend is zero (no observable rate yet) or when projection is under
+  // budget — runway is "until the wall," not "until the cycle ends." When
+  // the projection sits under budget, the runway exceeds the cycle length
+  // and the cycle resets first, which makes runway uninteresting.
+  runwayDays: number | null;
+  resetAt: string;
+  // True when the cycle has fewer than this many days of observed data.
+  // Renderers should mark these projections as "limited data" per #39's
+  // acceptance criteria.
+  limitedData: boolean;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const LIMITED_DATA_DAYS = 7;
+
+export interface ComputePlanUsageOptions {
+  pricing: PricingTable;
+  now?: Date;
+}
+
+export function computePlanUsage(
+  plan: Plan,
+  turns: Iterable<TurnRecord>,
+  opts: ComputePlanUsageOptions,
+): PlanUsage {
+  const now = opts.now ?? new Date();
+  const { cycleStart, cycleEnd } = cycleBounds(plan.resetDay, now);
+  const cycleStartMs = cycleStart.getTime();
+  const cycleEndMs = cycleEnd.getTime();
+  const nowMs = now.getTime();
+
+  let spent = 0;
+  for (const t of turns) {
+    if (!matchesProvider(plan.provider, t)) continue;
+    const ts = Date.parse(t.ts);
+    if (!Number.isFinite(ts)) continue;
+    if (ts < cycleStartMs || ts >= cycleEndMs) continue;
+    const cost = costForTurn(t, opts.pricing);
+    if (cost) spent += cost.total;
+  }
+
+  const elapsedMs = Math.max(0, nowMs - cycleStartMs);
+  const cycleMs = Math.max(1, cycleEndMs - cycleStartMs);
+  const daysElapsed = Math.floor(elapsedMs / MS_PER_DAY);
+  const daysInCycle = Math.max(1, Math.round(cycleMs / MS_PER_DAY));
+
+  const fractionElapsed = elapsedMs / cycleMs;
+  // Linear projection from observed spend across the elapsed slice. When
+  // the cycle just started, fall back to the spent total so the projection
+  // never explodes to infinity.
+  const projected = fractionElapsed > 0 ? spent / fractionElapsed : spent;
+
+  const overBudget = projected > plan.budgetUsd;
+
+  let runwayDays: number | null = null;
+  if (overBudget && elapsedMs > 0) {
+    const dailyRate = spent / (elapsedMs / MS_PER_DAY);
+    if (dailyRate > 0) {
+      const remaining = Math.max(0, plan.budgetUsd - spent);
+      runwayDays = Math.floor(remaining / dailyRate);
+    }
+  }
+
+  return {
+    plan,
+    cycleStart,
+    cycleEnd,
+    spentUsd: spent,
+    daysElapsed,
+    daysInCycle,
+    projectedEndOfCycleUsd: projected,
+    overBudget,
+    runwayDays,
+    resetAt: cycleEnd.toISOString(),
+    limitedData: daysElapsed < LIMITED_DATA_DAYS,
+  };
+}
+
+// Returns the [start, end) window for the cycle containing `now`. The
+// start is the most recent occurrence of resetDay (clamped to the month's
+// last day if resetDay > month length); the end is the next occurrence.
+// Both are anchored to UTC midnight so the boundary is unambiguous across
+// timezones.
+export function cycleBounds(resetDay: number, now: Date): { cycleStart: Date; cycleEnd: Date } {
+  const utcYear = now.getUTCFullYear();
+  const utcMonth = now.getUTCMonth();
+
+  // Candidate start in the *current* UTC month.
+  const thisMonthStart = makeCycleAnchor(utcYear, utcMonth, resetDay);
+
+  let cycleStart: Date;
+  if (now.getTime() >= thisMonthStart.getTime()) {
+    cycleStart = thisMonthStart;
+  } else {
+    // We're before this month's anchor → cycle started in the previous month.
+    cycleStart = makeCycleAnchor(utcYear, utcMonth - 1, resetDay);
+  }
+  const cycleEnd = makeCycleAnchor(
+    cycleStart.getUTCFullYear(),
+    cycleStart.getUTCMonth() + 1,
+    resetDay,
+  );
+  // Defensive: a month boundary that lands the same calendar day (DST/leap
+  // shift edge case) shouldn't produce a zero-length cycle.
+  if (cycleEnd.getTime() <= cycleStart.getTime()) {
+    return { cycleStart, cycleEnd: new Date(cycleStart.getTime() + 28 * MS_PER_DAY) };
+  }
+  return { cycleStart, cycleEnd };
+}
+
+function makeCycleAnchor(year: number, month: number, day: number): Date {
+  // Date.UTC handles month over/underflow (month -1 → previous December,
+  // month 12 → next January). For day, we manually clamp to the actual
+  // month length so resetDay=31 in February resolves to Feb 28/29.
+  const normYear = year + Math.floor(month / 12);
+  const normMonth = ((month % 12) + 12) % 12;
+  const lastOfMonth = new Date(Date.UTC(normYear, normMonth + 1, 0)).getUTCDate();
+  const clampedDay = Math.min(day, lastOfMonth);
+  return new Date(Date.UTC(normYear, normMonth, clampedDay));
+}
+
+function matchesProvider(provider: Plan['provider'], turn: TurnRecord): boolean {
+  switch (provider) {
+    case 'claude':
+      return turn.source === 'claude-code' || turn.source === 'anthropic-api';
+    case 'cursor':
+      // No reader emits `cursor` turns yet (see SourceKind in @relayburn/reader);
+      // this branch will start picking up spend once a Cursor adapter lands.
+      return turn.source === ('cursor' as TurnRecord['source']);
+    case 'custom':
+      // Custom plans count every turn the ledger has — the user opts in by
+      // labelling their plan as `custom`.
+      return true;
+  }
+}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`burn limits`** — Claude quota-window tracker. Pairs the OAuth `usage` endpoint snapshot (`five_hour`, `seven_day`, `seven_day_opus`, `extra_usage`) with a local-ledger forecast (burn rate + linearly-extrapolated projected % at reset). Supports `--watch [5s]`, `--json`, `--no-api` (offline), `--no-forecast`. Reads the OAuth token from `CLAUDE_CODE_OAUTH_TOKEN`, `~/.claude/.credentials.json`, or macOS Keychain without persisting it; responses cached ≤30s in-process. Token-missing exits 2 with a one-line message. (#5)
+- **`burn plans`** — monthly plan budget tracking. Subcommands: `add --provider <p> --preset <name>` (built-in presets: claude/pro $20, claude/max $200, cursor/pro $20), `add --provider custom --id <id> --name <"…"> --budget <usd> [--reset-day <1-31>]`, `remove <id>`, `set-reset-day <id> <day>`. Bare `burn plans` lists configured plans with current cycle spend, projected end-of-cycle, and elapsed days; `--json` emits the raw `PlanUsage` shape. Plans persist to `~/.relayburn/plans.json`. (#39)
+- **`burn limits` integrates plan status** when plans are configured: a `Monthly plan (<name>):` block per plan reports cycle spend / budget / elapsed / projected end-of-cycle (`$X over` or `Y% under`) plus `Runway: N more days at current rate` when over-pace. Projections with fewer than 7 days of cycle data render with a `(limited data)` marker so users don't anchor on noise from the first week. The `--json` payload gains a `plans[]` array with the full numeric breakdown. (#39)
 
 ## [0.9.0] - 2026-04-24
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { runDiagnose } from './commands/diagnose.js';
 import { runIngest } from './commands/ingest.js';
 import { runLimits } from './commands/limits.js';
 import { runOpencodeWrapper } from './commands/opencode.js';
+import { runPlans } from './commands/plans.js';
 import { runRebuild } from './commands/rebuild.js';
 import { runRebuildIndex } from './commands/rebuild-index.js';
 import { runSummary } from './commands/summary.js';
@@ -25,6 +26,7 @@ Usage:
                      [--patterns[=retries,failures,compaction,reverts]]
   burn diagnose      <session-id> [--json]
   burn limits        [--watch [5s]] [--json] [--no-api] [--no-forecast]
+  burn plans         [add|remove|set-reset-day] …  (run \`burn plans help\` for full usage)
   burn context       [advise] [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]
   burn compare       [--models a,b] [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--json|--csv]
   burn claude        [--tag k=v ...] [-- <claude args>]
@@ -46,6 +48,9 @@ Examples:
   burn limits
   burn limits --watch
   burn limits --no-api
+  burn plans
+  burn plans add --provider claude --preset max
+  burn plans set-reset-day claude-max 15
   burn context --since 30d
   burn context --kind claude-md
   burn context advise --top 3
@@ -80,6 +85,8 @@ async function main(): Promise<number> {
       return runDiagnose(args);
     case 'limits':
       return runLimits(args);
+    case 'plans':
+      return runPlans(args);
     case 'context':
       return runContext(args);
     case 'compare':

--- a/packages/cli/src/commands/limits.test.ts
+++ b/packages/cli/src/commands/limits.test.ts
@@ -50,6 +50,7 @@ function noTokenDeps(): LimitsDeps {
     fetchUsage: async () => ({}),
     now: fakeNow,
     loadForecast: async () => null,
+    loadPlanStatuses: async () => [],
   };
 }
 
@@ -59,6 +60,7 @@ function tokenDeps(usage: UsageResponse, forecast: ForecastInput | null = null):
     fetchUsage: async () => usage,
     now: fakeNow,
     loadForecast: async () => forecast,
+    loadPlanStatuses: async () => [],
   };
 }
 
@@ -188,6 +190,120 @@ describe('burn limits', () => {
     );
     assert.equal(result, 2);
     assert.match(stderr, /invalid --watch value/);
+  });
+
+  it('renders Monthly plan block when a plan status is provided', async () => {
+    const usage: UsageResponse = {
+      five_hour: { percent_used: 30, reset_at: '2026-04-24T13:00:00.000Z' },
+    };
+    const deps: LimitsDeps = {
+      loadToken: async () => 'tok',
+      fetchUsage: async () => usage,
+      now: fakeNow,
+      loadForecast: async () => null,
+      loadPlanStatuses: async () => [
+        {
+          usage: {
+            plan: {
+              id: 'claude-max',
+              provider: 'claude',
+              name: 'Claude Max',
+              budgetUsd: 200,
+              resetDay: 1,
+            },
+            cycleStart: new Date('2026-04-01T00:00:00.000Z'),
+            cycleEnd: new Date('2026-05-01T00:00:00.000Z'),
+            spentUsd: 87.42,
+            daysElapsed: 13,
+            daysInCycle: 30,
+            projectedEndOfCycleUsd: 201.73,
+            overBudget: true,
+            runwayDays: 29,
+            resetAt: '2026-05-01T00:00:00.000Z',
+            limitedData: false,
+          },
+        },
+      ],
+    };
+    const { stdout } = await captureStdout(() => runLimits(args(), deps));
+    assert.match(stdout, /Monthly plan \(Claude Max\):/);
+    // 87.42 / 200 = 43.71% → rounds to 44%
+    assert.match(stdout, /Spent:\s+\$87\.42 \/ \$200\.00\s+\(44%\)/);
+    assert.match(stdout, /Elapsed:\s+13 \/ 30 days/);
+    assert.match(stdout, /Projected: \$201.73 end-of-cycle \(\$1\.73 over\)/);
+    assert.match(stdout, /Runway:\s+29 more days/);
+  });
+
+  it('annotates plan projection as "(limited data)" when daysElapsed < 7', async () => {
+    const deps: LimitsDeps = {
+      loadToken: async () => 'tok',
+      fetchUsage: async () => ({}),
+      now: fakeNow,
+      loadForecast: async () => null,
+      loadPlanStatuses: async () => [
+        {
+          usage: {
+            plan: {
+              id: 'claude-pro',
+              provider: 'claude',
+              name: 'Claude Pro',
+              budgetUsd: 20,
+              resetDay: 1,
+            },
+            cycleStart: new Date('2026-04-22T00:00:00.000Z'),
+            cycleEnd: new Date('2026-05-22T00:00:00.000Z'),
+            spentUsd: 1,
+            daysElapsed: 2,
+            daysInCycle: 30,
+            projectedEndOfCycleUsd: 15,
+            overBudget: false,
+            runwayDays: null,
+            resetAt: '2026-05-22T00:00:00.000Z',
+            limitedData: true,
+          },
+        },
+      ],
+    };
+    const { stdout } = await captureStdout(() => runLimits(args(), deps));
+    assert.match(stdout, /\(limited data\)/);
+  });
+
+  it('emits plan statuses in --json output', async () => {
+    const deps: LimitsDeps = {
+      loadToken: async () => 'tok',
+      fetchUsage: async () => ({}),
+      now: fakeNow,
+      loadForecast: async () => null,
+      loadPlanStatuses: async () => [
+        {
+          usage: {
+            plan: {
+              id: 'claude-pro',
+              provider: 'claude',
+              name: 'Claude Pro',
+              budgetUsd: 20,
+              resetDay: 1,
+            },
+            cycleStart: new Date('2026-04-01T00:00:00.000Z'),
+            cycleEnd: new Date('2026-05-01T00:00:00.000Z'),
+            spentUsd: 5.5,
+            daysElapsed: 23,
+            daysInCycle: 30,
+            projectedEndOfCycleUsd: 7.17,
+            overBudget: false,
+            runwayDays: null,
+            resetAt: '2026-05-01T00:00:00.000Z',
+            limitedData: false,
+          },
+        },
+      ],
+    };
+    const { stdout } = await captureStdout(() => runLimits(args({ json: true }), deps));
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.plans.length, 1);
+    assert.equal(parsed.plans[0].id, 'claude-pro');
+    assert.equal(parsed.plans[0].budgetUsd, 20);
+    assert.equal(parsed.plans[0].limitedData, false);
   });
 
   it('renders very-low projected % without double-normalizing back to 0..1', async () => {

--- a/packages/cli/src/commands/limits.test.ts
+++ b/packages/cli/src/commands/limits.test.ts
@@ -268,6 +268,30 @@ describe('burn limits', () => {
     assert.match(stdout, /\(limited data\)/);
   });
 
+  it('survives loadPlanStatuses throwing (malformed plans.json) and warns on stderr', async () => {
+    // Regression for the unprotected loadPlanStatuses call: a malformed
+    // user-editable plans.json should warn and degrade to an empty list,
+    // not crash the command (especially under --watch).
+    const usage: UsageResponse = {
+      five_hour: { percent_used: 30, reset_at: '2026-04-24T13:00:00.000Z' },
+    };
+    const deps: LimitsDeps = {
+      loadToken: async () => 'tok',
+      fetchUsage: async () => usage,
+      now: fakeNow,
+      loadForecast: async () => null,
+      loadPlanStatuses: async () => {
+        throw new Error('invalid JSON in /home/u/.relayburn/plans.json: Unexpected token');
+      },
+    };
+    const { result, stdout, stderr } = await captureStdout(() => runLimits(args(), deps));
+    assert.equal(result, 0);
+    assert.match(stderr, /could not load plans.*invalid JSON/);
+    // 5-hour quota block must still render — the OAuth fetch isn't gated on plans.
+    assert.match(stdout, /5-hour\s+30% used/);
+    assert.doesNotMatch(stdout, /Monthly plan/);
+  });
+
   it('emits plan statuses in --json output', async () => {
     const deps: LimitsDeps = {
       loadToken: async () => 'tok',

--- a/packages/cli/src/commands/limits.ts
+++ b/packages/cli/src/commands/limits.ts
@@ -3,10 +3,13 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
-import { queryAll } from '@relayburn/ledger';
+import { loadPlans, queryAll } from '@relayburn/ledger';
+import type { Plan } from '@relayburn/ledger';
 
 import type { ParsedArgs } from '../args.js';
+import { formatUsd } from '../format.js';
 import { ingestAll } from '../ingest.js';
+import { statusForPlans, type PlanStatus } from './plans.js';
 
 const USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage';
 const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20';
@@ -40,6 +43,7 @@ export interface LimitsDeps {
   fetchUsage?: (token: string) => Promise<UsageResponse>;
   now?: () => Date;
   loadForecast?: (windowStartMs: number, nowMs: number) => Promise<ForecastInput | null>;
+  loadPlanStatuses?: () => Promise<PlanStatus[]>;
 }
 
 export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promise<number> {
@@ -52,6 +56,7 @@ export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promis
   const fetchUsage = deps.fetchUsage ?? fetchUsageFromApi;
   const now = deps.now ?? (() => new Date());
   const loadForecast = deps.loadForecast ?? loadForecastFromLedger;
+  const loadPlanStatuses = deps.loadPlanStatuses ?? defaultLoadPlanStatuses;
 
   // Resolve the OAuth token once per invocation, not per render. The macOS
   // Keychain path spawns `security`, which is expensive enough that calling
@@ -95,6 +100,8 @@ export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promis
       ? projectFromOauth(usage.five_hour.percent_used, forecast.data)
       : null;
 
+    const planStatuses = await loadPlanStatuses();
+
     if (json) {
       return {
         exitCode: usageError ? 1 : 0,
@@ -113,6 +120,21 @@ export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promis
                   projectedPercentAtReset: projectedPercent,
                 }
               : null,
+            plans: planStatuses.map((s) => ({
+              id: s.usage.plan.id,
+              provider: s.usage.plan.provider,
+              name: s.usage.plan.name,
+              budgetUsd: s.usage.plan.budgetUsd,
+              resetDay: s.usage.plan.resetDay,
+              spentUsd: s.usage.spentUsd,
+              daysElapsed: s.usage.daysElapsed,
+              daysInCycle: s.usage.daysInCycle,
+              projectedEndOfCycleUsd: s.usage.projectedEndOfCycleUsd,
+              overBudget: s.usage.overBudget,
+              runwayDays: s.usage.runwayDays,
+              resetAt: s.usage.resetAt,
+              limitedData: s.usage.limitedData,
+            })),
           },
           null,
           2,
@@ -122,7 +144,7 @@ export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promis
 
     return {
       exitCode: usageError ? 1 : 0,
-      output: renderTty({ usage, usageError, forecast, projectedPercent, now: nowDate }),
+      output: renderTty({ usage, usageError, forecast, projectedPercent, planStatuses, now: nowDate }),
     };
   };
 
@@ -151,9 +173,10 @@ function renderTty(opts: {
   usageError: string | null;
   forecast: { window: ForecastWindow; data: ForecastInput } | null;
   projectedPercent: number | null;
+  planStatuses: PlanStatus[];
   now: Date;
 }): string {
-  const { usage, usageError, forecast, projectedPercent, now } = opts;
+  const { usage, usageError, forecast, projectedPercent, planStatuses, now } = opts;
   const lines: string[] = [];
   lines.push('Claude');
 
@@ -201,6 +224,26 @@ function renderTty(opts: {
         parts.push(`projected ${projectedPercent.toFixed(0)}% at reset`);
       }
       lines.push(`  ${parts.join(', ')}`);
+    }
+  }
+
+  for (const status of planStatuses) {
+    lines.push('');
+    lines.push(`Monthly plan (${status.usage.plan.name}):`);
+    const u = status.usage;
+    const spentPct = u.plan.budgetUsd > 0 ? (u.spentUsd / u.plan.budgetUsd) * 100 : 0;
+    lines.push(
+      `  Spent:     ${formatUsd(u.spentUsd)} / ${formatUsd(u.plan.budgetUsd)}   (${spentPct.toFixed(0)}%)`,
+    );
+    lines.push(`  Elapsed:   ${u.daysElapsed} / ${u.daysInCycle} days`);
+    const projected = formatUsd(u.projectedEndOfCycleUsd);
+    const overOrUnder = u.overBudget
+      ? `${formatUsd(u.projectedEndOfCycleUsd - u.plan.budgetUsd)} over`
+      : `${(((u.plan.budgetUsd - u.projectedEndOfCycleUsd) / u.plan.budgetUsd) * 100).toFixed(0)}% under`;
+    const limited = u.limitedData ? '  (limited data)' : '';
+    lines.push(`  Projected: ${projected} end-of-cycle (${overOrUnder})${limited}`);
+    if (u.runwayDays !== null) {
+      lines.push(`  Runway:    ${u.runwayDays} more day${u.runwayDays === 1 ? '' : 's'} at current rate`);
     }
   }
 
@@ -423,6 +466,12 @@ async function safeBody(res: Response): Promise<string> {
   } catch {
     return '';
   }
+}
+
+async function defaultLoadPlanStatuses(): Promise<PlanStatus[]> {
+  const plans: Plan[] = await loadPlans();
+  if (plans.length === 0) return [];
+  return statusForPlans(plans);
 }
 
 async function loadForecastFromLedger(

--- a/packages/cli/src/commands/limits.ts
+++ b/packages/cli/src/commands/limits.ts
@@ -100,7 +100,17 @@ export async function runLimits(args: ParsedArgs, deps: LimitsDeps = {}): Promis
       ? projectFromOauth(usage.five_hour.percent_used, forecast.data)
       : null;
 
-    const planStatuses = await loadPlanStatuses();
+    // Match the resilience pattern used for `fetchOnce` above: a malformed
+    // ~/.relayburn/plans.json (user-editable) shouldn't crash the whole
+    // command — and especially shouldn't terminate the --watch loop. Warn
+    // once on stderr and degrade to an empty plan list.
+    let planStatuses: PlanStatus[] = [];
+    try {
+      planStatuses = await loadPlanStatuses();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[burn] warning: could not load plans (${msg})\n`);
+    }
 
     if (json) {
       return {

--- a/packages/cli/src/commands/plans.test.ts
+++ b/packages/cli/src/commands/plans.test.ts
@@ -1,0 +1,166 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { after, beforeEach, describe, it } from 'node:test';
+
+import { loadPlans } from '@relayburn/ledger';
+
+import type { ParsedArgs } from '../args.js';
+import { runPlans } from './plans.js';
+
+function args(positional: string[] = [], flags: Record<string, string | true> = {}): ParsedArgs {
+  return { positional, flags, tags: {}, passthrough: [] };
+}
+
+async function captureStdio<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; stdout: string; stderr: string }> {
+  let stdout = '';
+  let stderr = '';
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((c: string | Uint8Array) => {
+    stdout += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: string | Uint8Array) => {
+    stderr += typeof c === 'string' ? c : Buffer.from(c).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await fn();
+    return { result, stdout, stderr };
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+}
+
+describe('burn plans CLI', () => {
+  let tmp: string;
+  const originalRelay = process.env['RELAYBURN_HOME'];
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'burn-plans-cli-'));
+    process.env['RELAYBURN_HOME'] = tmp;
+  });
+
+  after(async () => {
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('list with no plans points the user at `add`', async () => {
+    const { result, stdout } = await captureStdio(() => runPlans(args()));
+    assert.equal(result, 0);
+    assert.match(stdout, /No plans configured/);
+    assert.match(stdout, /burn plans add/);
+  });
+
+  it('add --provider claude --preset max persists the plan', async () => {
+    const { result } = await captureStdio(() =>
+      runPlans(args(['add'], { provider: 'claude', preset: 'max' })),
+    );
+    assert.equal(result, 0);
+    const plans = await loadPlans();
+    assert.equal(plans.length, 1);
+    assert.equal(plans[0]!.id, 'claude-max');
+    assert.equal(plans[0]!.budgetUsd, 200);
+    assert.equal(plans[0]!.resetDay, 1);
+  });
+
+  it('add accepts --reset-day override on a preset', async () => {
+    const { result } = await captureStdio(() =>
+      runPlans(args(['add'], { provider: 'claude', preset: 'pro', 'reset-day': '15' })),
+    );
+    assert.equal(result, 0);
+    const plans = await loadPlans();
+    assert.equal(plans[0]!.resetDay, 15);
+  });
+
+  it('rejects --reset-day outside 1-31', async () => {
+    const { result, stderr } = await captureStdio(() =>
+      runPlans(args(['add'], { provider: 'claude', preset: 'pro', 'reset-day': '99' })),
+    );
+    assert.equal(result, 2);
+    assert.match(stderr, /reset-day must be an integer 1-31/);
+  });
+
+  it('add --provider custom without --id surfaces a clear error', async () => {
+    const { result, stderr } = await captureStdio(() =>
+      runPlans(args(['add'], { provider: 'custom' })),
+    );
+    assert.equal(result, 2);
+    assert.match(stderr, /--id is required/);
+  });
+
+  it('add --provider custom with required flags writes a custom plan', async () => {
+    const { result } = await captureStdio(() =>
+      runPlans(
+        args(['add'], {
+          provider: 'custom',
+          id: 'work-api',
+          name: 'Work Anthropic API',
+          budget: '500',
+          'reset-day': '7',
+        }),
+      ),
+    );
+    assert.equal(result, 0);
+    const plans = await loadPlans();
+    assert.equal(plans[0]!.id, 'work-api');
+    assert.equal(plans[0]!.provider, 'custom');
+    assert.equal(plans[0]!.budgetUsd, 500);
+    assert.equal(plans[0]!.resetDay, 7);
+  });
+
+  it('refuses to add a plan with a duplicate id', async () => {
+    await captureStdio(() => runPlans(args(['add'], { provider: 'claude', preset: 'pro' })));
+    const { result, stderr } = await captureStdio(() =>
+      runPlans(args(['add'], { provider: 'claude', preset: 'pro' })),
+    );
+    assert.equal(result, 2);
+    assert.match(stderr, /already exists/);
+  });
+
+  it('remove drops the plan', async () => {
+    await captureStdio(() => runPlans(args(['add'], { provider: 'claude', preset: 'max' })));
+    const { result } = await captureStdio(() => runPlans(args(['remove', 'claude-max'])));
+    assert.equal(result, 0);
+    const plans = await loadPlans();
+    assert.equal(plans.length, 0);
+  });
+
+  it('remove with unknown id exits 1 with a clear message', async () => {
+    const { result, stderr } = await captureStdio(() =>
+      runPlans(args(['remove', 'does-not-exist'])),
+    );
+    assert.equal(result, 1);
+    assert.match(stderr, /no plan with id "does-not-exist"/);
+  });
+
+  it('set-reset-day updates the day in place', async () => {
+    await captureStdio(() => runPlans(args(['add'], { provider: 'claude', preset: 'max' })));
+    const { result } = await captureStdio(() => runPlans(args(['set-reset-day', 'claude-max', '15'])));
+    assert.equal(result, 0);
+    const plans = await loadPlans();
+    assert.equal(plans[0]!.resetDay, 15);
+  });
+
+  it('set-reset-day rejects non-integer days', async () => {
+    await captureStdio(() => runPlans(args(['add'], { provider: 'claude', preset: 'pro' })));
+    const { result, stderr } = await captureStdio(() =>
+      runPlans(args(['set-reset-day', 'claude-pro', 'tuesday'])),
+    );
+    assert.equal(result, 2);
+    assert.match(stderr, /must be an integer 1-31/);
+  });
+
+  it('unknown subcommand exits 2 with help', async () => {
+    const { result, stderr } = await captureStdio(() => runPlans(args(['noop'])));
+    assert.equal(result, 2);
+    assert.match(stderr, /unknown subcommand "noop"/);
+  });
+});

--- a/packages/cli/src/commands/plans.ts
+++ b/packages/cli/src/commands/plans.ts
@@ -26,7 +26,10 @@ Usage:
   burn plans set-reset-day <id> <day>                     change a plan's reset day
 
 Built-in presets:
-${BUILTIN_PRESETS.map((p) => `  ${p.preset.padEnd(14)} ${p.plan.name} ($${p.plan.budgetUsd}/mo, resets day ${p.plan.resetDay})`).join('\n')}
+${BUILTIN_PRESETS.map((p) => {
+  const note = p.plan.provider === 'cursor' ? ' — spend tracking unavailable (see #22)' : '';
+  return `  ${p.preset.padEnd(14)} ${p.plan.name} ($${p.plan.budgetUsd}/mo, resets day ${p.plan.resetDay})${note}`;
+}).join('\n')}
 
 Examples:
   burn plans add --provider claude --preset max
@@ -154,6 +157,12 @@ async function runAdd(args: ParsedArgs): Promise<number> {
   }
   await savePlans([...existing, plan]);
   process.stdout.write(`added ${plan.id}: ${plan.name} ($${plan.budgetUsd}/mo, resets day ${plan.resetDay})\n`);
+  if (plan.provider === 'cursor') {
+    process.stdout.write(
+      'note: Cursor moved usage tracking server-side in early 2026 (see #22), so this ' +
+        "plan's spend will report as $0 until Cursor exposes a local data source again.\n",
+    );
+  }
   return 0;
 }
 

--- a/packages/cli/src/commands/plans.ts
+++ b/packages/cli/src/commands/plans.ts
@@ -1,0 +1,257 @@
+import {
+  BUILTIN_PRESETS,
+  findPreset,
+  loadPlans,
+  plansPath,
+  queryAll,
+  savePlans,
+} from '@relayburn/ledger';
+import type { Plan, PlanProvider } from '@relayburn/ledger';
+import { computePlanUsage, loadPricing } from '@relayburn/analyze';
+import type { PlanUsage } from '@relayburn/analyze';
+
+import type { ParsedArgs } from '../args.js';
+import { ingestAll } from '../ingest.js';
+import { formatUsd, table } from '../format.js';
+
+const PLANS_HELP = `burn plans — monthly quota tracking against your plan budget
+
+Usage:
+  burn plans                                              list configured plans + status
+  burn plans add --provider <p> --preset <name>           add a built-in preset
+  burn plans add --id <id> --provider custom \\
+                 --name <"Label"> --budget <usd> \\
+                 [--reset-day <1-31>]                     add a custom plan
+  burn plans remove <id>                                  drop a plan from the list
+  burn plans set-reset-day <id> <day>                     change a plan's reset day
+
+Built-in presets:
+${BUILTIN_PRESETS.map((p) => `  ${p.preset.padEnd(14)} ${p.plan.name} ($${p.plan.budgetUsd}/mo, resets day ${p.plan.resetDay})`).join('\n')}
+
+Examples:
+  burn plans add --provider claude --preset max
+  burn plans add --id work-api --provider custom --name "Work Anthropic API" --budget 500
+  burn plans set-reset-day claude-max 15
+  burn plans remove cursor-pro
+
+Plans are stored at:
+  ${plansPath()}
+`;
+
+export async function runPlans(args: ParsedArgs): Promise<number> {
+  const sub = args.positional[0];
+  if (sub === 'help' || sub === '--help' || sub === '-h') {
+    process.stdout.write(PLANS_HELP);
+    return 0;
+  }
+  if (sub === undefined) return runList(args);
+  if (sub === 'add') return runAdd(args);
+  if (sub === 'remove') return runRemove(args);
+  if (sub === 'set-reset-day') return runSetResetDay(args);
+  process.stderr.write(`burn plans: unknown subcommand "${sub}"\n\n${PLANS_HELP}`);
+  return 2;
+}
+
+async function runList(args: ParsedArgs): Promise<number> {
+  const json = args.flags['json'] === true;
+  const plans = await loadPlans();
+  const statuses = await statusForPlans(plans);
+
+  if (json) {
+    process.stdout.write(JSON.stringify({ plans: statuses }, null, 2) + '\n');
+    return 0;
+  }
+
+  if (statuses.length === 0) {
+    process.stdout.write(
+      'No plans configured. Add one with `burn plans add --provider claude --preset pro`.\n',
+    );
+    return 0;
+  }
+
+  const rows: string[][] = [['id', 'name', 'spent', 'projected', 'budget', 'reset']];
+  for (const s of statuses) {
+    const u = s.usage;
+    const projected = formatUsd(u.projectedEndOfCycleUsd);
+    const projectedCell = u.limitedData ? `${projected} (limited data)` : projected;
+    rows.push([
+      u.plan.id,
+      u.plan.name,
+      formatUsd(u.spentUsd),
+      projectedCell,
+      formatUsd(u.plan.budgetUsd),
+      `${u.daysElapsed}/${u.daysInCycle} days`,
+    ]);
+  }
+  process.stdout.write(table(rows) + '\n');
+  return 0;
+}
+
+async function runAdd(args: ParsedArgs): Promise<number> {
+  const provider = args.flags['provider'];
+  if (typeof provider !== 'string' || !isProvider(provider)) {
+    process.stderr.write(
+      `burn plans add: --provider must be one of claude, cursor, custom\n\n${PLANS_HELP}`,
+    );
+    return 2;
+  }
+
+  const preset = args.flags['preset'];
+  let plan: Plan;
+  if (typeof preset === 'string') {
+    const found = findPreset(provider, preset);
+    if (!found) {
+      process.stderr.write(
+        `burn plans add: unknown preset "${provider}/${preset}". Available: ${BUILTIN_PRESETS.map((p) => p.preset).join(', ')}\n`,
+      );
+      return 2;
+    }
+    plan = found;
+  } else if (provider === 'custom') {
+    try {
+      plan = customFromFlags(args);
+    } catch (err) {
+      process.stderr.write(
+        `burn plans add: ${err instanceof Error ? err.message : String(err)}\n` +
+          'pass --preset <name> for a built-in plan, or --provider custom with --id/--name/--budget for a custom one.\n',
+      );
+      return 2;
+    }
+  } else {
+    process.stderr.write(
+      'burn plans add: pass --preset <name> for a built-in plan, or --provider custom with --id/--name/--budget for a custom one.\n',
+    );
+    return 2;
+  }
+
+  // Allow flag overrides on top of presets so users can tweak budget / id
+  // without writing the JSON file by hand.
+  if (typeof args.flags['id'] === 'string') plan.id = args.flags['id'];
+  if (typeof args.flags['name'] === 'string') plan.name = args.flags['name'];
+  if (typeof args.flags['budget'] === 'string') {
+    const n = Number(args.flags['budget']);
+    if (!Number.isFinite(n) || n <= 0) {
+      process.stderr.write(`burn plans add: --budget must be a positive number\n`);
+      return 2;
+    }
+    plan.budgetUsd = n;
+  }
+  if (typeof args.flags['reset-day'] === 'string') {
+    const day = parseResetDay(args.flags['reset-day']);
+    if (day === null) {
+      process.stderr.write(`burn plans add: --reset-day must be an integer 1-31\n`);
+      return 2;
+    }
+    plan.resetDay = day;
+  }
+
+  const existing = await loadPlans();
+  if (existing.some((p) => p.id === plan.id)) {
+    process.stderr.write(
+      `burn plans add: plan with id "${plan.id}" already exists. Remove it first or pass --id <new-id>.\n`,
+    );
+    return 2;
+  }
+  await savePlans([...existing, plan]);
+  process.stdout.write(`added ${plan.id}: ${plan.name} ($${plan.budgetUsd}/mo, resets day ${plan.resetDay})\n`);
+  return 0;
+}
+
+function customFromFlags(args: ParsedArgs): Plan {
+  const requireString = (key: string): string => {
+    const v = args.flags[key];
+    if (typeof v !== 'string' || v.length === 0) {
+      throw new Error(`--${key} is required for custom plans`);
+    }
+    return v;
+  };
+  const requireBudget = (): number => {
+    const v = args.flags['budget'];
+    if (typeof v !== 'string') throw new Error('--budget is required for custom plans');
+    const n = Number(v);
+    if (!Number.isFinite(n) || n <= 0) throw new Error('--budget must be a positive number');
+    return n;
+  };
+  const id = requireString('id');
+  const name = requireString('name');
+  const budgetUsd = requireBudget();
+  const resetDayRaw = args.flags['reset-day'];
+  const resetDay = typeof resetDayRaw === 'string' ? parseResetDay(resetDayRaw) ?? 1 : 1;
+  return { id, provider: 'custom', name, budgetUsd, resetDay };
+}
+
+async function runRemove(args: ParsedArgs): Promise<number> {
+  const id = args.positional[1];
+  if (!id) {
+    process.stderr.write(`burn plans remove: missing plan id\n\n${PLANS_HELP}`);
+    return 2;
+  }
+  const plans = await loadPlans();
+  const next = plans.filter((p) => p.id !== id);
+  if (next.length === plans.length) {
+    process.stderr.write(`burn plans remove: no plan with id "${id}"\n`);
+    return 1;
+  }
+  await savePlans(next);
+  process.stdout.write(`removed ${id}\n`);
+  return 0;
+}
+
+async function runSetResetDay(args: ParsedArgs): Promise<number> {
+  const id = args.positional[1];
+  const dayArg = args.positional[2];
+  if (!id || !dayArg) {
+    process.stderr.write(
+      `burn plans set-reset-day: usage: burn plans set-reset-day <id> <1-31>\n`,
+    );
+    return 2;
+  }
+  const day = parseResetDay(dayArg);
+  if (day === null) {
+    process.stderr.write(`burn plans set-reset-day: <day> must be an integer 1-31, got ${dayArg}\n`);
+    return 2;
+  }
+  const plans = await loadPlans();
+  const idx = plans.findIndex((p) => p.id === id);
+  if (idx === -1) {
+    process.stderr.write(`burn plans set-reset-day: no plan with id "${id}"\n`);
+    return 1;
+  }
+  plans[idx] = { ...plans[idx]!, resetDay: day };
+  await savePlans(plans);
+  process.stdout.write(`updated ${id}: resets on day ${day}\n`);
+  return 0;
+}
+
+export interface PlanStatus {
+  usage: PlanUsage;
+}
+
+// Shared by `burn plans` (list view) and `burn limits` (composite view) so
+// both surfaces show identical numbers.
+export async function statusForPlans(plans: Plan[]): Promise<PlanStatus[]> {
+  if (plans.length === 0) return [];
+  await ingestAll();
+  const pricing = await loadPricing();
+  // Pull the widest cycle window across plans so we only walk the ledger
+  // once. Cheaper than per-plan queryAll for users with several plans.
+  const oldestStart = plans
+    .map((p) => {
+      const usageStub = computePlanUsage(p, [], { pricing, now: new Date() });
+      return usageStub.cycleStart.getTime();
+    })
+    .reduce((a, b) => Math.min(a, b), Date.now());
+  const since = new Date(oldestStart).toISOString();
+  const turns = await queryAll({ since });
+  return plans.map((plan) => ({ usage: computePlanUsage(plan, turns, { pricing }) }));
+}
+
+function isProvider(s: string): s is PlanProvider {
+  return s === 'claude' || s === 'cursor' || s === 'custom';
+}
+
+function parseResetDay(s: string): number | null {
+  const n = Number(s);
+  if (!Number.isInteger(n) || n < 1 || n > 31) return null;
+  return n;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ export { runContext } from './commands/context.js';
 export { runClaudeWrapper } from './commands/claude.js';
 export { runIngest } from './commands/ingest.js';
 export { runLimits } from './commands/limits.js';
+export { runPlans } from './commands/plans.js';
 export { parseArgs } from './args.js';
 export { ingestClaudeProjects, ingestOpencodeSessions, ingestAll } from './ingest.js';
 export { runOpencodeWrapper } from './commands/opencode.js';

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Plans config primitives** (#39). New `Plan` / `PlansFile` / `PlanProvider` types, `loadPlans()` / `savePlans()` against `~/.relayburn/plans.json`, `BUILTIN_PRESETS` covering claude/pro ($20), claude/max ($200), cursor/pro ($20), and `findPreset(provider, name)`. `normalizePlan` validates each row (positive `budgetUsd`, integer `resetDay` 1-31, known `provider`) so a malformed file throws once at load rather than producing garbage downstream. New `plansPath()` exported alongside the existing path helpers.
+
 ## [0.8.0] - 2026-04-24
 
 ### Added

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -11,6 +11,7 @@ export {
   lockPath,
   pricingOverridePath,
   configPath,
+  plansPath,
   contentDir,
   contentFilePath,
   isValidSessionId,
@@ -51,3 +52,11 @@ export type {
   BuildClaudeHookSettingsOptions,
   ClaudeHookSettingsResult,
 } from './hook-settings.js';
+export {
+  BUILTIN_PRESETS,
+  findPreset,
+  loadPlans,
+  normalizePlan,
+  savePlans,
+} from './plans.js';
+export type { Plan, PlanPreset, PlanProvider, PlansFile } from './plans.js';

--- a/packages/ledger/src/paths.ts
+++ b/packages/ledger/src/paths.ts
@@ -39,6 +39,10 @@ export function configPath(): string {
   return path.join(ledgerHome(), 'config.json');
 }
 
+export function plansPath(): string {
+  return path.join(ledgerHome(), 'plans.json');
+}
+
 export function contentDir(): string {
   return path.join(ledgerHome(), 'content');
 }

--- a/packages/ledger/src/plans.test.ts
+++ b/packages/ledger/src/plans.test.ts
@@ -1,0 +1,110 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { after, beforeEach, describe, it } from 'node:test';
+
+import {
+  BUILTIN_PRESETS,
+  findPreset,
+  loadPlans,
+  normalizePlan,
+  plansPath,
+  savePlans,
+} from './index.js';
+
+describe('plans config', () => {
+  let tmp: string;
+  const originalRelay = process.env['RELAYBURN_HOME'];
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'burn-plans-'));
+    process.env['RELAYBURN_HOME'] = tmp;
+  });
+
+  after(async () => {
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('returns [] when plans.json does not exist', async () => {
+    const plans = await loadPlans();
+    assert.deepEqual(plans, []);
+  });
+
+  it('round-trips a saved plans list', async () => {
+    const plan = { ...BUILTIN_PRESETS[0]!.plan };
+    await savePlans([plan]);
+    const loaded = await loadPlans();
+    assert.deepEqual(loaded, [plan]);
+  });
+
+  it('throws on malformed JSON', async () => {
+    await writeFile(plansPath(), 'not json', 'utf8');
+    await assert.rejects(loadPlans, /invalid JSON/);
+  });
+
+  it('throws when plans.json is not an object with a plans array', async () => {
+    await writeFile(plansPath(), '[]', 'utf8');
+    await assert.rejects(loadPlans, /missing a "plans" array/);
+  });
+
+  it('rejects rows with missing or invalid fields', async () => {
+    assert.throws(() => normalizePlan({ id: '', provider: 'claude' }, 0), /id must be a non-empty string/);
+    assert.throws(
+      () => normalizePlan({ id: 'x', provider: 'foo', name: 'X', budgetUsd: 1, resetDay: 1 }, 0),
+      /provider must be/,
+    );
+    assert.throws(
+      () => normalizePlan({ id: 'x', provider: 'claude', name: 'X', budgetUsd: -1, resetDay: 1 }, 0),
+      /budgetUsd must be a positive number/,
+    );
+    assert.throws(
+      () => normalizePlan({ id: 'x', provider: 'claude', name: 'X', budgetUsd: 1, resetDay: 32 }, 0),
+      /resetDay must be an integer 1-31/,
+    );
+    assert.throws(
+      () => normalizePlan({ id: 'x', provider: 'claude', name: 'X', budgetUsd: 1, resetDay: 1.5 }, 0),
+      /resetDay must be an integer 1-31/,
+    );
+  });
+});
+
+describe('findPreset', () => {
+  it('returns claude/pro preset with $20 budget', () => {
+    const p = findPreset('claude', 'pro');
+    assert.ok(p);
+    assert.equal(p!.id, 'claude-pro');
+    assert.equal(p!.budgetUsd, 20);
+  });
+
+  it('returns claude/max preset with $200 budget', () => {
+    const p = findPreset('claude', 'max');
+    assert.ok(p);
+    assert.equal(p!.budgetUsd, 200);
+  });
+
+  it('returns cursor/pro preset', () => {
+    const p = findPreset('cursor', 'pro');
+    assert.ok(p);
+    assert.equal(p!.provider, 'cursor');
+  });
+
+  it('returns null for unknown preset', () => {
+    assert.equal(findPreset('claude', 'bogus'), null);
+    assert.equal(findPreset('custom', 'anything'), null);
+  });
+
+  it('is case-insensitive', () => {
+    assert.ok(findPreset('claude', 'PRO'));
+    assert.ok(findPreset('claude', 'Max'));
+  });
+
+  it('returns a copy so callers cannot mutate the registry', () => {
+    const a = findPreset('claude', 'pro')!;
+    a.budgetUsd = 999;
+    const b = findPreset('claude', 'pro')!;
+    assert.equal(b.budgetUsd, 20);
+  });
+});

--- a/packages/ledger/src/plans.ts
+++ b/packages/ledger/src/plans.ts
@@ -1,0 +1,144 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { plansPath } from './paths.js';
+
+export type PlanProvider = 'claude' | 'cursor' | 'custom';
+
+export interface Plan {
+  // Stable identifier the user passes to `burn plans remove <id>` and
+  // `set-reset-day <id>`. Defaults to `<provider>-<preset>` for built-in
+  // presets and is required for custom plans.
+  id: string;
+  provider: PlanProvider;
+  // Human-readable label shown in `burn plans` and `burn limits` output.
+  name: string;
+  budgetUsd: number;
+  // Day-of-month the cycle resets on (1-31). Day 1 is calendar-month reset.
+  // Days >28 clamp to the actual month length when the target month is
+  // shorter (e.g. resetDay=31 in February resets on the 28th/29th).
+  resetDay: number;
+}
+
+export interface PlansFile {
+  plans: Plan[];
+}
+
+export interface PlanPreset {
+  // Key the CLI accepts via `burn plans add --provider claude --preset pro`.
+  preset: string;
+  plan: Plan;
+}
+
+// Built-in presets per issue #39. Cursor spend is not currently surfaced by
+// any of the readers (see `SourceKind` in `@relayburn/reader`), so registering
+// the cursor preset is a UX nicety only — its spend will report as $0 until
+// a Cursor adapter lands.
+export const BUILTIN_PRESETS: PlanPreset[] = [
+  {
+    preset: 'claude/pro',
+    plan: {
+      id: 'claude-pro',
+      provider: 'claude',
+      name: 'Claude Pro',
+      budgetUsd: 20,
+      resetDay: 1,
+    },
+  },
+  {
+    preset: 'claude/max',
+    plan: {
+      id: 'claude-max',
+      provider: 'claude',
+      name: 'Claude Max',
+      budgetUsd: 200,
+      resetDay: 1,
+    },
+  },
+  {
+    preset: 'cursor/pro',
+    plan: {
+      id: 'cursor-pro',
+      provider: 'cursor',
+      name: 'Cursor Pro',
+      budgetUsd: 20,
+      resetDay: 1,
+    },
+  },
+];
+
+export function findPreset(provider: PlanProvider, preset: string): Plan | null {
+  const key = `${provider}/${preset}`.toLowerCase();
+  const hit = BUILTIN_PRESETS.find((p) => p.preset.toLowerCase() === key);
+  return hit ? { ...hit.plan } : null;
+}
+
+export async function loadPlans(): Promise<Plan[]> {
+  let raw: string;
+  try {
+    raw = await readFile(plansPath(), 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`invalid JSON in ${plansPath()}: ${(err as Error).message}`);
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`${plansPath()} must contain a JSON object with a "plans" array`);
+  }
+  const list = (parsed as { plans?: unknown }).plans;
+  if (!Array.isArray(list)) {
+    throw new Error(`${plansPath()} is missing a "plans" array`);
+  }
+  return list.map((row, i) => normalizePlan(row, i));
+}
+
+export async function savePlans(plans: Plan[]): Promise<void> {
+  await mkdir(path.dirname(plansPath()), { recursive: true });
+  const body: PlansFile = { plans };
+  await writeFile(plansPath(), JSON.stringify(body, null, 2) + '\n', 'utf8');
+}
+
+export function normalizePlan(raw: unknown, index: number): Plan {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`plans[${index}] is not an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  const id = pickString(r['id'], `plans[${index}].id`);
+  const provider = pickProvider(r['provider'], `plans[${index}].provider`);
+  const name = pickString(r['name'], `plans[${index}].name`);
+  const budgetUsd = pickPositiveNumber(r['budgetUsd'], `plans[${index}].budgetUsd`);
+  const resetDay = pickResetDay(r['resetDay'], `plans[${index}].resetDay`);
+  return { id, provider, name, budgetUsd, resetDay };
+}
+
+function pickString(v: unknown, label: string): string {
+  if (typeof v !== 'string' || v.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return v.trim();
+}
+
+function pickProvider(v: unknown, label: string): PlanProvider {
+  if (v === 'claude' || v === 'cursor' || v === 'custom') return v;
+  throw new Error(`${label} must be "claude", "cursor", or "custom"`);
+}
+
+function pickPositiveNumber(v: unknown, label: string): number {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
+    throw new Error(`${label} must be a positive number`);
+  }
+  return v;
+}
+
+function pickResetDay(v: unknown, label: string): number {
+  if (typeof v !== 'number' || !Number.isInteger(v) || v < 1 || v > 31) {
+    throw new Error(`${label} must be an integer 1-31`);
+  }
+  return v;
+}
+


### PR DESCRIPTION
## Summary

Closes #39 — complement to `burn limits`'s 5-hour OAuth window. Tracks spend against monthly plan budgets (Claude Pro/Max, Cursor Pro, custom) and surfaces projected end-of-cycle spend, runway-days-at-current-rate, and over/under-budget delta. Plans are configured via a new `burn plans` subcommand and persisted to `~/.relayburn/plans.json`; status flows automatically into `burn limits` output as a `Monthly plan` block alongside the 5-hour view.

## What ships

**`@relayburn/ledger`** — config primitives:
- `Plan` / `PlansFile` / `PlanProvider` types, `loadPlans()` / `savePlans()` against `~/.relayburn/plans.json` (override via `RELAYBURN_HOME`).
- `BUILTIN_PRESETS` covering claude/pro ($20), claude/max ($200), cursor/pro ($20). `findPreset(provider, name)` looks them up.
- `normalizePlan` validates each row (positive `budgetUsd`, integer `resetDay` 1-31, known `provider`) so a malformed `plans.json` throws once at load with a path-prefixed error rather than producing garbage downstream.

**`@relayburn/analyze`** — math:
- `computePlanUsage(plan, turns, { pricing, now })` aggregates spend over the active cycle and returns `PlanUsage`: `spentUsd`, `daysElapsed`, `daysInCycle`, `projectedEndOfCycleUsd` (linear extrapolation), `overBudget`, `runwayDays` (only populated when over-pace — runway is "until the wall", not "until the cycle ends"), `resetAt`, `limitedData` (true when fewer than 7 days have elapsed).
- `cycleBounds(resetDay, now)` — UTC-anchored, end-of-month clamping for `resetDay > 28` (e.g. resetDay=31 in February resolves to Feb 28/29), year-boundary safe, never returns a zero-length cycle.
- Provider-aware filtering: `claude` plans count `claude-code` + `anthropic-api` turns; `cursor` plans count `cursor` turns (no reader emits these yet — the branch is in place for when a Cursor adapter lands); `custom` plans count every turn.

**`@relayburn/cli`** — surface:
- `burn plans` subcommand: `add --provider <p> --preset <name>` for built-ins; `add --provider custom --id <id> --name "<…>" --budget <usd> [--reset-day <1-31>]` for custom. `remove <id>`, `set-reset-day <id> <day>`. Bare `burn plans` lists configured plans with cycle spend, projection, budget, and elapsed days. `--json` on the list view.
- `burn limits` integrates plan status: a `Monthly plan (<name>):` block per plan reports `Spent / Budget`, `Elapsed`, `Projected end-of-cycle ($X over | Y% under)`, and `Runway: N more days at current rate` when over-pace. Projections with `limitedData` render with a `(limited data)` marker per the issue's acceptance. The `--json` payload gains a `plans[]` array with the full numeric breakdown.

## Acceptance criteria check

- [x] `burn plans add --provider claude --plan max` registers a plan with known defaults — works with `--preset max` (issue spec said `--plan` but the implementation uses `--preset` to disambiguate from the verb sense; documented in `burn plans help`).
- [x] `burn limits` shows monthly status alongside 5-hour status when a plan is configured.
- [x] Projection is honest about confidence: `< 7 days` of cycle data → `(limited data)` marker.
- [x] Over-budget case shows clearly: `Projected: $201.73 end-of-cycle ($1.73 over)`.
- [x] Custom `resetDay` cycles respected (anniversary-style billing).

## Test plan

- [x] `pnpm run test:ts` passes — **314 tests** (+36 new across `plans` config / `plan-usage` math / `burn plans` CLI / `burn limits` integration).
- [x] `cycleBounds` covered for: calendar (day 1), mid-cycle anniversary (day 15), pre-anniversary (day 15 from day 10), leap-year clamping (day 31 in Feb), end-of-month roll-forward, year-boundary crossing.
- [x] `computePlanUsage` covered for: cycle filtering, linear projection math, overBudget + runway, runway-null-when-under-budget, limitedData flag, zero-projection-without-NaN at cycle start, claude-vs-custom provider filtering, anniversary cycle, garbage timestamp tolerance.
- [x] `burn plans` CLI covered for: empty list message, preset add, `--reset-day` override on preset, invalid `--reset-day`, missing custom flags, custom add, duplicate id refusal, remove, remove unknown id, `set-reset-day` happy + invalid path, unknown subcommand.
- [x] `burn limits` covered for: Monthly plan block rendering, `(limited data)` marker, `plans[]` in JSON output.
- [x] End-to-end smoke against my real ledger — `burn plans add --provider claude --preset max` then `burn plans` showed actual cycle spend computed from claude-code session logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
