### PR TITLE
Claim at most one pending stamp per session (#162)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pending-stamp resolution no longer cross-contaminates concurrent same-cwd same-harness runs** ([#162](https://github.com/AgentWorkforce/burn/issues/162)). When two `burn run codex` (or two `burn run opencode`) processes are running in the same directory, the `{harness, cwd, mtime ≥ spawnStart, sessionDirHint}` filter cannot tell their stamps apart, so the resolver was applying every matching stamp's enrichment to whichever session ingested first — leaving the other session unstamped. Each session now claims at most one stamp (FIFO by `spawnStartTs`), so the older stamp goes to the first session that ingests and the newer stamp stays pending until its own session shows up. Different cwds, different harnesses, and Claude (which uses pre-allocated session IDs and never writes pending stamps) were unaffected and remain unchanged.
+
 ### Added
 
 - **Content-sidecar enrichments surface in `burn diagnose` and `burn waste --patterns`** ([#57](https://github.com/AgentWorkforce/burn/issues/57)). When a session was captured with `content.store=full`, the four waste-pattern detectors now emit additional fields that `burn diagnose <session>` and `burn waste --patterns` render through the existing tables and `WasteFinding` text: retry-loop titles include the shared error-line signature (e.g. `"Bash failed 4× in a row: 'npm ERR! code ENOENT'"`), failure-run details list per-tool first-line errors, compaction-loss details summarize the work in the compacted window (`N edit(s), M bash, K read(s) on src/foo.ts, src/bar.ts`), and edit-revert details show truncated `old_string`/`new_string` previews for both anchor edits. `--json` payloads carry the new fields verbatim (`errorSignature`, `errorSignatures`, `lostWork`, `samplePreview`). Sessions in `content.store=hash-only` or with pruned content render exactly as before. `burn waste` lazily loads content sidecars only for the four enrichable detectors (`retries`/`failures`/`compaction`/`reverts`) and only when at least one is selected, so unrelated runs pay no I/O cost.

--- a/packages/cli/src/pending-stamps.test.ts
+++ b/packages/cli/src/pending-stamps.test.ts
@@ -101,6 +101,59 @@ describe('pending stamp manifest', () => {
     assert.equal(line.enrichment['workflowId'], 'wf-once');
   });
 
+  it('does not cross-contaminate two same-cwd same-harness runs', async () => {
+    const now = Date.now();
+    const spawnStartA = new Date(now);
+    const spawnStartB = new Date(now + 1000);
+    await writePendingStamp({
+      harness: 'codex',
+      cwd: '/tmp/project',
+      enrichment: { tag: 'A' },
+      sessionDirHint: '/tmp/codex/sessions',
+      spawnStartTs: spawnStartA,
+      spawnerPid: 100,
+    });
+    await writePendingStamp({
+      harness: 'codex',
+      cwd: '/tmp/project',
+      enrichment: { tag: 'B' },
+      sessionDirHint: '/tmp/codex/sessions',
+      spawnStartTs: spawnStartB,
+      spawnerPid: 101,
+    });
+
+    const first = await resolvePendingStampsForSession({
+      harness: 'codex',
+      sessionId: 'sess_first',
+      sessionPath: '/tmp/codex/sessions/2026/04/24/first.jsonl',
+      sessionMtimeMs: spawnStartB.getTime() + 50,
+      cwd: '/tmp/project',
+    });
+    const second = await resolvePendingStampsForSession({
+      harness: 'codex',
+      sessionId: 'sess_second',
+      sessionPath: '/tmp/codex/sessions/2026/04/24/second.jsonl',
+      sessionMtimeMs: spawnStartB.getTime() + 60,
+      cwd: '/tmp/project',
+    });
+
+    assert.equal(first.applied, 1);
+    assert.equal(second.applied, 1);
+    // Oldest stamp (A) goes to whichever session ingests first.
+    assert.equal(first.enrichment['tag'], 'A');
+    assert.equal(second.enrichment['tag'], 'B');
+    assert.deepEqual(await listPendingFiles(), []);
+
+    const stampLines = (await readFile(ledgerPath(), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l) as { selector: { sessionId?: string }; enrichment: Record<string, string> });
+    assert.equal(stampLines.length, 2);
+    const bySession = new Map(stampLines.map((l) => [l.selector.sessionId, l.enrichment['tag']]));
+    assert.equal(bySession.get('sess_first'), 'A');
+    assert.equal(bySession.get('sess_second'), 'B');
+  });
+
   it('uses mtime causality as a fallback when session cwd is unavailable', async () => {
     const spawnStart = new Date();
     await writePendingStamp({

--- a/packages/cli/src/pending-stamps.ts
+++ b/packages/cli/src/pending-stamps.ts
@@ -155,6 +155,11 @@ export async function resolvePendingStampsForSession(
 
   matches.sort((a, b) => a.record.spawnStartTs.localeCompare(b.record.spawnStartTs));
 
+  // Claim at most one stamp per session: when multiple same-harness runs share
+  // a cwd, the cwd+mtime+sessionDirHint filter is too coarse to tell their
+  // stamps apart, so we'd otherwise apply every concurrent run's enrichment to
+  // whichever session ingested first. FIFO (oldest spawnStartTs first) leaves
+  // later stamps to match later sessions.
   const enrichment: Enrichment = {};
   let applied = 0;
   for (const { file, record } of matches) {
@@ -165,6 +170,7 @@ export async function resolvePendingStampsForSession(
       Object.assign(enrichment, record.enrichment);
       applied++;
       await unlink(claimed).catch(() => undefined);
+      break;
     } catch (err) {
       await rename(claimed, file).catch(() => undefined);
       throw err;


### PR DESCRIPTION
## Summary

Fixes #162. `resolvePendingStampsForSession` matched stamps by `{harness, cwd, mtime ≥ spawnStart, sessionDirHint}` and then looped over **all** matches for a single session — when two `burn run codex` (or two `burn run opencode`) processes shared a cwd, both stamps satisfied the filter for whichever session ingested first, so the late session got nothing and the early session got both stamps' enrichment merged via `Object.assign`.

The fix is option (1) from the issue: claim at most one stamp per session, taking the oldest (`spawnStartTs` ascending). Each session consumes one stamp; later stamps stay pending until later sessions show up. FIFO is a defensible heuristic when the matcher cannot otherwise tell concurrent runs apart.

Scope: only the same-harness + same-cwd concurrent case changes. Different cwds, different harnesses, and Claude (pre-allocated session IDs, no pending stamps) were already correct and remain unchanged. The stale-stamp-from-yesterday hazard mentioned in the issue is not addressed here — would need option (2) — but FIFO does mean a stale stamp is consumed by the next session in that cwd instead of every concurrent session at once.

## Test plan

- [x] New regression test in `packages/cli/src/pending-stamps.test.ts`: two stamps (A, B) in the same cwd resolve against two distinct sessions; first session gets `tag=A`, second gets `tag=B`, both pending files are deleted, and the ledger has exactly one stamp line per session.
- [x] Confirmed the new test fails on `main` (without the fix) and passes with it.
- [x] `pnpm run test:ts` — 715/715 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
