### PR TITLE
Fix user-turn sized tool attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 ### Changed
 
 - Provider-aware CLI rendering now uses shared analyze helpers for effective-provider resolution and aggregation.
+- Per-tool cost attribution now uses persisted user-turn block sizes in summary and waste reports, with rebuild backfill for historical sessions.
 
 ## [0.42.0] - 2026-04-28
 

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `@relayburn/analyze`.
 
 - Added shared effective-provider helpers and `aggregateByProvider()` for provider-scoped rendering.
 
+### Changed
+
+- Waste attribution now prefers persisted user-turn block sizes over content sidecar estimates before falling back to even-split attribution.
+
 ## [0.42.0] - 2026-04-28
 
 ### Added

--- a/packages/analyze/src/waste.test.ts
+++ b/packages/analyze/src/waste.test.ts
@@ -308,7 +308,7 @@ describe('attributeWaste', () => {
 
     const result = attributeWaste(turns, { pricing, userTurnsBySession });
     const byId = new Map(result.attributions.map((a) => [a.toolUseId, a]));
-    assert.equal(result.sessionTotals[0]!.attributionMethod, 'user-turn');
+    assert.equal(result.sessionTotals[0]!.attributionMethod, 'sized');
     assert.equal(byId.get('tu_big')!.initialTokens, 3000);
     assert.equal(byId.get('tu_small')!.initialTokens, 1000);
     assert.equal(byId.get('tu_big')!.persistenceTokens, 3000);
@@ -316,7 +316,7 @@ describe('attributeWaste', () => {
     assert.ok(byId.get('tu_big')!.totalCost > byId.get('tu_small')!.totalCost);
   });
 
-  it('keeps content sidecar sizes primary over user-turn fallback sizes', async () => {
+  it('prefers user-turn block sizes over content sidecar estimates', async () => {
     const pricing = await loadBuiltinPricing();
     const sessionId = 's-sidecar-primary';
     const turns: TurnRecord[] = [
@@ -330,7 +330,7 @@ describe('attributeWaste', () => {
         sessionId,
         messageId: 'msg-1',
         turnIndex: 1,
-        usage: { input: 5000, output: 5, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
+        usage: { input: 10_000, output: 5, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
       }),
     ];
     const contentBySession = new Map<string, ContentRecord[]>();
@@ -350,7 +350,7 @@ describe('attributeWaste', () => {
       userTurnsBySession,
     });
     assert.equal(result.sessionTotals[0]!.attributionMethod, 'sized');
-    assert.equal(result.attributions[0]!.initialTokens, 1000);
+    assert.equal(result.attributions[0]!.initialTokens, 9000);
   });
 
   it('caps sibling initial cost at the next turn\'s actual newContent', async () => {

--- a/packages/analyze/src/waste.ts
+++ b/packages/analyze/src/waste.ts
@@ -48,12 +48,12 @@ export interface AttributeWasteOptions {
   pricing: PricingTable;
   // sessionId -> ContentRecord[] in source order
   contentBySession?: Map<string, ContentRecord[]>;
-  // sessionId -> UserTurnRecord[] in source order. Used as a sized fallback
-  // when full content sidecars are missing; sidecar content stays primary.
+  // sessionId -> UserTurnRecord[] in source order. Preferred as the sized
+  // source because it survives hash-only/off content capture modes.
   userTurnsBySession?: Map<string, UserTurnRecord[]>;
 }
 
-export type AttributionMethod = 'sized' | 'user-turn' | 'even-split';
+export type AttributionMethod = 'sized' | 'even-split';
 
 interface PerTurnContent {
   // tool_result text by toolUseId for this turn's user message
@@ -147,29 +147,24 @@ function attributeSession(
 
   // Build tool-result size index by toolUseId across the full session.
   const sizeByToolUseId = new Map<string, number>();
+  for (const userTurn of userTurns) {
+    for (const block of userTurn.blocks) {
+      if (block.kind !== 'tool_result' || !block.toolUseId) continue;
+      sizeByToolUseId.set(block.toolUseId, Math.max(0, block.approxTokens));
+    }
+  }
+
   if (toolResultsByTurnTs) {
     for (const perTurn of toolResultsByTurnTs.values()) {
       for (const [toolUseId, text] of perTurn.toolResultText) {
+        if (sizeByToolUseId.has(toolUseId)) continue;
         sizeByToolUseId.set(toolUseId, estimateTokens(text));
       }
     }
   }
 
-  const haveSidecarSizes = sizeByToolUseId.size > 0;
-  for (const userTurn of userTurns) {
-    for (const block of userTurn.blocks) {
-      if (block.kind !== 'tool_result' || !block.toolUseId) continue;
-      if (sizeByToolUseId.has(block.toolUseId)) continue;
-      sizeByToolUseId.set(block.toolUseId, Math.max(0, block.approxTokens));
-    }
-  }
-
   const haveAnySizes = sizeByToolUseId.size > 0;
-  const method: AttributionMethod = haveSidecarSizes
-    ? 'sized'
-    : haveAnySizes
-      ? 'user-turn'
-      : 'even-split';
+  const method: AttributionMethod = haveAnySizes ? 'sized' : 'even-split';
 
   const attributions: ToolAttribution[] = [];
   // Attributions emitted at the immediately-prior turn that have not yet been

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to `@relayburn/cli`.
 ### Changed
 
 - Provider filters and `burn summary --by-provider` now use the shared analyze provider resolver.
+- `burn summary --by-tool` now uses persisted user-turn block sizes for proportional attribution and reports each JSON row's attribution method.
+- `burn rebuild --content` now backfills missing user-turn rows for historical sessions, even when content sidecars already exist.
 
 ## [0.42.0] - 2026-04-28
 

--- a/packages/cli/src/commands/rebuild.ts
+++ b/packages/cli/src/commands/rebuild.ts
@@ -17,7 +17,7 @@ Flags:
   --reclassify  re-run the activity classifier on every ledger turn
   --force       with --reclassify, overwrite activity even if already set
   --content     re-parse source session files to populate missing content
-                sidecars. Skips sessions that already have content on disk.
+                sidecars and user-turn rows. Skips sessions already complete.
                 Does not touch cursors or existing ledger rows.
 
 `;
@@ -57,10 +57,11 @@ export async function runRebuild(args: ParsedArgs): Promise<number> {
   if (doContent) {
     const r = await reingestMissingContent();
     lines.push(
-      `reingested content for ${formatInt(r.reingestedSessions)} sessions` +
+      `reingested derived content for ${formatInt(r.reingestedSessions)} sessions` +
         ` (${formatInt(r.scannedFiles)} files scanned,` +
-        ` ${formatInt(r.skippedExisting)} already had content,` +
+        ` ${formatInt(r.skippedExisting)} already complete,` +
         ` ${formatInt(r.appendedContent)} records appended,` +
+        ` ${formatInt(r.appendedUserTurns)} user turns appended,` +
         ` ${formatInt(r.failed)} failed)`,
     );
   }

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -5,12 +5,13 @@ import * as path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import {
+  appendUserTurns,
   appendTurns,
   archivePath,
   stamp,
   __resetIndexCacheForTesting,
 } from '@relayburn/ledger';
-import type { Fidelity, TurnRecord } from '@relayburn/reader';
+import type { Fidelity, TurnRecord, UserTurnRecord } from '@relayburn/reader';
 
 import { runSummary } from './summary.js';
 
@@ -33,6 +34,20 @@ function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
     },
     toolCalls: [],
     project: '/tmp/project',
+    ...overrides,
+  };
+}
+
+function fakeUserTurn(overrides: Partial<UserTurnRecord> = {}): UserTurnRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    sessionId: 's-1',
+    userUuid: 'u-1',
+    ts: '2026-04-20T00:00:30.000Z',
+    precedingMessageId: 'msg-1',
+    followingMessageId: 'msg-2',
+    blocks: [],
     ...overrides,
   };
 }
@@ -492,11 +507,11 @@ describe('burn summary per-cell fidelity (#136)', () => {
     assert.match(out.stdout, /turns analyzed: 2/);
     assert.match(out.stdout, /Read/);
     assert.match(out.stdout, /attributedCost/);
-    assert.match(out.stdout, /attributedCost = \(turn N input cost\)/);
+    assert.match(out.stdout, /user-turn byte size/);
     assert.match(out.stdout, /unattributed cost/);
   });
 
-  it('--by-tool --json emits { byTool, unattributed } with fidelity', async () => {
+  it('--by-tool --json emits { byTool, unattributed } with fidelity and even-split fallback', async () => {
     await appendTurns([
       fakeTurn({
         sessionId: 'btj-1',
@@ -515,16 +530,82 @@ describe('burn summary per-cell fidelity (#136)', () => {
     interface Payload {
       ingest: { ingestedSessions: number; appendedTurns: number };
       turns: number;
-      byTool: Array<{ tool: string; calls: number; attributedCost: number }>;
+      byTool: Array<{
+        tool: string;
+        calls: number;
+        attributedCost: number;
+        attributionMethod: 'sized' | 'even-split' | 'unattributed';
+      }>;
       unattributed: number;
       fidelity: { summary: unknown };
     }
     const payload = JSON.parse(out.stdout) as Payload;
     assert.equal(payload.turns, 2);
     assert.ok(Array.isArray(payload.byTool));
-    assert.equal(payload.byTool.some((r) => r.tool === 'Edit'), true);
+    const edit = payload.byTool.find((r) => r.tool === 'Edit');
+    assert.ok(edit);
+    assert.equal(edit!.attributionMethod, 'even-split');
     assert.equal(typeof payload.unattributed, 'number');
     assert.ok(payload.fidelity.summary, 'fidelity.summary block expected');
+  });
+
+  it('--by-tool --json uses user-turn byteLen for proportional attribution', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'bt-sized',
+        messageId: 'bt-sized-1',
+        toolCalls: [
+          { id: 'tc-big', name: 'Read', target: 'large.log', argsHash: 'read-big' },
+          { id: 'tc-small', name: 'Bash', target: 'true', argsHash: 'bash-small' },
+        ],
+      }),
+      fakeTurn({
+        sessionId: 'bt-sized',
+        messageId: 'bt-sized-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+      }),
+    ]);
+    await appendUserTurns([
+      fakeUserTurn({
+        sessionId: 'bt-sized',
+        userUuid: 'bt-sized-u-1',
+        precedingMessageId: 'bt-sized-1',
+        followingMessageId: 'bt-sized-2',
+        blocks: [
+          { kind: 'tool_result', toolUseId: 'tc-big', byteLen: 9000, approxTokens: 2250 },
+          {
+            kind: 'tool_result',
+            toolUseId: 'tc-small',
+            byteLen: 1000,
+            approxTokens: 250,
+            isError: true,
+          },
+          { kind: 'text', byteLen: 50_000, approxTokens: 12_500 },
+        ],
+      }),
+    ]);
+
+    const out = await captureSummary({ 'by-tool': true, json: true });
+    assert.equal(out.code, 0);
+    interface Payload {
+      byTool: Array<{
+        tool: string;
+        attributedCost: number;
+        attributionMethod: 'sized' | 'even-split' | 'unattributed';
+      }>;
+    }
+    const payload = JSON.parse(out.stdout) as Payload;
+    const read = payload.byTool.find((r) => r.tool === 'Read');
+    const bash = payload.byTool.find((r) => r.tool === 'Bash');
+    assert.ok(read);
+    assert.ok(bash);
+    assert.equal(read!.attributionMethod, 'sized');
+    assert.equal(bash!.attributionMethod, 'sized');
+    assert.ok(
+      read!.attributedCost > bash!.attributedCost * 8,
+      `Read should dominate Bash by byteLen: read=${read!.attributedCost} bash=${bash!.attributedCost}`,
+    );
   });
 
   it('--by-tool combined with --by-provider exits non-zero with a clear error', async () => {

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -21,11 +21,12 @@ import {
   buildArchive,
   queryAll,
   queryAllFromArchive,
+  queryUserTurns,
   readContent,
   type Query,
 } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
-import type { ContentRecord, Coverage } from '@relayburn/reader';
+import type { ContentRecord, Coverage, UserTurnRecord } from '@relayburn/reader';
 
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
@@ -327,13 +328,18 @@ function renderSubagentTreeMode(
   return 0;
 }
 
-function renderByToolMode(
+async function renderByToolMode(
   args: ParsedArgs,
   ingestReport: { ingestedSessions: number; appendedTurns: number },
   turns: EnrichedTurn[],
   pricing: Parameters<typeof costForTurn>[1],
-): number {
-  const { byTool, unattributed } = attributeCostToTools(turns, pricing);
+): Promise<number> {
+  const userTurnsBySession = await loadUserTurnsForByTool(turns);
+  const { byTool, unattributed } = attributeCostToTools(
+    turns,
+    pricing,
+    userTurnsBySession,
+  );
   const fidelity = summarizeFidelity(turns);
   const sorted = [...byTool.entries()].sort((a, b) => b[1].cost - a[1].cost);
 
@@ -348,6 +354,7 @@ function renderByToolMode(
         tool,
         calls: agg.calls,
         attributedCost: agg.cost,
+        attributionMethod: toolAttributionMethod(agg),
       })),
       unattributed,
       fidelity: { summary: fidelity },
@@ -376,9 +383,11 @@ function renderByToolMode(
   // and the by-model `cost` number without context is an easy way to draw the
   // wrong conclusion.
   out.push(
-    `attributedCost = (turn N input cost) split evenly across tool_use blocks in turn N-1, grouped by tool name.`,
+    `attributedCost = turn N ingest cost assigned to turn N-1 tool_use blocks by user-turn byte size when available, otherwise split evenly.`,
   );
-  out.push(`unattributed cost (no prior tool call, e.g. first turn): ${formatUsd(unattributed)}`);
+  out.push(
+    `unattributed cost (no prior tool call or non-tool user text): ${formatUsd(unattributed)}`,
+  );
   out.push('');
   process.stdout.write(out.join('\n'));
   return 0;
@@ -387,11 +396,21 @@ function renderByToolMode(
 interface ToolAgg {
   calls: number;
   cost: number;
+  sizedCost: number;
+  evenSplitCost: number;
+}
+
+type ByToolAttributionMethod = 'sized' | 'even-split' | 'unattributed';
+
+interface UserTurnSizeBucket {
+  toolBytesById: Map<string, number>;
+  totalBytes: number;
 }
 
 function attributeCostToTools(
   turns: EnrichedTurn[],
   pricing: Parameters<typeof costForTurn>[1],
+  userTurnsBySession: Map<string, UserTurnRecord[]> = new Map(),
 ): { byTool: Map<string, ToolAgg>; unattributed: number } {
   const byTool = new Map<string, ToolAgg>();
   let unattributed = 0;
@@ -409,6 +428,11 @@ function attributeCostToTools(
 
   for (const list of bySession.values()) {
     list.sort((a, b) => a.turnIndex - b.turnIndex);
+    const sessionId = list[0]?.sessionId;
+    const userTurnSizeIndex =
+      sessionId === undefined
+        ? new Map<string, UserTurnSizeBucket>()
+        : indexUserTurnBlockSizes(userTurnsBySession.get(sessionId) ?? []);
     for (let i = 0; i < list.length; i++) {
       const turn = list[i]!;
       const c = costForTurn(turn, pricing);
@@ -418,7 +442,7 @@ function attributeCostToTools(
 
       // Also count the tool-calls this turn emits (so they appear even if the next turn is unpriced).
       for (const tc of turn.toolCalls) {
-        const agg = byTool.get(tc.name) ?? { calls: 0, cost: 0 };
+        const agg = byTool.get(tc.name) ?? emptyToolAgg();
         agg.calls++;
         byTool.set(tc.name, agg);
       }
@@ -432,16 +456,100 @@ function attributeCostToTools(
         unattributed += ingestCost;
         continue;
       }
-      const share = ingestCost / prior.toolCalls.length;
-      for (const tc of prior.toolCalls) {
-        const agg = byTool.get(tc.name) ?? { calls: 0, cost: 0 };
-        agg.cost += share;
-        byTool.set(tc.name, agg);
+      const sizes = userTurnSizeIndex.get(bridgeKey(prior.messageId, turn.messageId));
+      const sizedBytes = sizes
+        ? prior.toolCalls.reduce(
+            (sum, tc) => sum + (sizes.toolBytesById.get(tc.id) ?? 0),
+            0,
+          )
+        : 0;
+      if (sizes && sizedBytes > 0) {
+        const allocatableCost =
+          sizes.totalBytes > 0
+            ? ingestCost * Math.min(1, sizedBytes / sizes.totalBytes)
+            : ingestCost;
+        unattributed += ingestCost - allocatableCost;
+        const rawShares: Array<{ tool: string; cost: number }> = [];
+        for (const tc of prior.toolCalls) {
+          const bytes = sizes.toolBytesById.get(tc.id) ?? 0;
+          if (bytes <= 0) continue;
+          rawShares.push({ tool: tc.name, cost: (bytes / sizedBytes) * allocatableCost });
+        }
+        const rawSubtotal = rawShares.reduce((sum, row) => sum + row.cost, 0);
+        const scale = rawSubtotal > allocatableCost && rawSubtotal > 0
+          ? allocatableCost / rawSubtotal
+          : 1;
+        for (const row of rawShares) {
+          const share = row.cost * scale;
+          const agg = byTool.get(row.tool) ?? emptyToolAgg();
+          agg.cost += share;
+          agg.sizedCost += share;
+          byTool.set(row.tool, agg);
+        }
+      } else {
+        const share = ingestCost / prior.toolCalls.length;
+        for (const tc of prior.toolCalls) {
+          const agg = byTool.get(tc.name) ?? emptyToolAgg();
+          agg.cost += share;
+          agg.evenSplitCost += share;
+          byTool.set(tc.name, agg);
+        }
       }
     }
   }
 
   return { byTool, unattributed };
+}
+
+async function loadUserTurnsForByTool(
+  turns: EnrichedTurn[],
+): Promise<Map<string, UserTurnRecord[]>> {
+  const sessionIds = [...new Set(turns.map((t) => t.sessionId))];
+  const out = new Map<string, UserTurnRecord[]>();
+  for (const sessionId of sessionIds) {
+    const userTurns = await queryUserTurns({ sessionId });
+    if (userTurns.length > 0) out.set(sessionId, userTurns);
+  }
+  return out;
+}
+
+function indexUserTurnBlockSizes(
+  userTurns: readonly UserTurnRecord[],
+): Map<string, UserTurnSizeBucket> {
+  const out = new Map<string, UserTurnSizeBucket>();
+  for (const userTurn of userTurns) {
+    if (!userTurn.precedingMessageId || !userTurn.followingMessageId) continue;
+    const key = bridgeKey(userTurn.precedingMessageId, userTurn.followingMessageId);
+    let bucket = out.get(key);
+    if (!bucket) {
+      bucket = { toolBytesById: new Map<string, number>(), totalBytes: 0 };
+      out.set(key, bucket);
+    }
+    for (const block of userTurn.blocks) {
+      const bytes = Math.max(0, block.byteLen);
+      bucket.totalBytes += bytes;
+      if (block.kind !== 'tool_result' || !block.toolUseId) continue;
+      bucket.toolBytesById.set(
+        block.toolUseId,
+        (bucket.toolBytesById.get(block.toolUseId) ?? 0) + bytes,
+      );
+    }
+  }
+  return out;
+}
+
+function bridgeKey(precedingMessageId: string, followingMessageId: string): string {
+  return `${precedingMessageId}\0${followingMessageId}`;
+}
+
+function emptyToolAgg(): ToolAgg {
+  return { calls: 0, cost: 0, sizedCost: 0, evenSplitCost: 0 };
+}
+
+function toolAttributionMethod(agg: ToolAgg): ByToolAttributionMethod {
+  if (agg.sizedCost === 0 && agg.evenSplitCost === 0) return 'unattributed';
+  if (agg.sizedCost >= agg.evenSplitCost) return 'sized';
+  return 'even-split';
 }
 
 function renderSubagentTypeMode(

--- a/packages/cli/src/commands/waste.test.ts
+++ b/packages/cli/src/commands/waste.test.ts
@@ -171,7 +171,7 @@ describe('formatWasteReport', () => {
     // Banner is emitted with the warning glyph and the right counts.
     assert.match(
       out,
-      /⚠ attribution is degraded: 2 of 3 sessions \(66\.7%\) have no content/,
+      /⚠ attribution is degraded: 2 of 3 sessions \(66\.7%\) have no sized/,
     );
     // Remediation pointer is present.
     assert.match(out, /burn rebuild --content/);

--- a/packages/cli/src/commands/waste.ts
+++ b/packages/cli/src/commands/waste.ts
@@ -411,16 +411,16 @@ export function formatWasteReport(input: FormatWasteReportInput): string {
     const pct = total > 0 ? (ev / total) * 100 : 0;
     out.push('');
     out.push(
-      `⚠ attribution is degraded: ${formatInt(ev)} of ${formatInt(total)} sessions (${pct.toFixed(1)}%) have no content`,
+      `⚠ attribution is degraded: ${formatInt(ev)} of ${formatInt(total)} sessions (${pct.toFixed(1)}%) have no sized`,
     );
     out.push(
-      '  sidecar, so file / bash / subagent costs for those sessions are approximate',
+      '  tool-result data, so file / bash / subagent costs for those sessions are approximate',
     );
     out.push(
       "  (even-split over turn N+1 input/cacheCreate). Run 'burn rebuild --content'",
     );
     out.push(
-      "  to backfill sidecars from source session files, or see 'burn content' for",
+      "  to backfill source-derived sizes, or see 'burn content' for",
     );
     out.push('  why capture is disabled.');
     out.push('');
@@ -439,11 +439,11 @@ export function formatWasteReport(input: FormatWasteReportInput): string {
       evenSplitSessions.length === result.sessionTotals.length
     ) {
       out.push(
-        'note: no content sidecar data found — using even-split (initial cost only). Enable content.store=full in your config to get persistence attribution.',
+        'note: no user-turn or content sidecar sizes found — using even-split (initial cost only). Run burn rebuild --content or enable content.store=full to improve attribution.',
       );
     } else if (evenSplitSessions.length > 0) {
       out.push(
-        `note: ${evenSplitSessions.length}/${result.sessionTotals.length} sessions used even-split (no content sidecar).`,
+        `note: ${evenSplitSessions.length}/${result.sessionTotals.length} sessions used even-split (no user-turn or content sidecar sizes).`,
       );
     }
   }

--- a/packages/cli/src/ingest.test.ts
+++ b/packages/cli/src/ingest.test.ts
@@ -15,7 +15,7 @@ import * as path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import type { ContentRecord, TurnRecord } from '@relayburn/reader';
-import { ledgerPath, queryAll, queryUserTurns } from '@relayburn/ledger';
+import { appendContent, ledgerPath, queryAll, queryUserTurns } from '@relayburn/ledger';
 
 import {
   countToolCallGaps,
@@ -23,6 +23,7 @@ import {
   deriveCodexSessionId,
   ingestCodexSessions,
   ingestOpencodeSessions,
+  reingestMissingContent,
   resetIngestGapWarnings,
   setIngestGapWriter,
 } from './ingest.js';
@@ -253,6 +254,42 @@ describe('ingest forwards UserTurnRecord into the ledger (#94)', () => {
     assert.equal(sizeAfter, sizeBefore, 'ledger must not grow on idempotent re-ingest');
     const second = await queryUserTurns();
     assert.equal(second.length, 1, 'still one user-turn line after re-ingest');
+  });
+
+  it('rebuild --content backfills user-turn rows even when content already exists', async () => {
+    const sessionId = '33333333-3333-3333-3333-333333333333';
+    await writeClaudeSession(
+      tmpHome,
+      sessionId,
+      claudeSessionWithToolResultUserTurn(sessionId),
+    );
+    await appendContent([
+      {
+        v: 1,
+        source: 'claude-code',
+        sessionId,
+        messageId: 'seed-content',
+        ts: '2026-04-20T00:00:00.000Z',
+        role: 'assistant',
+        kind: 'text',
+        text: 'already had a content sidecar',
+      },
+    ]);
+
+    const report = await reingestMissingContent();
+    assert.equal(report.appendedContent, 0);
+    assert.ok(report.appendedUserTurns > 0, 'user-turn rows should be backfilled');
+
+    const userTurns = await queryUserTurns({ sessionId });
+    assert.ok(
+      userTurns.some((userTurn) =>
+        userTurn.blocks.some(
+          (block) =>
+            block.kind === 'tool_result' && block.toolUseId === 'toolu_rebuild_1',
+        ),
+      ),
+      'tool_result user-turn block should be persisted for sized attribution',
+    );
   });
 });
 
@@ -542,6 +579,110 @@ function claudeSessionWithUserTurn(): string {
       timestamp: '2026-04-20T00:00:01.000Z',
       cwd: '/tmp/project',
       sessionId: sid,
+      version: '2.1.96',
+    },
+  ];
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
+}
+
+function claudeSessionWithToolResultUserTurn(sessionId: string): string {
+  const lines = [
+    {
+      type: 'permission-mode',
+      permissionMode: 'default',
+      sessionId,
+    },
+    {
+      parentUuid: null,
+      isSidechain: false,
+      promptId: 'p-rebuild',
+      type: 'user',
+      message: { role: 'user', content: 'read the log' },
+      uuid: 'u-rebuild-user-1',
+      timestamp: '2026-04-20T00:00:00.000Z',
+      cwd: '/tmp/project',
+      sessionId,
+      version: '2.1.96',
+    },
+    {
+      parentUuid: 'u-rebuild-user-1',
+      isSidechain: false,
+      message: {
+        model: 'claude-sonnet-4-6',
+        id: 'msg_rebuild_1',
+        type: 'message',
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_rebuild_1',
+            name: 'Bash',
+            input: { command: 'cat large.log' },
+          },
+        ],
+        stop_reason: 'tool_use',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          output_tokens: 5,
+          service_tier: 'standard',
+        },
+      },
+      requestId: 'req_rebuild_1',
+      type: 'assistant',
+      uuid: 'u-rebuild-asst-1',
+      timestamp: '2026-04-20T00:00:01.000Z',
+      cwd: '/tmp/project',
+      sessionId,
+      version: '2.1.96',
+    },
+    {
+      parentUuid: 'u-rebuild-asst-1',
+      isSidechain: false,
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_rebuild_1',
+            content: 'large output from the command',
+          },
+        ],
+      },
+      uuid: 'u-rebuild-tool-result-1',
+      timestamp: '2026-04-20T00:00:02.000Z',
+      cwd: '/tmp/project',
+      sessionId,
+      version: '2.1.96',
+    },
+    {
+      parentUuid: 'u-rebuild-tool-result-1',
+      isSidechain: false,
+      message: {
+        model: 'claude-sonnet-4-6',
+        id: 'msg_rebuild_2',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 100,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          output_tokens: 5,
+          service_tier: 'standard',
+        },
+      },
+      requestId: 'req_rebuild_2',
+      type: 'assistant',
+      uuid: 'u-rebuild-asst-2',
+      timestamp: '2026-04-20T00:00:03.000Z',
+      cwd: '/tmp/project',
+      sessionId,
       version: '2.1.96',
     },
   ];

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -15,6 +15,7 @@ import type {
   ContentStoreMode,
   ReconcileClaudeRelationshipsInput,
   TurnRecord,
+  UserTurnRecord,
 } from '@relayburn/reader';
 import {
   appendCompactions,
@@ -26,6 +27,7 @@ import {
   listContentSessionIds,
   loadConfig,
   loadCursors,
+  queryUserTurns,
   saveCursors,
   type ClaudeCursor,
   type CodexCursor,
@@ -593,31 +595,36 @@ export interface ReingestContentReport {
   skippedExisting: number;
   reingestedSessions: number;
   appendedContent: number;
+  appendedUserTurns: number;
   failed: number;
 }
 
-// Re-parse source session files to populate missing content sidecars. Used by
-// `burn rebuild --content` to fix up historical sessions ingested before the
-// sidecar was written (or where the sidecar was pruned). Does NOT touch
-// cursors, ledger turns, or compactions — only writes content records for
-// sessions that currently have no sidecar on disk.
+// Re-parse source session files to populate missing content sidecars and
+// user-turn rows. Used by `burn rebuild --content` to fix up historical
+// sessions ingested before those derived records were written (or where the
+// sidecar was pruned). Does NOT touch cursors, ledger turns, or compactions.
 export async function reingestMissingContent(): Promise<ReingestContentReport> {
-  const existing = await listContentSessionIds();
+  const existingContent = await listContentSessionIds();
+  const existingUserTurns = new Set(
+    (await queryUserTurns()).map((userTurn) => userTurn.sessionId),
+  );
   const report: ReingestContentReport = {
     scannedFiles: 0,
     skippedExisting: 0,
     reingestedSessions: 0,
     appendedContent: 0,
+    appendedUserTurns: 0,
     failed: 0,
   };
-  await reingestClaudeContent(existing, report);
-  await reingestCodexContent(existing, report);
-  await reingestOpencodeContent(existing, report);
+  await reingestClaudeContent(existingContent, existingUserTurns, report);
+  await reingestCodexContent(existingContent, existingUserTurns, report);
+  await reingestOpencodeContent(existingContent, existingUserTurns, report);
   return report;
 }
 
 async function reingestClaudeContent(
-  existing: Set<string>,
+  existingContent: Set<string>,
+  existingUserTurns: Set<string>,
   report: ReingestContentReport,
 ): Promise<void> {
   const projects = await listDirs(claudeProjectsDir());
@@ -626,23 +633,23 @@ async function reingestClaudeContent(
     for (const file of files) {
       report.scannedFiles++;
       const sessionId = path.basename(file, '.jsonl');
-      if (existing.has(sessionId)) {
+      if (existingContent.has(sessionId) && existingUserTurns.has(sessionId)) {
         report.skippedExisting++;
         continue;
       }
       try {
-        const { content } = await parseClaudeSessionIncremental(file, {
+        const { content, userTurns } = await parseClaudeSessionIncremental(file, {
           startOffset: 0,
           sessionPath: file,
           contentMode: 'full',
         });
-        const filtered = content.filter((c) => !existing.has(c.sessionId));
-        if (filtered.length > 0) {
-          await appendContent(filtered);
-          report.appendedContent += filtered.length;
-          report.reingestedSessions++;
-          for (const c of filtered) existing.add(c.sessionId);
-        }
+        await appendReingestedDerivedRecords(
+          content,
+          userTurns,
+          existingContent,
+          existingUserTurns,
+          report,
+        );
       } catch (err) {
         report.failed++;
         const msg = err instanceof Error ? err.message : String(err);
@@ -653,29 +660,34 @@ async function reingestClaudeContent(
 }
 
 async function reingestCodexContent(
-  existing: Set<string>,
+  existingContent: Set<string>,
+  existingUserTurns: Set<string>,
   report: ReingestContentReport,
 ): Promise<void> {
   for (const file of await walkJsonl(codexSessionsDir())) {
     report.scannedFiles++;
     const derived = await deriveCodexSessionId(file);
-    if (derived && existing.has(derived)) {
+    if (
+      derived &&
+      existingContent.has(derived) &&
+      existingUserTurns.has(derived)
+    ) {
       report.skippedExisting++;
       continue;
     }
     try {
-      const { content } = await parseCodexSessionIncremental(file, {
+      const { content, userTurns } = await parseCodexSessionIncremental(file, {
         startOffset: 0,
         sessionPath: file,
         contentMode: 'full',
       });
-      const filtered = content.filter((c) => !existing.has(c.sessionId));
-      if (filtered.length > 0) {
-        await appendContent(filtered);
-        report.appendedContent += filtered.length;
-        report.reingestedSessions++;
-        for (const c of filtered) existing.add(c.sessionId);
-      }
+      await appendReingestedDerivedRecords(
+        content,
+        userTurns,
+        existingContent,
+        existingUserTurns,
+        report,
+      );
     } catch (err) {
       report.failed++;
       const msg = err instanceof Error ? err.message : String(err);
@@ -685,35 +697,68 @@ async function reingestCodexContent(
 }
 
 async function reingestOpencodeContent(
-  existing: Set<string>,
+  existingContent: Set<string>,
+  existingUserTurns: Set<string>,
   report: ReingestContentReport,
 ): Promise<void> {
   for (const file of await walkOpencodeSessions(opencodeSessionRoot())) {
     report.scannedFiles++;
     const sessionId = path.basename(file, '.json');
-    if (existing.has(sessionId)) {
+    if (existingContent.has(sessionId) && existingUserTurns.has(sessionId)) {
       report.skippedExisting++;
       continue;
     }
     try {
-      const { content } = await parseOpencodeSessionIncremental(file, {
+      const { content, userTurns } = await parseOpencodeSessionIncremental(file, {
         sessionPath: file,
         seenMessageIds: new Set<string>(),
         contentMode: 'full',
       });
-      const filtered = content.filter((c) => !existing.has(c.sessionId));
-      if (filtered.length > 0) {
-        await appendContent(filtered);
-        report.appendedContent += filtered.length;
-        report.reingestedSessions++;
-        for (const c of filtered) existing.add(c.sessionId);
-      }
+      await appendReingestedDerivedRecords(
+        content,
+        userTurns,
+        existingContent,
+        existingUserTurns,
+        report,
+      );
     } catch (err) {
       report.failed++;
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[burn] reingest skipped ${file}: ${msg}\n`);
     }
   }
+}
+
+async function appendReingestedDerivedRecords(
+  content: readonly ContentRecord[],
+  userTurns: readonly UserTurnRecord[],
+  existingContent: Set<string>,
+  existingUserTurns: Set<string>,
+  report: ReingestContentReport,
+): Promise<void> {
+  const filteredContent = content.filter((c) => !existingContent.has(c.sessionId));
+  const filteredUserTurns = userTurns.filter(
+    (userTurn) => !existingUserTurns.has(userTurn.sessionId),
+  );
+  if (filteredContent.length === 0 && filteredUserTurns.length === 0) return;
+
+  if (filteredContent.length > 0) {
+    await appendContent(filteredContent);
+    report.appendedContent += filteredContent.length;
+    for (const c of filteredContent) existingContent.add(c.sessionId);
+  }
+  if (filteredUserTurns.length > 0) {
+    await appendUserTurns([...filteredUserTurns]);
+    report.appendedUserTurns += filteredUserTurns.length;
+    for (const userTurn of filteredUserTurns) {
+      existingUserTurns.add(userTurn.sessionId);
+    }
+  }
+
+  const sessions = new Set<string>();
+  for (const c of filteredContent) sessions.add(c.sessionId);
+  for (const userTurn of filteredUserTurns) sessions.add(userTurn.sessionId);
+  report.reingestedSessions += sessions.size;
 }
 
 // Codex filenames are `rollout-<timestamp>-<uuid>.jsonl` where the UUID is the


### PR DESCRIPTION
Fixes #102

## Summary
- Use persisted UserTurnRecord block byte lengths for `burn summary --by-tool` proportional attribution, with JSON `attributionMethod` rows and even-split fallback.
- Prefer user-turn tool-result sizes in `burn waste`, falling back to sidecar estimates and then even-split.
- Extend `burn rebuild --content` to backfill missing user-turn rows for historical sessions even when content sidecars already exist.

## Tests
- `pnpm run build`
- `pnpm run test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
