### PR TITLE
Persist UserTurnRecord through ledger and ingest (#94)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **User-turn passthrough in ingest** (#94). `burn ingest`, `burn ingest --runtime claude` (hook path), and `burn claude` (subcommand wrapper) now persist `UserTurnRecord`s the Claude / Codex / OpenCode parsers produce, alongside the existing turns / content / compaction / relationship / tool-result-event lines. No new flags or output yet — this lays the substrate so per-tool-call cost attribution (#2) can read user-turn block sizes back out of the ledger instead of re-parsing source session files at query time.
+
 ## [0.20.0] - 2026-04-26
 
 ### Added

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -8,6 +8,7 @@ import {
   appendRelationships,
   appendToolResultEvents,
   appendTurns,
+  appendUserTurns,
   loadConfig,
   loadCursors,
   saveCursors,
@@ -74,7 +75,7 @@ export async function ingestSession(cwd: string, sessionId: string): Promise<voi
     return;
   }
   const cfg = await loadConfig();
-  const { turns, content, events, relationships, toolResultEvents } =
+  const { turns, content, events, relationships, toolResultEvents, userTurns } =
     await parseClaudeSession(file, {
       sessionPath: file,
       contentMode: cfg.content.store,
@@ -85,6 +86,7 @@ export async function ingestSession(cwd: string, sessionId: string): Promise<voi
   if (events.length > 0) await appendCompactions(events);
   if (relationships.length > 0) await appendRelationships(relationships);
   if (toolResultEvents.length > 0) await appendToolResultEvents(toolResultEvents);
+  if (userTurns.length > 0) await appendUserTurns(userTurns);
 
   // Persist a cursor so a later `burn summary` (which calls ingestAll) skips
   // this file instead of re-parsing and re-appending its content. Turns are

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -7,6 +7,7 @@ import {
   appendRelationships,
   appendToolResultEvents,
   appendTurns,
+  appendUserTurns,
   loadConfig,
   loadCursors,
   saveCursors,
@@ -133,6 +134,7 @@ async function ingestClaudeTranscript(
     events,
     relationships,
     toolResultEvents,
+    userTurns,
     endOffset,
     lastUserText,
   } = await parseClaudeSessionIncremental(file, parseOpts);
@@ -142,6 +144,7 @@ async function ingestClaudeTranscript(
   if (events.length > 0) await appendCompactions(events);
   if (relationships.length > 0) await appendRelationships(relationships);
   if (toolResultEvents.length > 0) await appendToolResultEvents(toolResultEvents);
+  if (userTurns.length > 0) await appendUserTurns(userTurns);
 
   const next: ClaudeCursor = {
     kind: 'claude',

--- a/packages/cli/src/ingest.test.ts
+++ b/packages/cli/src/ingest.test.ts
@@ -1,13 +1,16 @@
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import type { ContentRecord, TurnRecord } from '@relayburn/reader';
+import { queryUserTurns } from '@relayburn/ledger';
+import { ledgerPath } from '@relayburn/ledger';
 
 import {
   countToolCallGaps,
+  ingestClaudeProjects,
   ingestCodexSessions,
   resetIngestGapWarnings,
   setIngestGapWriter,
@@ -164,7 +167,113 @@ describe('ingest gap warning (codex parser-gap scenario)', () => {
   });
 });
 
+describe('ingest forwards UserTurnRecord into the ledger (#94)', () => {
+  let tmpHome: string;
+  let tmpRelay: string;
+  const originalHome = process.env['HOME'];
+  const originalRelay = process.env['RELAYBURN_HOME'];
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-ut-home-'));
+    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-ut-relay-'));
+    process.env['HOME'] = tmpHome;
+    process.env['RELAYBURN_HOME'] = tmpRelay;
+    resetIngestGapWarnings();
+  });
+
+  after(async () => {
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+    else delete process.env['HOME'];
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    resetIngestGapWarnings();
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(tmpRelay, { recursive: true, force: true });
+  });
+
+  it('writes user-turn lines for a Claude session and dedupes on re-ingest', async () => {
+    await writeClaudeSession(tmpHome, 'sess-ut-1', claudeSessionWithUserTurn());
+
+    await ingestClaudeProjects();
+    const first = await queryUserTurns();
+    assert.equal(first.length, 1, 'one user-turn line written');
+    assert.equal(first[0]!.userUuid, 'u-user-1');
+    assert.equal(first[0]!.blocks.length, 1);
+    assert.equal(first[0]!.blocks[0]!.kind, 'text');
+
+    // Re-ingest must be a no-op for already-persisted user turns.
+    const sizeBefore = (await stat(ledgerPath())).size;
+    await ingestClaudeProjects();
+    const sizeAfter = (await stat(ledgerPath())).size;
+    assert.equal(sizeAfter, sizeBefore, 'ledger must not grow on idempotent re-ingest');
+    const second = await queryUserTurns();
+    assert.equal(second.length, 1, 'still one user-turn line after re-ingest');
+  });
+});
+
 // ---------- helpers ----------
+
+async function writeClaudeSession(home: string, sessionId: string, body: string): Promise<void> {
+  // Real claude layout is ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl.
+  const encoded = '-tmp-project'; // matches '/tmp/project' encoded as '-' joins
+  const dir = path.join(home, '.claude', 'projects', encoded);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, `${sessionId}.jsonl`), body, 'utf8');
+}
+
+// One user line + one assistant line — the parser emits a single
+// UserTurnRecord with a `text` block carrying the user's prompt.
+function claudeSessionWithUserTurn(): string {
+  const sid = '22222222-2222-2222-2222-222222222222';
+  const lines = [
+    {
+      type: 'permission-mode',
+      permissionMode: 'default',
+      sessionId: sid,
+    },
+    {
+      parentUuid: null,
+      isSidechain: false,
+      promptId: 'p-1',
+      type: 'user',
+      message: { role: 'user', content: 'please fix the build' },
+      uuid: 'u-user-1',
+      timestamp: '2026-04-20T00:00:00.000Z',
+      cwd: '/tmp/project',
+      sessionId: sid,
+      version: '2.1.96',
+    },
+    {
+      parentUuid: 'u-user-1',
+      isSidechain: false,
+      message: {
+        model: 'claude-sonnet-4-6',
+        id: 'msg_ut_1',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 500,
+          cache_creation: { ephemeral_5m_input_tokens: 80, ephemeral_1h_input_tokens: 20 },
+          output_tokens: 5,
+          service_tier: 'standard',
+        },
+      },
+      requestId: 'req_1',
+      type: 'assistant',
+      uuid: 'u-asst-1',
+      timestamp: '2026-04-20T00:00:01.000Z',
+      cwd: '/tmp/project',
+      sessionId: sid,
+      version: '2.1.96',
+    },
+  ];
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
+}
 
 function makeTurn(opts: { messageId: string; toolCallCount: number }): TurnRecord {
   return {

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -19,6 +19,7 @@ import {
   appendRelationships,
   appendToolResultEvents,
   appendTurns,
+  appendUserTurns,
   listContentSessionIds,
   loadConfig,
   loadCursors,
@@ -242,6 +243,7 @@ async function ingestClaudeInto(
           events,
           relationships,
           toolResultEvents,
+          userTurns,
           endOffset,
           lastUserText,
         } = await parseClaudeSessionIncremental(file, parseOpts);
@@ -268,6 +270,9 @@ async function ingestClaudeInto(
         }
         if (toolResultEvents.length > 0) {
           await appendToolResultEvents(toolResultEvents);
+        }
+        if (userTurns.length > 0) {
+          await appendUserTurns(userTurns);
         }
         const next: ClaudeCursor = {
           kind: 'claude',
@@ -323,7 +328,7 @@ async function ingestCodexInto(
         contentMode,
       };
       if (resume !== undefined) opts.resume = resume;
-      const { turns, content, endOffset, resume: nextResume } =
+      const { turns, content, userTurns, endOffset, resume: nextResume } =
         await parseCodexSessionIncremental(file, opts);
       if (turns.length > 0) {
         await appendTurns(turns);
@@ -339,6 +344,9 @@ async function ingestCodexInto(
       }
       if (content.length > 0) {
         await appendContent(content);
+      }
+      if (userTurns.length > 0) {
+        await appendUserTurns(userTurns);
       }
       const next: CodexCursor = {
         kind: 'codex',
@@ -386,7 +394,7 @@ async function ingestOpencodeInto(
         continue;
       }
 
-      const { turns, content, seenMessageIds: nextSeen } =
+      const { turns, content, userTurns, seenMessageIds: nextSeen } =
         await parseOpencodeSessionIncremental(file, {
           sessionPath: file,
           seenMessageIds,
@@ -406,6 +414,9 @@ async function ingestOpencodeInto(
       }
       if (content.length > 0) {
         await appendContent(content);
+      }
+      if (userTurns.length > 0) {
+        await appendUserTurns(userTurns);
       }
       const next: OpencodeCursor = {
         kind: 'opencode',

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **User-turn ledger line: `UserTurnLine`** (#94, follows #74). New `LedgerLine` kind (`user_turn`) with matching `appendUserTurns` writer, `queryUserTurns` reader, and `isUserTurnLine` guard. Append-only and dedup'd through the same `~/.relayburn/ledger-index` namespace as turns / compactions / relationships / tool-result events via `userTurnIdHash` keyed on `(source, sessionId, userUuid)`. `rebuildIndex` re-indexes the new kind. Old readers that don't recognize `kind: 'user_turn'` simply skip the line — the existing per-kind guards already filter to known kinds. Persists the per-user-turn block sizes the reader started emitting in #74 so consumers can read them back without re-parsing source session files; backfilling user turns into existing ledgers is not done automatically — see follow-up.
+
 ## [0.20.0] - 2026-04-26
 
 ### Added

--- a/packages/ledger/src/index-sidecar.ts
+++ b/packages/ledger/src/index-sidecar.ts
@@ -9,6 +9,7 @@ import type {
   SessionRelationshipRecord,
   ToolResultEventRecord,
   TurnRecord,
+  UserTurnRecord,
 } from '@relayburn/reader';
 
 import { withLock } from './lock.js';
@@ -22,6 +23,7 @@ import {
   isSessionRelationshipLine,
   isToolResultEventLine,
   isTurnLine,
+  isUserTurnLine,
 } from './schema.js';
 
 export const CONTENT_WINDOW = 10_000;
@@ -68,6 +70,19 @@ export function relationshipIdHash(r: SessionRelationshipRecord): string {
 export function toolResultEventIdHash(r: ToolResultEventRecord): string {
   const key = [r.source, r.sessionId, r.toolUseId, r.eventIndex].join('|');
   return createHash('sha256').update(key).digest('hex').slice(0, 16);
+}
+
+// Stable id for a UserTurnRecord. (source, sessionId, userUuid) uniquely
+// identifies a user line within the source — the parser preserves the source
+// log's per-line uuid so two ingest passes re-reading the same bytes produce
+// the same id. Shares the ledger-id namespace with turns / compactions /
+// relationships / tool-result events; the hash inputs differ enough that
+// collisions are not a practical concern.
+export function userTurnIdHash(r: UserTurnRecord): string {
+  return createHash('sha256')
+    .update(`${r.source}|${r.sessionId}|${r.userUuid}`)
+    .digest('hex')
+    .slice(0, 16);
 }
 
 export function turnContentFingerprint(t: TurnRecord): string {
@@ -182,6 +197,8 @@ export async function rebuildIndex(): Promise<{ ids: number; content: number }> 
           ids.add(relationshipIdHash(parsed.record));
         } else if (isToolResultEventLine(parsed)) {
           ids.add(toolResultEventIdHash(parsed.record));
+        } else if (isUserTurnLine(parsed)) {
+          ids.add(userTurnIdHash(parsed.record));
         }
       }
     } finally {

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -3,6 +3,7 @@ export {
   appendRelationships,
   appendToolResultEvents,
   appendTurns,
+  appendUserTurns,
   stamp,
 } from './writer.js';
 export {
@@ -11,6 +12,7 @@ export {
   queryCompactions,
   queryRelationships,
   queryToolResultEvents,
+  queryUserTurns,
 } from './reader.js';
 export type { Query, EnrichedTurn } from './reader.js';
 export {
@@ -56,6 +58,7 @@ export type {
   StampSelector,
   ToolResultEventLine,
   TurnLine,
+  UserTurnLine,
 } from './schema.js';
 export {
   isCompactionLine,
@@ -63,6 +66,7 @@ export {
   isStampLine,
   isToolResultEventLine,
   isTurnLine,
+  isUserTurnLine,
   stampMatches,
 } from './schema.js';
 export { loadHwm, saveHwm } from './hwm.js';
@@ -76,6 +80,7 @@ export {
   toolResultEventIdHash,
   turnIdHash,
   turnContentFingerprint,
+  userTurnIdHash,
 } from './index-sidecar.js';
 export { reclassifyLedger } from './reclassify.js';
 export type { ReclassifyOptions, ReclassifyReport } from './reclassify.js';

--- a/packages/ledger/src/ledger.test.ts
+++ b/packages/ledger/src/ledger.test.ts
@@ -8,15 +8,22 @@ import type {
   SessionRelationshipRecord,
   ToolResultEventRecord,
   TurnRecord,
+  UserTurnRecord,
 } from '@relayburn/reader';
 
 import {
   appendRelationships,
   appendToolResultEvents,
   appendTurns,
+  appendUserTurns,
   stamp,
 } from './writer.js';
-import { queryAll, queryRelationships, queryToolResultEvents } from './reader.js';
+import {
+  queryAll,
+  queryRelationships,
+  queryToolResultEvents,
+  queryUserTurns,
+} from './reader.js';
 import { ledgerContentIndexPath, ledgerIndexPath, ledgerPath } from './paths.js';
 import { __resetIndexCacheForTesting, rebuildIndex } from './index-sidecar.js';
 
@@ -349,6 +356,119 @@ describe('ledger', () => {
     // Verify index files are populated
     const idsContent = await readFile(ledgerIndexPath(), 'utf8');
     assert.equal(idsContent.trim().split('\n').length, 2);
+  });
+
+  it('round-trips UserTurnRecord through append + query and dedupes by (source, sessionId, userUuid)', async () => {
+    const u1: UserTurnRecord = {
+      v: 1,
+      source: 'claude-code',
+      sessionId: 's-ut',
+      userUuid: 'u-1',
+      ts: '2026-04-20T00:00:00.000Z',
+      followingMessageId: 'msg-1',
+      blocks: [
+        { kind: 'text', byteLen: 12, approxTokens: 3 },
+      ],
+    };
+    const u2: UserTurnRecord = {
+      v: 1,
+      source: 'claude-code',
+      sessionId: 's-ut',
+      userUuid: 'u-2',
+      ts: '2026-04-20T00:00:01.000Z',
+      precedingMessageId: 'msg-1',
+      followingMessageId: 'msg-2',
+      blocks: [
+        { kind: 'tool_result', toolUseId: 'tu_a', byteLen: 40, approxTokens: 10 },
+        { kind: 'tool_result', toolUseId: 'tu_b', byteLen: 80, approxTokens: 20, isError: true },
+      ],
+    };
+    await appendUserTurns([u1, u2]);
+    await appendUserTurns([u1]); // dup: same userUuid
+    const got = await queryUserTurns();
+    assert.equal(got.length, 2, 'second append must not produce a duplicate');
+    const second = got.find((r) => r.userUuid === 'u-2')!;
+    assert.equal(second.blocks.length, 2);
+    assert.equal(second.blocks[1]!.isError, true);
+  });
+
+  it('queryUserTurns filters by sessionId, source, and time range', async () => {
+    const a: UserTurnRecord = {
+      v: 1,
+      source: 'claude-code',
+      sessionId: 's-A',
+      userUuid: 'u-A1',
+      ts: '2026-04-19T00:00:00.000Z',
+      blocks: [{ kind: 'text', byteLen: 4, approxTokens: 1 }],
+    };
+    const b: UserTurnRecord = {
+      v: 1,
+      source: 'claude-code',
+      sessionId: 's-B',
+      userUuid: 'u-B1',
+      ts: '2026-04-21T00:00:00.000Z',
+      blocks: [{ kind: 'text', byteLen: 4, approxTokens: 1 }],
+    };
+    const c: UserTurnRecord = {
+      v: 1,
+      source: 'codex',
+      sessionId: 's-C',
+      userUuid: 'u-C1',
+      ts: '2026-04-21T00:00:00.000Z',
+      blocks: [{ kind: 'text', byteLen: 4, approxTokens: 1 }],
+    };
+    await appendUserTurns([a, b, c]);
+    assert.equal((await queryUserTurns({ sessionId: 's-A' })).length, 1);
+    assert.equal((await queryUserTurns({ source: 'codex' })).length, 1);
+    const sinceFiltered = await queryUserTurns({ since: '2026-04-20T00:00:00.000Z' });
+    assert.equal(sinceFiltered.length, 2);
+  });
+
+  it('user-turn append + later turn append do not collide on the ledger lock or id index', async () => {
+    // Sanity: a user-turn line and a turn line written for overlapping
+    // sessionIds share the same ledger but live in distinct id slots.
+    await appendUserTurns([
+      {
+        v: 1,
+        source: 'claude-code',
+        sessionId: 's-mix',
+        userUuid: 'u-mix-1',
+        ts: '2026-04-20T00:00:00.000Z',
+        blocks: [{ kind: 'text', byteLen: 8, approxTokens: 2 }],
+      },
+    ]);
+    await appendTurns([fakeTurn({ sessionId: 's-mix', messageId: 'msg-mix-1' })]);
+    const turns = await queryAll({ sessionId: 's-mix' });
+    const userTurns = await queryUserTurns({ sessionId: 's-mix' });
+    assert.equal(turns.length, 1);
+    assert.equal(userTurns.length, 1);
+  });
+
+  it('rebuildIndex re-indexes user_turn lines', async () => {
+    const turn = fakeTurn({ messageId: 'rebuild-ut-1' });
+    const u: UserTurnRecord = {
+      v: 1,
+      source: 'claude-code',
+      sessionId: 's-rebuild-ut',
+      userUuid: 'u-rebuild-1',
+      ts: '2026-04-20T00:00:00.000Z',
+      blocks: [{ kind: 'text', byteLen: 16, approxTokens: 4 }],
+    };
+    await appendTurns([turn]);
+    await appendUserTurns([u]);
+
+    await unlink(ledgerIndexPath());
+    await unlink(ledgerContentIndexPath());
+    __resetIndexCacheForTesting();
+
+    const { ids } = await rebuildIndex();
+    // 1 turn + 1 user_turn = 2 ids.
+    assert.equal(ids, 2);
+
+    // After rebuild, re-appending the same user turn must not duplicate.
+    const sizeBefore = (await stat(ledgerPath())).size;
+    await appendUserTurns([u]);
+    assert.equal((await stat(ledgerPath())).size, sizeBefore);
   });
 
   it('rebuildIndex re-indexes relationship and tool_result_event lines', async () => {

--- a/packages/ledger/src/reader.ts
+++ b/packages/ledger/src/reader.ts
@@ -8,6 +8,7 @@ import type {
   SourceKind,
   ToolResultEventRecord,
   TurnRecord,
+  UserTurnRecord,
 } from '@relayburn/reader';
 
 import { ledgerPath } from './paths.js';
@@ -17,6 +18,7 @@ import {
   isStampLine,
   isToolResultEventLine,
   isTurnLine,
+  isUserTurnLine,
   stampMatches,
   type Enrichment,
   type StampLine,
@@ -180,6 +182,29 @@ export async function queryToolResultEvents(
   for await (const parsed of streamLines(filePath)) {
     if (!isToolResultEventLine(parsed)) continue;
     if (!toolResultEventPasses(parsed.record, q)) continue;
+    out.push(parsed.record);
+  }
+  return out;
+}
+
+function userTurnPasses(r: UserTurnRecord, q: Query): boolean {
+  if (q.since && r.ts < q.since) return false;
+  if (q.until && r.ts > q.until) return false;
+  if (q.sessionId && r.sessionId !== q.sessionId) return false;
+  if (q.source && r.source !== q.source) return false;
+  // project and enrichment don't filter user turns (they live at the session
+  // level; callers that need project-scoping should pre-filter by sessionId
+  // from a turn query).
+  return true;
+}
+
+export async function queryUserTurns(q: Query = {}): Promise<UserTurnRecord[]> {
+  const filePath = ledgerPath();
+  if (!(await fileExists(filePath))) return [];
+  const out: UserTurnRecord[] = [];
+  for await (const parsed of streamLines(filePath)) {
+    if (!isUserTurnLine(parsed)) continue;
+    if (!userTurnPasses(parsed.record, q)) continue;
     out.push(parsed.record);
   }
   return out;

--- a/packages/ledger/src/schema.ts
+++ b/packages/ledger/src/schema.ts
@@ -3,6 +3,7 @@ import type {
   SessionRelationshipRecord,
   ToolResultEventRecord,
   TurnRecord,
+  UserTurnRecord,
 } from '@relayburn/reader';
 
 export type Enrichment = Record<string, string>;
@@ -57,12 +58,26 @@ export interface ToolResultEventLine {
   record: ToolResultEventRecord;
 }
 
+// Per-user-turn block info (#2 / #94). One line per user line in a session,
+// carrying the byte/approx-token size of each tool_result and free-text block
+// the user supplied. Append-only and dedup'd through the same ledger-id index
+// as turns/compactions via `userTurnIdHash` keyed on (source, sessionId,
+// userUuid). Old readers that don't recognize `kind: 'user_turn'` simply skip
+// the line — the existing `isTurnLine` / `isStampLine` / etc. guards already
+// filter to known kinds.
+export interface UserTurnLine {
+  v: 1;
+  kind: 'user_turn';
+  record: UserTurnRecord;
+}
+
 export type LedgerLine =
   | TurnLine
   | StampLine
   | CompactionLine
   | SessionRelationshipLine
-  | ToolResultEventLine;
+  | ToolResultEventLine
+  | UserTurnLine;
 
 export function isTurnLine(line: unknown): line is TurnLine {
   return (
@@ -109,6 +124,15 @@ export function isToolResultEventLine(
     !!line &&
     typeof line === 'object' &&
     (line as { kind?: string }).kind === 'tool_result_event' &&
+    (line as { v?: number }).v === 1
+  );
+}
+
+export function isUserTurnLine(line: unknown): line is UserTurnLine {
+  return (
+    !!line &&
+    typeof line === 'object' &&
+    (line as { kind?: string }).kind === 'user_turn' &&
     (line as { v?: number }).v === 1
   );
 }

--- a/packages/ledger/src/writer.ts
+++ b/packages/ledger/src/writer.ts
@@ -6,6 +6,7 @@ import type {
   SessionRelationshipRecord,
   ToolResultEventRecord,
   TurnRecord,
+  UserTurnRecord,
 } from '@relayburn/reader';
 
 import {
@@ -16,6 +17,7 @@ import {
   toolResultEventIdHash,
   turnContentFingerprint,
   turnIdHash,
+  userTurnIdHash,
 } from './index-sidecar.js';
 import { withLock } from './lock.js';
 import { ledgerPath } from './paths.js';
@@ -28,6 +30,7 @@ import type {
   StampSelector,
   ToolResultEventLine,
   TurnLine,
+  UserTurnLine,
 } from './schema.js';
 
 async function ensureDir(filePath: string): Promise<void> {
@@ -120,6 +123,32 @@ export async function appendRelationships(
   const lines: SessionRelationshipLine[] = fresh.map((record) => ({
     v: 1,
     kind: 'relationship',
+    record,
+  }));
+  await appendLines(lines);
+  await appendHashes(newIds, []);
+}
+
+export async function appendUserTurns(records: UserTurnRecord[]): Promise<void> {
+  if (records.length === 0) return;
+  // Dedup piggybacks on the ledger-id index. User-turn ids share the same
+  // namespace as turn / compaction / relationship / tool-result-event ids —
+  // they hash different inputs (source|sessionId|userUuid) so collisions are
+  // not a practical concern, and we get crash-safe persistence for free.
+  const idx = await loadIndex();
+  const fresh: UserTurnRecord[] = [];
+  const newIds: string[] = [];
+  for (const r of records) {
+    const id = userTurnIdHash(r);
+    if (idx.ids.has(id)) continue;
+    fresh.push(r);
+    newIds.push(id);
+    idx.ids.add(id);
+  }
+  if (fresh.length === 0) return;
+  const lines: UserTurnLine[] = fresh.map((record) => ({
+    v: 1,
+    kind: 'user_turn',
     record,
   }));
   await appendLines(lines);


### PR DESCRIPTION
## Summary

- New `user_turn` ledger line kind (`appendUserTurns` writer + `queryUserTurns` reader + `isUserTurnLine` guard), dedup'd by `userTurnIdHash(source|sessionId|userUuid)` through the same `~/.relayburn/ledger-index` namespace as turns / compactions / relationships / tool-result events. `rebuildIndex` re-indexes the new kind.
- `burn ingest` (runtime + hook paths) and `burn claude` now forward the `userTurns` the Claude / Codex / OpenCode parsers already emit (since #74) into `appendUserTurns`, so per-user-turn block sizes finally land on disk instead of being thrown away.
- Additive on the wire: `UserTurnLine` carries `v: 1`, no bump on `TurnRecord`. Older readers ignore unknown line kinds, and `reclassify` preserves them verbatim. Backfilling user turns into existing ledgers is not done automatically — flagged in the ledger CHANGELOG.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run test:ts` — 457/457 pass, including:
  - [x] `appendUserTurns` round-trips through `queryUserTurns` and dedupes on `(source, sessionId, userUuid)`
  - [x] `queryUserTurns` filters by `sessionId`, `source`, and time range
  - [x] User-turn append + later turn append do not collide on the ledger lock or id index
  - [x] `rebuildIndex` re-indexes `user_turn` lines (and re-append is idempotent after rebuild)
  - [x] `ingestClaudeProjects` writes a user-turn line for a fresh Claude session and re-ingest is a no-op (file size unchanged)

## Refs

Closes #94. Refs #2, #74.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
