### PR TITLE
Add CI workflow to build + test on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# Build + test the full workspace on every PR and on every push to main.
+# Catches the failure mode where a syntactically-broken file lands on main
+# undetected because publish.yml only runs on workflow_dispatch — e.g. the
+# unescaped backticks in archive.ts's SCHEMA_SQL template literal that
+# slipped past review and broke `tsc` for everyone downstream.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.14.0'
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      # `tsc --build` walks every package in the workspace and is the gate
+      # for parse-level failures. Run it as its own step so a syntax error
+      # surfaces clearly in the failure summary instead of being lumped in
+      # with test output.
+      - name: Build workspace
+        run: pnpm -r run build
+
+      - name: Run tests
+        run: pnpm run test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs `pnpm -r run build` and `pnpm run test` on every `pull_request` and on `push` to `main`.
- Catches the failure mode where a syntactically-broken file lands on `main` undetected because `publish.yml` only runs on `workflow_dispatch`. Concretely: the #129 merge introduced unescaped backticks inside the `SCHEMA_SQL` template literal in `packages/ledger/src/archive.ts` (in a SQL comment referencing `` `burn summary --subagent-tree --json` ``), which broke `tsc` workspace-wide. PR #130 had to fix it as part of its merge resolution because no PR-time check would have flagged it.
- Mirrors the Node + pnpm setup from `publish.yml` (Node 22.14.0, `pnpm/action-setup@v5`, `--frozen-lockfile`) so the build environment matches what release uses.
- `concurrency` group cancels superseded runs on the same ref so a fast push sequence doesn't queue stale builds.

## Test plan

- [ ] After merge, confirm a follow-up PR triggers the new `build-and-test` check.
- [ ] Confirm a deliberate `tsc` parse error in a PR fails the check (smoke test by reverting the archive.ts backtick fix on a throwaway branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
