### PR TITLE
Surface per-cell fidelity in `burn summary` (#136)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`burn summary` surfaces per-cell fidelity** ([#136](https://github.com/AgentWorkforce/burn/issues/136)). The (model | provider) table now distinguishes a literal `0` from "no source data" inside individual cells: a token-field cell whose every contributing turn omitted the field renders as `—`, and a cell whose contributing turns are mixed (some reported, some omitted) renders the value with a trailing `*` plus a single footer note (`* partial coverage: N of M turns omitted per-turn token data`). Full-fidelity slices print no marker and no footer, so the common all-Claude case looks identical to before. Records emitted before `TurnRecord.fidelity` existed (pre-#41 ledgers) are treated as best-effort full and never trigger the marker. `--json` output replaces the bare `fidelity: FidelitySummary` block with `fidelity: { summary, perCell }`, where `perCell.cells[]` carries per-(model|provider) per-field `{ known, missing }` counters and a `partial` flag — the same shape pattern the sibling fidelity PRs (#135 / #133 / #134 / #132) already emit.
 - **Codex ingest persists compaction events.** The Codex passive ingest path now appends parser-emitted compactions through the existing ledger compaction writer, so `burn waste --kind compaction` can see Codex context compactions with the same event shape Claude uses.
 
 ### Removed

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -470,4 +470,46 @@ describe('burn summary per-cell fidelity (#136)', () => {
     assert.equal(out.stdout.includes('*'), false);
     assert.equal(out.stdout.includes('partial coverage:'), false);
   });
+
+  it('footer N sums per-field missing across rows (multi-model regression)', async () => {
+    // Devin-review regression: with two model rows that each have some
+    // turns missing output, the footer denominator should report the
+    // cross-row sum of `missing` for the worst-covered field — not the
+    // per-(row, field) max. Two rows × 2 missing-output turns each → 4.
+    const partialOutput = (model: string, sessionId: string, msg: string, ts: string) =>
+      fakeTurn({
+        sessionId,
+        messageId: msg,
+        ts,
+        model,
+        fidelity: partialMissingOutput(),
+      });
+    await appendTurns([
+      // Model A: 1 full + 2 partial-output
+      fakeTurn({
+        sessionId: 'mr-A',
+        messageId: 'mr-A-1',
+        model: 'claude-sonnet-4-6',
+        fidelity: fullFidelity(),
+      }),
+      partialOutput('claude-sonnet-4-6', 'mr-A', 'mr-A-2', '2026-04-20T00:01:00.000Z'),
+      partialOutput('claude-sonnet-4-6', 'mr-A', 'mr-A-3', '2026-04-20T00:02:00.000Z'),
+      // Model B: 1 full + 2 partial-output
+      fakeTurn({
+        sessionId: 'mr-B',
+        messageId: 'mr-B-1',
+        ts: '2026-04-20T00:03:00.000Z',
+        model: 'claude-haiku-4-5',
+        fidelity: fullFidelity(),
+      }),
+      partialOutput('claude-haiku-4-5', 'mr-B', 'mr-B-2', '2026-04-20T00:04:00.000Z'),
+      partialOutput('claude-haiku-4-5', 'mr-B', 'mr-B-3', '2026-04-20T00:05:00.000Z'),
+    ]);
+    const out = await captureSummary({});
+    assert.equal(out.code, 0);
+    // 4 turns missing output across 6 total. The pre-fix bug took the
+    // per-(row, field) max (2 instead of 4); this assertion would have
+    // failed against that arithmetic.
+    assert.match(out.stdout, /partial coverage: 4 of 6 turns/);
+  });
 });

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -4,8 +4,13 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
-import { appendTurns, archivePath, stamp } from '@relayburn/ledger';
-import type { TurnRecord } from '@relayburn/reader';
+import {
+  appendTurns,
+  archivePath,
+  stamp,
+  __resetIndexCacheForTesting,
+} from '@relayburn/ledger';
+import type { Fidelity, TurnRecord } from '@relayburn/reader';
 
 import { runSummary } from './summary.js';
 
