### PR TITLE
Add cross-harness edit-heavy session detector (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-harness edit-heavy session detector** ([#167](https://github.com/AgentWorkforce/burn/issues/167)). `burn waste --patterns edit-heavy` flags sessions whose edit-tool count exceeds 4× read-tool count (≥ 5 edits) — a fuzzy "many small edits, not enough reads" signal complementary to the existing edit-revert detector. Reaches parity across Claude / Codex / OpenCode through the existing `normalizeToolName` table; renders a table with source, reads, edits, ratio, intra-turn retry count, and cost. Codex's `apply_patch` bundles multiple files per call, so the same threshold flags Codex more conservatively — documented as a known per-harness tunable. First child of [#55](https://github.com/AgentWorkforce/burn/issues/55) (cross-harness codeburn-style waste detectors).
+
 ## [0.35.0] - 2026-04-28
 
 ### Added

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-harness edit-heavy session detector** ([#167](https://github.com/AgentWorkforce/burn/issues/167)). `detectPatterns` now flags sessions whose normalized edit-tool count exceeds 4× their read-tool count (with ≥ 5 edits), reaching parity across Claude / Codex / OpenCode via `normalizeToolName`. Reads are restricted to file-content tools (`Read`, `NotebookRead`); `Grep` / `Glob` / `LS` / `Bash` are deliberately excluded — they discover or shell out, but don't record that the model has read the file. Codex's `apply_patch` may bundle multiple files per call, so the same threshold flags Codex more conservatively than a file-level count would — known per-harness tunable. Emits `EditHeavySession { source, sessionId, readCount, editCount, ratio, likelyRetries, cost }` with `ratio = +Infinity` when reads is zero; `likelyRetries` is the sum of `countRetries()` over the session's turns. `PatternsResult` gains an `editHeavySessions` array; `SessionPatternSummary` gains `editHeavyCount`. The cost field is **not** added to `totalPatternCost` because the same edit-bearing turns also feed `editReverts` and `retryLoops` costs — adding them again would double-count.
+
 ## [0.35.0] - 2026-04-28
 
 ### Added

--- a/packages/analyze/src/index.ts
+++ b/packages/analyze/src/index.ts
@@ -35,6 +35,7 @@ export { detectPatterns } from './patterns.js';
 export type {
   CompactionLoss,
   DetectPatternsOptions,
+  EditHeavySession,
   EditRevertCycle,
   FailureRun,
   PatternsResult,

--- a/packages/analyze/src/patterns.test.ts
+++ b/packages/analyze/src/patterns.test.ts
@@ -657,3 +657,145 @@ describe('detectPatterns — OpenCode system prompt tax', () => {
     assert.equal(result.systemPromptTaxes.length, 0);
   });
 });
+
+// One edit-bearing turn per element, six total — above MIN_EDITS=5.
+function editHeavyTurns(source: 'claude-code' | 'codex' | 'opencode', editTool: string, sessionId = 's'): TurnRecord[] {
+  const out: TurnRecord[] = [];
+  for (let i = 0; i < 6; i++) {
+    out.push(
+      turn({
+        sessionId,
+        messageId: `m${i}`,
+        turnIndex: i,
+        source,
+        toolCalls: [tc(`u${i}`, editTool, `h${i}`, { target: `/src/file${i}.ts` })],
+      }),
+    );
+  }
+  return out;
+}
+
+describe('detectPatterns — edit-heavy sessions (cross-harness)', () => {
+  it('flags Claude session with 6 edits and 0 reads', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = editHeavyTurns('claude-code', 'Edit');
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 1);
+    const r = result.editHeavySessions[0]!;
+    assert.equal(r.source, 'claude-code');
+    assert.equal(r.editCount, 6);
+    assert.equal(r.readCount, 0);
+    assert.equal(r.ratio, Number.POSITIVE_INFINITY);
+  });
+
+  it('flags OpenCode session using lowercase tool names', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = editHeavyTurns('opencode', 'edit');
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 1);
+    assert.equal(result.editHeavySessions[0]!.source, 'opencode');
+    assert.equal(result.editHeavySessions[0]!.editCount, 6);
+  });
+
+  it('flags Codex session using apply_patch (normalized to Edit)', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = editHeavyTurns('codex', 'apply_patch');
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 1);
+    assert.equal(result.editHeavySessions[0]!.source, 'codex');
+    assert.equal(result.editHeavySessions[0]!.editCount, 6);
+  });
+
+  it('does not flag a session with sufficient reads (ratio under threshold)', async () => {
+    const pricing = await loadBuiltinPricing();
+    // 6 edits, 3 reads → ratio 2.0 ≤ 4. Should not flag.
+    const turns = [
+      ...editHeavyTurns('claude-code', 'Edit'),
+      turn({ sessionId: 's', messageId: 'r1', turnIndex: 6, toolCalls: [tc('r1', 'Read', 'a', { target: '/a.ts' })] }),
+      turn({ sessionId: 's', messageId: 'r2', turnIndex: 7, toolCalls: [tc('r2', 'Read', 'b', { target: '/b.ts' })] }),
+      turn({ sessionId: 's', messageId: 'r3', turnIndex: 8, toolCalls: [tc('r3', 'Read', 'c', { target: '/c.ts' })] }),
+    ];
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 0);
+  });
+
+  it('does not flag below MIN_EDITS (4 edits, 0 reads)', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns: TurnRecord[] = [];
+    for (let i = 0; i < 4; i++) {
+      turns.push(
+        turn({
+          sessionId: 's',
+          messageId: `m${i}`,
+          turnIndex: i,
+          toolCalls: [tc(`u${i}`, 'Edit', `h${i}`, { target: `/f${i}.ts` })],
+        }),
+      );
+    }
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 0);
+  });
+
+  it('grep / glob / LS / bash do NOT count as reads', async () => {
+    const pricing = await loadBuiltinPricing();
+    // 6 edits, plus 5 non-Read tools (Grep/Glob/LS/Bash). Ratio should still
+    // be infinite — reads stay at 0.
+    const turns = [
+      ...editHeavyTurns('claude-code', 'Edit'),
+      turn({ sessionId: 's', messageId: 'g1', turnIndex: 6, toolCalls: [tc('g1', 'Grep', 'a')] }),
+      turn({ sessionId: 's', messageId: 'g2', turnIndex: 7, toolCalls: [tc('g2', 'Glob', 'b')] }),
+      turn({ sessionId: 's', messageId: 'g3', turnIndex: 8, toolCalls: [tc('g3', 'LS', 'c')] }),
+      turn({ sessionId: 's', messageId: 'g4', turnIndex: 9, toolCalls: [tc('g4', 'Bash', 'cat /etc/hosts')] }),
+    ];
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 1);
+    assert.equal(result.editHeavySessions[0]!.readCount, 0);
+  });
+
+  it('Codex read_file normalizes to Read and brings ratio under threshold', async () => {
+    const pricing = await loadBuiltinPricing();
+    // 6 edits + 2 read_file calls → ratio 3.0, ≤ 4, no flag.
+    const turns = [
+      ...editHeavyTurns('codex', 'apply_patch'),
+      turn({ sessionId: 's', messageId: 'r1', turnIndex: 6, source: 'codex' as const, toolCalls: [tc('r1', 'read_file', 'a')] }),
+      turn({ sessionId: 's', messageId: 'r2', turnIndex: 7, source: 'codex' as const, toolCalls: [tc('r2', 'read_file', 'b')] }),
+    ];
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 0);
+  });
+
+  it('reports likelyRetries from intra-turn edit→bash→edit cycles', async () => {
+    const pricing = await loadBuiltinPricing();
+    // One turn with [Edit, Bash, Edit] = 1 retry. Repeat across 5 turns to
+    // pass MIN_EDITS=5 (each turn contributes 2 edits → 10 edits total).
+    const turns: TurnRecord[] = [];
+    for (let i = 0; i < 5; i++) {
+      turns.push(
+        turn({
+          sessionId: 's',
+          messageId: `m${i}`,
+          turnIndex: i,
+          toolCalls: [
+            tc(`e1-${i}`, 'Edit', `h${i}a`, { target: `/f${i}.ts` }),
+            tc(`b-${i}`, 'Bash', `bh${i}`, { target: 'pytest' }),
+            tc(`e2-${i}`, 'Edit', `h${i}b`, { target: `/f${i}.ts` }),
+          ],
+        }),
+      );
+    }
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 1);
+    const r = result.editHeavySessions[0]!;
+    assert.equal(r.editCount, 10);
+    assert.equal(r.likelyRetries, 5, 'one retry per turn × 5 turns');
+  });
+
+  it('aggregates editHeavyCount into the session summary', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = editHeavyTurns('claude-code', 'Edit');
+    const result = detectPatterns(turns, { pricing });
+    const summary = result.sessionSummaries.find((s) => s.sessionId === 's');
+    assert.ok(summary, 'summary present');
+    assert.equal(summary!.editHeavyCount, 1);
+  });
+});

