### PR TITLE
Add --provider filter to burn compare (closes #138)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`burn compare --provider <name>`** ([#138](https://github.com/AgentWorkforce/burn/issues/138)). Filters the per-(model, activity) comparison table to turns whose effective provider matches, using the same classifier `summary` / `by-tool` / `waste` already expose. Single value or comma-separated (e.g. `--provider synthetic`, `--provider anthropic,synthetic`); resolution goes through the pricing-layer rules in `resolveProvider`, so `hf:deepseek-ai/...` aggregates under `synthetic`. When the filter is set, `compare` always uses the in-memory path (the SQLite archive's grouped SQL doesn't see the per-turn classifier).
+
 ## [0.35.0] - 2026-04-28
 
 ### Added

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -348,3 +348,85 @@ describe('burn compare — fidelity gating', () => {
     assert.match(stdout, /excluded 1 turn below usage-only fidelity/);
   });
 });
+
+describe('burn compare — --provider filter', () => {
+  it('filters the compare table to only synthetic-routed turns', async () => {
+    // Pricing classifier maps `hf:deepseek-ai/...` to provider=synthetic.
+    // Anthropic turns fall through to source=claude-code → provider=anthropic.
+    const turns: EnrichedTurn[] = [
+      turn('hf:deepseek-ai/deepseek-r1', 'coding', FULL_FIDELITY, {
+        hasEdits: true,
+        retries: 0,
+      }),
+      turn('hf:deepseek-ai/deepseek-r1', 'coding', FULL_FIDELITY, {
+        hasEdits: true,
+        retries: 0,
+      }),
+      turn('claude-sonnet-4-6', 'coding', FULL_FIDELITY, {
+        hasEdits: true,
+        retries: 0,
+      }),
+    ];
+    const { result, stdout } = await captureStdout(() =>
+      runCompare(args({ json: true, provider: 'synthetic' }), makeDeps(turns)),
+    );
+    assert.equal(result, 0);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.analyzedTurns, 2);
+    assert.deepEqual(parsed.models, ['hf:deepseek-ai/deepseek-r1']);
+  });
+
+  it('accepts a comma-separated list (matches summary parser)', async () => {
+    const turns: EnrichedTurn[] = [
+      turn('hf:deepseek-ai/deepseek-r1', 'coding', FULL_FIDELITY, {
+        hasEdits: true,
+        retries: 0,
+      }),
+      turn('claude-sonnet-4-6', 'coding', FULL_FIDELITY, {
+        hasEdits: true,
+        retries: 0,
+      }),
+      // Codex source → provider=openai → excluded by anthropic,synthetic.
+      turn('gpt-5', 'coding', FULL_FIDELITY, {
+        hasEdits: true,
+        retries: 0,
+        source: 'codex',
+      }),
+    ];
+    const { result, stdout } = await captureStdout(() =>
+      runCompare(
+        args({ json: true, provider: 'anthropic,synthetic' }),
+        makeDeps(turns),
+      ),
+    );
+    assert.equal(result, 0);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.analyzedTurns, 2);
+    assert.deepEqual(
+      [...parsed.models].sort(),
+      ['claude-sonnet-4-6', 'hf:deepseek-ai/deepseek-r1'].sort(),
+    );
+  });
+
+  it('renders the empty-table message when the filter excludes every turn', async () => {
+    const turns: EnrichedTurn[] = [
+      turn('claude-sonnet-4-6', 'coding', FULL_FIDELITY, {
+        hasEdits: true,
+        retries: 0,
+      }),
+    ];
+    const { result, stdout } = await captureStdout(() =>
+      runCompare(args({ provider: 'synthetic' }), makeDeps(turns)),
+    );
+    assert.equal(result, 0);
+    assert.match(stdout, /no data to compare/);
+  });
+
+  it('exits 2 when --provider is passed without a value', async () => {
+    const { result, stderr } = await captureStdout(() =>
+      runCompare(args({ provider: true }), makeDeps([])),
+    );
+    assert.equal(result, 2);
+    assert.match(stderr, /--provider requires a value/);
+  });
+});

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -15,16 +15,20 @@ import type { FidelityClass } from '@relayburn/reader';
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg } from '../format.js';
 import type { ParsedArgs } from '../args.js';
