### PR TITLE
Drop `burn rebuild-index`; use `burn rebuild --index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - **Codex compaction parity with Claude.** Codex passive ingest now detects `compacted` session-log records, persists them as ledger compaction events, and anchors them to the preceding Codex turn so compaction-loss analysis can cover Codex sessions instead of only Claude Code.
 
+### Removed
+
+- **`burn rebuild-index`** ([#151](https://github.com/AgentWorkforce/burn/issues/151)). The standalone subcommand has been dropped — it was a thin alias for `burn rebuild --index` with identical behavior. Run `burn rebuild --index` instead.
+
 ## [0.34.0] - 2026-04-27
 
 ### Changed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Codex ingest persists compaction events.** The Codex passive ingest path now appends parser-emitted compactions through the existing ledger compaction writer, so `burn waste --kind compaction` can see Codex context compactions with the same event shape Claude uses.
 
+### Removed
+
+- **`burn rebuild-index`** ([#151](https://github.com/AgentWorkforce/burn/issues/151)). The standalone subcommand has been dropped — it was a thin alias for `burn rebuild --index` with identical behavior. Run `burn rebuild --index` instead.
+
 ## [0.34.0] - 2026-04-27
 
 ### Added

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,6 @@ import { runMcpServer } from './commands/mcp-server.js';
 import { runOpencodeWrapper } from './commands/opencode.js';
 import { runPlans } from './commands/plans.js';
 import { runRebuild } from './commands/rebuild.js';
-import { runRebuildIndex } from './commands/rebuild-index.js';
 import { runSummary } from './commands/summary.js';
 import { runWaste } from './commands/waste.js';
 import { runWatch } from './commands/watch.js';
@@ -41,7 +40,6 @@ Usage:
   burn content prune [--days <n>] [--force]
   burn archive       build | rebuild | status [--json]
   burn rebuild         --index | --reclassify [--force]
-  burn rebuild-index   (alias for 'burn rebuild --index')
 
 Examples:
   burn summary --since 24h
@@ -124,8 +122,6 @@ async function main(): Promise<number> {
       return runArchive(args);
     case 'rebuild':
       return runRebuild(args);
-    case 'rebuild-index':
-      return runRebuildIndex();
     default:
       process.stderr.write(`unknown command: ${cmd}\n\n${HELP}`);
       return 1;

--- a/packages/cli/src/commands/rebuild-index.ts
+++ b/packages/cli/src/commands/rebuild-index.ts
@@ -1,9 +1,0 @@
-import { rebuildIndex } from '@relayburn/ledger';
-
-export async function runRebuildIndex(): Promise<number> {
-  const { ids, content } = await rebuildIndex();
-  process.stdout.write(
-    `rebuilt ledger index: ${ids} id hashes, ${content} content fingerprints\n`,
-  );
-  return 0;
-}

--- a/packages/cli/src/commands/rebuild.ts
+++ b/packages/cli/src/commands/rebuild.ts
@@ -13,7 +13,7 @@ Usage:
   burn rebuild --index --reclassify [--force]
 
 Flags:
-  --index       rebuild the sidecar index (equivalent to 'burn rebuild-index')
+  --index       rebuild the sidecar index
   --reclassify  re-run the activity classifier on every ledger turn
   --force       with --reclassify, overwrite activity even if already set
   --content     re-parse source session files to populate missing content


### PR DESCRIPTION
## Summary
- Drops `burn rebuild-index` — it was a thin alias for `burn rebuild --index` with no behavioral difference. One verb is enough, and it removes a second code path to keep in sync.
- Deletes `packages/cli/src/commands/rebuild-index.ts`, removes the dispatch case + import + alias line from `cli.ts`, and tidies the `burn rebuild` help text that referenced it.
- CHANGELOG entries added under `[Unreleased]` in both the root `CHANGELOG.md` and `packages/cli/CHANGELOG.md`. Users should run `burn rebuild --index` instead.

Closes #151.

## Test plan
- [x] `pnpm run build` clean
- [x] `pnpm run test` — 626/626 pass
- [x] `burn --help` no longer lists `rebuild-index`
- [x] `burn rebuild-index` exits 1 with `unknown command: rebuild-index` and prints the help block
- [x] `burn rebuild --index` path unchanged (no edits to its behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
