### PR TITLE
Add aggregate content-capture report to burn diagnose (closes #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **Aggregate parser content-capture report in `burn diagnose`** ([#79](https://github.com/AgentWorkforce/burn/issues/79)). `burn diagnose` (no positional argument) now walks the ledger and emits a per-adapter content-capture gap table — total sessions, sessions with ≥1 tool call, gapped sessions (≥1 tool call but zero `tool_result` ContentRecords), orphan tool-call count, and `degradedPct`. Honors `--json`. The existing per-session `burn diagnose <session-id>` behavior is unchanged. Permanent, queryable surface for the gap that the per-invocation ingest warning ([#75](https://github.com/AgentWorkforce/burn/issues/75)) only flags once per `burn` run; rows omit the gap signal with an explanatory note when `RELAYBURN_CONTENT_STORE` is `hash-only` or `off`.
+
 ## [0.37.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
-### Added
-
-- **Aggregate parser content-capture report in `burn diagnose`** ([#79](https://github.com/AgentWorkforce/burn/issues/79)). `burn diagnose` (no positional argument) now walks the ledger and emits a per-adapter content-capture gap table — total sessions, sessions with ≥1 tool call, gapped sessions (≥1 tool call but zero `tool_result` ContentRecords), orphan tool-call count, and `degradedPct`. Honors `--json`. The existing per-session `burn diagnose <session-id>` behavior is unchanged. Permanent, queryable surface for the gap that the per-invocation ingest warning ([#75](https://github.com/AgentWorkforce/burn/issues/75)) only flags once per `burn` run; rows omit the gap signal with an explanatory note when `RELAYBURN_CONTENT_STORE` is `hash-only` or `off`.
-
 ## [0.37.0] - 2026-04-28
 
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Aggregate parser content-capture report in `burn diagnose`** ([#79](https://github.com/AgentWorkforce/burn/issues/79)). `burn diagnose` (no positional argument) now walks the ledger and emits a per-adapter content-capture gap table — total sessions, sessions with ≥1 tool call, gapped sessions (≥1 tool call but zero `tool_result` ContentRecords), orphan tool-call count, and `degradedPct`. Honors `--json` (`{ adapters: [{ adapter, sessions, sessionsWithToolCalls, gappedSessions, orphanToolCalls, degradedPct }, ...], contentMode }`). The existing per-session `burn diagnose <session-id>` behavior is unchanged. Permanent, queryable surface for the gap that the per-invocation ingest warning ([#75](https://github.com/AgentWorkforce/burn/issues/75)) only flags once per `burn` run; rows omit the gap signal with an explanatory note when `RELAYBURN_CONTENT_STORE` is `hash-only` or `off`. Adapters with no sessions in the ledger are omitted entirely.
+
 ## [0.38.0] - 2026-04-28
 
 ### Changed

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,7 +26,7 @@ Usage:
                      (mode flags are mutually exclusive; --by-tool emits tool | calls | attributedCost)
   burn waste         [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--provider <p>] [--all] [--json]
                      [--patterns[=retries,failures,compaction,reverts]]
-  burn diagnose      <session-id> [--json]
+  burn diagnose      [<session-id>] [--json]
   burn limits        [--watch [5s]] [--json] [--no-api] [--no-forecast]
   burn plans         [add|remove|set-reset-day] …  (run \`burn plans help\` for full usage)
   burn context       [advise] [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]
@@ -48,6 +48,7 @@ Examples:
   burn waste --since 7d
   burn waste --patterns --since 7d
   burn diagnose <session-id>
+  burn diagnose                       # per-adapter content-capture gap report
   burn limits
   burn limits --watch
   burn limits --no-api

--- a/packages/cli/src/commands/diagnose.test.ts
+++ b/packages/cli/src/commands/diagnose.test.ts
@@ -1,0 +1,387 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { after, beforeEach, describe, it } from 'node:test';
+
+import {
+  __resetIndexCacheForTesting,
+  appendContent,
+  appendTurns,
+} from '@relayburn/ledger';
+import type { ContentRecord, SourceKind, TurnRecord } from '@relayburn/reader';
+
+import { runDiagnose } from './diagnose.js';
+
+// Cross-batch counter so every fakeTurn lands a unique (ts, model, usage,
+// argsHashPrefix) tuple — otherwise the writer's content-fingerprint dedup
+// (see turnContentFingerprint in @relayburn/ledger) would silently drop
+// later turns that happen to share defaults with an already-committed one.
+let turnCounter = 0;
+
+function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
+  turnCounter++;
+  const ss = String(turnCounter % 60).padStart(2, '0');
+  return {
+    v: 1,
+    source: 'claude-code',
+    sessionId: 's-1',
+    messageId: 'msg-1',
+    turnIndex: 0,
+    ts: `2026-04-20T00:00:${ss}.000Z`,
+    model: 'claude-sonnet-4-6',
+    usage: {
+      input: 1000 + turnCounter,
+      output: 500,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    },
+    toolCalls: [],
+    project: '/tmp/project',
+    ...overrides,
+  };
+}
+
+function toolCallTurn(opts: {
+  source: SourceKind;
+  sessionId: string;
+  messageId: string;
+  toolCallIds: string[];
+}): TurnRecord {
+  return fakeTurn({
+    source: opts.source,
+    sessionId: opts.sessionId,
+    messageId: opts.messageId,
+    toolCalls: opts.toolCallIds.map((id) => ({
+      id,
+      name: 'Read',
+      // Prefix the argsHash with the tool-call id so turnContentFingerprint's
+      // first-4-char hash slice is distinct between turns (the writer dedups
+      // on (ts, model, usage, firstArgsHashPrefix) across batches).
+      argsHash: `${id}-args`,
+    })),
+  });
+}
+
+function toolResultContent(opts: {
+  source: SourceKind;
+  sessionId: string;
+  messageId: string;
+  toolUseId: string;
+}): ContentRecord {
+  return {
+    v: 1,
+    source: opts.source,
+    sessionId: opts.sessionId,
+    messageId: opts.messageId,
+    ts: '2026-04-20T00:00:01.000Z',
+    role: 'tool_result',
+    kind: 'tool_result',
+    toolResult: {
+      toolUseId: opts.toolUseId,
+      content: 'ok',
+    },
+  };
+}
+
+interface CapturedOutput {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+async function captureDiagnose(
+  args: Parameters<typeof runDiagnose>[0],
+): Promise<CapturedOutput> {
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origStderr = process.stderr.write.bind(process.stderr);
+  let stdout = '';
+  let stderr = '';
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdout += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderr += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  let code: number;
+  try {
+    code = await runDiagnose(args);
+  } finally {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+  }
+  return { stdout, stderr, code };
+}
+
+describe('burn diagnose aggregate (#79)', () => {
+  let tmpHome: string;
+  let tmpRelay: string;
+  const originalHome = process.env['HOME'];
+  const originalRelay = process.env['RELAYBURN_HOME'];
+  const originalStore = process.env['RELAYBURN_CONTENT_STORE'];
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-diagnose-home-'));
+    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-diagnose-relay-'));
+    // Point HOME at an empty dir so ingestAll() finds no transcripts to walk —
+    // the test fixtures here are pre-seeded directly into the ledger.
+    process.env['HOME'] = tmpHome;
+    process.env['RELAYBURN_HOME'] = tmpRelay;
+    process.env['RELAYBURN_CONTENT_STORE'] = 'full';
+    __resetIndexCacheForTesting();
+    turnCounter = 0;
+  });
+
+  after(async () => {
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+    else delete process.env['HOME'];
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    if (originalStore !== undefined) process.env['RELAYBURN_CONTENT_STORE'] = originalStore;
+    else delete process.env['RELAYBURN_CONTENT_STORE'];
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(tmpRelay, { recursive: true, force: true });
+  });
+
+  it('reports zero gaps on a ledger where every adapter captures tool_result records', async () => {
+    // Claude: 1 session w/ 1 tool call + matching tool_result
+    await appendTurns([
+      toolCallTurn({
+        source: 'claude-code',
+        sessionId: 'cl-1',
+        messageId: 'cl-1-msg-1',
+        toolCallIds: ['tu-cl-1'],
+      }),
+    ]);
+    await appendContent([
+      toolResultContent({
+        source: 'claude-code',
+        sessionId: 'cl-1',
+        messageId: 'cl-1-msg-1',
+        toolUseId: 'tu-cl-1',
+      }),
+    ]);
+    // Codex: 1 session with no tool calls (still counted in `sessions`).
+    await appendTurns([
+      fakeTurn({
+        source: 'codex',
+        sessionId: 'cx-1',
+        messageId: 'cx-1-msg-1',
+      }),
+    ]);
+
+    const out = await captureDiagnose({
+      flags: { json: true },
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    const parsed = JSON.parse(out.stdout) as {
+      adapters: Array<{
+        adapter: string;
+        sessions: number;
+        sessionsWithToolCalls: number;
+        gappedSessions: number | null;
+        orphanToolCalls: number | null;
+        degradedPct: number | null;
+      }>;
+      contentMode: string;
+    };
+    assert.equal(parsed.contentMode, 'full');
+    const claude = parsed.adapters.find((a) => a.adapter === 'claude');
+    const codex = parsed.adapters.find((a) => a.adapter === 'codex');
+    assert.ok(claude, 'claude row present');
+    assert.equal(claude!.sessions, 1);
+    assert.equal(claude!.sessionsWithToolCalls, 1);
+    assert.equal(claude!.gappedSessions, 0);
+    assert.equal(claude!.orphanToolCalls, 0);
+    assert.equal(claude!.degradedPct, 0);
+    assert.ok(codex, 'codex row present');
+    assert.equal(codex!.sessions, 1);
+    assert.equal(codex!.sessionsWithToolCalls, 0);
+    assert.equal(codex!.gappedSessions, 0);
+  });
+
+  it('reports gapped sessions and degradedPct when adapters emit tool calls without tool_result records', async () => {
+    // Codex: two sessions with tool calls but no tool_result content.
+    await appendTurns([
+      toolCallTurn({
+        source: 'codex',
+        sessionId: 'cx-A',
+        messageId: 'cx-A-msg-1',
+        toolCallIds: ['tu-A-1', 'tu-A-2'],
+      }),
+      toolCallTurn({
+        source: 'codex',
+        sessionId: 'cx-B',
+        messageId: 'cx-B-msg-1',
+        toolCallIds: ['tu-B-1'],
+      }),
+      // Codex no-tool-call session — present in `sessions` but excluded from
+      // withToolCalls so degradedPct stays comparable.
+      fakeTurn({
+        source: 'codex',
+        sessionId: 'cx-C',
+        messageId: 'cx-C-msg-1',
+      }),
+    ]);
+    // OpenCode: one session that captured content correctly. Demonstrates
+    // mixed adapter health in the same ledger.
+    await appendTurns([
+      toolCallTurn({
+        source: 'opencode',
+        sessionId: 'oc-1',
+        messageId: 'oc-1-msg-1',
+        toolCallIds: ['tu-oc-1'],
+      }),
+    ]);
+    await appendContent([
+      toolResultContent({
+        source: 'opencode',
+        sessionId: 'oc-1',
+        messageId: 'oc-1-msg-1',
+        toolUseId: 'tu-oc-1',
+      }),
+    ]);
+
+    const out = await captureDiagnose({
+      flags: { json: true },
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    const parsed = JSON.parse(out.stdout) as {
+      adapters: Array<{
+        adapter: string;
+        sessions: number;
+        sessionsWithToolCalls: number;
+        gappedSessions: number;
+        orphanToolCalls: number;
+        degradedPct: number;
+      }>;
+    };
+    const codex = parsed.adapters.find((a) => a.adapter === 'codex');
+    assert.ok(codex);
+    assert.equal(codex!.sessions, 3);
+    assert.equal(codex!.sessionsWithToolCalls, 2);
+    assert.equal(codex!.gappedSessions, 2);
+    assert.equal(codex!.orphanToolCalls, 3);
+    assert.equal(codex!.degradedPct, 100);
+
+    const opencode = parsed.adapters.find((a) => a.adapter === 'opencode');
+    assert.ok(opencode);
+    assert.equal(opencode!.sessions, 1);
+    assert.equal(opencode!.sessionsWithToolCalls, 1);
+    assert.equal(opencode!.gappedSessions, 0);
+    assert.equal(opencode!.degradedPct, 0);
+
+    // Claude has no sessions in this ledger, so we omit it entirely (as
+    // documented in the table-of-zero-rows alternative — see commit body).
+    assert.equal(
+      parsed.adapters.find((a) => a.adapter === 'claude'),
+      undefined,
+    );
+  });
+
+  it('emits the per-adapter table on the human-readable path', async () => {
+    await appendTurns([
+      toolCallTurn({
+        source: 'codex',
+        sessionId: 'cx-X',
+        messageId: 'cx-X-msg-1',
+        toolCallIds: ['tu-X'],
+      }),
+    ]);
+    const out = await captureDiagnose({
+      flags: {},
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    assert.match(out.stdout, /Content-capture gaps by adapter/);
+    assert.match(out.stdout, /codex/);
+    // Header columns from the issue spec.
+    assert.match(out.stdout, /sessions/);
+    assert.match(out.stdout, /withToolCalls/);
+    assert.match(out.stdout, /gapped/);
+    assert.match(out.stdout, /degraded%/);
+    // codex row: 1 session, 1 with tool calls, 1 gapped, 100% degraded.
+    assert.match(out.stdout, /100\.0%/);
+  });
+
+  it('omits the gap signal and prints a note when content store is hash-only', async () => {
+    process.env['RELAYBURN_CONTENT_STORE'] = 'hash-only';
+    await appendTurns([
+      toolCallTurn({
+        source: 'claude-code',
+        sessionId: 'cl-h',
+        messageId: 'cl-h-msg-1',
+        toolCallIds: ['tu-h'],
+      }),
+    ]);
+    const out = await captureDiagnose({
+      flags: { json: true },
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    const parsed = JSON.parse(out.stdout) as {
+      adapters: Array<{
+        adapter: string;
+        gappedSessions: number | null;
+        orphanToolCalls: number | null;
+        degradedPct: number | null;
+      }>;
+      contentMode: string;
+    };
+    assert.equal(parsed.contentMode, 'hash-only');
+    const claude = parsed.adapters.find((a) => a.adapter === 'claude');
+    assert.ok(claude);
+    assert.equal(claude!.gappedSessions, null);
+    assert.equal(claude!.orphanToolCalls, null);
+    assert.equal(claude!.degradedPct, null);
+
+    // Human path includes the explanatory note.
+    const human = await captureDiagnose({
+      flags: {},
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(human.code, 0);
+    assert.match(human.stdout, /content store is hash-only/);
+  });
+
+  it('preserves the existing per-session diagnose path when a session id is supplied', async () => {
+    // Empty ledger → existing behavior is exit 1 with a "no turns found"
+    // message on stderr. We're asserting the per-session branch wasn't
+    // accidentally rerouted into the aggregate path.
+    const out = await captureDiagnose({
+      flags: {},
+      tags: {},
+      positional: ['does-not-exist'],
+      passthrough: [],
+    });
+    assert.equal(out.code, 1);
+    assert.match(out.stderr, /no turns found for session does-not-exist/);
+  });
+
+  it('renders an empty-ledger note when there are no adapter sessions at all', async () => {
+    const out = await captureDiagnose({
+      flags: {},
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    assert.match(out.stdout, /no sessions in ledger/);
+  });
+});

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -8,22 +8,27 @@ import {
   type PatternsResult,
 } from '@relayburn/analyze';
 import {
+  loadConfig,
   queryAll,
   queryCompactions,
   queryUserTurns,
   readContent,
 } from '@relayburn/ledger';
-import type { ContentRecord, UserTurnRecord } from '@relayburn/reader';
+import type {
+  ContentRecord,
+  SourceKind,
+  TurnRecord,
+  UserTurnRecord,
+} from '@relayburn/reader';
 
-import { ingestAll } from '../ingest.js';
+import { countToolCallGaps, ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
 export async function runDiagnose(args: ParsedArgs): Promise<number> {
   const sessionId = args.positional[0];
   if (!sessionId) {
-    process.stderr.write('burn diagnose: missing session id\n');
-    return 2;
+    return runDiagnoseAggregate(args);
   }
 
   await ingestAll();
@@ -289,4 +294,161 @@ function renderSystemPrompt(taxes: PatternsResult['systemPromptTaxes']): string 
 function truncate(s: string, n: number): string {
   if (s.length <= n) return s;
   return s.slice(0, n - 1) + '…';
+}
+
+// Aggregate per-adapter content-capture gap report (#79). Walks the ledger and
+// tells the user how many sessions per adapter have ≥1 tool call but zero
+// `tool_result` ContentRecords — the symptom that motivated #58 / #59. Unlike
+// the per-invocation ingest warning (which fires once per `burn` run for a
+// fresh affected session), this is a permanent, queryable surface.
+type Adapter = 'claude' | 'codex' | 'opencode';
+const ADAPTER_ORDER: Adapter[] = ['claude', 'codex', 'opencode'];
+
+interface AdapterRow {
+  adapter: Adapter;
+  sessions: number;
+  sessionsWithToolCalls: number;
+  // null when contentMode is hash-only / off — we can't tell gap from
+  // "store disabled", so we omit the signal rather than mislead.
+  gappedSessions: number | null;
+  orphanToolCalls: number | null;
+  degradedPct: number | null;
+}
+
+async function runDiagnoseAggregate(args: ParsedArgs): Promise<number> {
+  await ingestAll();
+  const config = await loadConfig();
+  const contentMode = config.content.store;
+  const turns = await queryAll();
+
+  const sessionsByAdapter = new Map<Adapter, Map<string, TurnRecord[]>>();
+  for (const t of turns) {
+    const adapter = sourceToAdapter(t.source);
+    if (!adapter) continue;
+    let bySession = sessionsByAdapter.get(adapter);
+    if (!bySession) {
+      bySession = new Map();
+      sessionsByAdapter.set(adapter, bySession);
+    }
+    let bucket = bySession.get(t.sessionId);
+    if (!bucket) {
+      bucket = [];
+      bySession.set(t.sessionId, bucket);
+    }
+    bucket.push(t);
+  }
+
+  const rows: AdapterRow[] = [];
+  for (const adapter of ADAPTER_ORDER) {
+    const bySession = sessionsByAdapter.get(adapter);
+    if (!bySession || bySession.size === 0) continue;
+    let gapped = 0;
+    let orphans = 0;
+    let withToolCalls = 0;
+    for (const [sid, sessionTurns] of bySession) {
+      const hasToolCalls = sessionTurns.some((t) => t.toolCalls.length > 0);
+      if (!hasToolCalls) continue;
+      withToolCalls++;
+      if (contentMode !== 'full') continue;
+      const content = await readContent({ sessionId: sid });
+      const { sessionAffected, orphanToolCalls } = countToolCallGaps(
+        sessionTurns,
+        content,
+      );
+      if (sessionAffected) {
+        gapped++;
+        orphans += orphanToolCalls;
+      }
+    }
+    const row: AdapterRow = {
+      adapter,
+      sessions: bySession.size,
+      sessionsWithToolCalls: withToolCalls,
+      gappedSessions: contentMode === 'full' ? gapped : null,
+      orphanToolCalls: contentMode === 'full' ? orphans : null,
+      degradedPct:
+        contentMode === 'full'
+          ? withToolCalls > 0
+            ? (gapped / withToolCalls) * 100
+            : 0
+          : null,
+    };
+    rows.push(row);
+  }
+
+  if (args.flags['json'] === true) {
+    process.stdout.write(
+      JSON.stringify({ adapters: rows, contentMode }, null, 2) + '\n',
+    );
+    return 0;
+  }
+
+  const out: string[] = [];
+  out.push('');
+  out.push('Content-capture gaps by adapter');
+  if (rows.length === 0) {
+    out.push('  (no sessions in ledger)');
+    out.push('');
+    process.stdout.write(out.join('\n'));
+    return 0;
+  }
+  if (contentMode !== 'full') {
+    out.push(
+      `  content store is ${contentMode}; gap signal unavailable. Set RELAYBURN_CONTENT_STORE=full to enable.`,
+    );
+    out.push(
+      table([
+        ['adapter', 'sessions', 'withToolCalls'],
+        ...rows.map((r) => [
+          r.adapter,
+          formatInt(r.sessions),
+          formatInt(r.sessionsWithToolCalls),
+        ]),
+      ]),
+    );
+  } else {
+    out.push(
+      table([
+        [
+          'adapter',
+          'sessions',
+          'withToolCalls',
+          'gapped',
+          'orphanToolCalls',
+          'degraded%',
+        ],
+        ...rows.map((r) => [
+          r.adapter,
+          formatInt(r.sessions),
+          formatInt(r.sessionsWithToolCalls),
+          formatInt(r.gappedSessions ?? 0),
+          formatInt(r.orphanToolCalls ?? 0),
+          formatPct(r.degradedPct ?? 0),
+        ]),
+      ]),
+    );
+  }
+  out.push('');
+  process.stdout.write(out.join('\n'));
+  return 0;
+}
+
+function sourceToAdapter(source: SourceKind): Adapter | null {
+  switch (source) {
+    case 'claude-code':
+      return 'claude';
+    case 'codex':
+      return 'codex';
+    case 'opencode':
+      return 'opencode';
+    default:
+      // API-direct sources don't correspond to a parser/harness adapter.
+      return null;
+  }
+}
+
+function formatPct(n: number): string {
+  // Match the precision that motivated this report (#58: a 99.7% reading was
+  // the original symptom). One decimal place keeps small differences visible.
+  return `${n.toFixed(1)}%`;
 }


### PR DESCRIPTION
## Summary

- `burn diagnose` (no positional arg) walks the ledger and emits a per-adapter content-capture gap table — total sessions, sessions with tool calls, gapped sessions, orphan tool-call count, and degraded%. Permanent, queryable surface for the gap that the per-invocation ingest warning from #75 only flags once per `burn` run.
- `--json` emits `{ adapters: [{ adapter, sessions, sessionsWithToolCalls, gappedSessions, orphanToolCalls, degradedPct }, ...], contentMode }`.
- Existing `burn diagnose <session-id>` path is untouched (same output, same exit codes, same `--json` shape).
- When the content store is `hash-only` / `off`, the gap signal is omitted with an explanatory note rather than misleading the user about whether content was captured or simply not stored. Adapters with no sessions are omitted entirely.

Closes #79.

## Test plan

- [x] `pnpm run build` clean
- [x] `pnpm run test` — full suite (673 tests, all green) including 6 new cases in `packages/cli/src/commands/diagnose.test.ts`:
  - zero-gap ledger across multiple adapters
  - codex sessions with tool calls but no `tool_result` records → `gappedSessions = 2`, `orphanToolCalls = 3`, `degradedPct = 100`
  - human-readable table includes the spec'd columns + `100.0%`
  - `RELAYBURN_CONTENT_STORE=hash-only` zeroes the gap fields and emits the explanatory note
  - per-session path with a missing session id still exits 1 with the existing message
  - empty ledger renders the "no sessions" note
- [x] Smoke test: `burn diagnose` and `burn diagnose --json` against an empty ledger produce the expected zero-row report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
