### PR TITLE
Add OpenCode stream wakeups to watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Codex and OpenCode do not expose Claude-style hooks or a pre-spawn session ID. T
 For passive ingest without a wrapper, run:
 
 ```
-burn watch [--interval <ms>]
+burn watch [--interval <ms>] [--opencode-stream] [--opencode-url <url>]
 ```
 
-`burn watch` scans Claude, Codex, and OpenCode stores in the foreground and uses the same cursor + dedup path as the reporting commands. `burn watch --daemon` is reserved but not implemented yet.
+`burn watch` scans Claude, Codex, and OpenCode stores in the foreground and uses the same cursor + dedup path as the reporting commands. `--opencode-stream` also subscribes to OpenCode's local SSE endpoint (`http://127.0.0.1:4096/event` by default, or `OPENCODE_SERVER_URL`) and wakes the same ingest loop on session/message events; polling remains enabled as the fallback. If the server uses Basic auth, `OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD` are forwarded. `burn watch --daemon` is reserved but not implemented yet.
 
 ### Spawner env-var contract (workflow / agent attribution)
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Added
+
+- `burn watch --opencode-stream` can subscribe to OpenCode's local SSE endpoint and wake ingest immediately on session/message events while polling remains the fallback.
+
 ## [0.42.0] - 2026-04-28
 
 ### Added

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,7 +32,7 @@ Usage:
   burn context       [advise] [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]
   burn compare       <model_a,model_b[,...]> [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--json|--csv]
   burn run <${HARNESS_LIST}>  [--tag k=v ...] [-- <harness args>]
-  burn watch         [--interval <ms>] [--once]
+  burn watch         [--interval <ms>] [--once] [--opencode-stream] [--opencode-url <url>]
   burn ingest        --runtime claude [--quiet]     (reads hook payload on stdin)
   burn mcp-server    [--session-id <uuid>]          (stdio MCP server for in-session self-query)
   burn content prune [--days <n>] [--force]
@@ -63,6 +63,7 @@ Examples:
   burn run codex    --tag workflow=refactor
   burn run opencode --tag workflow=refactor
   burn watch
+  burn watch --opencode-stream
   burn content prune --days 30
   burn archive status
   burn archive build

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -1,15 +1,22 @@
 import type { ParsedArgs } from '../args.js';
 import { formatInt } from '../format.js';
 import { ingestAll, type IngestReport } from '../ingest.js';
+import { startOpencodeEventStream } from '../opencode-stream.js';
 
 const WATCH_HELP = `burn watch — foreground incremental ingest
 
 Usage:
-  burn watch [--interval <ms>] [--once]
+  burn watch [--interval <ms>] [--once] [--opencode-stream] [--opencode-url <url>]
   burn watch --daemon
 
 Continuously scans Claude Code, Codex, and OpenCode session stores and ingests
 new committed turns using the same cursor + dedup paths as summary/compare.
+
+--opencode-stream also subscribes to OpenCode's local SSE endpoint and wakes
+the same ingest loop on session/message events. Polling remains enabled as the
+fallback path. The default OpenCode URL is http://127.0.0.1:4096 or
+OPENCODE_SERVER_URL. OPENCODE_SERVER_USERNAME/PASSWORD are used for Basic auth
+when present.
 
 --daemon is not supported yet; run burn watch in the foreground.
 `;
@@ -34,6 +41,10 @@ export async function runWatch(args: ParsedArgs): Promise<number> {
   }
   if (args.flags['daemon'] === true) {
     process.stderr.write(`burn: watch --daemon is not supported yet; run burn watch in the foreground.\n`);
+    return 2;
+  }
+  if (typeof args.flags['opencode-stream'] === 'string') {
+    process.stderr.write(`burn: watch --opencode-stream does not take a value\n`);
     return 2;
   }
 
@@ -61,8 +72,27 @@ export async function runWatch(args: ParsedArgs): Promise<number> {
       process.stderr.write(`[burn] watch: ${msg}\n`);
     },
   });
+  const stream =
+    args.flags['opencode-stream'] === true
+      ? startOpencodeEventStream({
+          ...opencodeStreamFlags(args),
+          onOpen(url) {
+            process.stderr.write(`[burn] watch: OpenCode event stream ${url}\n`);
+          },
+          onIngestHint() {
+            void controller.tick();
+          },
+          onError(err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(
+              `[burn] watch: OpenCode event stream unavailable (${msg}); polling continues\n`,
+            );
+          },
+        })
+      : undefined;
 
   await waitForStopSignal();