@@ -199,5 +204,270 @@ describe('burn summary archive integration (#82)', () => {
       return idx >= 0 ? s.slice(idx) : s;
     };
     assert.equal(stripPreamble(archiveOut.stdout), stripPreamble(ledgerOut.stdout));
+  });
+});
+
+describe('burn summary per-cell fidelity (#136)', () => {
+  let tmpHome: string;
+  let tmpRelay: string;
+  const originalHome = process.env['HOME'];
+  const originalRelay = process.env['RELAYBURN_HOME'];
+  const originalArchive = process.env['RELAYBURN_ARCHIVE'];
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-summary-cellfid-home-'));
+    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-summary-cellfid-relay-'));
+    process.env['HOME'] = tmpHome;
+    process.env['RELAYBURN_HOME'] = tmpRelay;
+    // Force the legacy ledger-walk path so the per-cell counters reflect the
+    // exact turns we appended; archive-backed pricing/coverage is exercised
+    // independently in the parity test above.
+    process.env['RELAYBURN_ARCHIVE'] = '0';
+    // The ledger's index-sidecar cache is module-level. Earlier suites
+    // populate it against their own tmpRelay; without resetting it we'd
+    // dedup against stale content fingerprints (same default ts + usage as
+    // the parity test → silent skip in `appendTurns`).
+    __resetIndexCacheForTesting();
+  });
+
+  after(async () => {
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+    else delete process.env['HOME'];
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    if (originalArchive !== undefined) process.env['RELAYBURN_ARCHIVE'] = originalArchive;
+    else delete process.env['RELAYBURN_ARCHIVE'];
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(tmpRelay, { recursive: true, force: true });
+  });
+
+  function fullFidelity(): Fidelity {
+    return {
+      granularity: 'per-turn',
+      coverage: {
+        hasInputTokens: true,
+        hasOutputTokens: true,
+        hasReasoningTokens: true,
+        hasCacheReadTokens: true,
+        hasCacheCreateTokens: true,
+        hasToolCalls: true,
+        hasToolResultEvents: true,
+        hasSessionRelationships: true,
+        hasRawContent: true,
+      },
+      class: 'full',
+    };
+  }
+
+  function partialMissingOutput(): Fidelity {
+    const f = fullFidelity();
+    return {
+      ...f,
+      coverage: { ...f.coverage, hasOutputTokens: false },
+      class: 'partial',
+    };
+  }
+
+  function aggregateNoOutputOrReasoning(): Fidelity {
+    const f = fullFidelity();
+    return {
+      ...f,
+      granularity: 'per-session-aggregate',
+      coverage: {
+        ...f.coverage,
+        hasOutputTokens: false,
+        hasReasoningTokens: false,
+      },
+      class: 'aggregate-only',
+    };
+  }
+
+  it('renders no marker and no footer when every turn is full fidelity', async () => {
+    await appendTurns([
+      fakeTurn({ sessionId: 'fc-1', messageId: 'fc-1', fidelity: fullFidelity() }),
+      fakeTurn({
+        sessionId: 'fc-1',
+        messageId: 'fc-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        fidelity: fullFidelity(),
+      }),
+    ]);
+    const out = await captureSummary({});
+    assert.equal(out.code, 0);
+    // No `*` partial marker on any cell, no footer line.
+    assert.equal(out.stdout.includes('*'), false, 'no partial marker should appear');
+    assert.equal(
+      out.stdout.includes('partial coverage:'),
+      false,
+      'no partial-coverage footer for all-full slice',
+    );
+  });
+
+  it('renders `—` (never `0`) for a field every turn omitted', async () => {
+    // Two turns, both with output omitted from upstream. Pricing layer would
+    // happily report `output: 0`, but the per-cell counter says "knew about
+    // 0 of 2 turns" → render the dash sentinel instead of `0`.
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'mz-1',
+        messageId: 'mz-1',
+        usage: {
+          input: 1000,
+          output: 0,
+          reasoning: 0,
+          cacheRead: 1000,
+          cacheCreate5m: 0,
+          cacheCreate1h: 0,
+        },
+        fidelity: {
+          granularity: 'per-turn',
+          coverage: {
+            hasInputTokens: true,
+            hasOutputTokens: false,
+            hasReasoningTokens: false,
+            hasCacheReadTokens: true,
+            hasCacheCreateTokens: false,
+            hasToolCalls: false,
+            hasToolResultEvents: false,
+            hasSessionRelationships: false,
+            hasRawContent: false,
+          },
+          class: 'partial',
+        },
+      }),
+      fakeTurn({
+        sessionId: 'mz-1',
+        messageId: 'mz-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        usage: {
+          input: 2000,
+          output: 0,
+          reasoning: 0,
+          cacheRead: 1500,
+          cacheCreate5m: 0,
+          cacheCreate1h: 0,
+        },
+        fidelity: {
+          granularity: 'per-turn',
+          coverage: {
+            hasInputTokens: true,
+            hasOutputTokens: false,
+            hasReasoningTokens: false,
+            hasCacheReadTokens: true,
+            hasCacheCreateTokens: false,
+            hasToolCalls: false,
+            hasToolResultEvents: false,
+            hasSessionRelationships: false,
+            hasRawContent: false,
+          },
+          class: 'partial',
+        },
+      }),
+    ]);
+    const out = await captureSummary({});
+    assert.equal(out.code, 0);
+    // Find the model row and assert the output column rendered as `—`,
+    // never literal `0`.
+    const modelLine = out.stdout
+      .split('\n')
+      .find((l) => l.includes('claude-sonnet-4-6'));
+    assert.ok(modelLine, 'expected a model row in summary output');
+    // Expect a `—` somewhere on the row (output and reasoning + cacheCreate
+    // are all fully missing in this fixture).
+    assert.ok(modelLine!.includes('—'), `expected a — in row: ${modelLine}`);
+  });
+
+  it('marks mixed cells with `*` and prints a single footer note', async () => {
+    // One full-fidelity turn + one partial (missing output) for the same
+    // model. The output column should carry the value with `*` and the
+    // footer should appear exactly once.
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'mx-1',
+        messageId: 'mx-1',
+        fidelity: fullFidelity(),
+      }),
+      fakeTurn({
+        sessionId: 'mx-1',
+        messageId: 'mx-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        fidelity: partialMissingOutput(),
+      }),
+    ]);
+    const out = await captureSummary({});
+    assert.equal(out.code, 0);
+    assert.ok(
+      out.stdout.includes('*'),
+      'expected a * partial marker on at least one cell',
+    );
+    const footerMatches = out.stdout.match(/\* partial coverage:/g) ?? [];
+    assert.equal(footerMatches.length, 1, 'expected exactly one partial-coverage footer');
+    // Denominator should be 2 (we appended 2 turns).
+    assert.match(out.stdout, /partial coverage: \d+ of 2 turns/);
+  });
+
+  it('--json emits a fidelity block with summary + perCell', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'js-1',
+        messageId: 'js-1',
+        fidelity: fullFidelity(),
+      }),
+      fakeTurn({
+        sessionId: 'js-1',
+        messageId: 'js-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        fidelity: aggregateNoOutputOrReasoning(),
+      }),
+    ]);
+    const out = await captureSummary({ json: true });
+    assert.equal(out.code, 0);
+    interface Payload {
+      fidelity: {
+        summary: { total: number; missingCoverage: Record<string, number> };
+        perCell: {
+          groupBy: string;
+          cells: Array<{
+            label: string;
+            partial: boolean;
+            fields: Record<string, { known: number; missing: number }>;
+          }>;
+        };
+      };
+    }
+    const payload = JSON.parse(out.stdout) as Payload;
+    // Summary shape: 2 turns, 1 missing output, 1 missing reasoning.
+    assert.equal(payload.fidelity.summary.total, 2);
+    assert.equal(payload.fidelity.summary.missingCoverage['hasOutputTokens'], 1);
+    assert.equal(payload.fidelity.summary.missingCoverage['hasReasoningTokens'], 1);
+    // perCell shape: one row keyed by model, partial=true, output known=1/missing=1.
+    assert.equal(payload.fidelity.perCell.groupBy, 'model');
+    assert.equal(payload.fidelity.perCell.cells.length, 1);
+    const cell = payload.fidelity.perCell.cells[0]!;
+    assert.equal(cell.partial, true);
+    assert.deepEqual(cell.fields['output'], { known: 1, missing: 1 });
+    assert.deepEqual(cell.fields['input'], { known: 2, missing: 0 });
+  });
+
+  it('treats records with no fidelity field as best-effort full (no partial marker)', async () => {
+    // Pre-#41 records (no `fidelity` at all). They should be counted as
+    // `known` for every field — so no partial marker, no footer.
+    await appendTurns([
+      fakeTurn({ sessionId: 'pf-1', messageId: 'pf-1' }),
+      fakeTurn({
+        sessionId: 'pf-1',
+        messageId: 'pf-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+      }),
+    ]);
+    const out = await captureSummary({});
+    assert.equal(out.code, 0);
+    assert.equal(out.stdout.includes('*'), false);
+    assert.equal(out.stdout.includes('partial coverage:'), false);
   });
 });

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -415,26 +415,26 @@ function mergeCoverage(cacheCreate: FieldCoverage): FieldCoverage {
   return cacheCreate;
 }
 
