### PR TITLE
Complete passive execution graph coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **Execution-graph passive reader coverage completed** (#42). Codex and OpenCode now populate the normalized relationship / tool-result-event substrate alongside Claude: Codex captures function/custom tool outputs, exposed spawn-agent child ids, statuses, event indexes, and output hashes; OpenCode captures root/parentID subagent relationships plus tool-part statuses and hashes. Passive ingest persists these graph rows for all three adapters, and ledger-level consumers can derive retry/failure and subagent outcome analyses from the cross-source record shapes.
+
 ## [0.19.0] - 2026-04-26
 
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Persist Codex and OpenCode execution-graph records during passive ingest** (#42). `burn codex` / `burn opencode` background ingest now appends the `SessionRelationshipRecord`s and `ToolResultEventRecord`s emitted by their readers, matching the Claude ingest path. Codex cursor state also carries the parser's graph/user-turn resume metadata so incremental ingest preserves event chronology across runs.
+
 ## [0.21.0] - 2026-04-26
 
 ### Added

--- a/packages/cli/src/ingest.test.ts
+++ b/packages/cli/src/ingest.test.ts
@@ -5,13 +5,18 @@ import * as path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import type { ContentRecord, TurnRecord } from '@relayburn/reader';
-import { queryUserTurns } from '@relayburn/ledger';
-import { ledgerPath } from '@relayburn/ledger';
+import {
+  ledgerPath,
+  queryRelationships,
+  queryToolResultEvents,
+  queryUserTurns,
+} from '@relayburn/ledger';
 
 import {
   countToolCallGaps,
   ingestClaudeProjects,
   ingestCodexSessions,
+  ingestOpencodeSessions,
   resetIngestGapWarnings,
   setIngestGapWriter,
 } from './ingest.js';
@@ -164,6 +169,39 @@ describe('ingest gap warning (codex parser-gap scenario)', () => {
       setIngestGapWriter(restore);
     }
     assert.equal(captured.length, 1, 'second/third ingest stays silent');
+  });
+
+  it('persists Codex graph records emitted by passive ingest', async () => {
+    await writeCodexSession(tmpHome, 'rollout-graph', codexSessionWithToolOutput());
+    await ingestCodexSessions();
+
+    const relationships = await queryRelationships({ source: 'codex' });
+    assert.equal(relationships.length, 1);
+    assert.equal(relationships[0]!.relationshipType, 'root');
+    assert.equal(relationships[0]!.sessionId, 'sess_graph_1');
+
+    const events = await queryToolResultEvents({ source: 'codex' });
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.toolUseId, 'call_graph_1');
+    assert.equal(events[0]!.status, 'completed');
+    assert.equal(typeof events[0]!.contentHash, 'string');
+  });
+
+  it('persists OpenCode graph records emitted by passive ingest', async () => {
+    await writeOpencodeSession(tmpHome);
+    await ingestOpencodeSessions();
+
+    const relationships = await queryRelationships({ source: 'opencode' });
+    assert.equal(relationships.length, 1);
+    assert.equal(relationships[0]!.relationshipType, 'root');
+    assert.equal(relationships[0]!.sessionId, 'ses_oc_graph');
+
+    const events = await queryToolResultEvents({ source: 'opencode' });
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.toolUseId, 'call_oc_graph');
+    assert.equal(events[0]!.status, 'errored');
+    assert.equal(events[0]!.isError, true);
+    assert.equal(typeof events[0]!.contentHash, 'string');
   });
 });
 
@@ -450,4 +488,114 @@ function codexChatOnlySession(): string {
     },
   ];
   return lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
