### PR TITLE
Promote even-split note to a banner when it dominates (#60)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`burn mcp-server`** — stdio MCP (Model Context Protocol) server that lets a running agent self-query its own cost and quota state mid-session. Registers `burn__sessionCost` and `burn__currentBlock`. Read-only. Pair with `buildMcpConfig({sessionId})` from `@relayburn/mcp` to inject the server into a spawned `claude --mcp-config <…>` session. (#26)
 
+### Changed
+
+- **`burn waste` promotes the even-split caveat to a banner when it dominates.** When ≥ 50% of matched sessions used even-split attribution (no content sidecar), the report now emits a `⚠ attribution is degraded:` banner *above* the tables, softens the attributed-dollar line to `attributed ≈ … (approximate — see above)`, and suffixes each table heading with `(approximate)`. The banner points at `burn rebuild --content` for remediation. Below 50% the existing footer note is unchanged; fully-sized ledgers stay silent. `--json` output gains an `attributionDegraded: boolean` field so pipelines don't have to reverse-engineer the state from the session list. (#60)
+
 ## [0.11.0] - 2026-04-25
 
 ### Added

--- a/packages/cli/src/commands/waste.test.ts
+++ b/packages/cli/src/commands/waste.test.ts
@@ -1,0 +1,196 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type {
+  BashAggregation,
+  FileAggregation,
+  SessionWasteTotals,
+  SubagentAggregation,
+  WasteResult,
+} from '@relayburn/analyze';
+
+import { formatWasteReport, isAttributionDegraded } from './waste.js';
+
+function session(
+  id: string,
+  method: 'sized' | 'even-split',
+): SessionWasteTotals {
+  return {
+    sessionId: id,
+    grandCost: 1,
+    attributedCost: 0.5,
+    unattributedCost: 0.5,
+    attributionMethod: method,
+  };
+}
+
+function makeResult(sessions: SessionWasteTotals[]): WasteResult {
+  return {
+    attributions: [],
+    sessionTotals: sessions,
+    grandTotal: 100,
+    attributedTotal: 25,
+    unattributedTotal: 75,
+  };
+}
+
+const NO_FILES: FileAggregation[] = [];
+const NO_BASH: BashAggregation[] = [];
+const NO_SUBAGENTS: SubagentAggregation[] = [];
+
+describe('isAttributionDegraded', () => {
+  it('returns false when there are no sessions', () => {
+    assert.equal(isAttributionDegraded(makeResult([])), false);
+  });
+
+  it('returns false when all sessions are sized', () => {
+    const r = makeResult([session('a', 'sized'), session('b', 'sized')]);
+    assert.equal(isAttributionDegraded(r), false);
+  });
+
+  it('returns false when even-split is below 50%', () => {
+    const r = makeResult([
+      session('a', 'even-split'),
+      session('b', 'sized'),
+      session('c', 'sized'),
+    ]);
+    assert.equal(isAttributionDegraded(r), false);
+  });
+
+  it('returns true at exactly 50% even-split', () => {
+    const r = makeResult([
+      session('a', 'even-split'),
+      session('b', 'sized'),
+    ]);
+    assert.equal(isAttributionDegraded(r), true);
+  });
+
+  it('returns true when even-split dominates', () => {
+    const r = makeResult([
+      session('a', 'even-split'),
+      session('b', 'even-split'),
+      session('c', 'even-split'),
+      session('d', 'sized'),
+    ]);
+    assert.equal(isAttributionDegraded(r), true);
+  });
+
+  it('honors a custom threshold', () => {
+    // 1/3 even-split, threshold 0.25 → degraded
+    const r = makeResult([
+      session('a', 'even-split'),
+      session('b', 'sized'),
+      session('c', 'sized'),
+    ]);
+    assert.equal(isAttributionDegraded(r, 0.25), true);
+    assert.equal(isAttributionDegraded(r, 0.5), false);
+  });
+});
+
+describe('formatWasteReport', () => {
+  it('renders no even-split note when all sessions are sized', () => {
+    const result = makeResult([
+      session('a', 'sized'),
+      session('b', 'sized'),
+    ]);
+    const out = formatWasteReport({
+      turnsAnalyzed: 100,
+      result,
+      files: NO_FILES,
+      bashes: NO_BASH,
+      subagents: NO_SUBAGENTS,
+      limit: 10,
+      degraded: false,
+    });
+    assert.doesNotMatch(out, /even-split/);
+    assert.doesNotMatch(out, /attribution is degraded/);
+    assert.doesNotMatch(out, /\(approximate\)/);
+    // Headings render plain.
+    assert.match(out, /Top files by cumulative cost\n/);
+    assert.match(out, /Top Bash commands by cost\n/);
+    assert.match(out, /Top subagent calls by cost\n/);
+    // Original combined attributed/unattributed line.
+    assert.match(out, /attributed to tool calls: \$25\.00/);
+  });
+
+  it('keeps the footer note when partial even-split (< 50%)', () => {
+    const result = makeResult([
+      session('a', 'even-split'),
+      session('b', 'sized'),
+      session('c', 'sized'),
+    ]);
+    const out = formatWasteReport({
+      turnsAnalyzed: 100,
+      result,
+      files: NO_FILES,
+      bashes: NO_BASH,
+      subagents: NO_SUBAGENTS,
+      limit: 10,
+      degraded: false,
+    });
+    assert.match(out, /note: 1\/3 sessions used even-split/);
+    assert.doesNotMatch(out, /attribution is degraded/);
+    assert.doesNotMatch(out, /\(approximate\)/);
+    assert.match(out, /attributed to tool calls: \$25\.00/);
+  });
+
+  it('promotes to a banner with (approximate) suffixes when degraded', () => {
+    // 2 of 3 → 66.7% even-split
+    const result = makeResult([
+      session('a', 'even-split'),
+      session('b', 'even-split'),
+      session('c', 'sized'),
+    ]);
+    const out = formatWasteReport({
+      turnsAnalyzed: 64117,
+      result,
+      files: NO_FILES,
+      bashes: NO_BASH,
+      subagents: NO_SUBAGENTS,
+      limit: 10,
+      degraded: true,
+    });
+    // Banner is emitted with the warning glyph and the right counts.
+    assert.match(
+      out,
+      /⚠ attribution is degraded: 2 of 3 sessions \(66\.7%\) have no content/,
+    );
+    // Remediation pointer is present.
+    assert.match(out, /burn rebuild --content/);
+    assert.match(out, /burn content/);
+    // Softened attributed line uses ≈ and the qualifier.
+    assert.match(out, /attributed ≈ \$25\.00\s+\(approximate — see above\)/);
+    // Unattributed line keeps its breakdown.
+    assert.match(
+      out,
+      /unattributed \$75\.00\s+\(output, system overhead, untracked\)/,
+    );
+    // All three table headings are suffixed with "(approximate)".
+    assert.match(out, /Top files by cumulative cost \(approximate\)/);
+    assert.match(out, /Top Bash commands by cost \(approximate\)/);
+    assert.match(out, /Top subagent calls by cost \(approximate\)/);
+    // Old footer note must NOT appear when banner is shown.
+    assert.doesNotMatch(out, /^note: \d+\/\d+ sessions used even-split/m);
+  });
+
+  it('formats large session counts with thousands separators in the banner', () => {
+    const sessions: SessionWasteTotals[] = [];
+    for (let i = 0; i < 39_587; i++) {
+      sessions.push(session(`s${i}`, i < 39_486 ? 'even-split' : 'sized'));
+    }
+    const result = makeResult(sessions);
+    const out = formatWasteReport({
+      turnsAnalyzed: 64117,
+      result,
+      files: NO_FILES,
+      bashes: NO_BASH,
+      subagents: NO_SUBAGENTS,
+      limit: 10,
+      degraded: true,
+    });
+    assert.match(
+      out,
+      /⚠ attribution is degraded: 39,486 of 39,587 sessions \(99\.7%\)/,
+    );
+  });
+});

--- a/packages/cli/src/commands/waste.ts
+++ b/packages/cli/src/commands/waste.ts
@@ -5,8 +5,11 @@ import {
   attributeWaste,
   detectPatterns,
   loadPricing,
+  type BashAggregation,
   type FileAggregation,
   type PatternsResult,
+  type SubagentAggregation,
+  type WasteResult,
 } from '@relayburn/analyze';
 import { queryAll, queryCompactions, readContent, type Query } from '@relayburn/ledger';
 import type { ContentRecord } from '@relayburn/reader';
@@ -18,6 +21,23 @@ import type { ParsedArgs } from '../args.js';
 const DEFAULT_TOP_N = 10;
 const PATTERN_KINDS = ['retries', 'failures', 'compaction', 'reverts'] as const;
 type PatternKind = (typeof PATTERN_KINDS)[number];
+
+// When even-split sessions reach this fraction of the matched set, the
+// attribution caveat is promoted from a footer note to a top banner and
+// every dollar table heading is suffixed with "(approximate)". Below this
+// fraction the current footer note is preserved. (#60)
+const EVEN_SPLIT_DEGRADED_THRESHOLD = 0.5;
+
+export function isAttributionDegraded(
+  result: WasteResult,
+  threshold: number = EVEN_SPLIT_DEGRADED_THRESHOLD,
+): boolean {
+  if (result.sessionTotals.length === 0) return false;
+  const evenSplit = result.sessionTotals.filter(
+    (s) => s.attributionMethod === 'even-split',
+  ).length;
+  return evenSplit / result.sessionTotals.length >= threshold;
+}
 
 export async function runWaste(args: ParsedArgs): Promise<number> {
   const q: Query = {};
@@ -51,6 +71,7 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
   const files = aggregateByFile(result.attributions);
   const bashes = aggregateByBash(result.attributions);
   const subagents = aggregateBySubagent(result.attributions);
+  const degraded = isAttributionDegraded(result);
 
   if (args.flags['json'] === true) {
     process.stdout.write(
@@ -60,6 +81,7 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
           grandTotal: result.grandTotal,
           attributedTotal: result.attributedTotal,
           unattributedTotal: result.unattributedTotal,
+          attributionDegraded: degraded,
           sessions: result.sessionTotals,
           files,
           bash: bashes,
@@ -75,26 +97,89 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
   const showAll = args.flags['all'] === true;
   const limit = showAll ? Number.POSITIVE_INFINITY : DEFAULT_TOP_N;
 
+  process.stdout.write(
+    formatWasteReport({
+      turnsAnalyzed: turns.length,
+      result,
+      files,
+      bashes,
+      subagents,
+      limit,
+      degraded,
+    }),
+  );
+  return 0;
+}
+
+interface FormatWasteReportInput {
+  turnsAnalyzed: number;
+  result: WasteResult;
+  files: FileAggregation[];
+  bashes: BashAggregation[];
+  subagents: SubagentAggregation[];
+  limit: number;
+  degraded: boolean;
+}
+
+export function formatWasteReport(input: FormatWasteReportInput): string {
+  const { turnsAnalyzed, result, files, bashes, subagents, limit, degraded } = input;
+  const evenSplitSessions = result.sessionTotals.filter(
+    (s) => s.attributionMethod === 'even-split',
+  );
+
   const out: string[] = [];
   out.push('');
-  out.push(`turns analyzed: ${formatInt(turns.length)}`);
+  out.push(`turns analyzed: ${formatInt(turnsAnalyzed)}`);
   out.push(`session grand total: ${formatUsd(result.grandTotal)}`);
-  out.push(
-    `attributed to tool calls: ${formatUsd(result.attributedTotal)}  /  unattributed (output, system overhead, untracked): ${formatUsd(result.unattributedTotal)}`,
-  );
-  const evenSplitSessions = result.sessionTotals.filter((s) => s.attributionMethod === 'even-split');
-  if (evenSplitSessions.length > 0 && evenSplitSessions.length === result.sessionTotals.length) {
+
+  if (degraded) {
+    // Banner above the tables. Numbers are formatted with thousands
+    // separators since at degraded scale they're often 5-6 digits.
+    const total = result.sessionTotals.length;
+    const ev = evenSplitSessions.length;
+    const pct = total > 0 ? (ev / total) * 100 : 0;
+    out.push('');
     out.push(
-      'note: no content sidecar data found — using even-split (initial cost only). Enable content.store=full in your config to get persistence attribution.',
+      `⚠ attribution is degraded: ${formatInt(ev)} of ${formatInt(total)} sessions (${pct.toFixed(1)}%) have no content`,
     );
-  } else if (evenSplitSessions.length > 0) {
     out.push(
-      `note: ${evenSplitSessions.length}/${result.sessionTotals.length} sessions used even-split (no content sidecar).`,
+      '  sidecar, so file / bash / subagent costs for those sessions are approximate',
     );
+    out.push(
+      "  (even-split over turn N+1 input/cacheCreate). Run 'burn rebuild --content'",
+    );
+    out.push(
+      "  to backfill sidecars from source session files, or see 'burn content' for",
+    );
+    out.push('  why capture is disabled.');
+    out.push('');
+    out.push(
+      `attributed ≈ ${formatUsd(result.attributedTotal)}  (approximate — see above)`,
+    );
+    out.push(
+      `unattributed ${formatUsd(result.unattributedTotal)}  (output, system overhead, untracked)`,
+    );
+  } else {
+    out.push(
+      `attributed to tool calls: ${formatUsd(result.attributedTotal)}  /  unattributed (output, system overhead, untracked): ${formatUsd(result.unattributedTotal)}`,
+    );
+    if (
+      evenSplitSessions.length > 0 &&
+      evenSplitSessions.length === result.sessionTotals.length
+    ) {
+      out.push(
+        'note: no content sidecar data found — using even-split (initial cost only). Enable content.store=full in your config to get persistence attribution.',
+      );
+    } else if (evenSplitSessions.length > 0) {
+      out.push(
+        `note: ${evenSplitSessions.length}/${result.sessionTotals.length} sessions used even-split (no content sidecar).`,
+      );
+    }
   }
   out.push('');
 
-  out.push('Top files by cumulative cost');
+  const approxSuffix = degraded ? ' (approximate)' : '';
+  out.push(`Top files by cumulative cost${approxSuffix}`);
   if (files.length === 0) {
     out.push('  (no Read/Edit/Write tool calls)');
   } else {
@@ -102,7 +187,7 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
   }
   out.push('');
 
-  out.push('Top Bash commands by cost');
+  out.push(`Top Bash commands by cost${approxSuffix}`);
   if (bashes.length === 0) {
     out.push('  (no Bash tool calls)');
   } else {
@@ -110,7 +195,7 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
   }
   out.push('');
 
-  out.push('Top subagent calls by cost');
+  out.push(`Top subagent calls by cost${approxSuffix}`);
   if (subagents.length === 0) {
     out.push('  (no Agent/Task tool calls)');
   } else {
@@ -118,8 +203,7 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
   }
   out.push('');
 
-  process.stdout.write(out.join('\n'));
-  return 0;
+  return out.join('\n');
 }
 
 function renderFileTable(files: FileAggregation[], limit: number, attributed: number): string {
@@ -142,7 +226,7 @@ function renderFileTable(files: FileAggregation[], limit: number, attributed: nu
   return table(rows);
 }
 
-function renderBashTable(bashes: ReturnType<typeof aggregateByBash>, limit: number): string {
+function renderBashTable(bashes: BashAggregation[], limit: number): string {
   const rows: string[][] = [['command', 'calls', 'initial(tok)', 'persist(tok)', 'cost']];
   const slice = bashes.slice(0, limit);
   for (const b of slice) {
@@ -157,7 +241,7 @@ function renderBashTable(bashes: ReturnType<typeof aggregateByBash>, limit: numb
   return table(rows);
 }
 
-function renderSubagentTable(subagents: ReturnType<typeof aggregateBySubagent>, limit: number): string {
+function renderSubagentTable(subagents: SubagentAggregation[], limit: number): string {
   const rows: string[][] = [['subagent', 'calls', 'initial(tok)', 'persist(tok)', 'cost']];
   const slice = subagents.slice(0, limit);
   for (const s of slice) {


### PR DESCRIPTION
Fixes #60

## Summary

- When >= 50% of matched sessions used even-split attribution, `burn waste` now emits a prominent `attribution is degraded:` banner above the tables, softens the attributed-dollar line to `attributed ~ ... (approximate -- see above)`, and suffixes each of the three table headings (Top files / Top Bash / Top subagents) with `(approximate)`. The banner points at `burn rebuild --content` for remediation, with `burn content` as the secondary pointer for "why is capture disabled".
- Below 50% the existing `note: N/M sessions used even-split (no content sidecar).` footer is preserved verbatim; fully-sized ledgers stay silent.
- `--json` output gains a top-level `attributionDegraded: boolean` field next to `sessions[]` so consumers don't have to recompute the ratio from `attributionMethod` counts.
- Refactored the formatting path out of `runWaste` into a pure `formatWasteReport(...)` so the three states (sized / partial / degraded) can be covered by direct tests without an ingest fixture. Threshold is a const (`EVEN_SPLIT_DEGRADED_THRESHOLD = 0.5`); the helper accepts an override so a future `--warn-even-split-threshold` flag is a drop-in.

## Test plan

- [x] `pnpm run test:ts` (349/349 pass)
- [x] New `packages/cli/src/commands/waste.test.ts` covers:
  - `isAttributionDegraded`: empty / all-sized / < 50% / exactly 50% / > 50% / custom threshold
  - `formatWasteReport`: silent on all-sized, footer note on partial, banner + `(approximate)` suffixes on degraded, and a 39,486 / 39,587 case to verify thousands separators in the banner numbers

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