-// Footer note explaining the `*` marker. Sums `known` / `missing` across every
-// row's input field as a proxy for "of M turns". Input is the canonical token
-// field — if a record has any per-turn coverage at all, it has input — so
-// treating its counters as the denominator gives an honest "N of M" for the
-// partial-coverage case without having to pick an arbitrary field.
+// Footer note explaining the `*` marker. Denominator is the cross-row sum of
+// `known + missing` for input — input is the canonical token field, so if a
+// record has any per-turn coverage at all, it carries input. Numerator is the
+// worst-covered axis: for each coverage field, sum its `missing` across every
+// row, then take the max. Picking just `input.missing` would understate the
+// gap when the partial coverage is on a *different* field (e.g. an
+// output-omitting collector); picking the per-(row, field) max would
+// understate it across multi-row aggregates. The cross-row sum per field is
+// the right "N of M" — it's the count of turns missing the most-affected
+// field across the whole slice.
 function formatPartialFooter(rows: ReadonlyArray<ModelRow>): string {
   let total = 0;
-  let missing = 0;
   for (const r of rows) {
     total += r.coverage.input.known + r.coverage.input.missing;
-    missing += r.coverage.input.missing;
   }
-  // Sum across every coverage field — input alone may not capture the
-  // "missing" turns when the gap is actually elsewhere (e.g. reasoning-only
-  // collectors that report input but not output). Take the largest missing
-  // count across fields so the footer reflects the worst-covered axis.
-  for (const r of rows) {
-    for (const f of COVERAGE_FIELDS) {
-      if (r.coverage[f].missing > missing) missing = r.coverage[f].missing;
-    }
+  let missing = 0;
+  for (const f of COVERAGE_FIELDS) {
+    let fieldMissing = 0;
+    for (const r of rows) fieldMissing += r.coverage[f].missing;
+    if (fieldMissing > missing) missing = fieldMissing;
   }
   return `${PARTIAL_MARK} partial coverage: ${formatInt(missing)} of ${formatInt(total)} turns omitted per-turn token data`;
 }

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -21,7 +21,7 @@ import {
   type Query,
 } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
-import type { ContentRecord } from '@relayburn/reader';
+import type { ContentRecord, Coverage } from '@relayburn/reader';
 
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
@@ -69,8 +69,11 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   if (args.flags['json'] === true) {
     // JSON contract: numeric usage fields are always numbers, but the
     // companion `fidelity` block is the only honest answer to "are these
-    // zeros real?". Programmatic consumers should consult `missingCoverage`
-    // before trusting any aggregate.
+    // zeros real?". Programmatic consumers should consult `summary` (the
+    // slice-wide rollup, same shape compare/waste/limits/plans emit) and
+    // `perCell` (per-(model|provider) per-field known/missing counts) before
+    // trusting any aggregate.
+    const perCell = buildPerCellFidelity(rows, byProvider ? 'provider' : 'model');
     const payload = {
       ingest: {
         ingestedSessions: ingestReport.ingestedSessions,
@@ -95,7 +98,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
               cost: r.cost,
             })),
           }),