--- a/packages/analyze/src/patterns.ts
+++ b/packages/analyze/src/patterns.ts
@@ -1,4 +1,11 @@
-import type { CompactionEvent, ToolCall, TurnRecord, UserTurnRecord } from '@relayburn/reader';
+import type {
+  CompactionEvent,
+  SourceKind,
+  ToolCall,
+  TurnRecord,
+  UserTurnRecord,
+} from '@relayburn/reader';
+import { countRetries, normalizeToolName } from '@relayburn/reader';
 
 import { costForTurn, costForUsage } from './cost.js';
 import type { PricingTable } from './pricing.js';
@@ -104,6 +111,31 @@ export interface SystemPromptTax {
   totalCost: number;
 }
 
+// Edit-heavy session: edit-tool count >> read-tool count. A session that
+// mostly writes without first reading the surrounding context correlates with
+// careless editing. Complementary to edit-revert — content-hash catches the
+// clean A→B→A revert; ratio catches the fuzzy "many small edits, not enough
+// reads" case.
+//
+// Cross-harness via `normalizeToolName`: Claude `Read`/`Edit`/`Write`/...,
+// OpenCode `read`/`edit`/`write`, Codex `read_file`/`apply_patch`. Codex's
+// `apply_patch` may bundle multiple files per call, so the same threshold
+// flags Codex more conservatively than it would if we counted files — known
+// per-harness tunable, see #167.
+export interface EditHeavySession {
+  source: SourceKind;
+  sessionId: string;
+  readCount: number;
+  editCount: number;
+  // editCount / readCount; +Infinity when reads === 0
+  ratio: number;
+  // Sum of edit→bash→edit retries (from `countRetries`) across the session's
+  // turns. A high retry count alongside a high ratio is the strongest signal.
+  likelyRetries: number;
+  // Sum of per-turn cost across turns containing an edit-tool call.
+  cost: number;
+}
+
 // Per-session rollup mentioned in the issue discussion. Downstream commands
 // (`burn compare --worst`, health grading, etc.) can read this shape without
 // re-running the full detector suite.