+  if (stream) await stream.stop();
   await controller.stop();
   return 0;
 }
@@ -124,6 +154,18 @@ function parseIntervalMs(raw: string | true | undefined): number | null {
   const n = Number(raw);
   if (!Number.isInteger(n) || n <= 0) return null;
   return n;
+}
+
+function stringFlag(raw: string | true | undefined): string | undefined {
+  return typeof raw === 'string' ? raw : undefined;
+}
+
+function opencodeStreamFlags(args: ParsedArgs): { baseUrl?: string; global?: boolean } {
+  const out: { baseUrl?: string; global?: boolean } = {};
+  const baseUrl = stringFlag(args.flags['opencode-url']);
+  if (baseUrl !== undefined) out.baseUrl = baseUrl;
+  if (args.flags['opencode-global'] === true) out.global = true;
+  return out;
 }
 
 async function waitForStopSignal(): Promise<void> {

--- a/packages/cli/src/opencode-stream.test.ts
+++ b/packages/cli/src/opencode-stream.test.ts
@@ -1,0 +1,106 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  buildOpencodeEventHeaders,
+  consumeOpencodeEventStream,
+  isOpencodeIngestHint,
+  parseSseEvent,
+  resolveOpencodeEventUrl,
+  splitSseFrames,
+  type FetchResponseLike,
+} from './opencode-stream.js';
+
+describe('opencode event stream helpers', () => {
+  it('resolves default and explicit OpenCode event URLs', () => {
+    assert.equal(resolveOpencodeEventUrl(undefined, { env: {} }), 'http://127.0.0.1:4096/event');
+    assert.equal(
+      resolveOpencodeEventUrl(undefined, {
+        global: true,
+        env: { OPENCODE_SERVER_URL: 'http://localhost:5099' },
+      }),
+      'http://localhost:5099/global/event',
+    );
+    assert.equal(
+      resolveOpencodeEventUrl('http://localhost:4096/event', { env: {} }),
+      'http://localhost:4096/event',
+    );
+  });
+
+  it('builds Basic auth headers from OpenCode server env vars', () => {
+    const headers = buildOpencodeEventHeaders({
+      OPENCODE_SERVER_USERNAME: 'alice',
+      OPENCODE_SERVER_PASSWORD: 'secret',
+    });
+    assert.equal(headers['Accept'], 'text/event-stream');
+    assert.equal(headers['Authorization'], 'Basic YWxpY2U6c2VjcmV0');
+  });
+
+  it('parses SSE frames and multiline data fields', () => {
+    const split = splitSseFrames(
+      ': hello\nid: 7\nevent: message\ndata: { "a": 1,\ndata: "b": 2 }\n\npartial',
+    );
+    assert.equal(split.frames.length, 1);
+    assert.equal(split.rest, 'partial');
+    const event = parseSseEvent(split.frames[0]!);
+    assert.deepEqual(event, {
+      id: '7',
+      event: 'message',
+      data: '{ "a": 1,\n"b": 2 }',
+    });
+  });
+
+  it('recognizes project and global OpenCode events that should wake ingest', () => {
+    assert.equal(isOpencodeIngestHint({ type: 'server.connected', properties: {} }), false);
+    assert.equal(isOpencodeIngestHint({ type: 'message.part.updated', properties: {} }), true);
+    assert.equal(
+      isOpencodeIngestHint({
+        directory: '/tmp/project',
+        payload: { type: 'session.updated', properties: {} },
+      }),
+      true,
+    );
+  });
+
+  it('consumes an SSE stream and calls onIngestHint for session/message events', async () => {
+    let requestedUrl = '';
+    const wakeTypes: string[] = [];
+    const fetchImpl = async (url: string): Promise<FetchResponseLike> => {
+      requestedUrl = url;
+      return responseFromChunks([
+        'data: {"type":"server.connected","properties":{}}\n\n',
+        'data: {"type":"message.part.updated","properties":{"sessionID":"ses_1"}}\n\n',
+        'data: {"directory":"/tmp/project","payload":{"type":"session.updated","properties":{"sessionID":"ses_1"}}}\n\n',
+      ]);
+    };
+
+    const report = await consumeOpencodeEventStream({
+      baseUrl: 'http://localhost:4096',
+      fetchImpl,
+      env: {},
+      onIngestHint(payload) {
+        const rec = payload as { type?: string; payload?: { type?: string } };
+        wakeTypes.push(rec.type ?? rec.payload?.type ?? '');
+      },
+    });
+
+    assert.equal(requestedUrl, 'http://localhost:4096/event');
+    assert.deepEqual(report, { events: 3, wakeups: 2 });
+    assert.deepEqual(wakeTypes, ['message.part.updated', 'session.updated']);
+  });
+});
+
+function responseFromChunks(chunks: string[]): FetchResponseLike {
+  const encoder = new TextEncoder();
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    }),
+  };
+}

