### PR TITLE
Add Claude hook event emitters

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `@relayburn/cli`.
 
 ### Added
 
+- `burn ingest --runtime claude` now records hook-path tool-result events for Claude `PreToolUse`, `PostToolUse`, `SubagentStop`, and tool-tied `Notification` payloads.
 - `burn watch --opencode-stream` can subscribe to OpenCode's local SSE endpoint and wake ingest immediately on session/message events while polling remains the fallback.
 
 ### Changed

--- a/packages/cli/src/commands/ingest.test.ts
+++ b/packages/cli/src/commands/ingest.test.ts
@@ -5,13 +5,160 @@ import * as path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import {
+  __resetIndexCacheForTesting,
   ledgerPath,
   loadCursors,
+  queryRelationships,
+  queryToolResultEvents,
   queryUserTurns,
   readContent,
 } from '@relayburn/ledger';
 
 import { ingestClaudeHookPayload } from './ingest.js';
+
+function toolTranscript(
+  sessionId: string,
+  cwd: string,
+  toolUseId: string,
+  content: string,
+  isError = false,
+): string {
+  return [
+    JSON.stringify({
+      parentUuid: null,
+      isSidechain: false,
+      type: 'user',
+      message: { role: 'user', content: 'run the tool' },
+      uuid: `${toolUseId}-user-1`,
+      timestamp: '2026-04-22T00:00:00.000Z',
+      cwd,
+      sessionId,
+    }),
+    JSON.stringify({
+      parentUuid: `${toolUseId}-user-1`,
+      isSidechain: false,
+      type: 'assistant',
+      message: {
+        model: 'claude-sonnet-4-6',
+        id: `${toolUseId}-msg-1`,
+        type: 'message',
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: toolUseId, name: 'Bash', input: { command: 'npm test' } },
+        ],
+        stop_reason: 'tool_use',
+        usage: {
+          input_tokens: 3,
+          output_tokens: 5,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+        },
+      },
+      uuid: `${toolUseId}-asst-1`,
+      timestamp: '2026-04-22T00:00:01.000Z',
+      cwd,
+      sessionId,
+    }),
+    JSON.stringify({
+      parentUuid: `${toolUseId}-asst-1`,
+      isSidechain: false,
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: toolUseId, content, is_error: isError },
+        ],
+      },
+      uuid: `${toolUseId}-user-2`,
+      timestamp: '2026-04-22T00:00:02.000Z',
+      cwd,
+      sessionId,
+    }),
+    '',
+  ].join('\n');
+}
+
+function multiToolTranscript(
+  sessionId: string,
+  cwd: string,
+  tools: Array<{ toolUseId: string; content: string; isError?: boolean }>,
+): string {
+  const lines: string[] = [
+    JSON.stringify({
+      parentUuid: null,
+      isSidechain: false,
+      type: 'user',
+      message: { role: 'user', content: 'run the tools' },
+      uuid: 'multi-user-0',
+      timestamp: '2026-04-22T00:00:00.000Z',
+      cwd,
+      sessionId,
+    }),
+  ];
+  let parentUuid = 'multi-user-0';
+  tools.forEach((tool, idx) => {
+    const assistantUuid = `multi-asst-${idx}`;
+    lines.push(
+      JSON.stringify({
+        parentUuid,
+        isSidechain: false,
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-4-6',
+          id: `multi-msg-${idx}`,
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: tool.toolUseId,
+              name: 'Bash',
+              input: { command: `echo ${idx}` },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: {
+            input_tokens: 3,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+          },
+        },
+        uuid: assistantUuid,
+        timestamp: `2026-04-22T00:00:0${idx + 1}.000Z`,
+        cwd,
+        sessionId,
+      }),
+    );
+    parentUuid = `multi-user-${idx + 1}`;
+    lines.push(
+      JSON.stringify({
+        parentUuid: assistantUuid,
+        isSidechain: false,
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: tool.toolUseId,
+              content: tool.content,
+              is_error: tool.isError === true,
+            },
+          ],
+        },
+        uuid: parentUuid,
+        timestamp: `2026-04-22T00:00:0${idx + 2}.000Z`,
+        cwd,
+        sessionId,
+      }),
+    );
+  });
+  lines.push('');
+  return lines.join('\n');
+}
 
 describe('burn ingest (hook-driven)', () => {
   let tmpRelay: string;
@@ -24,6 +171,7 @@ describe('burn ingest (hook-driven)', () => {
     tmpTranscriptDir = await mkdtemp(path.join(tmpdir(), 'burn-ingest-tx-'));
     process.env['RELAYBURN_HOME'] = tmpRelay;
     delete process.env['RELAYBURN_CONTENT_STORE'];
+    __resetIndexCacheForTesting();
   });
 
   after(async () => {
@@ -126,6 +274,138 @@ describe('burn ingest (hook-driven)', () => {
     assert.ok(toolResultUserTurn, 'tool_result user-turn block is persisted');
     assert.equal(toolResultUserTurn!.precedingMessageId, 'msg-1');
     assert.equal(toolResultUserTurn!.blocks[0]!.approxTokens, Math.ceil(toolResponseText.length / 4));
+  });
+
+  it('emits PreToolUse and PostToolUse events before multi-tool reader replay dedupes', async () => {
+    const sessionId = 'hook-prepost-session';
+    const transcriptPath = path.join(tmpTranscriptDir, `${sessionId}.jsonl`);
+    const tools = [
+      { toolUseId: 'toolu_hook_pair_a', content: 'first passed\n' },
+      { toolUseId: 'toolu_hook_pair_b', content: 'second passed\n' },
+    ];
+    await writeFile(transcriptPath, '', 'utf8');
+
+    for (const tool of tools) {
+      await ingestClaudeHookPayload(
+        JSON.stringify({
+          session_id: sessionId,
+          transcript_path: transcriptPath,
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_use_id: tool.toolUseId,
+          tool_input: { command: 'npm test' },
+        }),
+        { quiet: true },
+      );
+    }
+    for (const tool of tools) {
+      await ingestClaudeHookPayload(
+        JSON.stringify({
+          session_id: sessionId,
+          transcript_path: transcriptPath,
+          hook_event_name: 'PostToolUse',
+          tool_name: 'Bash',
+          tool_use_id: tool.toolUseId,
+          tool_response: tool.content,
+        }),
+        { quiet: true },
+      );
+    }
+    await writeFile(
+      transcriptPath,
+      multiToolTranscript(sessionId, tmpTranscriptDir, tools),
+      'utf8',
+    );
+    await ingestClaudeHookPayload(
+      JSON.stringify({
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        hook_event_name: 'SessionEnd',
+      }),
+      { quiet: true },
+    );
+
+    const events = await queryToolResultEvents({ sessionId });
+    assert.equal(events.length, 4, 'reader replay should not add duplicate terminal events');
+    assert.deepEqual(events.map((e) => e.eventIndex), [0, 1, 2, 3]);
+    for (const tool of tools) {
+      const running = events.find(
+        (e) => e.toolUseId === tool.toolUseId && e.status === 'running',
+      );
+      const completed = events.find(
+        (e) => e.toolUseId === tool.toolUseId && e.status === 'completed',
+      );
+      assert.ok(running, 'PreToolUse emits a running event');
+      assert.ok(completed, 'PostToolUse emits the terminal event');
+      assert.equal(running!.eventSource, 'tool_result');
+      assert.equal(running!.callIndex, 0);
+      assert.equal(completed!.eventSource, 'tool_result');
+      assert.equal(completed!.callIndex, 1);
+      assert.equal(completed!.contentLength, tool.content.length);
+      assert.equal(typeof completed!.contentHash, 'string');
+    }
+  });
+
+  it('marks PostToolUse hook responses with is_error as errored events', async () => {
+    const sessionId = 'hook-post-error-session';
+    const transcriptPath = path.join(tmpTranscriptDir, `${sessionId}.jsonl`);
+    await writeFile(transcriptPath, '', 'utf8');
+
+    await ingestClaudeHookPayload(
+      JSON.stringify({
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_use_id: 'toolu_hook_error',
+        tool_response: { is_error: true, stderr: 'boom' },
+      }),
+      { quiet: true },
+    );
+
+    const events = await queryToolResultEvents({ sessionId });
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.status, 'errored');
+    assert.equal(events[0]!.isError, true);
+    assert.equal(events[0]!.callIndex, 0);
+    assert.equal(events[0]!.eventIndex, 0);
+    assert.equal(typeof events[0]!.contentHash, 'string');
+  });
+
+  it('emits SubagentStop notifications and subagent relationships', async () => {
+    const sessionId = 'hook-subagent-session';
+    const transcriptPath = path.join(tmpTranscriptDir, `${sessionId}.jsonl`);
+    await writeFile(transcriptPath, '', 'utf8');
+
+    await ingestClaudeHookPayload(
+      JSON.stringify({
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        hook_event_name: 'SubagentStop',
+        tool_use_id: 'toolu_agent_spawn',
+        agent_id: 'agent-123',
+        agent_type: 'Explore',
+        last_assistant_message: 'done',
+      }),
+      { quiet: true },
+    );
+
+    const events = await queryToolResultEvents({ sessionId });
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.eventSource, 'subagent_notification');
+    assert.equal(events[0]!.status, 'completed');
+    assert.equal(events[0]!.toolUseId, 'toolu_agent_spawn');
+    assert.equal(events[0]!.agentId, 'agent-123');
+    assert.equal(events[0]!.contentLength, 'done'.length);
+
+    const relationships = await queryRelationships({ sessionId });
+    assert.equal(relationships.length, 1);
+    assert.equal(relationships[0]!.relationshipType, 'subagent');
+    assert.equal(relationships[0]!.sessionId, sessionId);
+    assert.equal(relationships[0]!.relatedSessionId, sessionId);
+    assert.equal(relationships[0]!.agentId, 'agent-123');
+    assert.equal(relationships[0]!.parentToolUseId, 'toolu_agent_spawn');
+    assert.equal(relationships[0]!.subagentType, 'Explore');
   });
 
   it('is idempotent across repeat hook invocations on the same transcript', async () => {

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -1,6 +1,13 @@
+import { createHash } from 'node:crypto';
 import { stat } from 'node:fs/promises';
 
 import { parseClaudeSessionIncremental } from '@relayburn/reader';
+import type {
+  SessionRelationshipRecord,
+  ToolResultEventRecord,
+  ToolResultEventSource,
+  ToolResultStatus,
+} from '@relayburn/reader';
 import {
   appendCompactions,
   appendContent,
@@ -10,7 +17,9 @@ import {
   appendUserTurns,
   loadConfig,
   loadCursors,
+  queryToolResultEvents,
   saveCursors,
+  withLock,
 } from '@relayburn/ledger';
 import type { ClaudeCursor } from '@relayburn/ledger';
 
@@ -27,10 +36,27 @@ transcript it references. Safe to call from every Claude Code hook
 ledger's cursor + dedup index keep re-invocations idempotent.
 `;
 
-interface ClaudeHookPayload {
+interface ClaudeHookPayload extends Record<string, unknown> {
   session_id?: string;
   transcript_path?: string;
   hook_event_name?: string;
+  tool_use_id?: string;
+  tool_response?: unknown;
+  message?: string;
+  agent_id?: string;
+  agent_type?: string;
+  last_assistant_message?: string;
+}
+
+interface HookEventDraft {
+  toolUseId: string;
+  status: ToolResultStatus;
+  eventSource: ToolResultEventSource;
+  contentLength?: number;
+  contentHash?: string;
+  isError?: boolean;
+  agentId?: string;
+  subagentSessionId?: string;
 }
 
 export async function runIngest(args: ParsedArgs): Promise<number> {
@@ -80,6 +106,14 @@ export async function ingestClaudeHookPayload(
     return 0;
   }
   try {
+    await ingestClaudeHookRecords(payload);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Never propagate failure back to Claude Code — a non-zero exit from a
+    // hook command can block the tool call. Log and move on.
+    process.stderr.write(`[burn] ingest: ${msg}\n`);
+  }
+  try {
     await ingestClaudeTranscript(transcriptPath, opts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -88,6 +122,338 @@ export async function ingestClaudeHookPayload(
     process.stderr.write(`[burn] ingest: ${msg}\n`);
   }
   return 0;
+}
+
+async function ingestClaudeHookRecords(payload: ClaudeHookPayload): Promise<void> {
+  const sessionId = stringField(payload, 'session_id');
+  if (!sessionId) return;
+
+  const drafts = buildClaudeHookEventDrafts(payload);
+  const relationships = buildClaudeHookRelationships(payload);
+  if (drafts.length === 0 && relationships.length === 0) return;
+
+  await withLock('ledger', async () => {
+    if (relationships.length > 0) await appendRelationships(relationships);
+    if (drafts.length === 0) return;
+
+    const existing = await queryToolResultEvents({ sessionId, source: 'claude-code' });
+    const records: ToolResultEventRecord[] = [];
+    const visible = [...existing];
+    for (const draft of drafts) {
+      const record = allocateHookEvent(sessionId, draft, visible);
+      if (!record) continue;
+      records.push(record);
+      visible.push(record);
+    }
+    if (records.length > 0) await appendToolResultEvents(records);
+  });
+}
+
+function buildClaudeHookEventDrafts(payload: ClaudeHookPayload): HookEventDraft[] {
+  switch (payload.hook_event_name) {
+    case 'PreToolUse':
+      return buildPreToolUseDraft(payload);
+    case 'PostToolUse':
+      return buildPostToolUseDraft(payload);
+    case 'SubagentStop':
+      return buildSubagentStopDraft(payload);
+    case 'Notification':
+      return buildNotificationDraft(payload);
+    default:
+      return [];
+  }
+}
+
+function buildPreToolUseDraft(payload: ClaudeHookPayload): HookEventDraft[] {
+  const toolUseId = extractToolUseId(payload);
+  if (!toolUseId) return [];
+  return [
+    {
+      toolUseId,
+      status: 'running',
+      eventSource: 'tool_result',
+    },
+  ];
+}
+
+function buildPostToolUseDraft(payload: ClaudeHookPayload): HookEventDraft[] {
+  const toolUseId = extractToolUseId(payload);
+  if (!toolUseId) return [];
+  const isError = toolResponseIsError(payload.tool_response);
+  const draft: HookEventDraft = {
+    toolUseId,
+    status: isError ? 'errored' : 'completed',
+    eventSource: 'tool_result',
+  };
+  if (isError) draft.isError = true;
+  const measured = measureHookContent(payload.tool_response);
+  if (measured.length !== undefined) draft.contentLength = measured.length;
+  if (measured.hash !== undefined) draft.contentHash = measured.hash;
+  return [draft];
+}
+
+function buildSubagentStopDraft(payload: ClaudeHookPayload): HookEventDraft[] {
+  const agentId = stringField(payload, 'agent_id');
+  const toolUseId = extractParentToolUseId(payload) ?? agentId;
+  if (!toolUseId) return [];
+  const status = deriveTerminalHookStatus(payload);
+  const draft: HookEventDraft = {
+    toolUseId,
+    status,
+    eventSource: 'subagent_notification',
+  };
+  if (status === 'errored') draft.isError = true;
+  if (agentId !== undefined) draft.agentId = agentId;
+  const measured = measureHookContent(payload.last_assistant_message);
+  if (measured.length !== undefined) draft.contentLength = measured.length;
+  if (measured.hash !== undefined) draft.contentHash = measured.hash;
+  return [draft];
+}
+
+function buildNotificationDraft(payload: ClaudeHookPayload): HookEventDraft[] {
+  const toolUseId = extractToolUseId(payload);
+  if (!toolUseId) return [];
+  const draft: HookEventDraft = {
+    toolUseId,
+    status: 'unknown',
+    eventSource: 'progress_event',
+  };
+  const measured = measureHookContent(payload.message);
+  if (measured.length !== undefined) draft.contentLength = measured.length;
+  if (measured.hash !== undefined) draft.contentHash = measured.hash;
+  return [draft];
+}
+
+function buildClaudeHookRelationships(
+  payload: ClaudeHookPayload,
+): SessionRelationshipRecord[] {
+  if (payload.hook_event_name !== 'SubagentStop') return [];
+  const sessionId = stringField(payload, 'session_id');
+  const agentId = stringField(payload, 'agent_id');
+  if (!sessionId || !agentId) return [];
+  const row: SessionRelationshipRecord = {
+    v: 1,
+    source: 'claude-code',
+    sessionId,
+    relationshipType: 'subagent',
+    relatedSessionId: stringField(payload, 'parent_agent_id') ?? sessionId,
+    agentId,
+  };
+  const parentToolUseId = extractParentToolUseId(payload);
+  if (parentToolUseId !== undefined) row.parentToolUseId = parentToolUseId;
+  const subagentType = stringField(payload, 'agent_type');
+  if (subagentType !== undefined) row.subagentType = subagentType;
+  return [row];
+}
+
+function allocateHookEvent(
+  sessionId: string,
+  draft: HookEventDraft,
+  existing: readonly ToolResultEventRecord[],
+): ToolResultEventRecord | undefined {
+  if (findMatchingHookEvent(draft, existing)) return undefined;
+
+  const callIndex = nextCallIndex(draft.toolUseId, existing);
+  const eventIndex = nextEventIndex(existing);
+  const record: ToolResultEventRecord = {
+    v: 1,
+    source: 'claude-code',
+    sessionId,
+    toolUseId: draft.toolUseId,
+    callIndex,
+    eventIndex,
+    status: draft.status,
+    eventSource: draft.eventSource,
+  };
+  if (draft.contentLength !== undefined) record.contentLength = draft.contentLength;
+  if (draft.contentHash !== undefined) record.contentHash = draft.contentHash;
+  if (draft.isError !== undefined) record.isError = draft.isError;
+  if (draft.agentId !== undefined) record.agentId = draft.agentId;
+  if (draft.subagentSessionId !== undefined) record.subagentSessionId = draft.subagentSessionId;
+  return record;
+}
+
+function findMatchingHookEvent(
+  draft: HookEventDraft,
+  existing: readonly ToolResultEventRecord[],
+): ToolResultEventRecord | undefined {
+  return existing.find((record) => {
+    if (record.toolUseId !== draft.toolUseId) return false;
+    if (record.eventSource !== draft.eventSource) return false;
+    if (record.status !== draft.status) return false;
+    if (draft.agentId !== undefined && record.agentId !== draft.agentId) return false;
+    if (draft.eventSource === 'progress_event' && draft.contentHash !== undefined) {
+      return record.contentHash === draft.contentHash;
+    }
+    return true;
+  });
+}
+
+function nextCallIndex(
+  toolUseId: string,
+  existing: readonly ToolResultEventRecord[],
+): number {
+  let max = -1;
+  for (const record of existing) {
+    if (record.toolUseId !== toolUseId) continue;
+    if (typeof record.callIndex !== 'number') continue;
+    if (record.callIndex > max) max = record.callIndex;
+  }
+  return max + 1;
+}
+
+function nextEventIndex(existing: readonly ToolResultEventRecord[]): number {
+  let max = -1;
+  for (const record of existing) {
+    if (record.eventIndex > max) max = record.eventIndex;
+  }
+  return max + 1;
+}
+
+async function appendReconciledToolResultEvents(
+  records: ToolResultEventRecord[],
+): Promise<void> {
+  if (records.length === 0) return;
+
+  await withLock('ledger', async () => {
+    const visibleBySession = new Map<string, ToolResultEventRecord[]>();
+    const reconciled: ToolResultEventRecord[] = [];
+
+    for (const record of records) {
+      let visible = visibleBySession.get(record.sessionId);
+      if (!visible) {
+        visible = await queryToolResultEvents({
+          sessionId: record.sessionId,
+          source: record.source,
+        });
+        visibleBySession.set(record.sessionId, visible);
+      }
+
+      if (hasTerminalToolResultEvent(record, visible)) continue;
+
+      const nextRecord =
+        visible.length === 0 ? record : reindexToolResultEvent(record, visible);
+      reconciled.push(nextRecord);
+      visible.push(nextRecord);
+    }
+
+    if (reconciled.length > 0) await appendToolResultEvents(reconciled);
+  });
+}
+
+function reindexToolResultEvent(
+  record: ToolResultEventRecord,
+  visible: readonly ToolResultEventRecord[],
+): ToolResultEventRecord {
+  return {
+    ...record,
+    callIndex: nextCallIndex(record.toolUseId, visible),
+    eventIndex: nextEventIndex(visible),
+  };
+}
+
+function hasTerminalToolResultEvent(
+  record: ToolResultEventRecord,
+  visible: readonly ToolResultEventRecord[],
+): boolean {
+  if (record.eventSource !== 'tool_result') return false;
+  if (!isTerminalToolResultStatus(record.status)) return false;
+  return visible.some(
+    (prior) =>
+      prior.toolUseId === record.toolUseId &&
+      prior.eventSource === 'tool_result' &&
+      isTerminalToolResultStatus(prior.status),
+  );
+}
+
+function isTerminalToolResultStatus(status: ToolResultStatus): boolean {
+  return status === 'completed' || status === 'errored' || status === 'cancelled';
+}
+
+function extractToolUseId(payload: ClaudeHookPayload): string | undefined {
+  return (
+    stringField(payload, 'tool_use_id') ??
+    stringField(payload, 'toolUseId') ??
+    stringField(payload, 'parent_tool_use_id') ??
+    stringField(payload, 'parentToolUseId')
+  );
+}
+
+function extractParentToolUseId(payload: ClaudeHookPayload): string | undefined {
+  return (
+    stringField(payload, 'parent_tool_use_id') ??
+    stringField(payload, 'parentToolUseId') ??
+    stringField(payload, 'tool_use_id') ??
+    stringField(payload, 'toolUseId') ??
+    stringField(payload, 'agent_tool_use_id') ??
+    stringField(payload, 'task_tool_use_id')
+  );
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function boolField(record: Record<string, unknown>, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function toolResponseIsError(response: unknown): boolean {
+  if (!response || typeof response !== 'object') return false;
+  const rec = response as Record<string, unknown>;
+  return (
+    boolField(rec, 'is_error') === true ||
+    boolField(rec, 'isError') === true ||
+    boolField(rec, 'success') === false
+  );
+}
+
+function deriveTerminalHookStatus(payload: ClaudeHookPayload): ToolResultStatus {
+  const explicit = stringField(payload, 'status');
+  if (explicit === 'completed' || explicit === 'errored' || explicit === 'cancelled') {
+    return explicit;
+  }
+  if (explicit === 'error' || explicit === 'failed' || explicit === 'failure') return 'errored';
+  if (explicit === 'canceled') return 'cancelled';
+  if (
+    boolField(payload, 'is_error') === true ||
+    boolField(payload, 'isError') === true ||
+    stringField(payload, 'error') !== undefined ||
+    stringField(payload, 'error_message') !== undefined
+  ) {
+    return 'errored';
+  }
+  if (
+    boolField(payload, 'cancelled') === true ||
+    boolField(payload, 'canceled') === true ||
+    boolField(payload, 'interrupted') === true
+  ) {
+    return 'cancelled';
+  }
+  return 'completed';
+}
+
+function measureHookContent(content: unknown): { length?: number; hash?: string } {
+  if (typeof content === 'string') {
+    return { length: content.length, hash: contentHash(content) };
+  }
+  if (content === undefined || content === null) return {};
+  try {
+    const serialized = JSON.stringify(content);
+    if (typeof serialized !== 'string') return {};
+    return { length: serialized.length, hash: contentHash(serialized) };
+  } catch {
+    return {};
+  }
+}
+
+function contentHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
 }
 
 async function ingestClaudeTranscript(
@@ -143,7 +509,7 @@ async function ingestClaudeTranscript(
   if (content.length > 0) await appendContent(content);
   if (events.length > 0) await appendCompactions(events);
   if (relationships.length > 0) await appendRelationships(relationships);
-  if (toolResultEvents.length > 0) await appendToolResultEvents(toolResultEvents);
+  if (toolResultEvents.length > 0) await appendReconciledToolResultEvents(toolResultEvents);
   if (userTurns.length > 0) await appendUserTurns(userTurns);
 
   const next: ClaudeCursor = {

--- a/packages/ledger/src/lock.test.ts
+++ b/packages/ledger/src/lock.test.ts
@@ -98,6 +98,20 @@ describe('withLock', () => {
     assert.equal(log.filter((l) => l.startsWith('exit')).length, 2);
   });
 
+  it('allows nested acquisition in the same async flow', async () => {
+    let innerRan = false;
+    await withLock('nested', async () => {
+      await assert.doesNotReject(() => stat(lockPath('nested')));
+      await withLock('nested', async () => {
+        innerRan = true;
+        await assert.doesNotReject(() => stat(lockPath('nested')));
+      });
+      await assert.doesNotReject(() => stat(lockPath('nested')));
+    });
+    assert.equal(innerRan, true);
+    await assert.rejects(() => stat(lockPath('nested')), { code: 'ENOENT' });
+  });
+
   it('exposes a retry budget that spans STALE_MS plus at least one retry cycle', async () => {
     // Static invariant: future tuning of the constants must not re-introduce
     // the #62 gap where the retry budget was shorter than the stale-detection

--- a/packages/ledger/src/lock.ts
+++ b/packages/ledger/src/lock.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { open, stat, unlink, mkdir } from 'node:fs/promises';
 import * as path from 'node:path';
 
@@ -52,12 +53,19 @@ const DEFAULT_OPTIONS: AcquireOptions = {
   staleMs: STALE_MS,
 };
 
+const heldLocks = new AsyncLocalStorage<Set<string>>();
+
 export async function withLock<T>(name: string, fn: () => Promise<T>): Promise<T> {
   const lp = lockPath(name);
+  const held = heldLocks.getStore();
+  if (held?.has(lp)) return fn();
+
   await mkdir(path.dirname(lp), { recursive: true });
   await acquire(lp, DEFAULT_OPTIONS);
+  const nextHeld = new Set(held ?? []);
+  nextHeld.add(lp);
   try {
-    return await fn();
+    return await heldLocks.run(nextHeld, fn);
   } finally {
     try {
       await unlink(lp);


### PR DESCRIPTION
## Summary
- emit Claude hook-path ToolResultEventRecords for PreToolUse, PostToolUse, SubagentStop, and tool-tied Notification payloads
- persist SubagentStop relationship metadata when hook payloads carry agent/tool identifiers
- keep hook-emitted events deduped against the reader replay path

## Tests
- pnpm run build
- node --test --test-reporter=spec packages/cli/dist/commands/ingest.test.js
- pnpm run test

Closes #99
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