@@ -117,6 +149,7 @@ export interface SessionPatternSummary {
   skillRecallDupCount: number;
   skillPruningProtectionCount: number;
   systemPromptTaxCount: number;
+  editHeavyCount: number;
   totalRetries: number;
   totalPatternCost: number;
 }
@@ -129,6 +162,7 @@ export interface PatternsResult {
   skillRecallDups: SkillRecallDup[];
   skillPruningProtection: SkillPruningProtection[];
   systemPromptTaxes: SystemPromptTax[];
+  editHeavySessions: EditHeavySession[];
   sessionSummaries: SessionPatternSummary[];
 }
 
@@ -143,6 +177,24 @@ export interface DetectPatternsOptions {
 const MIN_RETRY_LEN = 3;
 const MIN_FAILURE_RUN_LEN = 3;
 
+// edits / reads above this and editCount ≥ MIN flags the session.
+// Threshold ported from codeburn (Claude-derived). Codex `apply_patch` bundles
+// multiple files per call, so this same threshold flags Codex more
+// conservatively than a file-level count would — documented in #167 as a
+// known per-harness tunable.
+const EDIT_HEAVY_RATIO = 4;
+const EDIT_HEAVY_MIN_EDITS = 5;
+
+// Tools whose normalized name (post `normalizeToolName`) counts as a "read of
+// file content" for the purposes of the read:edit ratio. Grep / Glob / LS
+// don't count — they discover files but don't read content. Bash is excluded
+// for the same reason: the model may `cat` via shell, but identifying that
+// from arguments is fragile and would inflate the read count for unrelated
+// shell calls. Keeping the set narrow matches the codeburn intent ("did the
+// model read the file before editing it?").
+const READ_TOOLS = new Set(['Read', 'NotebookRead']);
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
+
 export function detectPatterns(
   turns: TurnRecord[],
   opts: DetectPatternsOptions,
@@ -155,6 +207,7 @@ export function detectPatterns(
   const skillRecallDups: SkillRecallDup[] = [];
   const skillPruningProtection: SkillPruningProtection[] = [];
   const systemPromptTaxes: SystemPromptTax[] = [];
+  const editHeavySessions: EditHeavySession[] = [];
 
   for (const [sessionId, sessionTurns] of bySession) {
     sessionTurns.sort((a, b) => a.turnIndex - b.turnIndex);
@@ -166,6 +219,7 @@ export function detectPatterns(
     skillRecallDups.push(...detectSkillRecallDupsForSession(sessionId, sessionTurns, opts.pricing));
     skillPruningProtection.push(...detectSkillPruningProtectionForSession(sessionId, sessionTurns, opts.pricing));
     systemPromptTaxes.push(...detectSystemPromptTaxForSession(sessionId, sessionTurns, opts.pricing, opts.userTurnsBySession?.get(sessionId)));
+    editHeavySessions.push(...detectEditHeavyForSession(sessionId, sessionTurns, opts.pricing));
   }
 
   const compactions = opts.compactions
@@ -180,7 +234,17 @@ export function detectPatterns(
     skillRecallDups,
     skillPruningProtection,
     systemPromptTaxes,
-    sessionSummaries: buildSummaries(retryLoops, failureRuns, compactions, editReverts, skillRecallDups, skillPruningProtection, systemPromptTaxes),
+    editHeavySessions,
+    sessionSummaries: buildSummaries(
+      retryLoops,
+      failureRuns,
+      compactions,
+      editReverts,
+      skillRecallDups,
+      skillPruningProtection,
+      systemPromptTaxes,
+      editHeavySessions,
+    ),
   };
 }
 
@@ -557,6 +621,47 @@ function detectSystemPromptTaxForSession(
   }];
 }
 
+function detectEditHeavyForSession(
+  sessionId: string,
+  turns: TurnRecord[],
+  pricing: PricingTable,
+): EditHeavySession[] {
+  if (turns.length === 0) return [];
+
+  let readCount = 0;
+  let editCount = 0;
+  let likelyRetries = 0;
+  const editTurns: TurnRecord[] = [];
+
+  for (const t of turns) {
+    let turnHasEdit = false;
+    for (const call of t.toolCalls) {
+      const name = normalizeToolName(call.name);
+      if (READ_TOOLS.has(name)) readCount++;
+      else if (EDIT_TOOLS.has(name)) {
+        editCount++;
+        turnHasEdit = true;
+      }
+    }
+    if (turnHasEdit) editTurns.push(t);
+    likelyRetries += countRetries(t.toolCalls);
+  }
+
+  if (editCount < EDIT_HEAVY_MIN_EDITS) return [];
+  const ratio = readCount === 0 ? Number.POSITIVE_INFINITY : editCount / readCount;
+  if (ratio <= EDIT_HEAVY_RATIO) return [];
+
+  return [{
+    source: turns[0]!.source,
+    sessionId,
+    readCount,
+    editCount,
+    ratio,
+    likelyRetries,
+    cost: sumCostForTurns(dedupTurns(editTurns), pricing),
+  }];
+}
+
 function dedupTurns(turns: TurnRecord[]): TurnRecord[] {
   const seen = new Set<string>();
   const out: TurnRecord[] = [];
@@ -577,6 +682,7 @@ function buildSummaries(
   skillRecallDups: SkillRecallDup[],
   skillPruningProtection: SkillPruningProtection[],
   systemPromptTaxes: SystemPromptTax[],
+  editHeavySessions: EditHeavySession[],
 ): SessionPatternSummary[] {
   const by = new Map<string, SessionPatternSummary>();
   const get = (sessionId: string): SessionPatternSummary => {
@@ -592,6 +698,7 @@ function buildSummaries(
         skillRecallDupCount: 0,
         skillPruningProtectionCount: 0,
         systemPromptTaxCount: 0,
+        editHeavyCount: 0,
         totalRetries: 0,
         totalPatternCost: 0,
       };
@@ -635,6 +742,13 @@ function buildSummaries(
     const row = get(s.sessionId);
     row.systemPromptTaxCount++;
     row.totalPatternCost += s.totalCost;
+  }
+  for (const e of editHeavySessions) {
+    const row = get(e.sessionId);
+    row.editHeavyCount++;
+    // Cost is recorded on the row but not added to totalPatternCost — the
+    // edit-bearing turns also feed into edit-revert and retry-loop costs, and
+    // adding them again would double-count the same dollars.
   }
   return [...by.values()].sort((a, b) => b.totalPatternCost - a.totalPatternCost);
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`burn waste --patterns edit-heavy`** ([#167](https://github.com/AgentWorkforce/burn/issues/167)). New cross-harness detector flagging sessions whose edit-tool count exceeds 4× read-tool count (≥ 5 edits). Reaches parity across Claude / Codex / OpenCode through the existing `normalizeToolName` table — Claude `Read`/`Edit`/`Write`/..., OpenCode `read`/`edit`/`write`, Codex `read_file`/`apply_patch` all flow through one detector. Renders a table with source, reads, edits, ratio, intra-turn retry count, and cost; appears in `--json` output as `editHeavySessions`. Coverage prereq is `hasToolCalls` only — tool_result is not consulted, so the detector runs on Codex/OpenCode slices that aggregate-only ledgers can't drive the retry / failure detectors against. `burn diagnose` also renders the new section per-session.
+
 ## [0.36.0] - 2026-04-28
 
 ### Added

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -84,7 +84,7 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
   }
   if (summary) {
     out.push(
-      `patterns: ${summary.retryLoopCount} retry-loops, ${summary.failureRunCount} failure-runs (max ${summary.consecutiveFailureMax}), ${summary.compactionCount} compactions, ${summary.editRevertCount} edit-reverts, ${summary.skillRecallDupCount} skill-recall-dups, ${summary.skillPruningProtectionCount} skill-pruning, ${summary.systemPromptTaxCount} system-prompt-tax`,
+      `patterns: ${summary.retryLoopCount} retry-loops, ${summary.failureRunCount} failure-runs (max ${summary.consecutiveFailureMax}), ${summary.compactionCount} compactions, ${summary.editRevertCount} edit-reverts, ${summary.editHeavyCount} edit-heavy, ${summary.skillRecallDupCount} skill-recall-dups, ${summary.skillPruningProtectionCount} skill-pruning, ${summary.systemPromptTaxCount} system-prompt-tax`,
     );
     out.push(`pattern cost: ${formatUsd(summary.totalPatternCost)}`);
   } else {
@@ -105,6 +105,9 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
   out.push('');
   out.push('Edit-revert cycles');
   out.push(renderReverts(scoped.editReverts));
+  out.push('');
+  out.push('Edit-heavy session signal');
+  out.push(renderEditHeavy(scoped.editHeavySessions));
   out.push('');
   out.push('OpenCode skill recall duplicates');
   out.push(renderSkillRecall(scoped.skillRecallDups));
@@ -169,6 +172,7 @@ function filterPatterns(patterns: PatternsResult, sessionId: string): PatternsRe
     skillRecallDups: patterns.skillRecallDups.filter((r) => r.sessionId === sessionId),
     skillPruningProtection: patterns.skillPruningProtection.filter((r) => r.sessionId === sessionId),
     systemPromptTaxes: patterns.systemPromptTaxes.filter((r) => r.sessionId === sessionId),
+    editHeavySessions: patterns.editHeavySessions.filter((r) => r.sessionId === sessionId),
     sessionSummaries: patterns.sessionSummaries.filter((r) => r.sessionId === sessionId),
   };
 }
@@ -249,6 +253,21 @@ function renderSkillPruning(events: PatternsResult['skillPruningProtection']): s
       String(e.ridingTurns),
       String(e.lastCachedTurnIndex),
       formatUsd(e.cost),
+    ]),
+  ]);
+}
+
+function renderEditHeavy(sessions: PatternsResult['editHeavySessions']): string {
+  if (sessions.length === 0) return '  (none)';
+  return table([
+    ['source', 'reads', 'edits', 'ratio', 'retries', 'cost'],
+    ...sessions.map((s) => [
+      s.source,
+      String(s.readCount),
+      String(s.editCount),
+      Number.isFinite(s.ratio) ? s.ratio.toFixed(1) : '∞',
+      String(s.likelyRetries),
+      formatUsd(s.cost),
     ]),
   ]);
 }

