### PR TITLE
Wire provider rendering through analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Changed
+
+- Provider-aware CLI rendering now uses shared analyze helpers for effective-provider resolution and aggregation.
+
 ## [0.42.0] - 2026-04-28
 
 ### Added

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/analyze`.
 
 ## [Unreleased]
 
+### Added
+
+- Added shared effective-provider helpers and `aggregateByProvider()` for provider-scoped rendering.
+
 ## [0.42.0] - 2026-04-28
 
 ### Added

--- a/packages/analyze/src/index.ts
+++ b/packages/analyze/src/index.ts
@@ -129,6 +129,24 @@ export {
 export type { FidelitySummary } from './fidelity.js';
 export { DEFAULT_RULES, resolveProvider } from './provider-reattribution.js';
 export type { ProviderResolution, ProviderRule } from './provider-reattribution.js';
+export {
+  aggregateByProvider,
+  filterTurnsByProvider,
+  providerFor,
+  providerForModel,
+  providerForTurn,
+  resolveTurnProvider,
+} from './provider.js';
+export type {
+  AggregateByProviderOptions,
+  CoverageField,
+  FieldCoverage,
+  ProviderAggregateRow,
+  ProviderFilter,
+  RowCoverage,
+  TurnProvider,
+  UsageCostAggregateRow,
+} from './provider.js';
 export type {
   AttributeContextInput,
   ContextAttributionResult,

--- a/packages/analyze/src/provider.test.ts
+++ b/packages/analyze/src/provider.test.ts
@@ -1,0 +1,113 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { TurnRecord } from '@relayburn/reader';
+
+import { aggregateByProvider, providerFor } from './provider.js';
+import type { PricingTable } from './pricing.js';
+
+const pricing: PricingTable = {
+  'deepseek-r1': {
+    input: 1,
+    output: 2,
+    cacheRead: 0.1,
+    cacheWrite: 1.25,
+    reasoningMode: 'same_as_output',
+  },
+  'gpt-5': {
+    input: 3,
+    output: 6,
+    cacheRead: 0.3,
+    cacheWrite: 3.75,
+    reasoningMode: 'same_as_output',
+  },
+};
+
+function turn(overrides: Partial<TurnRecord> = {}): TurnRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    sessionId: 's-provider',
+    messageId: 'm-provider',
+    turnIndex: 0,
+    ts: '2026-04-20T00:00:00.000Z',
+    model: 'claude-sonnet-4-6',
+    usage: {
+      input: 1_000_000,
+      output: 1_000_000,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    },
+    toolCalls: [],
+    ...overrides,
+  };
+}
+
+describe('effective provider helpers', () => {
+  it('reattributes synthetic-routed models before source fallback', () => {
+    const provider = providerFor(turn({ model: 'hf:deepseek-ai/deepseek-r1' }));
+    assert.equal(provider.provider, 'synthetic');
+    assert.equal(provider.normalizedModel, 'deepseek-r1');
+    assert.equal(provider.matchedRule, 'synthetic-huggingface');
+  });
+
+  it('falls through to collector-implied providers for normal turns', () => {
+    assert.equal(providerFor(turn({ source: 'codex', model: 'gpt-5' })).provider, 'openai');
+    assert.equal(
+      providerFor(turn({ source: 'opencode', model: 'anthropic/claude-sonnet-4-6' })).provider,
+      'anthropic',
+    );
+  });
+});
+
+describe('aggregateByProvider', () => {
+  it('aggregates synthetic turns together regardless of routing prefix', () => {
+    const rows = aggregateByProvider([
+      turn({
+        model: 'hf:deepseek-ai/deepseek-r1',
+        usage: {
+          input: 1_000_000,
+          output: 0,
+          reasoning: 0,
+          cacheRead: 0,
+          cacheCreate5m: 0,
+          cacheCreate1h: 0,
+        },
+      }),
+      turn({
+        model: 'synthetic/deepseek-r1',
+        usage: {
+          input: 0,
+          output: 1_000_000,
+          reasoning: 0,
+          cacheRead: 0,
+          cacheCreate5m: 0,
+          cacheCreate1h: 0,
+        },
+      }),
+    ], { pricing });
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.provider, 'synthetic');
+    assert.equal(rows[0]!.turns, 2);
+    assert.equal(rows[0]!.usage.input, 1_000_000);
+    assert.equal(rows[0]!.usage.output, 1_000_000);
+    assert.equal(rows[0]!.cost.total, 3);
+  });
+
+  it('falls through to collector provider for non-synthetic turns', () => {
+    const rows = aggregateByProvider([
+      turn({ source: 'codex', model: 'gpt-5' }),
+    ], { pricing });
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.provider, 'openai');
+    assert.equal(rows[0]!.cost.total, 9);
+  });
+
+  it('returns an empty row set for empty input', () => {
+    assert.deepEqual(aggregateByProvider([], { pricing }), []);
+  });
+});

--- a/packages/analyze/src/provider.ts
+++ b/packages/analyze/src/provider.ts
@@ -1,0 +1,228 @@
+import type { SourceKind, TurnRecord, Usage, Coverage } from '@relayburn/reader';
+
+import { costForTurn } from './cost.js';
+import type { CostBreakdown } from './cost.js';
+import type { PricingTable } from './pricing.js';
+import {
+  DEFAULT_RULES,
+  resolveProvider,
+  type ProviderRule,
+} from './provider-reattribution.js';
+
+export interface TurnProvider {
+  provider: string;
+  rawModel: string;
+  normalizedModel: string;
+  matchedRule?: string;
+}
+
+export type ProviderFilter = ReadonlySet<string>;
+
+export interface FieldCoverage {
+  known: number;
+  missing: number;
+}
+
+export type CoverageField =
+  | 'input'
+  | 'output'
+  | 'reasoning'
+  | 'cacheRead'
+  | 'cacheCreate';
+
+export type RowCoverage = Record<CoverageField, FieldCoverage>;
+
+export interface UsageCostAggregateRow {
+  label: string;
+  turns: number;
+  usage: Usage;
+  cost: CostBreakdown;
+  coverage: RowCoverage;
+}
+
+export interface ProviderAggregateRow extends UsageCostAggregateRow {
+  provider: string;
+}
+
+export interface AggregateByProviderOptions {
+  pricing: PricingTable;
+  rules?: readonly ProviderRule[];
+}
+
+/**
+ * Resolve the effective provider for a turn.
+ *
+ * Synthetic-style router prefixes win first. Otherwise we keep provider
+ * semantics aligned with CLI rendering by using a raw `provider/model` model
+ * prefix when present, then falling back to the collector-implied provider.
+ */
+export function providerFor(
+  turn: Pick<TurnRecord, 'model' | 'source'>,
+  rules: readonly ProviderRule[] = DEFAULT_RULES,
+): TurnProvider {
+  return providerForModel(turn.model, turn.source, rules);
+}
+
+export const providerForTurn = providerFor;
+export const resolveTurnProvider = providerFor;
+
+export function providerForModel(
+  model: string,
+  source?: SourceKind,
+  rules: readonly ProviderRule[] = DEFAULT_RULES,
+): TurnProvider {
+  const resolved = resolveProvider(model, rules);
+  if (resolved.provider) {
+    const out: TurnProvider = {
+      provider: resolved.provider,
+      rawModel: model,
+      normalizedModel: resolved.normalizedModel,
+    };
+    if (resolved.matchedRule) out.matchedRule = resolved.matchedRule;
+    return out;
+  }
+
+  const providerPrefix = providerFromModelPrefix(model);
+  if (providerPrefix) {
+    return {
+      provider: providerPrefix,
+      rawModel: model,
+      normalizedModel: stripProviderPrefix(model),
+    };
+  }
+
+  return {
+    provider: source ? providerFromSource(source) : 'unknown',
+    rawModel: model,
+    normalizedModel: model,
+  };
+}
+
+export function filterTurnsByProvider<T extends Pick<TurnRecord, 'model' | 'source'>>(
+  turns: T[],
+  filter: ProviderFilter | undefined,
+  rules: readonly ProviderRule[] = DEFAULT_RULES,
+): T[] {
+  if (!filter) return turns;
+  return turns.filter((t) => filter.has(providerFor(t, rules).provider.toLowerCase()));
+}
+
+export function aggregateByProvider(
+  turns: readonly TurnRecord[],
+  opts: AggregateByProviderOptions,
+): ProviderAggregateRow[] {
+  const byProvider = new Map<string, ProviderAggregateRow>();
+  const rules = opts.rules ?? DEFAULT_RULES;
+  for (const t of turns) {
+    const provider = providerFor(t, rules).provider || 'unknown';
+    let row = byProvider.get(provider);
+    if (!row) {
+      row = emptyProviderRow(provider);
+      byProvider.set(provider, row);
+    }
+    row.turns++;
+    row.usage.input += t.usage.input;
+    row.usage.output += t.usage.output;
+    row.usage.reasoning += t.usage.reasoning;
+    row.usage.cacheRead += t.usage.cacheRead;
+    row.usage.cacheCreate5m += t.usage.cacheCreate5m;
+    row.usage.cacheCreate1h += t.usage.cacheCreate1h;
+    accumulateCoverage(row.coverage, t.fidelity?.coverage);
+    const c = costForTurn(t, opts.pricing);
+    if (c) {
+      row.cost.total += c.total;
+      row.cost.input += c.input;
+      row.cost.output += c.output;
+      row.cost.reasoning += c.reasoning;
+      row.cost.cacheRead += c.cacheRead;
+      row.cost.cacheCreate += c.cacheCreate;
+    }
+  }
+  return [...byProvider.values()].sort((a, b) => b.cost.total - a.cost.total);
+}
+
+function emptyProviderRow(provider: string): ProviderAggregateRow {
+  return {
+    label: provider,
+    provider,
+    turns: 0,
+    usage: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    },
+    cost: {
+      model: provider,
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheCreate: 0,
+    },
+    coverage: emptyCoverage(),
+  };
+}
+
+function emptyCoverage(): RowCoverage {
+  return {
+    input: { known: 0, missing: 0 },
+    output: { known: 0, missing: 0 },
+    reasoning: { known: 0, missing: 0 },
+    cacheRead: { known: 0, missing: 0 },
+    cacheCreate: { known: 0, missing: 0 },
+  };
+}
+
+function accumulateCoverage(target: RowCoverage, coverage: Coverage | undefined): void {
+  for (const f of COVERAGE_FIELDS) {
+    if (!coverage || coverage[COVERAGE_FLAG[f]]) target[f].known++;
+    else target[f].missing++;
+  }
+}
+
+const COVERAGE_FIELDS: ReadonlyArray<CoverageField> = [
+  'input',
+  'output',
+  'reasoning',
+  'cacheRead',
+  'cacheCreate',
+];
+
+const COVERAGE_FLAG: Record<CoverageField, keyof Coverage> = {
+  input: 'hasInputTokens',
+  output: 'hasOutputTokens',
+  reasoning: 'hasReasoningTokens',
+  cacheRead: 'hasCacheReadTokens',
+  cacheCreate: 'hasCacheCreateTokens',
+};
+
+function providerFromModelPrefix(model: string): string | undefined {
+  const i = model.indexOf('/');
+  if (i <= 0) return undefined;
+  return model.slice(0, i).toLowerCase();
+}
+
+function stripProviderPrefix(model: string): string {
+  const i = model.indexOf('/');
+  return i >= 0 ? model.slice(i + 1) : model;
+}
+
+function providerFromSource(source: SourceKind): string {
+  switch (source) {
+    case 'claude-code':
+    case 'anthropic-api':
+      return 'anthropic';
+    case 'codex':
+    case 'openai-api':
+      return 'openai';
+    case 'gemini-api':
+      return 'google';
+    case 'opencode':
+    default:
+      return source;
+  }
+}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Changed
+
+- Provider filters and `burn summary --by-provider` now use the shared analyze provider resolver.
+
 ## [0.42.0] - 2026-04-28
 
 ### Added

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -536,6 +536,22 @@ describe('burn summary per-cell fidelity (#136)', () => {
     );
   });
 
+  it('--by-provider combined with subagent modes exits non-zero with a clear error', async () => {
+    const byType = await captureSummary({ 'by-provider': true, 'by-subagent-type': true });
+    assert.equal(byType.code, 2);
+    assert.match(
+      byType.stderr,
+      /--by-provider cannot be combined with --by-subagent-type\/--subagent-tree/,
+    );
+
+    const tree = await captureSummary({ 'by-provider': true, 'subagent-tree': 's-1' });
+    assert.equal(tree.code, 2);
+    assert.match(
+      tree.stderr,
+      /--by-provider cannot be combined with --by-subagent-type\/--subagent-tree/,
+    );
+  });
+
   it('footer N sums per-field missing across rows (multi-model regression)', async () => {
     // Devin-review regression: with two model rows that each have some
     // turns missing output, the footer denominator should report the

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -1,4 +1,5 @@
 import {
+  aggregateByProvider,
   aggregateSubagentTypeStats,
   buildSubagentTree,
   computeQuality,
@@ -7,11 +8,14 @@ import {
 } from '@relayburn/analyze';
 import { costForTurn, sumCosts } from '@relayburn/analyze';
 import type {
-  CostBreakdown,
+  CoverageField,
+  FieldCoverage,
   FidelitySummary,
   OutcomeLabel,
   QualityResult,
+  RowCoverage,
   SubagentTreeNode,
+  UsageCostAggregateRow,
 } from '@relayburn/analyze';
 import {
   buildArchive,
@@ -29,7 +33,6 @@ import type { ParsedArgs } from '../args.js';
 import {
   filterTurnsByProvider,
   parseProviderFilter,
-  resolveTurnProvider,
 } from '../provider.js';
 
 export async function runSummary(args: ParsedArgs): Promise<number> {
@@ -60,6 +63,12 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
     );
     return 2;
   }
+  if (byProvider && (subagentTypeFlag || subagentTreeFlag !== undefined)) {
+    process.stderr.write(
+      'burn: --by-provider cannot be combined with --by-subagent-type/--subagent-tree\n',
+    );
+    return 2;
+  }
 
   const ingestReport = await ingestAll();
   const pricing = await loadPricing();
@@ -76,7 +85,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   }
 
   const rows = byProvider
-    ? aggregateByProvider(turns, pricing)
+    ? aggregateByProvider(turns, { pricing })
     : aggregateByModel(turns, pricing);
   const totalCost = sumCosts(rows.map((r) => r.cost));
   const fidelity = summarizeFidelity(turns);
@@ -261,20 +270,6 @@ function weightedOneShotRate(q: QualityResult): number | undefined {
 // `Coverage` flag was false). Records emitted before #41 (no `fidelity` at
 // all) are treated as best-effort full and counted as `known` — the same
 // backward-compat stance taken by `summarizeFidelity` / `hasMinimumFidelity`.
-interface FieldCoverage {
-  known: number;
-  missing: number;
-}
-
-type CoverageField =
-  | 'input'
-  | 'output'
-  | 'reasoning'
-  | 'cacheRead'
-  | 'cacheCreate';
-
-type RowCoverage = Record<CoverageField, FieldCoverage>;
-
 const COVERAGE_FIELDS: ReadonlyArray<CoverageField> = [
   'input',
   'output',
@@ -291,13 +286,7 @@ const COVERAGE_FLAG: Record<CoverageField, keyof Coverage> = {
   cacheCreate: 'hasCacheCreateTokens',
 };
 
-interface ModelRow {
-  label: string;
-  turns: number;
-  usage: EnrichedTurn['usage'];
-  cost: CostBreakdown;
-  coverage: RowCoverage;
-}
+type ModelRow = UsageCostAggregateRow;
 
 function renderSubagentTreeMode(
   args: ParsedArgs,
@@ -668,13 +657,6 @@ async function loadTurns(q: Query, args: ParsedArgs): Promise<EnrichedTurn[]> {
 
 function aggregateByModel(turns: EnrichedTurn[], pricing: Parameters<typeof costForTurn>[1]): ModelRow[] {
   return aggregateTurns(turns, pricing, (t) => t.model || 'unknown');
-}
-
-function aggregateByProvider(
-  turns: EnrichedTurn[],
-  pricing: Parameters<typeof costForTurn>[1],
-): ModelRow[] {
-  return aggregateTurns(turns, pricing, (t) => resolveTurnProvider(t).provider);
 }
 
 function aggregateTurns(

--- a/packages/cli/src/provider.ts
+++ b/packages/cli/src/provider.ts
@@ -1,44 +1,12 @@
-import { resolveProvider } from '@relayburn/analyze';
-import type { SourceKind, TurnRecord } from '@relayburn/reader';
+import {
+  filterTurnsByProvider as filterTurnsByProviderShared,
+  resolveTurnProvider,
+} from '@relayburn/analyze';
+import type { ProviderFilter, TurnProvider } from '@relayburn/analyze';
+import type { TurnRecord } from '@relayburn/reader';
 
-export interface TurnProvider {
-  provider: string;
-  rawModel: string;
-  normalizedModel: string;
-  matchedRule?: string;
-}
-
-export type ProviderFilter = Set<string>;
-
-export function resolveTurnProvider(
-  turn: Pick<TurnRecord, 'model' | 'source'>,
-): TurnProvider {
-  const resolved = resolveProvider(turn.model);
-  if (resolved.provider) {
-    const out: TurnProvider = {
-      provider: resolved.provider,
-      rawModel: turn.model,
-      normalizedModel: resolved.normalizedModel,
-    };
-    if (resolved.matchedRule) out.matchedRule = resolved.matchedRule;
-    return out;
-  }
-
-  const providerPrefix = providerFromModelPrefix(turn.model);
-  if (providerPrefix) {
-    return {
-      provider: providerPrefix,
-      rawModel: turn.model,
-      normalizedModel: stripProviderPrefix(turn.model),
-    };
-  }
-
-  return {
-    provider: providerFromSource(turn.source),
-    rawModel: turn.model,
-    normalizedModel: turn.model,
-  };
-}
+export { resolveTurnProvider };
+export type { ProviderFilter, TurnProvider };
 
 export function parseProviderFilter(
   flag: string | true | undefined,
@@ -57,33 +25,5 @@ export function filterTurnsByProvider<T extends Pick<TurnRecord, 'model' | 'sour
   turns: T[],
   filter: ProviderFilter | undefined,
 ): T[] {
-  if (!filter) return turns;
-  return turns.filter((t) => filter.has(resolveTurnProvider(t).provider.toLowerCase()));
-}
-
-function providerFromModelPrefix(model: string): string | undefined {
-  const i = model.indexOf('/');
-  if (i <= 0) return undefined;
-  return model.slice(0, i).toLowerCase();
-}
-
-function stripProviderPrefix(model: string): string {
-  const i = model.indexOf('/');
-  return i >= 0 ? model.slice(i + 1) : model;
-}
-
-function providerFromSource(source: SourceKind): string {
-  switch (source) {
-    case 'claude-code':
-    case 'anthropic-api':
-      return 'anthropic';
-    case 'codex':
-    case 'openai-api':
-      return 'openai';
-    case 'gemini-api':
-      return 'google';
-    case 'opencode':
-    default:
-      return source;
-  }
+  return filterTurnsByProviderShared(turns, filter);
 }


### PR DESCRIPTION
## Summary
- add shared effective-provider helpers and aggregateByProvider() in @relayburn/analyze
- route CLI provider filtering and summary --by-provider through the shared analyze resolver
- enforce summary --by-provider exclusivity with subagent summary modes

## Tests
- pnpm run test:ts

Closes #83
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