-      fidelity,
+      fidelity: { summary: fidelity, perCell },
     };
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
     return 0;
@@ -118,15 +121,26 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
 
   const header = [byProvider ? 'provider' : 'model', 'turns', 'input', 'output', 'reasoning', 'cacheRead', 'cacheCreate', 'cost'];
   const dataRows: string[][] = [header];
+  let anyPartialCell = false;
   for (const r of rows) {
+    const cacheCreateCov = mergeCoverage(r.coverage.cacheCreate);
+    if (
+      cellIsPartial(r.coverage.input) ||
+      cellIsPartial(r.coverage.output) ||
+      cellIsPartial(r.coverage.reasoning) ||
+      cellIsPartial(r.coverage.cacheRead) ||
+      cellIsPartial(cacheCreateCov)
+    ) {
+      anyPartialCell = true;
+    }
     dataRows.push([
       r.label,
       formatInt(r.turns),
-      formatInt(r.usage.input),
-      formatInt(r.usage.output),
-      formatInt(r.usage.reasoning),
-      formatInt(r.usage.cacheRead),
-      formatInt(r.usage.cacheCreate5m + r.usage.cacheCreate1h),
+      coverageCell(r.usage.input, r.coverage.input),
+      coverageCell(r.usage.output, r.coverage.output),
+      coverageCell(r.usage.reasoning, r.coverage.reasoning),
+      coverageCell(r.usage.cacheRead, r.coverage.cacheRead),
+      coverageCell(r.usage.cacheCreate5m + r.usage.cacheCreate1h, cacheCreateCov),
       formatUsd(r.cost.total),
     ]);
   }