--- a/packages/cli/src/commands/waste.test.ts
+++ b/packages/cli/src/commands/waste.test.ts
@@ -450,7 +450,7 @@ describe('resolvePatternSelection', () => {
 
   it('returns all detectors when the flag is bare (true)', () => {
     const set = resolvePatternSelection(true);
-    assert.equal(set.size, 7);
+    assert.equal(set.size, 8);
   });
 });
 

--- a/packages/cli/src/commands/waste.ts
+++ b/packages/cli/src/commands/waste.ts
@@ -34,7 +34,7 @@ import type { ParsedArgs } from '../args.js';
 import { filterTurnsByProvider, parseProviderFilter } from '../provider.js';
 
 const DEFAULT_TOP_N = 10;
-const PATTERN_KINDS = ['retries', 'failures', 'compaction', 'reverts', 'opencode-skill-recall', 'opencode-skill-pruning', 'opencode-system-prompt'] as const;
+const PATTERN_KINDS = ['retries', 'failures', 'compaction', 'reverts', 'edit-heavy', 'opencode-skill-recall', 'opencode-skill-pruning', 'opencode-system-prompt'] as const;
 type PatternKind = (typeof PATTERN_KINDS)[number];
 
 // When even-split sessions reach this fraction of the matched set, the
@@ -534,6 +534,9 @@ export const PATTERN_REQUIRED: Record<
   retries: ['hasToolCalls', 'hasToolResultEvents'],
   failures: ['hasToolCalls', 'hasToolResultEvents'],
   reverts: ['hasToolCalls', 'hasRawContent'],