--- a/packages/cli/src/opencode-stream.ts
+++ b/packages/cli/src/opencode-stream.ts
@@ -1,0 +1,252 @@
+import { Buffer } from 'node:buffer';
+
+export interface SseEvent {
+  event?: string;
+  id?: string;
+  data: string;
+}
+
+export interface OpencodeEventStreamReport {
+  events: number;
+  wakeups: number;
+}
+
+export interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body: ReadableStream<Uint8Array> | null;
+}
+
+export type FetchLike = (
+  url: string,
+  init: { headers: Record<string, string>; signal?: AbortSignal },
+) => Promise<FetchResponseLike>;
+
+export interface ConsumeOpencodeEventStreamOptions {
+  baseUrl?: string;
+  global?: boolean;
+  fetchImpl?: FetchLike;
+  signal?: AbortSignal;
+  env?: NodeJS.ProcessEnv;
+  onEvent?: (event: SseEvent, payload: unknown) => void;
+  onIngestHint?: (payload: unknown) => void;
+}
+
+export interface OpencodeEventStreamController {
+  stop(): Promise<void>;
+}
+
+export interface StartOpencodeEventStreamOptions extends ConsumeOpencodeEventStreamOptions {
+  onError?: (err: unknown) => void;
+  onOpen?: (url: string) => void;
+}
+
+const DEFAULT_OPENCODE_BASE_URL = 'http://127.0.0.1:4096';
+
+export function resolveOpencodeEventUrl(
+  baseUrl: string | undefined,
+  opts: { global?: boolean; env?: NodeJS.ProcessEnv } = {},
+): string {
+  const env = opts.env ?? process.env;
+  const raw = baseUrl ?? env['OPENCODE_SERVER_URL'] ?? DEFAULT_OPENCODE_BASE_URL;
+  const url = new URL(raw);
+  if (url.pathname === '' || url.pathname === '/') {
+    url.pathname = opts.global === true ? '/global/event' : '/event';
+  }
+  return url.toString();
+}
+
+export function buildOpencodeEventHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const headers: Record<string, string> = { Accept: 'text/event-stream' };
+  const password = env['OPENCODE_SERVER_PASSWORD'];
+  if (password !== undefined && password.length > 0) {
+    const username = env['OPENCODE_SERVER_USERNAME'] || 'opencode';
+    const token = Buffer.from(`${username}:${password}`, 'utf8').toString('base64');
+    headers['Authorization'] = `Basic ${token}`;
+  }
+  return headers;
+}
+
+export function splitSseFrames(buffer: string): { frames: string[]; rest: string } {
+  const frames: string[] = [];
+  const re = /\r?\n\r?\n/g;
+  let start = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(buffer)) !== null) {
+    frames.push(buffer.slice(start, match.index));
+    start = match.index + match[0].length;
+  }
+  return { frames, rest: buffer.slice(start) };
+}
+
+export function parseSseEvent(block: string): SseEvent | null {
+  let event: string | undefined;
+  let id: string | undefined;
+  const data: string[] = [];
+
+  for (const rawLine of block.split(/\r?\n/)) {
+    if (rawLine.length === 0 || rawLine.startsWith(':')) continue;
+    const colon = rawLine.indexOf(':');
+    const field = colon >= 0 ? rawLine.slice(0, colon) : rawLine;
+    let value = colon >= 0 ? rawLine.slice(colon + 1) : '';
+    if (value.startsWith(' ')) value = value.slice(1);
+    if (field === 'event') event = value;
+    else if (field === 'id') id = value;
+    else if (field === 'data') data.push(value);
+  }
+
+  if (data.length === 0) return null;
+  const parsed: SseEvent = { data: data.join('\n') };
+  if (event !== undefined) parsed.event = event;
+  if (id !== undefined) parsed.id = id;
+  return parsed;
+}
+
+export function isOpencodeIngestHint(payload: unknown): boolean {
+  const type = opencodeEventType(payload);
+  if (type === undefined) return false;
+  return (
+    type === 'message.updated' ||
+    type === 'message.part.updated' ||
+    type === 'message.part.removed' ||
+    type === 'session.created' ||
+    type === 'session.updated' ||
+    type === 'session.deleted' ||
+    type === 'session.idle' ||
+    type === 'session.compacted' ||
+    type === 'session.status' ||
+    type === 'message.updated.1' ||
+    type === 'message.part.updated.1' ||
+    type === 'message.part.removed.1' ||
+    type === 'session.created.1' ||
+    type === 'session.updated.1' ||
+    type === 'session.deleted.1'
+  );
+}
+
+export async function consumeOpencodeEventStream(
+  opts: ConsumeOpencodeEventStreamOptions,
+): Promise<OpencodeEventStreamReport> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const env = opts.env ?? process.env;
+  const url = resolveOpencodeEventUrl(opts.baseUrl, resolveUrlOptions(opts.global, env));
+  const response = await fetchImpl(url, {
+    headers: buildOpencodeEventHeaders(env),
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `OpenCode event stream ${url} returned HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  if (response.body === null) {
+    throw new Error(`OpenCode event stream ${url} returned no response body`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let events = 0;
+  let wakeups = 0;
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const split = splitSseFrames(buffer);
+    buffer = split.rest;
+    for (const frame of split.frames) {
+      const parsed = parseSseEvent(frame);
+      if (!parsed) continue;
+      const payload = parseEventPayload(parsed.data);
+      events++;
+      opts.onEvent?.(parsed, payload);
+      if (isOpencodeIngestHint(payload)) {
+        wakeups++;
+        opts.onIngestHint?.(payload);
+      }
+    }
+  }
+
+  buffer += decoder.decode();
+  const trailing = buffer.trim().length > 0 ? parseSseEvent(buffer) : null;
+  if (trailing) {
+    const payload = parseEventPayload(trailing.data);
+    events++;
+    opts.onEvent?.(trailing, payload);
+    if (isOpencodeIngestHint(payload)) {
+      wakeups++;
+      opts.onIngestHint?.(payload);
+    }
+  }
+
+  return { events, wakeups };
+}
+
+export function startOpencodeEventStream(
+  opts: StartOpencodeEventStreamOptions,
+): OpencodeEventStreamController {
+  const controller = new AbortController();
+  let stopped = false;
+  const url = resolveOpencodeEventUrl(
+    opts.baseUrl,
+    resolveUrlOptions(opts.global, opts.env),
+  );
+  opts.onOpen?.(url);
+  const done = consumeOpencodeEventStream({
+    ...opts,
+    baseUrl: url,
+    signal: controller.signal,
+  })
+    .then(() => {
+      if (!stopped) opts.onError?.(new Error('connection closed'));
+    })
+    .catch((err: unknown) => {
+      if (isAbortError(err)) return;
+      opts.onError?.(err);
+    });
+
+  return {
+    async stop() {
+      stopped = true;
+      controller.abort();
+      await done;
+    },
+  };
+}
+
+function parseEventPayload(data: string): unknown {
+  try {
+    return JSON.parse(data) as unknown;
+  } catch {
+    return data;
+  }
+}
+
+function resolveUrlOptions(
+  global: boolean | undefined,
+  env: NodeJS.ProcessEnv | undefined,
+): { global?: boolean; env?: NodeJS.ProcessEnv } {
+  const out: { global?: boolean; env?: NodeJS.ProcessEnv } = {};
+  if (global !== undefined) out.global = global;
+  if (env !== undefined) out.env = env;
+  return out;
+}
+
+function opencodeEventType(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const rec = payload as { type?: unknown; payload?: unknown };
+  if (typeof rec.type === 'string') return rec.type;
+  if (rec.payload && typeof rec.payload === 'object') {
+    const nested = rec.payload as { type?: unknown };
+    if (typeof nested.type === 'string') return nested.type;
+  }
+  return undefined;
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}


### PR DESCRIPTION
## Summary
- add an OpenCode SSE consumer for /event and /global/event frames
- wire `burn watch --opencode-stream` to wake the existing ingest loop on OpenCode session/message events while polling remains the fallback
- document the flag, OPENCODE_SERVER_URL, and Basic auth env forwarding

This is the narrow live-stream part of #92; it does not replace the file-grain reader or consume tool-result chronology directly.

## Tests
- `pnpm run build`
- `pnpm run test`
- `node --test --test-reporter=spec packages/cli/dist/opencode-stream.test.js packages/cli/dist/commands/watch.test.js`

Refs #92
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