+import { filterTurnsByProvider, parseProviderFilter } from '../provider.js';
 
 const COMPARE_HELP = `burn compare — per-(model, activity) comparison table
 
 Usage:
-  burn compare [--models a,b] [--since 7d] [--project <path>] [--session <id>]
-               [--workflow <id>] [--agent <id>] [--min-sample <n>]
+  burn compare [--models a,b] [--provider a,b] [--since 7d] [--project <path>]
+               [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>]
                [--fidelity <class>] [--include-partial] [--json|--csv] [--no-archive]
 
 Flags:
   --models      comma-separated list of model names to include (default: all)
+  --provider    comma-separated list of effective providers to include
+                (e.g. synthetic, anthropic, openai); resolved via the same
+                pricing-layer classifier summary/by-tool/waste use
   --since       relative (e.g. 24h, 7d, 4w) or ISO timestamp; default: all time
   --project     filter by project path or git-canonical projectKey
   --session     filter by sessionId
@@ -100,6 +104,11 @@ export async function runCompare(
 
   const modelsArg = typeof args.flags['models'] === 'string' ? args.flags['models'] : undefined;
   const models = modelsArg ? modelsArg.split(',').map((s) => s.trim()).filter(Boolean) : undefined;
+  const providerFilter = parseProviderFilter(args.flags['provider']);
+  if (providerFilter instanceof Error) {
+    process.stderr.write(providerFilter.message);
+    return 2;
+  }
   const minSample = typeof args.flags['min-sample'] === 'string'
     ? Number(args.flags['min-sample'])
     : DEFAULT_MIN_SAMPLE;
@@ -159,13 +168,21 @@ export async function runCompare(
   // gate is correctly applied. `--include-partial` / `--fidelity partial`
   // disables filtering and reuses the archive's grouped SQL.
   //
+  // `--provider` likewise bypasses the archive: provider is derived per
+  // turn from (model, source) at query time, and the archive's grouped
+  // SQL doesn't expose that classifier. The in-memory path applies the
+  // filter via `filterTurnsByProvider` before `buildCompareTable`.
+  //
   // Skip the archive when the caller injected `queryAll` (test mode):
   // `buildArchive` and `compareFromArchive` are not part of `CompareDeps`
   // and would hit the real `~/.relayburn/archive.sqlite`, breaking test
   // isolation. The non-archive branch already handles `--fidelity partial`
   // correctly (the filter becomes a no-op).
   const useArchive =
-    !shouldBypassArchive(args) && minFidelity === 'partial' && !deps.queryAll;
+    !shouldBypassArchive(args) &&
+    minFidelity === 'partial' &&
+    !providerFilter &&
+    !deps.queryAll;
   let table: CompareTable;
   let filteredTurns: EnrichedTurn[];
   let summary: FidelitySummary;
@@ -184,11 +201,14 @@ export async function runCompare(
     filteredTurns = turnsForSummary;
     void result.analyzedTurns;
   } else {
-    const turns = await query(q);
-    // Summarize fidelity over the *unfiltered* slice so coverage notes and
-    // the JSON `summary` reflect the input the user actually queried, not
-    // what survived the gate. The summary is what tells them why N turns
-    // were dropped.
+    // `--provider` narrows the queried slice up front so coverage / fidelity
+    // counts reflect the provider-scoped input, not the cross-provider total
+    // (which would over-count "excluded" turns relative to what's rendered).
+    const turns = filterTurnsByProvider(await query(q), providerFilter);
+    // Summarize fidelity over the *unfiltered* slice (modulo provider) so
+    // coverage notes and the JSON `summary` reflect the input the user
+    // actually queried, not what survived the fidelity gate. The summary
+    // is what tells them why N turns were dropped.
     summary = summarizeFidelity(turns);
     // `--fidelity partial` (and its `--include-partial` shorthand) is the
     // "let everything through" escape hatch per #41. The FidelityClass


### PR DESCRIPTION
## Summary

- Adds `--provider <name>` to `burn compare`, finishing the rendering surface from #83 (PR #124 landed it on `summary` / `by-tool` / `waste` and explicitly deferred `compare`).
- Reuses the existing `parseProviderFilter` / `filterTurnsByProvider` helpers in `packages/cli/src/provider.ts` — same parser semantics as `summary --provider` (single value or comma-separated, lower-cased, exits 2 with no value).
- Bypasses the SQLite archive path when `--provider` is set: provider is derived per turn from `(model, source)` at query time and the archive's grouped SQL doesn't expose that classifier. Mirrors the existing `--fidelity` bypass.
- Empty-result rendering routes through the same `t.models.length === 0` branch as the `--models` filter, so the "no data to compare" message is unchanged.

## Files changed

| File | Change |
|---|---|
| `packages/cli/src/commands/compare.ts` | Parse `--provider`; filter turns on the in-memory path; force the in-memory path when the flag is set; help text. |
| `packages/cli/src/commands/compare.test.ts` | Four new tests under `burn compare — --provider filter`. |

## Test plan

- [x] `pnpm run test` — 657 passing, 0 failing locally.
- [x] New cases: synthetic-only filter, `synthetic,anthropic` multi-value, empty-table rendering, exit 2 for `--provider` without a value.
- [x] `burn compare --help` shows the new flag.

## Out of scope

- `compare --by-provider` grouping (#83 marks it as a stretch; this PR is the higher-leverage filter half per #138).
- Extracting `aggregateByProvider` into `@relayburn/analyze` (also optional per #138).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