+  // Edit-heavy only needs the tool-call stream (counts of read vs edit).
+  // tool_result is not consulted, so `hasToolResultEvents` isn't required.
+  'edit-heavy': ['hasToolCalls'],
   'opencode-skill-recall': ['hasToolCalls', 'hasToolResultEvents'],
   'opencode-skill-pruning': ['hasToolCalls', 'hasToolResultEvents'],
   'opencode-system-prompt': ['hasToolCalls', 'hasToolResultEvents'],
@@ -629,6 +632,7 @@ export async function runPatternsMode(
             failureRuns: [],
             compactions: [],
             editReverts: [],
+            editHeavySessions: [],
             skillRecallDups: [],
             skillPruningProtection: [],
             systemPromptTaxes: [],
@@ -659,6 +663,7 @@ export async function runPatternsMode(
   let skillRecallDups: PatternsResult['skillRecallDups'] = [];
   let skillPruningProtection: PatternsResult['skillPruningProtection'] = [];
   let systemPromptTaxes: PatternsResult['systemPromptTaxes'] = [];
+  let editHeavySessions: PatternsResult['editHeavySessions'] = [];
   let sessionSummaries: PatternsResult['sessionSummaries'] = [];
 
   // Load user turns if the system-prompt detector is selected (needs first
@@ -683,6 +688,10 @@ export async function runPatternsMode(
   if (selected.has('reverts')) {
     const r = detectPatterns(perDetector.get('reverts')!, { pricing, userTurnsBySession });
     editReverts = r.editReverts;
+  }
+  if (selected.has('edit-heavy')) {
+    const r = detectPatterns(perDetector.get('edit-heavy')!, { pricing, userTurnsBySession });
+    editHeavySessions = r.editHeavySessions;
   }
   if (selected.has('opencode-skill-recall')) {
     const r = detectPatterns(perDetector.get('opencode-skill-recall')!, { pricing, compactions, userTurnsBySession });
@@ -709,6 +718,7 @@ export async function runPatternsMode(
     skillRecallDups,
     skillPruningProtection,
     systemPromptTaxes,
+    editHeavySessions,
   );
 
   // For the "turns analyzed" headline we report the union of analyzed slices —
@@ -734,6 +744,7 @@ export async function runPatternsMode(
           skillRecallDups,
           skillPruningProtection,
           systemPromptTaxes,
+          editHeavySessions,
           sessionSummaries,
           fidelity: {
             analyzed: analyzedCount,
@@ -785,6 +796,11 @@ export async function runPatternsMode(
   if (selected.has('reverts')) {
     out.push('Edit-revert cycles (file returned to a prior state)');
     out.push(renderRevertTable(editReverts, limit));
+    out.push('');
+  }
+  if (selected.has('edit-heavy')) {
+    out.push('Edit-heavy sessions (edits/reads > 4, ≥5 edits)');
+    out.push(renderEditHeavyTable(editHeavySessions, limit));
     out.push('');
   }
   if (selected.has('opencode-skill-recall')) {
@@ -860,6 +876,7 @@ function buildSessionSummaries(
   skillRecallDups: PatternsResult['skillRecallDups'],
   skillPruningProtection: PatternsResult['skillPruningProtection'],
   systemPromptTaxes: PatternsResult['systemPromptTaxes'],
+  editHeavySessions: PatternsResult['editHeavySessions'],
 ): PatternsResult['sessionSummaries'] {
   const by = new Map<string, PatternsResult['sessionSummaries'][number]>();
   const get = (sessionId: string): PatternsResult['sessionSummaries'][number] => {
@@ -875,6 +892,7 @@ function buildSessionSummaries(
         skillRecallDupCount: 0,
         skillPruningProtectionCount: 0,
         systemPromptTaxCount: 0,
+        editHeavyCount: 0,
         totalRetries: 0,
         totalPatternCost: 0,
       };
@@ -918,6 +936,13 @@ function buildSessionSummaries(
     const row = get(s.sessionId);
     row.systemPromptTaxCount++;
     row.totalPatternCost += s.totalCost;
+  }
+  for (const e of editHeavySessions) {
+    const row = get(e.sessionId);
+    row.editHeavyCount++;
+    // Cost intentionally omitted from totalPatternCost — see the matching
+    // note in patterns.ts: edit-heavy turns also feed retry-loop and
+    // edit-revert costs, so adding them again would double-count.
   }
   return [...by.values()].sort((a, b) => b.totalPatternCost - a.totalPatternCost);
 }
@@ -1063,6 +1088,29 @@ function renderSystemPromptTable(
       formatInt(t.estimatedSystemPromptTokens),
       formatInt(t.ridingTurns),
       formatUsd(t.totalCost),
+    ]);
+  }
+  return table(rows);
+}
+
+function renderEditHeavyTable(
+  sessions: PatternsResult['editHeavySessions'],
+  limit: number,
+): string {
+  if (sessions.length === 0) return '  (none)';
+  const rows: string[][] = [
+    ['source', 'session', 'reads', 'edits', 'ratio', 'retries', 'cost'],
+  ];
+  const slice = [...sessions].sort((a, b) => b.editCount - a.editCount).slice(0, limit);
+  for (const s of slice) {
+    rows.push([
+      s.source,
+      s.sessionId.slice(0, 8),
+      formatInt(s.readCount),
+      formatInt(s.editCount),
+      Number.isFinite(s.ratio) ? s.ratio.toFixed(1) : '∞',
+      String(s.likelyRetries),
+      formatUsd(s.cost),
     ]);
   }
   return table(rows);


### PR DESCRIPTION
## Summary

- Add `EditHeavySession` waste detector that flags sessions with edit-tool count > 4× read-tool count and ≥ 5 edits.
- Cross-harness via the existing `normalizeToolName` table — Claude `Read`/`Edit`/..., OpenCode `read`/`edit`/..., Codex `read_file`/`apply_patch` all flow through one detector.
- Surface via `burn waste --patterns edit-heavy` and `burn diagnose <session>`.

## Why this shape

Reads are restricted to file-content tools (`Read`, `NotebookRead`). `Grep` / `Glob` / `LS` / `Bash` are deliberately excluded — they discover files or shell out, but don't record that the model has read the file. This matches the codeburn intent ("did the model read the file before editing it?").

Codex's `apply_patch` bundles multiple files per call, so the same 1:4 threshold flags Codex more conservatively than a file-level count would. Documented as a known per-harness tunable per #167's acceptance criteria. On real Codex sessions the threshold lights up aggressively because Codex tends to read via `shell` (`cat`/`head`/`grep`) rather than `read_file` — flagged here in the issue body and the source comment, not silently swept under the rug.

`SessionPatternSummary.editHeavyCount` is added but the cost is **not** rolled into `totalPatternCost` — the same edit-bearing turns also feed `retryLoops` and `editReverts` costs and adding them again would double-count.

`burn waste --patterns edit-heavy` only requires `hasToolCalls` coverage. The retry / failure detectors require `hasToolResultEvents` because they consult `is_error`; this detector counts call shapes only, so it can run on slices the others can't.

## Test plan

- [x] 9 new test cases in `packages/analyze/src/patterns.test.ts` covering Claude / Codex / OpenCode tool-name conventions, MIN_EDITS gate, ratio threshold, Grep/Glob/LS/Bash exclusion, intra-turn `likelyRetries`, and summary aggregation.
- [x] Existing `resolvePatternSelection` test updated for the new `PATTERN_KINDS` count (7 → 8).
- [x] Smoke-tested against my local ledger (68k turns):
  - `burn waste --patterns edit-heavy` flags real Codex apply_patch–heavy sessions and one Claude session with ratio 25.5 (51 edits, 2 reads).
  - `burn diagnose <session>` renders the new `Edit-heavy session signal` section.
- [x] Full test suite: 666/666 passing.

## Closes

- Closes #167
- First child of #55 (cross-harness codeburn-style waste detectors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
