### PR TITLE
chore: sync package.json versions to 0.32.0 to match npm

### DIFF
--- a/packages/analyze/package.json
+++ b/packages/analyze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relayburn/analyze",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Cost and usage derivations for relayburn TurnRecords",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relayburn/cli",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "burn CLI — spawn wrapper + summary/by-tool over the relayburn ledger",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relayburn/ledger",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Append-only JSONL ledger + stamp API for relayburn",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relayburn/mcp",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "MCP (Model Context Protocol) server exposing read-only relayburn ledger queries for in-session self-query",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/reader/package.json
+++ b/packages/reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relayburn/reader",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Pure parsers for agent CLI session logs → TurnRecord[]",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- A prior `publish all` workflow run shipped `@relayburn/reader@0.32.0`, `@relayburn/ledger@0.32.0`, and `@relayburn/analyze@0.32.0` to npm but failed before the version-bump commit + git tags landed. `@relayburn/mcp` and `@relayburn/cli` never published.
- The publish workflow's "local vs npm" parity check (`.github/workflows/publish.yml:120`) now blocks because `main` is at 0.31.0 for those three packages while npm has 0.32.0.
- This PR bumps all five packages to 0.32.0 in `package.json` so the next `publish all → minor` run cleanly takes everything to 0.33.0 with monorepo parity preserved. mcp/cli are bumped along with the others (even though they are not yet on npm at 0.32.0) so a single coordinated bump keeps the five-package release in lockstep.

No code changes — only the `version` field in each `packages/*/package.json`.

## Follow-ups (not in this PR)
- Optionally tag this commit as `reader-v0.32.0`, `ledger-v0.32.0`, `analyze-v0.32.0` so the changelog generator has a baseline for the otherwise-untracked 0.32.0 publish.
- After merge, re-run **Publish Package** with `package=all`, `version=minor` to produce 0.33.0.

## Test plan
- [ ] Merge to `main`
- [ ] Re-run Publish Package workflow with `package=all`, `version=minor`
- [ ] Confirm "Verify local versions are in sync with npm" step passes
- [ ] Confirm 0.33.0 publishes cleanly for all five packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