+}
+
+function codexSessionWithToolOutput(): string {
+  const lines = [
+    {
+      timestamp: '2026-04-20T01:00:00.000Z',
+      type: 'session_meta',
+      payload: { id: 'sess_graph_1', cwd: '/tmp/project', timestamp: '2026-04-20T01:00:00.000Z' },
+    },
+    {
+      timestamp: '2026-04-20T01:00:00.100Z',
+      type: 'turn_context',
+      payload: { turn_id: 'turn_graph_1', cwd: '/tmp/project', model: 'gpt-5.3-codex' },
+    },
+    {
+      timestamp: '2026-04-20T01:00:00.200Z',
+      type: 'event_msg',
+      payload: { type: 'task_started', turn_id: 'turn_graph_1' },
+    },
+    {
+      timestamp: '2026-04-20T01:00:01.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: '{"cmd":"git status"}',
+        call_id: 'call_graph_1',
+      },
+    },
+    {
+      timestamp: '2026-04-20T01:00:01.100Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'call_graph_1',
+        output: 'clean',
+      },
+    },
+    {
+      timestamp: '2026-04-20T01:00:01.200Z',
+      type: 'event_msg',
+      payload: { type: 'exec_command_end', call_id: 'call_graph_1', turn_id: 'turn_graph_1', exit_code: 0 },
+    },
+    {
+      timestamp: '2026-04-20T01:00:02.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { total_token_usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 10 } },
+      },
+    },
+    {
+      timestamp: '2026-04-20T01:00:02.100Z',
+      type: 'event_msg',
+      payload: { type: 'task_complete', turn_id: 'turn_graph_1' },
+    },
+  ];
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
+}
+
+async function writeOpencodeSession(home: string): Promise<void> {
+  const storage = path.join(home, '.local', 'share', 'opencode', 'storage');
+  const sessionDir = path.join(storage, 'session', 'global');
+  const messageDir = path.join(storage, 'message', 'ses_oc_graph');
+  const partDir = path.join(storage, 'part', 'msg_oc_graph_asst');
+  await mkdir(sessionDir, { recursive: true });
+  await mkdir(messageDir, { recursive: true });
+  await mkdir(partDir, { recursive: true });
+  await writeFile(
+    path.join(sessionDir, 'ses_oc_graph.json'),
+    JSON.stringify({
+      id: 'ses_oc_graph',
+      version: '1.0.0',
+      directory: '/tmp/project',
+      time: { created: 1_776_988_000_000, updated: 1_776_988_001_000 },
+    }),
+    'utf8',
+  );
+  await writeFile(
+    path.join(messageDir, 'msg_oc_graph_asst.json'),
+    JSON.stringify({
+      id: 'msg_oc_graph_asst',
+      sessionID: 'ses_oc_graph',
+      role: 'assistant',
+      providerID: 'anthropic',
+      modelID: 'claude-sonnet-4-5',
+      time: { created: 1_776_988_001_000 },
+      path: { cwd: '/tmp/project' },
+      tokens: { input: 10, output: 5, cache: { read: 0, write: 0 } },
+    }),
+    'utf8',
+  );
+  await writeFile(
+    path.join(partDir, 'prt_oc_graph_tool.json'),
+    JSON.stringify({
+      id: 'prt_oc_graph_tool',
+      sessionID: 'ses_oc_graph',
+      messageID: 'msg_oc_graph_asst',
+      type: 'tool',
+      callID: 'call_oc_graph',
+      tool: 'bash',
+      state: {
+        status: 'completed',
+        input: { command: 'npm test' },
+        output: 'failed',
+        metadata: { exit: 1 },
+      },
+    }),
+    'utf8',
+  );
 }

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -315,6 +315,10 @@ async function ingestCodexInto(
             sessionId: priorCodex.sessionId,
             turnContexts: { ...priorCodex.turnContexts },
             ...(priorCodex.sessionCwd !== undefined ? { sessionCwd: priorCodex.sessionCwd } : {}),
+            ...(priorCodex.userTurnSlot !== undefined
+              ? { userTurnSlot: priorCodex.userTurnSlot }
+              : {}),
+            ...(priorCodex.graph !== undefined ? { graph: priorCodex.graph } : {}),
           };
 
       if (!rotated && startOffset >= st.size) {
@@ -328,7 +332,15 @@ async function ingestCodexInto(
         contentMode,
       };
       if (resume !== undefined) opts.resume = resume;
-      const { turns, content, userTurns, endOffset, resume: nextResume } =
+      const {
+        turns,
+        content,
+        userTurns,
+        relationships,
+        toolResultEvents,
+        endOffset,
+        resume: nextResume,
+      } =
         await parseCodexSessionIncremental(file, opts);
       if (turns.length > 0) {
         await appendTurns(turns);
@@ -348,6 +360,12 @@ async function ingestCodexInto(
       if (userTurns.length > 0) {
         await appendUserTurns(userTurns);
       }
+      if (relationships.length > 0) {
+        await appendRelationships(relationships);
+      }
+      if (toolResultEvents.length > 0) {
+        await appendToolResultEvents(toolResultEvents);
+      }
       const next: CodexCursor = {
         kind: 'codex',
         inode: st.ino,
@@ -358,6 +376,8 @@ async function ingestCodexInto(
         turnContexts: nextResume.turnContexts,
       };
       if (nextResume.sessionCwd !== undefined) next.sessionCwd = nextResume.sessionCwd;
+      if (nextResume.userTurnSlot !== undefined) next.userTurnSlot = nextResume.userTurnSlot;
+      if (nextResume.graph !== undefined) next.graph = nextResume.graph;
       cursors[file] = next;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -394,7 +414,14 @@ async function ingestOpencodeInto(
         continue;
       }
 
-      const { turns, content, userTurns, seenMessageIds: nextSeen } =
+      const {
+        turns,
+        content,
+        userTurns,
+        relationships,
+        toolResultEvents,
+        seenMessageIds: nextSeen,
+      } =
         await parseOpencodeSessionIncremental(file, {
           sessionPath: file,
           seenMessageIds,
@@ -417,6 +444,12 @@ async function ingestOpencodeInto(
       }
       if (userTurns.length > 0) {
         await appendUserTurns(userTurns);
+      }
+      if (relationships.length > 0) {
+        await appendRelationships(relationships);
+      }
+      if (toolResultEvents.length > 0) {
+        await appendToolResultEvents(toolResultEvents);
       }
       const next: OpencodeCursor = {
         kind: 'opencode',

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Codex cursor resume metadata now includes execution-graph state** (#42), allowing CLI ingest to preserve Codex tool-result event indexes and pending user-turn slots across incremental runs. Ledger query tests now cover source-neutral retry/failure and subagent-outcome consumers over `SessionRelationshipRecord` and `ToolResultEventRecord`.
+
 ## [0.21.0] - 2026-04-26
 
 ### Added

--- a/packages/ledger/src/cursors.ts
+++ b/packages/ledger/src/cursors.ts
@@ -1,6 +1,11 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import type {
+  PersistedCodexGraphState,
+  PersistedUserTurnSlot,
+} from '@relayburn/reader';
+
 import { withLock } from './lock.js';
 import { cursorsPath } from './paths.js';
 
@@ -24,6 +29,8 @@ export interface CodexCursor {
   sessionId: string;
   sessionCwd?: string;
   turnContexts: Record<string, { turn_id?: string; cwd?: string; model?: string }>;
+  userTurnSlot?: PersistedUserTurnSlot;
+  graph?: PersistedCodexGraphState;
 }
 
 export interface OpencodeCursor {

--- a/packages/ledger/src/ledger.test.ts
+++ b/packages/ledger/src/ledger.test.ts
@@ -298,6 +298,83 @@ describe('ledger', () => {
     assert.equal(errored.eventIndex, 1);
   });
 
+  it('lets consumers derive retry failures and subagent outcomes from normalized graph records', async () => {
+    const rel: SessionRelationshipRecord = {
+      v: 1,
+      source: 'codex',
+      sessionId: 's-child',
+      relatedSessionId: 's-parent',
+      relationshipType: 'subagent',
+      parentToolUseId: 'spawn-agent',
+      agentId: 'agent-child',
+    };
+    await appendRelationships([rel]);
+    await appendToolResultEvents([
+      {
+        v: 1,
+        source: 'codex',
+        sessionId: 's-parent',
+        toolUseId: 'retry-tool',
+        callIndex: 0,
+        eventIndex: 0,
+        status: 'errored',
+        eventSource: 'function_call_output',
+        isError: true,
+      },
+      {
+        v: 1,
+        source: 'codex',
+        sessionId: 's-parent',
+        toolUseId: 'retry-tool',
+        callIndex: 1,
+        eventIndex: 1,
+        status: 'errored',
+        eventSource: 'function_call_output',
+        isError: true,
+      },
+      {
+        v: 1,
+        source: 'codex',
+        sessionId: 's-parent',
+        toolUseId: 'retry-tool',
+        callIndex: 2,
+        eventIndex: 2,
+        status: 'completed',
+        eventSource: 'function_call_output',
+      },
+      {
+        v: 1,
+        source: 'opencode',
+        sessionId: 's-parent',
+        toolUseId: 'spawn-agent',
+        eventIndex: 3,
+        status: 'errored',
+        eventSource: 'tool_result',
+        isError: true,
+        subagentSessionId: 's-child',
+        agentId: 'agent-child',
+      },
+    ]);
+
+    const events = await queryToolResultEvents({ sessionId: 's-parent' });
+    const retryEvents = events
+      .filter((e) => e.toolUseId === 'retry-tool')
+      .sort((a, b) => a.eventIndex - b.eventIndex);
+    assert.deepEqual(
+      retryEvents.map((e) => e.status),
+      ['errored', 'errored', 'completed'],
+      'retry/failure sequence is source-neutral',
+    );
+    assert.equal(retryEvents.filter((e) => e.isError).length, 2);
+
+    const spawnOutcome = events.find((e) => e.subagentSessionId === 's-child')!;
+    assert.ok(spawnOutcome.subagentSessionId);
+    const [relationship] = await queryRelationships({ sessionId: spawnOutcome.subagentSessionId });
+    assert.equal(relationship!.relationshipType, 'subagent');
+    assert.equal(relationship!.parentToolUseId, spawnOutcome.toolUseId);
+    assert.equal(spawnOutcome.status, 'errored');
+  });
+
   it('queryRelationships filters by source and sessionId (matching child or parent)', async () => {
     await appendRelationships([
       {

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Complete passive execution-graph population for Codex and OpenCode** (#42). Codex now emits root / explicit fork-or-continuation / exposed subagent relationship rows plus metadata-only `ToolResultEventRecord`s for `function_call_output` and `custom_tool_call_output`, including status, `callIndex`, `eventIndex`, `contentLength`, and `contentHash`; `spawn_agent`-style outputs are annotated with child session / agent ids when the log exposes them. OpenCode now emits root and `parentID` subagent relationships, marks sidechain turns with stable agent / parent ids, and converts tool parts into metadata-only tool-result events with status and output size/hash. Claude graph extraction also preserves explicit source-session fork/continuation metadata and system-level queue/progress/subagent notifications when present, while continuing not to invent fork/continuation rows from `parentUuid` alone.
+
 ## [0.19.0] - 2026-04-26
 
 ### Added

--- a/packages/reader/src/claude.test.ts
+++ b/packages/reader/src/claude.test.ts
@@ -199,6 +199,94 @@ describe('parseClaudeSession', () => {
     assert.equal(innerSpawn!.agentId, 'u-sub2-user');
   });
 
+  it('does not invent fork/continuation rows when Claude logs only expose parentUuid chains', async () => {
+    const { relationships } = await parseClaudeSession(
+      path.join(FIXTURES, 'nested-subagent.jsonl'),
+    );
+    assert.equal(
+      relationships.some(
+        (r) => r.relationshipType === 'fork' || r.relationshipType === 'continuation',
+      ),
+      false,
+    );
+  });
+
+  it('preserves explicit source-session continuation metadata when Claude logs expose it', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-claude-source-'));
+    try {
+      const file = path.join(tmp, 'continued.jsonl');
+      const lines = [
+        {
+          type: 'user',
+          sessionId: 'sess_new',
+          sourceSessionId: 'sess_old',
+          claudeCodeVersion: '1.2.3',
+          timestamp: '2026-04-23T00:00:00.000Z',
+          uuid: 'u-source',
+          parentUuid: null,
+          message: { role: 'user', content: 'continue' },
+        },
+        {
+          type: 'assistant',
+          sessionId: 'sess_new',
+          sourceSessionId: 'sess_old',
+          claudeCodeVersion: '1.2.3',
+          timestamp: '2026-04-23T00:00:01.000Z',
+          uuid: 'a-source',
+          parentUuid: 'u-source',
+          message: {
+            id: 'msg_source',
+            model: 'claude-sonnet-4-6',
+            content: [{ type: 'text', text: 'ok' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+        },
+      ];
+      await writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+      const { relationships } = await parseClaudeSession(file);
+      const continuation = relationships.find((r) => r.relationshipType === 'continuation')!;
+      assert.ok(continuation);
+      assert.equal(continuation.sessionId, 'sess_new');
+      assert.equal(continuation.relatedSessionId, 'sess_old');
+      assert.equal(continuation.sourceSessionId, 'sess_old');
+      assert.equal(continuation.sourceVersion, '1.2.3');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves Claude progress evidence as graph events when logs expose parentToolUseID', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-claude-progress-'));
+    try {
+      const file = path.join(tmp, 'progress.jsonl');
+      const lines = [
+        {
+          type: 'system',
+          subtype: 'agent_progress',
+          sessionId: 'sess_progress',
+          parentToolUseID: 'toolu_spawn',
+          agentId: 'agent-progress-1',
+          status: 'running',
+          message: 'queued',
+          timestamp: '2026-04-23T00:00:00.000Z',
+        },
+      ];
+      await writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+      const { toolResultEvents } = await parseClaudeSession(file);
+      assert.equal(toolResultEvents.length, 1);
+      const ev = toolResultEvents[0]!;
+      assert.equal(ev.eventSource, 'progress_event');
+      assert.equal(ev.toolUseId, 'toolu_spawn');
+      assert.equal(ev.agentId, 'agent-progress-1');
+      assert.equal(ev.status, 'running');
+      assert.equal(typeof ev.contentHash, 'string');
+      assert.equal(Object.prototype.hasOwnProperty.call(ev, 'message'), false);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('attaches per-turn fidelity metadata with full coverage on a normal turn', async () => {
     const { turns } = await parseClaudeSession(path.join(FIXTURES, 'simple-turn.jsonl'));
     const t = turns[0]!;

--- a/packages/reader/src/claude.ts
+++ b/packages/reader/src/claude.ts
@@ -16,7 +16,9 @@ import type {
   SessionRelationshipRecord,
   Subagent,
   ToolCall,
+  ToolResultEventSource,
   ToolResultEventRecord,
+  ToolResultStatus,
   TurnRecord,
   Usage,
   UserTurnBlock,
@@ -142,9 +144,10 @@ export interface ParseResult {
   content: ContentRecord[];
   events: CompactionEvent[];
   // Normalized execution-graph metadata (#42). `relationships` describes how
-  // sessions relate (root + one row per discovered subagent invocation in
-  // this PR; fork/continuation arrive in follow-up work). `toolResultEvents`
-  // is the chronological tool_result stream keyed by `toolUseId`.
+  // sessions relate (root + discovered subagent invocations, and explicit
+  // fork/continuation source-session metadata when logs expose it).
+  // `toolResultEvents` is the chronological tool_result / notification stream
+  // keyed by `toolUseId`.
   relationships: SessionRelationshipRecord[];
   toolResultEvents: ToolResultEventRecord[];
   // Per-user-turn block info between assistant turns (issue #2). Ordered by
@@ -196,6 +199,7 @@ export async function parseClaudeSession(
   // sessionId; subagent rows are derived after working records are resolved.
   const relationships: SessionRelationshipRecord[] = [];
   const seenRootSessionIds = new Set<string>();
+  const seenExplicitRelationshipIds = new Set<string>();
 
   const rl = createInterface({
     input: createReadStream(filePath, { encoding: 'utf8' }),
@@ -235,6 +239,13 @@ export async function parseClaudeSession(
         if (typeof mid === 'string') lastAssistantMessageId = mid;
         if (typeof al.sessionId === 'string' && al.sessionId.length > 0) {
           recordRoot(relationships, seenRootSessionIds, al.sessionId, al.timestamp);
+          collectClaudeExplicitSessionRelationship(
+            rec,
+            relationships,
+            seenExplicitRelationshipIds,
+            al.sessionId,
+            al.timestamp,
+          );
         }
         ingestAssistant(al, working, order, nodesByUuid);
       } else if (rec.type === 'user') {
@@ -245,6 +256,13 @@ export async function parseClaudeSession(
         collectErroredToolUseIds(ul, erroredToolUseIds);
         if (typeof ul.sessionId === 'string' && ul.sessionId.length > 0) {
           recordRoot(relationships, seenRootSessionIds, ul.sessionId, ul.timestamp);
+          collectClaudeExplicitSessionRelationship(
+            rec,
+            relationships,
+            seenExplicitRelationshipIds,
+            ul.sessionId,
+            ul.timestamp,
+          );
         }
         nextEventIndex = collectToolResultEvents(
           ul,
@@ -273,6 +291,12 @@ export async function parseClaudeSession(
           };
           if (lastAssistantMessageId) ev.precedingMessageId = lastAssistantMessageId;
           events.push(ev);
+        }
+      } else if (rec.type === 'system') {
+        const graphEvent = collectClaudeSystemGraphEvent(rec, nextEventIndex);
+        if (graphEvent) {
+          toolResultEvents.push(graphEvent);
+          nextEventIndex++;
         }
       }
       seq++;
@@ -810,6 +834,212 @@ function recordRoot(
   out.push(row);
 }
 
+function collectClaudeExplicitSessionRelationship(
+  line: Record<string, unknown>,
+  out: SessionRelationshipRecord[],
+  seen: Set<string>,
+  sessionId: string,
+  fallbackTs: string | undefined,
+): void {
+  const row = buildClaudeExplicitSessionRelationship(line, sessionId, fallbackTs);
+  if (!row) return;
+  const key = claudeRelationshipKey(row);
+  if (seen.has(key)) return;
+  seen.add(key);
+  out.push(row);
+}
+
+function collectClaudeExplicitSessionRelationshipIncremental(
+  line: Record<string, unknown>,
+  out: Array<{ offset: number; record: SessionRelationshipRecord }>,
+  seen: Set<string>,
+  sessionId: string,
+  fallbackTs: string | undefined,
+  offset: number,
+): void {
+  const row = buildClaudeExplicitSessionRelationship(line, sessionId, fallbackTs);
+  if (!row) return;
+  const key = claudeRelationshipKey(row);
+  if (seen.has(key)) return;
+  seen.add(key);
+  out.push({ offset, record: row });
+}
+
+function buildClaudeExplicitSessionRelationship(
+  line: Record<string, unknown>,
+  sessionId: string,
+  fallbackTs: string | undefined,
+): SessionRelationshipRecord | undefined {
+  const forkSource = pickDeepString(line, [
+    'forkSessionId',
+    'fork_session_id',
+    'forkedFromSessionId',
+    'forked_from_session_id',
+  ]);
+  const continuationSource = pickDeepString(line, [
+    'continuedFromSessionId',
+    'continued_from_session_id',
+    'sourceSessionId',
+    'source_session_id',
+    'sourceSession',
+    'source_session',
+  ]);
+  const relatedSessionId = forkSource ?? continuationSource;
+  if (relatedSessionId === undefined || relatedSessionId === sessionId) return undefined;
+  const row: SessionRelationshipRecord = {
+    v: 1,
+    source: 'claude-code',
+    sessionId,
+    relatedSessionId,
+    relationshipType: forkSource !== undefined ? 'fork' : 'continuation',
+    sourceSessionId: relatedSessionId,
+  };
+  const ts = pickDeepString(line, ['timestamp', 'ts']) ?? fallbackTs;
+  const sourceVersion = pickDeepString(line, [
+    'version',
+    'sourceVersion',
+    'source_version',
+    'claudeCodeVersion',
+    'claude_code_version',
+  ]);
+  if (ts !== undefined) row.ts = ts;
+  if (sourceVersion !== undefined) row.sourceVersion = sourceVersion;
+  return row;
+}
+
+function claudeRelationshipKey(row: SessionRelationshipRecord): string {
+  return [
+    row.source,
+    row.sessionId,
+    row.relationshipType,
+    row.relatedSessionId ?? '',
+    row.agentId ?? '',
+    row.parentToolUseId ?? '',
+  ].join('|');
+}
+
+function collectClaudeSystemGraphEvent(
+  line: Record<string, unknown>,
+  eventIndex: number,
+): ToolResultEventRecord | undefined {
+  const eventSource = classifyClaudeSystemEventSource(line);
+  if (eventSource === undefined) return undefined;
+  const sessionId = pickDeepString(line, ['sessionId', 'session_id']);
+  const toolUseId = pickDeepString(line, [
+    'toolUseId',
+    'tool_use_id',
+    'parentToolUseID',
+    'parentToolUseId',
+    'parent_tool_use_id',
+  ]);
+  if (sessionId === undefined || toolUseId === undefined) return undefined;
+  const record: ToolResultEventRecord = {
+    v: 1,
+    source: 'claude-code',
+    sessionId,
+    toolUseId,
+    eventIndex,
+    status: statusFromClaudeSystemEvent(line),
+    eventSource,
+  };
+  const ts = pickDeepString(line, ['timestamp', 'ts']);
+  const agentId = pickDeepString(line, ['agentId', 'agent_id', 'taskId', 'task_id']);
+  const subagentSessionId = pickDeepString(line, [
+    'subagentSessionId',
+    'subagent_session_id',
+    'childSessionId',
+    'child_session_id',
+  ]);
+  if (ts !== undefined) record.ts = ts;
+  if (agentId !== undefined) record.agentId = agentId;
+  if (subagentSessionId !== undefined) record.subagentSessionId = subagentSessionId;
+  if (record.status === 'errored') record.isError = true;
+  const content = pickGraphContent(line);
+  const measured = measureToolResult(content);
+  if (measured.length !== undefined) record.contentLength = measured.length;
+  if (measured.hash !== undefined) record.contentHash = measured.hash;
+  return record;
+}
+
+function classifyClaudeSystemEventSource(
+  line: Record<string, unknown>,
+): ToolResultEventSource | undefined {
+  const subtype = typeof line['subtype'] === 'string' ? line['subtype'].toLowerCase() : '';
+  const eventName =
+    typeof line['event'] === 'string' ? line['event'].toLowerCase() : '';
+  const type = `${subtype} ${eventName}`;
+  if (type.includes('queue') || type.includes('enqueue')) return 'queue_event';
+  if (type.includes('progress')) return 'progress_event';
+  if (type.includes('agent') || type.includes('subagent')) return 'subagent_notification';
+  return undefined;
+}
+
+function statusFromClaudeSystemEvent(line: Record<string, unknown>): ToolResultStatus {
+  const status = pickDeepString(line, [
+    'status',
+    'state',
+    'terminalStatus',
+    'terminal_status',
+    'result',
+  ]);
+  if (status === undefined) return 'unknown';
+  const normalized = status.toLowerCase().replace(/[-\s]/g, '_');
+  if (
+    normalized === 'completed' ||
+    normalized === 'complete' ||
+    normalized === 'success' ||
+    normalized === 'succeeded' ||
+    normalized === 'done'
+  ) {
+    return 'completed';
+  }
+  if (
+    normalized === 'error' ||
+    normalized === 'errored' ||
+    normalized === 'failed' ||
+    normalized === 'failure'
+  ) {
+    return 'errored';
+  }
+  if (
+    normalized === 'running' ||
+    normalized === 'in_progress' ||
+    normalized === 'queued' ||
+    normalized === 'pending' ||
+    normalized === 'started'
+  ) {
+    return 'running';
+  }
+  if (
+    normalized === 'cancelled' ||
+    normalized === 'canceled' ||
+    normalized === 'aborted'
+  ) {
+    return 'cancelled';
+  }
+  return 'unknown';
+}
+
+function pickGraphContent(line: Record<string, unknown>): unknown {
+  for (const key of ['content', 'message', 'output', 'result']) {
+    if (Object.prototype.hasOwnProperty.call(line, key)) return line[key];
+  }
+  return undefined;
+}
+
+function pickDeepString(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  for (const value of Object.values(obj)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const nested = pickDeepString(value as Record<string, unknown>, keys);
+    if (nested !== undefined) return nested;
+  }
+  return undefined;
+}
+
 // Walk a user line's tool_result blocks and emit one ToolResultEventRecord
 // per block. Status follows from is_error: errored vs completed; `running` /
 // `cancelled` are reserved for future progress / queue events that Claude
@@ -1250,6 +1480,7 @@ export async function parseClaudeSessionIncremental(
     record: SessionRelationshipRecord;
   }> = [];
   const seenRootSessionIds = new Set<string>();
+  const seenExplicitRelationshipIds = new Set<string>();
   // Per-user-turn records tagged with their line offset so we can drop any
   // that fall past endOffset (avoiding double-emission on resume), mirroring
   // the content/event handling.
@@ -1301,6 +1532,14 @@ export async function parseClaudeSessionIncremental(
           line.timestamp,
           lineStartOffset,
         );
+        collectClaudeExplicitSessionRelationshipIncremental(
+          rec,
+          pendingRelationships,
+          seenExplicitRelationshipIds,
+          line.sessionId,
+          line.timestamp,
+          lineStartOffset,
+        );
       }
       ingestAssistant(line, working, order, nodesByUuid);
     } else if (rec.type === 'user') {
@@ -1313,6 +1552,14 @@ export async function parseClaudeSessionIncremental(
         recordRootIncremental(
           pendingRelationships,
           seenRootSessionIds,
+          ul.sessionId,
+          ul.timestamp,
+          lineStartOffset,
+        );
+        collectClaudeExplicitSessionRelationshipIncremental(
+          rec,
+          pendingRelationships,
+          seenExplicitRelationshipIds,
           ul.sessionId,
           ul.timestamp,
           lineStartOffset,
@@ -1351,6 +1598,12 @@ export async function parseClaudeSessionIncremental(
         };
         if (lastAssistantMessageId) ev.precedingMessageId = lastAssistantMessageId;
         events.push({ offset: lineStartOffset, event: ev });
+      }
+    } else if (rec.type === 'system') {
+      const graphEvent = collectClaudeSystemGraphEvent(rec, nextEventIndex);
+      if (graphEvent) {
+        pendingToolResultEvents.push({ offset: lineStartOffset, record: graphEvent });
+        nextEventIndex++;
       }
     }
   }

--- a/packages/reader/src/codex.test.ts
+++ b/packages/reader/src/codex.test.ts
@@ -121,6 +121,116 @@ describe('parseCodexSession', () => {
     assert.equal(typeof t.retries, 'number');
   });
 
+  it('emits root relationships with source version metadata', async () => {
+    const { relationships } = await parseCodexSession(path.join(FIXTURES, 'simple-turn.jsonl'));
+    assert.equal(relationships.length, 1);
+    const root = relationships[0]!;
+    assert.equal(root.source, 'codex');
+    assert.equal(root.relationshipType, 'root');
+    assert.equal(root.sessionId, 'sess_simple_1');
+    assert.equal(root.sourceVersion, '0.121.0');
+    assert.equal(root.ts, '2026-04-20T00:00:00.000Z');
+  });
+
+  it('emits metadata-only ToolResultEventRecords for function_call_output blocks', async () => {
+    const { toolResultEvents } = await parseCodexSession(
+      path.join(FIXTURES, 'user-turn-blocks.jsonl'),
+    );
+    assert.equal(toolResultEvents.length, 4);
+    assert.deepEqual(
+      toolResultEvents.map((e) => e.toolUseId),
+      ['call_b1', 'call_b2', 'call_p1', 'call_b3'],
+    );
+    for (let i = 0; i < toolResultEvents.length; i++) {
+      const ev = toolResultEvents[i]!;
+      assert.equal(ev.source, 'codex');
+      assert.equal(ev.eventSource, 'function_call_output');
+      assert.equal(ev.callIndex, 0);
+      assert.equal(ev.eventIndex, i);
+      assert.equal(typeof ev.contentLength, 'number');
+      assert.equal(typeof ev.contentHash, 'string');
+      assert.equal(Object.prototype.hasOwnProperty.call(ev, 'output'), false);
+    }
+    const failed = toolResultEvents.find((e) => e.toolUseId === 'call_b2')!;
+    assert.equal(failed.status, 'errored');
+    assert.equal(failed.isError, true);
+    assert.equal(failed.contentLength, 'FAIL: 1 test broke'.length);
+    assert.equal(toolResultEvents.find((e) => e.toolUseId === 'call_p1')!.status, 'completed');
+  });
+
+  it('links spawn_agent outputs to subagent relationships when Codex exposes child ids', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-codex-spawn-'));
+    try {
+      const file = path.join(tmp, 'spawn.jsonl');
+      const lines = [
+        {
+          timestamp: '2026-04-22T00:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'sess_parent', cwd: '/tmp/proj', timestamp: '2026-04-22T00:00:00.000Z' },
+        },
+        {
+          timestamp: '2026-04-22T00:00:00.100Z',
+          type: 'turn_context',
+          payload: { turn_id: 'turn_spawn_1', cwd: '/tmp/proj', model: 'gpt-5.4' },
+        },
+        {
+          timestamp: '2026-04-22T00:00:00.200Z',
+          type: 'event_msg',
+          payload: { type: 'task_started', turn_id: 'turn_spawn_1' },
+        },
+        {
+          timestamp: '2026-04-22T00:00:00.300Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'spawn_agent',
+            call_id: 'spawn_1',
+            arguments: '{"subagent_type":"review","description":"Review patch"}',
+          },
+        },
+        {
+          timestamp: '2026-04-22T00:00:00.400Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call_output',
+            call_id: 'spawn_1',
+            output: { session_id: 'sess_child', agent_id: 'agent_child', status: 'completed' },
+          },
+        },
+        {
+          timestamp: '2026-04-22T00:00:00.500Z',
+          type: 'event_msg',
+          payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 5 } } },
+        },
+        {
+          timestamp: '2026-04-22T00:00:00.600Z',
+          type: 'event_msg',
+          payload: { type: 'task_complete', turn_id: 'turn_spawn_1' },
+        },
+      ];
+      await writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+      const { relationships, toolResultEvents } = await parseCodexSession(file);
+      const sub = relationships.find((r) => r.relationshipType === 'subagent')!;
+      assert.ok(sub);
+      assert.equal(sub.sessionId, 'sess_child');
+      assert.equal(sub.relatedSessionId, 'sess_parent');
+      assert.equal(sub.parentToolUseId, 'spawn_1');
+      assert.equal(sub.agentId, 'agent_child');
+      assert.equal(sub.subagentType, 'review');
+      assert.equal(sub.description, 'Review patch');
+
+      const ev = toolResultEvents.find((e) => e.toolUseId === 'spawn_1')!;
+      assert.equal(ev.status, 'completed');
+      assert.equal(ev.subagentSessionId, 'sess_child');
+      assert.equal(ev.agentId, 'agent_child');
+      assert.equal(typeof ev.contentHash, 'string');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('marks exec_command_end with non-zero exit as a failed tool → debugging', async () => {
     const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
     const { tmpdir } = await import('node:os');
@@ -667,6 +777,10 @@ describe('parseCodexSessionIncremental user-turn dedup (issue #81)', () => {
       // Pass 1 should have emitted: pre-turn-1 text user turn + between 1-2 user turn.
       const firstIds = partial.userTurns.map((u) => u.userUuid).sort();
       assert.equal(partial.userTurns.length, 2);
+      assert.deepEqual(
+        partial.toolResultEvents.map((e) => e.toolUseId),
+        ['call_b1', 'call_b2', 'call_p1'],
+      );
       assert.equal(partial.endOffset, cutoff);
 
       const fullPath = path.join(tmp, 'full.jsonl');
@@ -679,6 +793,13 @@ describe('parseCodexSessionIncremental user-turn dedup (issue #81)', () => {
 
       // Pass 2 should have emitted exactly the between-2-3 user turn.
       assert.equal(resumed.userTurns.length, 1);
+      assert.equal(resumed.toolResultEvents.length, 1);
+      assert.equal(resumed.toolResultEvents[0]!.toolUseId, 'call_b3');
+      assert.equal(
+        resumed.toolResultEvents[0]!.eventIndex,
+        3,
+        'eventIndex resumes after graph events emitted in pass 1',
+      );
       const between23 = resumed.userTurns[0]!;
       assert.equal(between23.precedingMessageId, 'turn_utb_2');
       assert.equal(between23.followingMessageId, 'turn_utb_3');

--- a/packages/reader/src/codex.ts
+++ b/packages/reader/src/codex.ts
@@ -2,11 +2,15 @@ import { open } from 'node:fs/promises';
 
 import { classifyActivity } from './classifier.js';
 import { resolveProject } from './git.js';
-import { argsHash } from './hash.js';
+import { argsHash, contentHash } from './hash.js';
 import type {
   ContentRecord,
   ContentStoreMode,
+  SessionRelationshipRecord,
   ToolCall,
+  ToolResultEventSource,
+  ToolResultEventRecord,
+  ToolResultStatus,
   TurnRecord,
   Usage,
   UserTurnBlock,
@@ -35,6 +39,7 @@ export interface CodexResumeState {
   // committed turn live here until the next task_started stamps `following`
   // and the subsequent task_complete commits the record. Issue #81.
   userTurnSlot?: PersistedUserTurnSlot;
+  graph?: PersistedCodexGraphState;
 }
 
 export interface PersistedUserTurnSlot {
@@ -43,10 +48,27 @@ export interface PersistedUserTurnSlot {
   ts: string;
 }
 
+export interface PersistedCodexSpawnCall {
+  parentToolUseId: string;
+  agentId?: string;
+  subagentSessionId?: string;
+  subagentType?: string;
+  description?: string;
+}
+
+export interface PersistedCodexGraphState {
+  nextEventIndex: number;
+  toolResultCounters: Record<string, number>;
+  seenRootSessionIds: string[];
+  spawnCalls?: Record<string, PersistedCodexSpawnCall>;
+}
+
 export interface ParseCodexIncrementalResult {
   turns: TurnRecord[];
   content: ContentRecord[];
   userTurns: UserTurnRecord[];
+  relationships: SessionRelationshipRecord[];
+  toolResultEvents: ToolResultEventRecord[];
   endOffset: number;
   resume: CodexResumeState;
 }
@@ -55,6 +77,18 @@ interface SessionMetaPayload {
   id?: string;
   cwd?: string;
   timestamp?: string;
+  cli_version?: string;
+  version?: string;
+  sourceSessionId?: string;
+  source_session_id?: string;
+  sourceSession?: string;
+  source_session?: string;
+  forkSessionId?: string;
+  fork_session_id?: string;
+  forkedFromSessionId?: string;
+  forked_from_session_id?: string;
+  continuedFromSessionId?: string;
+  continued_from_session_id?: string;
 }
 
 interface TurnContextPayload {
@@ -186,17 +220,20 @@ export interface ParseCodexResult {
   turns: TurnRecord[];
   content: ContentRecord[];
   userTurns: UserTurnRecord[];
+  relationships: SessionRelationshipRecord[];
+  toolResultEvents: ToolResultEventRecord[];
 }
 
 export async function parseCodexSession(
   filePath: string,
   options: ParseCodexOptions = {},
 ): Promise<ParseCodexResult> {
-  const { turns, content, userTurns } = await parseCodexSessionIncremental(filePath, {
-    ...options,
-    startOffset: 0,
-  });
-  return { turns, content, userTurns };
+  const { turns, content, userTurns, relationships, toolResultEvents } =
+    await parseCodexSessionIncremental(filePath, {
+      ...options,
+      startOffset: 0,
+    });
+  return { turns, content, userTurns, relationships, toolResultEvents };
 }
 
 export async function parseCodexSessionIncremental(
@@ -215,6 +252,8 @@ export async function parseCodexSessionIncremental(
         turns: [],
         content: [],
         userTurns: [],
+        relationships: [],
+        toolResultEvents: [],
         endOffset: startOffset,
         resume: cloneResume(options.resume),
       };
@@ -260,6 +299,22 @@ export async function parseCodexSessionIncremental(
     : { blocks: [], ts: '' };
   const userTurns: UserTurnRecord[] = [];
 
+  const graphState = cloneGraphState(options.resume?.graph);
+  let nextEventIndex = graphState.nextEventIndex;
+  const toolResultCounters = new Map<string, number>();
+  for (const [k, v] of Object.entries(graphState.toolResultCounters)) {
+    if (Number.isFinite(v)) toolResultCounters.set(k, v);
+  }
+  const seenRootSessionIds = new Set(graphState.seenRootSessionIds);
+  const spawnCalls = new Map<string, PersistedCodexSpawnCall>();
+  if (graphState.spawnCalls) {
+    for (const [k, v] of Object.entries(graphState.spawnCalls)) spawnCalls.set(k, { ...v });
+  }
+  const relationships: Array<{ offset: number; record: SessionRelationshipRecord }> = [];
+  const seenRelationshipIds = new Set<string>();
+  const toolResultEvents: Array<{ offset: number; record: ToolResultEventRecord }> = [];
+  const eventsByCallId = new Map<string, ToolResultEventRecord[]>();
+
   // Commit snapshot — only advanced at task_complete boundaries.
   let committedEndOffset = startOffset;
   let committedCumulative: CumulativeUsage = { ...cumulative };
@@ -269,6 +324,12 @@ export async function parseCodexSessionIncremental(
   let committedFinalizedCount = 0;
   let committedUserTurnsCount = 0;
   let committedUserTurnSlot: UserTurnSlot = cloneSlot(userTurnSlot);
+  let committedGraphState: PersistedCodexGraphState = snapshotGraphState(
+    nextEventIndex,
+    toolResultCounters,
+    seenRootSessionIds,
+    spawnCalls,
+  );
 
   let p = 0;
   while (p < buf.length) {
@@ -295,7 +356,17 @@ export async function parseCodexSessionIncremental(
 
     if (rec.type === 'session_meta') {
       const sp = payload as SessionMetaPayload;
-      if (typeof sp.id === 'string') sessionId = sp.id;
+      if (typeof sp.id === 'string') {
+        sessionId = sp.id;
+        collectSessionRelationships(
+          sp,
+          rec.timestamp,
+          lineEndOffset,
+          relationships,
+          seenRelationshipIds,
+          seenRootSessionIds,
+        );
+      }
       if (typeof sp.cwd === 'string') {
         sessionCwd = sp.cwd;
         if (openTurn && openTurn.project === undefined) openTurn.project = sp.cwd;
@@ -393,6 +464,9 @@ export async function parseCodexSessionIncremental(
               b.isError = true;
             }
           }
+          for (const callId of openTurn.erroredCallIds) {
+            markCodexToolResultStatus(eventsByCallId, callId, 'errored');
+          }
           // Stamp preceding so the next task_started knows this turn closed
           // off the slot and the record can be linked.
           userTurnSlot.precedingMessageId = openTurn.turnId;
@@ -406,6 +480,12 @@ export async function parseCodexSessionIncremental(
           committedFinalizedCount = finalized.length;
           committedUserTurnsCount = userTurns.length;
           committedUserTurnSlot = cloneSlot(userTurnSlot);
+          committedGraphState = snapshotGraphState(
+            nextEventIndex,
+            toolResultCounters,
+            seenRootSessionIds,
+            spawnCalls,
+          );
         }
         continue;
       }
@@ -414,8 +494,14 @@ export async function parseCodexSessionIncremental(
         const ev = payload as PatchApplyEndPayload;
         if (!openTurn || ev.turn_id !== openTurn.turnId) continue;
         if (ev.success === false) {
-          if (typeof ev.call_id === 'string') openTurn.erroredCallIds.add(ev.call_id);
+          if (typeof ev.call_id === 'string') {
+            openTurn.erroredCallIds.add(ev.call_id);
+            markCodexToolResultStatus(eventsByCallId, ev.call_id, 'errored');
+          }
           continue;
+        }
+        if (typeof ev.call_id === 'string') {
+          markCodexToolResultStatus(eventsByCallId, ev.call_id, 'completed');
         }
         const changes = ev.changes;
         if (changes && typeof changes === 'object') {
@@ -427,10 +513,28 @@ export async function parseCodexSessionIncremental(
       if (pl.type === 'exec_command_end') {
         const ev = payload as ExecCommandEndPayload;
         if (!openTurn || ev.turn_id !== openTurn.turnId) continue;
-        if (typeof ev.exit_code === 'number' && ev.exit_code !== 0 && typeof ev.call_id === 'string') {
-          openTurn.erroredCallIds.add(ev.call_id);
+        if (typeof ev.call_id === 'string') {
+          if (typeof ev.exit_code === 'number' && ev.exit_code !== 0) {
+            openTurn.erroredCallIds.add(ev.call_id);
+            markCodexToolResultStatus(eventsByCallId, ev.call_id, 'errored');
+          } else if (typeof ev.exit_code === 'number') {
+            markCodexToolResultStatus(eventsByCallId, ev.call_id, 'completed');
+          }
         }
         continue;
+      }
+
+      const notification = collectCodexNotificationEvent(
+        payload as Record<string, unknown>,
+        sessionId,
+        rec.timestamp,
+        toolResultCounters,
+        nextEventIndex,
+      );
+      if (notification) {
+        nextEventIndex++;
+        toolResultEvents.push({ offset: lineEndOffset, record: notification });
+        rememberEvent(eventsByCallId, notification);
       }
       continue;
     }
@@ -503,6 +607,35 @@ export async function parseCodexSessionIncremental(
         // have one, or buffer as pre-turn content otherwise.
         const out = payload as FunctionCallOutputPayload | CustomToolCallOutputPayload;
         if (typeof out.call_id !== 'string') continue;
+        const callIndex = toolResultCounters.get(out.call_id) ?? 0;
+        toolResultCounters.set(out.call_id, callIndex + 1);
+        const eventInput: Parameters<typeof buildCodexToolResultEvent>[0] = {
+          sessionId,
+          toolUseId: out.call_id,
+          callIndex,
+          eventIndex: nextEventIndex++,
+          ts: itemTs,
+          output: out.output,
+          status: 'completed',
+        };
+        if (openTurn?.turnId !== undefined) eventInput.messageId = openTurn.turnId;
+        const event = buildCodexToolResultEvent(eventInput);
+        const outcome = extractCodexSubagentOutcome(out.output);
+        const spawn = spawnCalls.get(out.call_id);
+        annotateCodexSubagentEvent(event, outcome, spawn);
+        if (event.status === 'errored' && openTurn) openTurn.erroredCallIds.add(out.call_id);
+        toolResultEvents.push({ offset: lineEndOffset, record: event });
+        rememberEvent(eventsByCallId, event);
+        collectCodexSubagentRelationship(
+          relationships,
+          seenRelationshipIds,
+          sessionId,
+          out.call_id,
+          itemTs,
+          lineEndOffset,
+          outcome,
+          spawn,
+        );
         // Always capture the output as a UserTurnBlock for the slot bridging
         // the open turn (or its predecessor) and the next assistant turn —
         // attribution doesn't require contentMode and shouldn't pay its cost.
@@ -539,6 +672,20 @@ export async function parseCodexSessionIncremental(
         const target = pickFunctionCallTarget(fc.name, parsedArgs);
         if (target !== undefined) call.target = target;
         openTurn.toolCalls.push(call);
+        const spawn = extractCodexSpawnCall(fc.name, fc.call_id, parsedArgs);
+        if (spawn) {
+          spawnCalls.set(fc.call_id, spawn);
+          collectCodexSubagentRelationship(
+            relationships,
+            seenRelationshipIds,
+            sessionId,
+            fc.call_id,
+            itemTs,
+            lineEndOffset,
+            spawn,
+            spawn,
+          );
+        }
         if (captureContent) {
           openTurn.content.push({
             v: 1,
@@ -565,6 +712,21 @@ export async function parseCodexSessionIncremental(
         const target = pickCustomToolTarget(ct.name, input);
         if (target !== undefined) call.target = target;
         openTurn.toolCalls.push(call);
+        const parsedInput = safeParseJson(input);
+        const spawn = extractCodexSpawnCall(ct.name, ct.call_id, parsedInput ?? { input });
+        if (spawn) {
+          spawnCalls.set(ct.call_id, spawn);
+          collectCodexSubagentRelationship(
+            relationships,
+            seenRelationshipIds,
+            sessionId,
+            ct.call_id,
+            itemTs,
+            lineEndOffset,
+            spawn,
+            spawn,
+          );
+        }
         if (captureContent) {
           openTurn.content.push({
             v: 1,
@@ -625,18 +787,506 @@ export async function parseCodexSessionIncremental(
     sessionId: committedSessionId,
     turnContexts: Object.fromEntries(committedTurnContexts),
     userTurnSlot: cloneSlot(committedUserTurnSlot),
+    graph: cloneGraphState(committedGraphState),
   };
   if (committedSessionCwd !== undefined) resume.sessionCwd = committedSessionCwd;
 
   const emittedUserTurns = userTurns.slice(0, committedUserTurnsCount);
+  const emittedRelationships = relationships
+    .filter((r) => r.offset < committedEndOffset)
+    .map((r) => r.record);
+  const emittedToolResultEvents = toolResultEvents
+    .filter((e) => e.offset < committedEndOffset)
+    .map((e) => e.record);
 
   return {
     turns,
     content,
     userTurns: emittedUserTurns,
+    relationships: emittedRelationships,
+    toolResultEvents: emittedToolResultEvents,
     endOffset: committedEndOffset,
     resume,
   };
+}
+
+function cloneGraphState(g: PersistedCodexGraphState | undefined): PersistedCodexGraphState {
+  if (!g) {
+    return {
+      nextEventIndex: 0,
+      toolResultCounters: {},
+      seenRootSessionIds: [],
+      spawnCalls: {},
+    };
+  }
+  const out: PersistedCodexGraphState = {
+    nextEventIndex: Number.isFinite(g.nextEventIndex) ? g.nextEventIndex : 0,
+    toolResultCounters: { ...g.toolResultCounters },
+    seenRootSessionIds: [...g.seenRootSessionIds],
+    spawnCalls: {},
+  };
+  if (g.spawnCalls) {
+    out.spawnCalls = Object.fromEntries(
+      Object.entries(g.spawnCalls).map(([k, v]) => [k, { ...v }]),
+    );
+  }
+  return out;
+}
+
+function snapshotGraphState(
+  nextEventIndex: number,
+  counters: Map<string, number>,
+  seenRootSessionIds: Set<string>,
+  spawnCalls: Map<string, PersistedCodexSpawnCall>,
+): PersistedCodexGraphState {
+  return {
+    nextEventIndex,
+    toolResultCounters: Object.fromEntries(counters),
+    seenRootSessionIds: [...seenRootSessionIds],
+    spawnCalls: Object.fromEntries(
+      [...spawnCalls].map(([k, v]) => [k, { ...v }]),
+    ),
+  };
+}
+
+function collectSessionRelationships(
+  meta: SessionMetaPayload,
+  fallbackTs: string | undefined,
+  offset: number,
+  out: Array<{ offset: number; record: SessionRelationshipRecord }>,
+  seenRelationships: Set<string>,
+  seenRootSessionIds: Set<string>,
+): void {
+  if (typeof meta.id !== 'string' || meta.id.length === 0) return;
+  const ts = nonEmpty(meta.timestamp) ?? nonEmpty(fallbackTs);
+  const sourceVersion = nonEmpty(meta.cli_version) ?? nonEmpty(meta.version);
+  if (!seenRootSessionIds.has(meta.id)) {
+    seenRootSessionIds.add(meta.id);
+    const root: SessionRelationshipRecord = {
+      v: 1,
+      source: 'codex',
+      sessionId: meta.id,
+      relationshipType: 'root',
+    };
+    if (ts !== undefined) root.ts = ts;
+    if (sourceVersion !== undefined) root.sourceVersion = sourceVersion;
+    pushCodexRelationship(out, seenRelationships, root, offset);
+  }
+
+  const forkSource =
+    nonEmpty(meta.forkSessionId) ??
+    nonEmpty(meta.fork_session_id) ??
+    nonEmpty(meta.forkedFromSessionId) ??
+    nonEmpty(meta.forked_from_session_id);
+  const continuationSource =
+    nonEmpty(meta.continuedFromSessionId) ??
+    nonEmpty(meta.continued_from_session_id) ??
+    nonEmpty(meta.sourceSessionId) ??
+    nonEmpty(meta.source_session_id) ??
+    nonEmpty(meta.sourceSession) ??
+    nonEmpty(meta.source_session);
+  const relatedSessionId = forkSource ?? continuationSource;
+  if (relatedSessionId === undefined || relatedSessionId === meta.id) return;
+  const rel: SessionRelationshipRecord = {
+    v: 1,
+    source: 'codex',
+    sessionId: meta.id,
+    relatedSessionId,
+    relationshipType: forkSource !== undefined ? 'fork' : 'continuation',
+    sourceSessionId: relatedSessionId,
+  };
+  if (ts !== undefined) rel.ts = ts;
+  if (sourceVersion !== undefined) rel.sourceVersion = sourceVersion;
+  pushCodexRelationship(out, seenRelationships, rel, offset);
+}
+
+function pushCodexRelationship(
+  out: Array<{ offset: number; record: SessionRelationshipRecord }>,
+  seen: Set<string>,
+  record: SessionRelationshipRecord,
+  offset: number,
+): void {
+  const key = [
+    record.source,
+    record.sessionId,
+    record.relationshipType,
+    record.relatedSessionId ?? '',
+    record.agentId ?? '',
+    record.parentToolUseId ?? '',
+  ].join('|');
+  if (seen.has(key)) return;
+  seen.add(key);
+  out.push({ offset, record });
+}
+
+function buildCodexToolResultEvent(input: {
+  sessionId: string;
+  messageId?: string;
+  toolUseId: string;
+  callIndex: number;
+  eventIndex: number;
+  ts: string;
+  output: unknown;
+  status: ToolResultStatus;
+}): ToolResultEventRecord {
+  const record: ToolResultEventRecord = {
+    v: 1,
+    source: 'codex',
+    sessionId: input.sessionId,
+    toolUseId: input.toolUseId,
+    callIndex: input.callIndex,
+    eventIndex: input.eventIndex,
+    status: input.status,
+    eventSource: 'function_call_output',
+  };
+  if (input.messageId !== undefined) record.messageId = input.messageId;
+  if (input.ts) record.ts = input.ts;
+  const measured = measureGraphContent(input.output);
+  if (measured.length !== undefined) record.contentLength = measured.length;
+  if (measured.hash !== undefined) record.contentHash = measured.hash;
+  return record;
+}
+
+function rememberEvent(
+  byCallId: Map<string, ToolResultEventRecord[]>,
+  event: ToolResultEventRecord,
+): void {
+  const existing = byCallId.get(event.toolUseId);
+  if (existing) existing.push(event);
+  else byCallId.set(event.toolUseId, [event]);
+}
+
+function markCodexToolResultStatus(
+  byCallId: Map<string, ToolResultEventRecord[]>,
+  callId: string,
+  status: ToolResultStatus,
+): void {
+  const events = byCallId.get(callId);
+  if (!events) return;
+  for (const ev of events) {
+    if (ev.status === 'errored' && status !== 'errored') continue;
+    ev.status = status;
+    if (status === 'errored') ev.isError = true;
+  }
+}
+
+interface CodexSubagentEvidence {
+  parentToolUseId?: string;
+  agentId?: string;
+  subagentSessionId?: string;
+  subagentType?: string;
+  description?: string;
+  status?: ToolResultStatus;
+}
+
+function extractCodexSpawnCall(
+  toolName: string,
+  callId: string,
+  args: Record<string, unknown> | undefined,
+): PersistedCodexSpawnCall | undefined {
+  if (!isCodexSpawnTool(toolName)) return undefined;
+  const input = args ?? {};
+  const out: PersistedCodexSpawnCall = { parentToolUseId: callId };
+  const agentId = pickDeepString(input, [
+    'agentId',
+    'agent_id',
+    'subagentId',
+    'subagent_id',
+    'taskId',
+    'task_id',
+  ]);
+  const sessionId = pickDeepString(input, [
+    'sessionId',
+    'session_id',
+    'subagentSessionId',
+    'subagent_session_id',
+    'childSessionId',
+    'child_session_id',
+  ]);
+  const subagentType = pickDeepString(input, ['subagent_type', 'subagentType', 'agentType']);
+  const description = pickDeepString(input, ['description', 'title', 'name']);
+  if (agentId !== undefined) out.agentId = agentId;
+  if (sessionId !== undefined) out.subagentSessionId = sessionId;
+  if (subagentType !== undefined) out.subagentType = subagentType;
+  if (description !== undefined) out.description = description;
+  return out;
+}
+
+function isCodexSpawnTool(name: string): boolean {
+  const normalized = name.toLowerCase().replace(/[-\s]/g, '_');
+  return (
+    normalized === 'spawn_agent' ||
+    normalized === 'spawn_subagent' ||
+    normalized === 'subagent' ||
+    normalized === 'agent' ||
+    normalized === 'task'
+  );
+}
+
+function extractCodexSubagentOutcome(output: unknown): CodexSubagentEvidence {
+  const obj = objectFromUnknown(output);
+  if (!obj) {
+    const status = statusFromUnknown(output);
+    return status ? { status } : {};
+  }
+  const parentToolUseId = pickDeepString(obj, [
+    'parentToolUseID',
+    'parentToolUseId',
+    'parent_tool_use_id',
+    'toolUseId',
+    'tool_use_id',
+    'spawnCallId',
+    'spawn_call_id',
+  ]);
+  const agentId = pickDeepString(obj, [
+    'agentId',
+    'agent_id',
+    'subagentId',
+    'subagent_id',
+    'taskId',
+    'task_id',
+  ]);
+  const subagentSessionId = pickDeepString(obj, [
+    'sessionId',
+    'session_id',
+    'subagentSessionId',
+    'subagent_session_id',
+    'childSessionId',
+    'child_session_id',
+  ]);
+  const subagentType = pickDeepString(obj, ['subagent_type', 'subagentType', 'agentType']);
+  const description = pickDeepString(obj, ['description', 'title', 'name']);
+  const status = statusFromUnknown(obj);
+  const out: CodexSubagentEvidence = {};
+  if (parentToolUseId !== undefined) out.parentToolUseId = parentToolUseId;
+  if (agentId !== undefined) out.agentId = agentId;
+  if (subagentSessionId !== undefined) out.subagentSessionId = subagentSessionId;
+  if (subagentType !== undefined) out.subagentType = subagentType;
+  if (description !== undefined) out.description = description;
+  if (status !== undefined) out.status = status;
+  return out;
+}
+
+function annotateCodexSubagentEvent(
+  event: ToolResultEventRecord,
+  outcome: CodexSubagentEvidence,
+  spawn: PersistedCodexSpawnCall | undefined,
+): void {
+  const status = outcome.status;
+  if (status !== undefined) {
+    event.status = status;
+    if (status === 'errored') event.isError = true;
+  }
+  const subagentSessionId = outcome.subagentSessionId ?? spawn?.subagentSessionId;
+  const agentId = outcome.agentId ?? spawn?.agentId ?? subagentSessionId;
+  if (subagentSessionId !== undefined) event.subagentSessionId = subagentSessionId;
+  if (agentId !== undefined) event.agentId = agentId;
+}
+
+function collectCodexSubagentRelationship(
+  out: Array<{ offset: number; record: SessionRelationshipRecord }>,
+  seen: Set<string>,
+  parentSessionId: string,
+  callId: string,
+  ts: string,
+  offset: number,
+  outcome: CodexSubagentEvidence,
+  spawn: PersistedCodexSpawnCall | undefined,
+): void {
+  if (!parentSessionId) return;
+  const childSessionId =
+    outcome.subagentSessionId ?? spawn?.subagentSessionId ?? outcome.agentId ?? spawn?.agentId;
+  if (childSessionId === undefined || childSessionId.length === 0) return;
+  const agentId = outcome.agentId ?? spawn?.agentId ?? childSessionId;
+  const parentToolUseId = outcome.parentToolUseId ?? spawn?.parentToolUseId ?? callId;
+  const row: SessionRelationshipRecord = {
+    v: 1,
+    source: 'codex',
+    sessionId: childSessionId,
+    relatedSessionId: parentSessionId,
+    relationshipType: 'subagent',
+    parentToolUseId,
+    agentId,
+  };
+  if (ts) row.ts = ts;
+  const subagentType = outcome.subagentType ?? spawn?.subagentType;
+  const description = outcome.description ?? spawn?.description;
+  if (subagentType !== undefined) row.subagentType = subagentType;
+  if (description !== undefined) row.description = description;
+  pushCodexRelationship(out, seen, row, offset);
+}
+
+function collectCodexNotificationEvent(
+  payload: Record<string, unknown>,
+  sessionId: string,
+  ts: string | undefined,
+  counters: Map<string, number>,
+  eventIndex: number,
+): ToolResultEventRecord | undefined {
+  if (!sessionId) return undefined;
+  const type = typeof payload['type'] === 'string' ? payload['type'] : '';
+  const eventSource = classifyCodexNotificationSource(type);
+  if (eventSource === undefined) return undefined;
+  const toolUseId = pickDeepString(payload, [
+    'toolUseId',
+    'tool_use_id',
+    'call_id',
+    'callId',
+    'parentToolUseID',
+    'parentToolUseId',
+    'parent_tool_use_id',
+  ]);
+  if (toolUseId === undefined) return undefined;
+  const callIndex = counters.get(toolUseId) ?? 0;
+  counters.set(toolUseId, callIndex + 1);
+  const record: ToolResultEventRecord = {
+    v: 1,
+    source: 'codex',
+    sessionId,
+    toolUseId,
+    callIndex,
+    eventIndex,
+    status: statusFromUnknown(payload) ?? 'unknown',
+    eventSource,
+  };
+  if (ts !== undefined) record.ts = ts;
+  const agentId = pickDeepString(payload, ['agentId', 'agent_id', 'taskId', 'task_id']);
+  const subagentSessionId = pickDeepString(payload, [
+    'sessionId',
+    'session_id',
+    'subagentSessionId',
+    'subagent_session_id',
+    'childSessionId',
+    'child_session_id',
+  ]);
+  if (agentId !== undefined) record.agentId = agentId;
+  if (subagentSessionId !== undefined && subagentSessionId !== sessionId) {
+    record.subagentSessionId = subagentSessionId;
+  }
+  if (record.status === 'errored') record.isError = true;
+  const content = pickNotificationContent(payload);
+  const measured = measureGraphContent(content);
+  if (measured.length !== undefined) record.contentLength = measured.length;
+  if (measured.hash !== undefined) record.contentHash = measured.hash;
+  return record;
+}
+
+function classifyCodexNotificationSource(type: string): ToolResultEventSource | undefined {
+  const normalized = type.toLowerCase();
+  if (normalized.includes('queue') || normalized.includes('enqueue')) return 'queue_event';
+  if (normalized.includes('progress')) return 'progress_event';
+  if (normalized.includes('subagent') || normalized.includes('agent')) {
+    return 'subagent_notification';
+  }
+  return undefined;
+}
+
+function pickNotificationContent(payload: Record<string, unknown>): unknown {
+  for (const key of ['content', 'message', 'output', 'result']) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) return payload[key];
+  }
+  return undefined;
+}
+
+function objectFromUnknown(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function pickDeepString(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const direct = obj[key];
+    if (typeof direct === 'string' && direct.length > 0) return direct;
+  }
+  for (const value of Object.values(obj)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const nested = pickDeepString(value as Record<string, unknown>, keys);
+    if (nested !== undefined) return nested;
+  }
+  return undefined;
+}
+
+function statusFromUnknown(value: unknown): ToolResultStatus | undefined {
+  if (typeof value === 'string') return normalizeToolResultStatus(value);
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const obj = value as Record<string, unknown>;
+  for (const key of ['status', 'state', 'result', 'terminalStatus', 'terminal_status']) {
+    const status = normalizeToolResultStatus(obj[key]);
+    if (status !== undefined) return status;
+  }
+  for (const nested of Object.values(obj)) {
+    const status = statusFromUnknown(nested);
+    if (status !== undefined) return status;
+  }
+  return undefined;
+}
+
+function normalizeToolResultStatus(value: unknown): ToolResultStatus | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.toLowerCase().replace(/[-\s]/g, '_');
+  if (
+    normalized === 'completed' ||
+    normalized === 'complete' ||
+    normalized === 'success' ||
+    normalized === 'succeeded' ||
+    normalized === 'done'
+  ) {
+    return 'completed';
+  }
+  if (
+    normalized === 'error' ||
+    normalized === 'errored' ||
+    normalized === 'failed' ||
+    normalized === 'failure'
+  ) {
+    return 'errored';
+  }
+  if (
+    normalized === 'running' ||
+    normalized === 'in_progress' ||
+    normalized === 'queued' ||
+    normalized === 'pending' ||
+    normalized === 'started'
+  ) {
+    return 'running';
+  }
+  if (
+    normalized === 'cancelled' ||
+    normalized === 'canceled' ||
+    normalized === 'aborted'
+  ) {
+    return 'cancelled';
+  }
+  return undefined;
+}
+
+function measureGraphContent(content: unknown): { length?: number; hash?: string } {
+  if (typeof content === 'string') {
+    return { length: content.length, hash: contentHash(content) };
+  }
+  if (content === undefined || content === null) return {};
+  try {
+    const serialized = JSON.stringify(content);
+    if (typeof serialized !== 'string') return {};
+    return { length: serialized.length, hash: contentHash(serialized) };
+  } catch {
+    return {};
+  }
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function pushContent(
@@ -670,6 +1320,7 @@ function cloneResume(r: CodexResumeState | undefined): CodexResumeState {
       sessionId: '',
       turnContexts: {},
       userTurnSlot: { blocks: [], ts: '' },
+      graph: cloneGraphState(undefined),
     };
   }
   const out: CodexResumeState = {
@@ -680,6 +1331,7 @@ function cloneResume(r: CodexResumeState | undefined): CodexResumeState {
   if (r.sessionCwd !== undefined) out.sessionCwd = r.sessionCwd;
   if (r.userTurnSlot) out.userTurnSlot = cloneSlot(r.userTurnSlot);
   else out.userTurnSlot = { blocks: [], ts: '' };
+  out.graph = cloneGraphState(r.graph);
   return out;
 }
 

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -42,6 +42,8 @@ export type {
   ParseCodexIncrementalResult,
   CodexResumeState,
   PersistedUserTurnSlot,
+  PersistedCodexGraphState,
+  PersistedCodexSpawnCall,
 } from './codex.js';
 export { parseOpencodeSession, parseOpencodeSessionIncremental } from './opencode.js';
 export type {

--- a/packages/reader/src/opencode.test.ts
+++ b/packages/reader/src/opencode.test.ts
@@ -94,7 +94,47 @@ describe('parseOpencodeSession', () => {
     const t = turns[0]!;
     assert.ok(t.subagent);
     assert.equal(t.subagent!.isSidechain, true);
+    assert.equal(t.subagent!.agentId, 'ses_child');
+    assert.equal(t.subagent!.parentAgentId, 'ses_multi');
     assert.equal(t.model, 'anthropic/claude-haiku-4-5');
+  });
+
+  it('emits root and parentID-backed subagent relationships', async () => {
+    const parent = await parseOpencodeSession(sessionFile('multi-turn', 'ses_multi'));
+    assert.equal(parent.relationships.length, 1);
+    assert.equal(parent.relationships[0]!.relationshipType, 'root');
+    assert.equal(parent.relationships[0]!.sessionId, 'ses_multi');
+    assert.equal(parent.relationships[0]!.sourceVersion, '1.0.0');
+
+    const child = await parseOpencodeSession(sessionFile('multi-turn', 'ses_child'));
+    assert.equal(child.relationships.length, 1);
+    const rel = child.relationships[0]!;
+    assert.equal(rel.relationshipType, 'subagent');
+    assert.equal(rel.sessionId, 'ses_child');
+    assert.equal(rel.relatedSessionId, 'ses_multi');
+    assert.equal(rel.agentId, 'ses_child');
+    assert.equal(rel.sourceVersion, '1.0.0');
+  });
+
+  it('emits metadata-only tool result events from tool parts', async () => {
+    const { toolResultEvents } = await parseOpencodeSession(sessionFile('with-tool', 'ses_tool'));
+    assert.equal(toolResultEvents.length, 3);
+    assert.deepEqual(
+      toolResultEvents.map((e) => e.toolUseId),
+      ['toolu_read_1', 'toolu_edit_1', 'toolu_bash_1'],
+    );
+    for (let i = 0; i < toolResultEvents.length; i++) {
+      const ev = toolResultEvents[i]!;
+      assert.equal(ev.source, 'opencode');
+      assert.equal(ev.eventSource, 'tool_result');
+      assert.equal(ev.status, 'completed');
+      assert.equal(ev.eventIndex, i);
+      assert.equal(ev.callIndex, 0);
+      assert.equal(ev.messageId, 'msg_tool_asst');
+      assert.equal(typeof ev.contentLength, 'number');
+      assert.equal(typeof ev.contentHash, 'string');
+      assert.equal(Object.prototype.hasOwnProperty.call(ev, 'output'), false);
+    }
   });
 
   it('produces stable argsHash for identical tool inputs', async () => {
@@ -186,11 +226,16 @@ describe('parseOpencodeSession', () => {
         }),
       );
       const file = path.join(sessionDir, 'ses_fail.json');
-      const { turns } = await parseOpencodeSession(file);
+      const { turns, toolResultEvents } = await parseOpencodeSession(file);
       assert.equal(turns.length, 1);
       // Non-zero exit on a bash call flags hasFailedTool → debugging wins.
       assert.equal(turns[0]!.activity, 'debugging');
       assert.equal(turns[0]!.hasEdits, false);
+      assert.equal(toolResultEvents.length, 1);
+      assert.equal(toolResultEvents[0]!.toolUseId, 'call_fail_bash');
+      assert.equal(toolResultEvents[0]!.status, 'errored');
+      assert.equal(toolResultEvents[0]!.isError, true);
+      assert.equal(toolResultEvents[0]!.contentLength, 'command not found: foo'.length);
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }

--- a/packages/reader/src/opencode.ts
+++ b/packages/reader/src/opencode.ts
@@ -3,12 +3,15 @@ import * as path from 'node:path';
 
 import { classifyActivity } from './classifier.js';
 import { resolveProject } from './git.js';
-import { argsHash } from './hash.js';
+import { argsHash, contentHash } from './hash.js';
 import type {
   ContentRecord,
   ContentStoreMode,
+  SessionRelationshipRecord,
   Subagent,
   ToolCall,
+  ToolResultEventRecord,
+  ToolResultStatus,
   TurnRecord,
   Usage,
   UserTurnBlock,
@@ -25,6 +28,12 @@ interface SessionInfo {
   id: string;
   parentID?: string;
   directory?: string;
+  version?: string;
+  title?: string;
+  time?: {
+    created?: number;
+    updated?: number;
+  };
 }
 
 interface MessageTokens {
@@ -93,17 +102,20 @@ export interface ParseOpencodeResult {
   turns: TurnRecord[];
   content: ContentRecord[];
   userTurns: UserTurnRecord[];
+  relationships: SessionRelationshipRecord[];
+  toolResultEvents: ToolResultEventRecord[];
 }
 
 export async function parseOpencodeSession(
   sessionFilePath: string,
   options: ParseOpencodeOptions = {},
 ): Promise<ParseOpencodeResult> {
-  const { turns, content, userTurns } = await parseOpencodeSessionIncremental(
-    sessionFilePath,
-    options,
-  );
-  return { turns, content, userTurns };
+  const { turns, content, userTurns, relationships, toolResultEvents } =
+    await parseOpencodeSessionIncremental(
+      sessionFilePath,
+      options,
+    );
+  return { turns, content, userTurns, relationships, toolResultEvents };
 }
 
 export interface ParseOpencodeIncrementalOptions extends ParseOpencodeOptions {
@@ -114,6 +126,8 @@ export interface ParseOpencodeIncrementalResult {
   turns: TurnRecord[];
   content: ContentRecord[];
   userTurns: UserTurnRecord[];
+  relationships: SessionRelationshipRecord[];
+  toolResultEvents: ToolResultEventRecord[];
   seenMessageIds: Set<string>;
 }
 
@@ -127,6 +141,8 @@ export async function parseOpencodeSessionIncremental(
       turns: [],
       content: [],
       userTurns: [],
+      relationships: [],
+      toolResultEvents: [],
       seenMessageIds: new Set(options.seenMessageIds ?? []),
     };
   }
@@ -144,10 +160,23 @@ export async function parseOpencodeSessionIncremental(
   const turns: TurnRecord[] = [];
   const content: ContentRecord[] = [];
   const userTurns: UserTurnRecord[] = [];
+  const relationships = buildOpencodeRelationships(session);
+  const toolResultEvents: ToolResultEventRecord[] = [];
+  const toolResultCounters = new Map<string, number>();
+  let nextEventIndex = 0;
 
   for (let i = 0; i < assistants.length; i++) {
     const m = assistants[i]!;
+    const parts = await readParts(storageRoot, m.id);
+    const harvested = collectOpencodeToolResultEvents(
+      parts,
+      m,
+      toolResultCounters,
+      nextEventIndex,
+    );
+    nextEventIndex += harvested.length;
     if (seen.has(m.id)) continue;
+    toolResultEvents.push(...harvested);
     // Build the user turn that bridges the previous assistant message and
     // this one — tool outputs from the predecessor's parts plus any user
     // text from the user message that precedes `m`. Issue #86.
@@ -170,7 +199,6 @@ export async function parseOpencodeSessionIncremental(
     );
     if (userTurn) userTurns.push(userTurn);
 
-    const parts = await readParts(storageRoot, m.id);
     const { toolCalls, filesTouched, erroredCallIds } = extractToolsAndFiles(parts);
     const stopReason = lastStepFinishReason(parts);
 
@@ -197,7 +225,8 @@ export async function parseOpencodeSessionIncremental(
     }
     if (filesTouched.length > 0) record.filesTouched = filesTouched;
     if (isSidechain) {
-      const sub: Subagent = { isSidechain: true };
+      const sub: Subagent = { isSidechain: true, agentId: session.id };
+      if (session.parentID !== undefined) sub.parentAgentId = session.parentID;
       record.subagent = sub;
     }
     if (stopReason !== undefined) record.stopReason = stopReason;
@@ -243,7 +272,7 @@ export async function parseOpencodeSessionIncremental(
     }
   }
 
-  return { turns, content, userTurns, seenMessageIds: seen };
+  return { turns, content, userTurns, relationships, toolResultEvents, seenMessageIds: seen };
 }
 
 // Build a UserTurnRecord for the gap between two consecutive assistant
@@ -377,6 +406,128 @@ function extractAssistantContent(
   return out;
 }
 
+function buildOpencodeRelationships(session: SessionInfo): SessionRelationshipRecord[] {
+  const ts =
+    typeof session.time?.created === 'number'
+      ? new Date(session.time.created).toISOString()
+      : undefined;
+  if (session.parentID && session.parentID.length > 0) {
+    const row: SessionRelationshipRecord = {
+      v: 1,
+      source: 'opencode',
+      sessionId: session.id,
+      relatedSessionId: session.parentID,
+      relationshipType: 'subagent',
+      agentId: session.id,
+    };
+    if (ts !== undefined) row.ts = ts;
+    if (session.version !== undefined) row.sourceVersion = session.version;
+    return [row];
+  }
+  const root: SessionRelationshipRecord = {
+    v: 1,
+    source: 'opencode',
+    sessionId: session.id,
+    relationshipType: 'root',
+  };
+  if (ts !== undefined) root.ts = ts;
+  if (session.version !== undefined) root.sourceVersion = session.version;
+  return [root];
+}
+
+function collectOpencodeToolResultEvents(
+  parts: Part[],
+  message: AssistantMessage,
+  counters: Map<string, number>,
+  startEventIndex: number,
+): ToolResultEventRecord[] {
+  const out: ToolResultEventRecord[] = [];
+  let eventIndex = startEventIndex;
+  const ts = new Date(message.time.created).toISOString();
+  for (const p of parts) {
+    if (p.type !== 'tool') continue;
+    const tp = p as ToolPart;
+    if (typeof tp.callID !== 'string') continue;
+    const callIndex = counters.get(tp.callID) ?? 0;
+    counters.set(tp.callID, callIndex + 1);
+    const status = opencodeToolStatus(tp);
+    const record: ToolResultEventRecord = {
+      v: 1,
+      source: 'opencode',
+      sessionId: message.sessionID,
+      messageId: message.id,
+      toolUseId: tp.callID,
+      callIndex,
+      eventIndex: eventIndex++,
+      ts,
+      status,
+      eventSource: 'tool_result',
+    };
+    if (status === 'errored') record.isError = true;
+    if (tp.state && Object.prototype.hasOwnProperty.call(tp.state, 'output')) {
+      const measured = measureGraphContent(tp.state.output);
+      if (measured.length !== undefined) record.contentLength = measured.length;
+      if (measured.hash !== undefined) record.contentHash = measured.hash;
+    }
+    out.push(record);
+  }
+  return out;
+}
+
+function opencodeToolStatus(tp: ToolPart): ToolResultStatus {
+  if (isFailedTool(tp)) return 'errored';
+  const raw = tp.state?.status;
+  if (typeof raw !== 'string') return 'unknown';
+  const normalized = raw.toLowerCase().replace(/[-\s]/g, '_');
+  if (
+    normalized === 'completed' ||
+    normalized === 'complete' ||
+    normalized === 'success' ||
+    normalized === 'succeeded'
+  ) {
+    return 'completed';
+  }
+  if (
+    normalized === 'error' ||
+    normalized === 'errored' ||
+    normalized === 'failed' ||
+    normalized === 'failure'
+  ) {
+    return 'errored';
+  }
+  if (
+    normalized === 'running' ||
+    normalized === 'pending' ||
+    normalized === 'queued' ||
+    normalized === 'in_progress' ||
+    normalized === 'started'
+  ) {
+    return 'running';
+  }
+  if (
+    normalized === 'cancelled' ||
+    normalized === 'canceled' ||
+    normalized === 'aborted'
+  ) {
+    return 'cancelled';
+  }
+  return 'unknown';
+}
+
+function measureGraphContent(content: unknown): { length?: number; hash?: string } {
+  if (typeof content === 'string') {
+    return { length: content.length, hash: contentHash(content) };
+  }
+  if (content === undefined || content === null) return {};
+  try {
+    const serialized = JSON.stringify(content);
+    if (typeof serialized !== 'string') return {};
+    return { length: serialized.length, hash: contentHash(serialized) };
+  } catch {
+    return {};
+  }
+}
+
 async function readUserTextParts(storageRoot: string, userMessageId: string): Promise<string[]> {
   const parts = await readParts(storageRoot, userMessageId);
   const out: string[] = [];
@@ -397,6 +548,15 @@ async function readSession(sessionFilePath: string): Promise<SessionInfo | null>
     const out: SessionInfo = { id: parsed.id };
     if (typeof parsed.parentID === 'string') out.parentID = parsed.parentID;
     if (typeof parsed.directory === 'string') out.directory = parsed.directory;
+    if (typeof parsed.version === 'string') out.version = parsed.version;
+    if (typeof parsed.title === 'string') out.title = parsed.title;
+    if (parsed.time && typeof parsed.time === 'object') {
+      const t = parsed.time as Record<string, unknown>;
+      const time: NonNullable<SessionInfo['time']> = {};
+      if (typeof t['created'] === 'number') time.created = t['created'];
+      if (typeof t['updated'] === 'number') time.updated = t['updated'];
+      out.time = time;
+    }
     return out;
   } catch {
     return null;

--- a/packages/reader/src/types.ts
+++ b/packages/reader/src/types.ts
@@ -206,10 +206,8 @@ export interface UserTurnRecord {
 //     we never store the raw bytes here.
 //
 // These are additive — existing TurnRecord consumers continue to work — and
-// the contract is intentionally cross-source so Codex / OpenCode / hook-path
-// ingest all populate the same shape over time. This file ships the shapes
-// + the Claude passive reader's first population pass; Codex / OpenCode
-// follow in a subsequent PR.
+// the contract is intentionally cross-source so Claude / Codex / OpenCode /
+// hook-path ingest all populate the same shape where their logs expose it.
 // ---------------------------------------------------------------------------
 
 export type RelationshipType = 'root' | 'continuation' | 'fork' | 'subagent';


### PR DESCRIPTION
Closes #42

Summary:
- Populate Codex passive execution graph relationships and metadata-only tool result events.
- Populate OpenCode root/subagent relationships and metadata-only tool result events.
- Improve Claude graph extraction where source logs expose continuation/progress evidence, without inventing unavailable metadata.
- Persist Codex/OpenCode graph records through CLI ingest and add source-neutral ledger/query coverage.

Tests:
- pnpm run build
- node --test packages/reader/dist/codex.test.js packages/reader/dist/opencode.test.js packages/reader/dist/claude.test.js packages/ledger/dist/ledger.test.js packages/cli/dist/ingest.test.js
- pnpm run test:ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