@@ -137,6 +151,14 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
     `  input ${formatUsd(totalCost.input)} / output ${formatUsd(totalCost.output)} / reasoning ${formatUsd(totalCost.reasoning)} / cacheRead ${formatUsd(totalCost.cacheRead)} / cacheCreate ${formatUsd(totalCost.cacheCreate)}`,
   );
   lines.push('');
+
+  // Footer marker explainer: only print when at least one cell carries `*`
+  // — the all-full case is the common one and we don't want to train people
+  // to ignore the marker.
+  if (anyPartialCell) {
+    lines.push(formatPartialFooter(rows));
+    lines.push('');
+  }
 
   // Only print a fidelity line when *something* is below full — the common
   // all-Claude case is full fidelity for every turn, and noise there would
@@ -218,11 +240,48 @@ function weightedOneShotRate(q: QualityResult): number | undefined {
   return edit > 0 ? oneShot / edit : undefined;
 }
 
+// Per-token-field coverage counters maintained alongside each aggregate row.
+// `known` is the number of contributing turns whose source actually reported
+// the field; `missing` counts turns whose source omitted it (the matching
+// `Coverage` flag was false). Records emitted before #41 (no `fidelity` at
+// all) are treated as best-effort full and counted as `known` — the same
+// backward-compat stance taken by `summarizeFidelity` / `hasMinimumFidelity`.
+interface FieldCoverage {
+  known: number;
+  missing: number;
+}
+
+type CoverageField =
+  | 'input'
+  | 'output'
+  | 'reasoning'
+  | 'cacheRead'
+  | 'cacheCreate';
+
+type RowCoverage = Record<CoverageField, FieldCoverage>;
+
+const COVERAGE_FIELDS: ReadonlyArray<CoverageField> = [
+  'input',
+  'output',
+  'reasoning',
+  'cacheRead',
+  'cacheCreate',
+];
+
+const COVERAGE_FLAG: Record<CoverageField, keyof Coverage> = {
+  input: 'hasInputTokens',
+  output: 'hasOutputTokens',
+  reasoning: 'hasReasoningTokens',
+  cacheRead: 'hasCacheReadTokens',
+  cacheCreate: 'hasCacheCreateTokens',
+};
+
 interface ModelRow {
   label: string;
   turns: number;
   usage: EnrichedTurn['usage'];
   cost: CostBreakdown;
+  coverage: RowCoverage;
 }
 
 function renderSubagentTreeMode(
@@ -331,6 +390,94 @@ function renderNodeLine(node: SubagentTreeNode, indent: string): string {
   return `${indent}${label}${model}  ${cost}  ${turns}`;
 }
 
+// Render one token-field cell. Three cases:
+//   - every contributing turn reported the field → numeric value, no marker
+//   - some turns reported, some didn't           → numeric value + `*`
+//   - no turn reported                           → `—` (never `0`, which
+//     would falsely claim a real zero from the source)
+// `cacheCreate` callers pre-merge the 5m/1h split via `mergeCoverage`; they
+// share a single coverage flag (`hasCacheCreateTokens`).
+function coverageCell(value: number, c: FieldCoverage): string {
+  if (c.known === 0 && c.missing > 0) return DASH;
+  if (c.known > 0 && c.missing > 0) return `${formatInt(value)}${PARTIAL_MARK}`;
+  return formatInt(value);
+}
+
+function cellIsPartial(c: FieldCoverage): boolean {
+  return c.known > 0 && c.missing > 0;
+}
+
+// `cacheCreate5m` and `cacheCreate1h` collapse into one ledger column and one
+// `Coverage` flag (`hasCacheCreateTokens`), so the per-cell counter is shared
+// between them. This helper just returns that single counter — the second
+// argument is intentional dead-code symmetry to make the call sites obvious.
+function mergeCoverage(cacheCreate: FieldCoverage): FieldCoverage {
+  return cacheCreate;
+}
+
+// Footer note explaining the `*` marker. Sums `known` / `missing` across every
+// row's input field as a proxy for "of M turns". Input is the canonical token
+// field — if a record has any per-turn coverage at all, it has input — so
+// treating its counters as the denominator gives an honest "N of M" for the
+// partial-coverage case without having to pick an arbitrary field.
+function formatPartialFooter(rows: ReadonlyArray<ModelRow>): string {
+  let total = 0;
+  let missing = 0;
+  for (const r of rows) {
+    total += r.coverage.input.known + r.coverage.input.missing;
+    missing += r.coverage.input.missing;
+  }
+  // Sum across every coverage field — input alone may not capture the
+  // "missing" turns when the gap is actually elsewhere (e.g. reasoning-only
+  // collectors that report input but not output). Take the largest missing
+  // count across fields so the footer reflects the worst-covered axis.
+  for (const r of rows) {
+    for (const f of COVERAGE_FIELDS) {
+      if (r.coverage[f].missing > missing) missing = r.coverage[f].missing;
+    }
+  }
+  return `${PARTIAL_MARK} partial coverage: ${formatInt(missing)} of ${formatInt(total)} turns omitted per-turn token data`;
+}
+
+interface PerCellFidelityEntry {
+  label: string;
+  partial: boolean;
+  fields: Record<CoverageField, FieldCoverage>;
+}
+
+interface PerCellFidelityBlock {
+  groupBy: 'model' | 'provider';
+  cells: PerCellFidelityEntry[];
+}
+
+// Per-(model|provider) per-field coverage block for `--json`. Shape mirrors
+// the pattern compare/waste use: a `summary` (slice-wide rollup) plus an
+// optional `perCell` payload programmatic callers can render without
+// re-walking the ledger. Empty `cells` array (no rows in scope) is a valid
+// payload — callers should treat it the same as "every cell is full".
+function buildPerCellFidelity(
+  rows: ReadonlyArray<ModelRow>,
+  groupBy: 'model' | 'provider',
+): PerCellFidelityBlock {
+  const cells: PerCellFidelityEntry[] = rows.map((r) => {
+    const cacheCreate = mergeCoverage(r.coverage.cacheCreate);
+    const fields: Record<CoverageField, FieldCoverage> = {
+      input: r.coverage.input,
+      output: r.coverage.output,
+      reasoning: r.coverage.reasoning,
+      cacheRead: r.coverage.cacheRead,
+      cacheCreate,
+    };
+    const partial = COVERAGE_FIELDS.some((f) => cellIsPartial(fields[f])) ||
+      COVERAGE_FIELDS.some((f) => fields[f].known === 0 && fields[f].missing > 0);
+    return { label: r.label, partial, fields };
+  });
+  return { groupBy, cells };
+}
+
+const PARTIAL_MARK = '*';
+const DASH = '—';
+
 function renderFidelityNotice(f: FidelitySummary): string | undefined {
   // Returns undefined when every classified turn is full fidelity *and* no
   // unknown turns exist — i.e. every number above is trustworthy. Otherwise
@@ -418,6 +565,7 @@ function aggregateTurns(
     row.usage.cacheRead += t.usage.cacheRead;
     row.usage.cacheCreate5m += t.usage.cacheCreate5m;
     row.usage.cacheCreate1h += t.usage.cacheCreate1h;
+    accumulateCoverage(row.coverage, t.fidelity?.coverage);
     const c = costForTurn(t, pricing);
     if (c) {
       row.cost.total += c.total;
@@ -431,11 +579,30 @@ function aggregateTurns(
   return [...byModel.values()].sort((a, b) => b.cost.total - a.cost.total);
 }
 
+// A turn whose record predates #41 has no `coverage` map; the long-standing
+// stance is to treat that as best-effort full fidelity. So if `coverage` is
+// undefined every field counts as `known`. When it is present, a field is
+// `missing` exactly when its flag is false — same predicate `summarizeFidelity`
+// uses against `missingCoverage`.
+function accumulateCoverage(target: RowCoverage, coverage: Coverage | undefined): void {
+  for (const f of COVERAGE_FIELDS) {
+    if (!coverage || coverage[COVERAGE_FLAG[f]]) target[f].known++;
+    else target[f].missing++;
+  }
+}
+
 function emptyRow(label: string): ModelRow {
   return {
     label,
     turns: 0,
     usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
     cost: { model: label, total: 0, input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheCreate: 0 },
+    coverage: {
+      input: { known: 0, missing: 0 },
+      output: { known: 0, missing: 0 },
+      reasoning: { known: 0, missing: 0 },
+      cacheRead: { known: 0, missing: 0 },
+      cacheCreate: { known: 0, missing: 0 },
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Closes the last `burn summary` gap from #41's command-behavior contract: the table no longer renders `0` for fields the source actually omitted.
- Per-(model|provider) per-field `{known, missing}` counters drive a three-way cell render: bare value when fully known, `value*` when mixed, `—` when every contributing turn omitted the field. A single `* partial coverage: N of M turns omitted per-turn token data` footer prints when at least one cell carries the marker; full-fidelity slices stay unchanged.
- `--json` `fidelity` block grows from a bare `FidelitySummary` to `{ summary, perCell }` — `perCell.cells[]` carries label, partial flag, and per-field known/missing counters. Same shape pattern as #135 / #133 / #134 / #132.
- Records emitted before `TurnRecord.fidelity` existed (pre-#41 ledgers) are treated as best-effort full and never trigger the marker.

## Why now

Issue #41 (the meta coverage/fidelity contract) was substantially complete via PRs #76, #84, #89, #95, #100, #105, #108, #110, #115, #116, #120, #132–#135. The single remaining piece — per-cell partial-coverage surfacing in `burn summary` — was spun out as #136. This PR lands that piece, which lets us close both #41 and #136.

## Test plan

- [x] `pnpm run test:ts` — full workspace build + all 639 tests pass
- [x] New suite `burn summary per-cell fidelity (#136)`:
  - all-full slice → no `*` marker, no footer
  - field every turn omits → renders `—` (never `0`)
  - mixed slice → `*` marker on the cell + exactly one footer line
  - `--json` payload exposes `fidelity.summary` + `fidelity.perCell` with correct known/missing counts
  - pre-#41 records (no `fidelity`) → treated as best-effort full, no marker
- [x] Existing parity test (archive vs. ledger paths) still passes — the new `fidelity: { summary, perCell }` shape is identical across both paths.

Closes #136
Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
