### PR TITLE
Cross-check spawn-env attribution against native signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ### Changed
 
+- Spawn-env and native sidechain attribution now share session relationship records, and `burn diagnose --explain-drift` surfaces sessions where they disagree.
 - Provider-aware CLI rendering now uses shared analyze helpers for effective-provider resolution and aggregation.
 - Per-tool cost attribution now uses persisted user-turn block sizes in summary and waste reports, with rebuild backfill for historical sessions.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to `@relayburn/cli`.
 
 ### Added
 
+- `burn diagnose` now reports spawn-env/native relationship drift, with `--explain-drift` for per-session details.
 - `burn watch --opencode-stream` can subscribe to OpenCode's local SSE endpoint and wake ingest immediately on session/message events while polling remains the fallback.
 
 ### Changed
 
+- `burn summary --agent` now includes sessions linked by relationship records, not only turns stamped with the agent id.
 - Provider filters and `burn summary --by-provider` now use the shared analyze provider resolver.
 - `burn summary --by-tool` now uses persisted user-turn block sizes for proportional attribution and reports each JSON row's attribution method.
 - `burn rebuild --content` now backfills missing user-turn rows for historical sessions, even when content sidecars already exist.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,7 +26,7 @@ Usage:
                      (mode flags are mutually exclusive; --by-tool emits tool | calls | attributedCost)
   burn waste         [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--provider <p>] [--all] [--json]
                      [--patterns[=retries,failures,compaction,reverts]] [--findings]
-  burn diagnose      [<session-id>] [--json]
+  burn diagnose      [<session-id>] [--json] [--explain-drift]
   burn limits        [--watch [5s]] [--json] [--no-api] [--no-forecast]
   burn plans         [add|remove|set-reset-day] …  (run \`burn plans help\` for full usage)
   burn context       [advise] [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]

--- a/packages/cli/src/commands/diagnose.test.ts
+++ b/packages/cli/src/commands/diagnose.test.ts
@@ -7,6 +7,7 @@ import { after, beforeEach, describe, it } from 'node:test';
 import {
   __resetIndexCacheForTesting,
   appendContent,
+  appendRelationships,
   appendTurns,
 } from '@relayburn/ledger';
 import type { ContentRecord, SourceKind, TurnRecord } from '@relayburn/reader';
@@ -314,6 +315,127 @@ describe('burn diagnose aggregate (#79)', () => {
     assert.match(out.stdout, /degraded%/);
     // codex row: 1 session, 1 with tool calls, 1 gapped, 100% degraded.
     assert.match(out.stdout, /100\.0%/);
+  });
+
+  it('reports spawn-env/native relationship drift with opt-in details', async () => {
+    await appendTurns([
+      fakeTurn({
+        source: 'claude-code',
+        sessionId: 'cl-drift',
+        messageId: 'cl-drift-1',
+      }),
+      fakeTurn({
+        source: 'claude-code',
+        sessionId: 'cl-native-only',
+        messageId: 'cl-native-only-1',
+      }),
+      fakeTurn({
+        source: 'claude-code',
+        sessionId: 'cl-agree',
+        messageId: 'cl-agree-1',
+      }),
+      fakeTurn({
+        source: 'codex',
+        sessionId: 'cx-env-only',
+        messageId: 'cx-env-only-1',
+      }),
+      fakeTurn({
+        source: 'opencode',
+        sessionId: 'oc-agree',
+        messageId: 'oc-agree-1',
+      }),
+    ]);
+    await appendRelationships([
+      {
+        v: 1,
+        source: 'spawn-env',
+        sessionId: 'cl-drift',
+        relatedSessionId: 'ag-parent',
+        relationshipType: 'subagent',
+      },
+      {
+        v: 1,
+        source: 'native-claude',
+        sessionId: 'cl-native-only',
+        relatedSessionId: 'cl-parent',
+        relationshipType: 'subagent',
+        agentId: 'ag-native',
+      },
+      {
+        v: 1,
+        source: 'spawn-env',
+        sessionId: 'cl-agree',
+        relatedSessionId: 'ag-parent',
+        relationshipType: 'subagent',
+      },
+      {
+        v: 1,
+        source: 'native-claude',
+        sessionId: 'cl-agree',
+        relatedSessionId: 'cl-parent',
+        relationshipType: 'subagent',
+        agentId: 'ag-claude-native',
+      },
+      {
+        v: 1,
+        source: 'spawn-env',
+        sessionId: 'cx-env-only',
+        relatedSessionId: 'ag-parent',
+        relationshipType: 'subagent',
+      },
+      {
+        v: 1,
+        source: 'spawn-env',
+        sessionId: 'oc-agree',
+        relatedSessionId: 'ag-parent',
+        relationshipType: 'subagent',
+      },
+      {
+        v: 1,
+        source: 'native-opencode',
+        sessionId: 'oc-agree',
+        relatedSessionId: 'oc-parent',
+        relationshipType: 'subagent',
+      },
+    ]);
+
+    const out = await captureDiagnose({
+      flags: { json: true, 'explain-drift': true },
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    const parsed = JSON.parse(out.stdout) as {
+      relationshipDrift: {
+        sessions: number;
+        details: Array<{
+          sessionId: string;
+          adapter: string;
+          reason: string;
+          envParentAgentId: string;
+        }>;
+      };
+    };
+    assert.equal(parsed.relationshipDrift.sessions, 1);
+    assert.deepEqual(parsed.relationshipDrift.details, [
+      {
+        sessionId: 'cl-drift',
+        adapter: 'claude',
+        reason: 'spawn-env-without-native',
+        envParentAgentId: 'ag-parent',
+      },
+    ]);
+
+    const human = await captureDiagnose({
+      flags: { 'explain-drift': true },
+      tags: {},
+      positional: [],
+      passthrough: [],
+    });
+    assert.equal(human.code, 0);
+    assert.match(human.stdout, /Relationship attribution drift/);
+    assert.match(human.stdout, /cl-drift/);
   });
 
   it('omits the gap signal and prints a note when content store is hash-only', async () => {

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -11,11 +11,13 @@ import {
   loadConfig,
   queryAll,
   queryCompactions,
+  queryRelationships,
   queryUserTurns,
   readContent,
 } from '@relayburn/ledger';
 import type {
   ContentRecord,
+  SessionRelationshipRecord,
   SourceKind,
   TurnRecord,
   UserTurnRecord,
@@ -301,11 +303,12 @@ function truncate(s: string, n: number): string {
   return s.slice(0, n - 1) + '…';
 }
 
-// Aggregate per-adapter content-capture gap report (#79). Walks the ledger and
-// tells the user how many sessions per adapter have ≥1 tool call but zero
-// `tool_result` ContentRecords — the symptom that motivated #58 / #59. Unlike
-// the per-invocation ingest warning (which fires once per `burn` run for a
-// fresh affected session), this is a permanent, queryable surface.
+// Aggregate per-adapter content-capture gap report (#79) plus relationship
+// attribution drift (#103). Walks the ledger and tells the user how many
+// sessions per adapter have ≥1 tool call but zero `tool_result` ContentRecords
+// — the symptom that motivated #58 / #59. Unlike the per-invocation ingest
+// warning (which fires once per `burn` run for a fresh affected session), this
+// is a permanent, queryable surface.
 type Adapter = 'claude' | 'codex' | 'opencode';
 const ADAPTER_ORDER: Adapter[] = ['claude', 'codex', 'opencode'];
 
@@ -320,16 +323,31 @@ interface AdapterRow {
   degradedPct: number | null;
 }
 
+interface RelationshipDriftDetail {
+  sessionId: string;
+  adapter: Adapter;
+  reason: 'spawn-env-without-native';
+  envParentAgentId: string;
+}
+
+interface RelationshipDriftReport {
+  sessions: number;
+  details: RelationshipDriftDetail[];
+}
+
 async function runDiagnoseAggregate(args: ParsedArgs): Promise<number> {
   await ingestAll();
   const config = await loadConfig();
   const contentMode = config.content.store;
   const turns = await queryAll();
+  const relationships = await queryRelationships();
 
   const sessionsByAdapter = new Map<Adapter, Map<string, TurnRecord[]>>();
+  const adapterBySession = new Map<string, Adapter>();
   for (const t of turns) {
     const adapter = sourceToAdapter(t.source);
     if (!adapter) continue;
+    adapterBySession.set(t.sessionId, adapter);
     let bySession = sessionsByAdapter.get(adapter);
     if (!bySession) {
       bySession = new Map();
@@ -380,10 +398,23 @@ async function runDiagnoseAggregate(args: ParsedArgs): Promise<number> {
     };
     rows.push(row);
   }
+  const relationshipDrift = findRelationshipDrift(relationships, adapterBySession);
 
   if (args.flags['json'] === true) {
+    const payload: {
+      adapters: AdapterRow[];
+      contentMode: string;
+      relationshipDrift: RelationshipDriftReport | { sessions: number };
+    } = {
+      adapters: rows,
+      contentMode,
+      relationshipDrift:
+        args.flags['explain-drift'] === true
+          ? relationshipDrift
+          : { sessions: relationshipDrift.sessions },
+    };
     process.stdout.write(
-      JSON.stringify({ adapters: rows, contentMode }, null, 2) + '\n',
+      JSON.stringify(payload, null, 2) + '\n',
     );
     return 0;
   }
@@ -434,8 +465,86 @@ async function runDiagnoseAggregate(args: ParsedArgs): Promise<number> {
     );
   }
   out.push('');
+  out.push('Relationship attribution drift');
+  out.push(`  sessions: ${formatInt(relationshipDrift.sessions)}`);
+  if (args.flags['explain-drift'] === true) {
+    if (relationshipDrift.details.length === 0) {
+      out.push('  (none)');
+    } else {
+      out.push(
+        table([
+          ['session', 'adapter', 'reason', 'envParentAgentId'],
+          ...relationshipDrift.details.map((d) => [
+            d.sessionId,
+            d.adapter,
+            d.reason,
+            d.envParentAgentId,
+          ]),
+        ]),
+      );
+    }
+  }
+  out.push('');
   process.stdout.write(out.join('\n'));
   return 0;
+}
+
+function findRelationshipDrift(
+  relationships: readonly SessionRelationshipRecord[],
+  adapterBySession: ReadonlyMap<string, Adapter>,
+): RelationshipDriftReport {
+  const spawnEnvBySession = new Map<string, SessionRelationshipRecord[]>();
+  const nativeBySession = new Map<string, SessionRelationshipRecord[]>();
+  for (const r of relationships) {
+    if (r.relationshipType !== 'subagent') continue;
+    if (r.source === 'spawn-env') {
+      pushRelationship(spawnEnvBySession, r);
+    } else if (r.source === 'native-claude' || r.source === 'native-opencode') {
+      pushRelationship(nativeBySession, r);
+    }
+  }
+
+  const details: RelationshipDriftDetail[] = [];
+  for (const [sessionId, envRows] of spawnEnvBySession) {
+    const adapter = adapterBySession.get(sessionId);
+    if (adapter !== 'claude' && adapter !== 'opencode') continue;
+    const nativeRows = nativeBySession.get(sessionId) ?? [];
+    if (nativeRows.length > 0) continue;
+    const envParentAgentId = firstRelatedSessionId(envRows);
+    if (envParentAgentId === undefined) continue;
+    details.push({
+      sessionId,
+      adapter,
+      reason: 'spawn-env-without-native',
+      envParentAgentId,
+    });
+  }
+
+  details.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
+  return { sessions: details.length, details };
+}
+
+function pushRelationship(
+  target: Map<string, SessionRelationshipRecord[]>,
+  relationship: SessionRelationshipRecord,
+): void {
+  let list = target.get(relationship.sessionId);
+  if (!list) {
+    list = [];
+    target.set(relationship.sessionId, list);
+  }
+  list.push(relationship);
+}
+
+function firstRelatedSessionId(
+  relationships: readonly SessionRelationshipRecord[],
+): string | undefined {
+  for (const r of relationships) {
+    if (typeof r.relatedSessionId === 'string' && r.relatedSessionId.length > 0) {
+      return r.relatedSessionId;
+    }
+  }
+  return undefined;
 }
 
 function sourceToAdapter(source: SourceKind): Adapter | null {

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import {
+  appendRelationships,
   appendUserTurns,
   appendTurns,
   archivePath,
@@ -96,6 +97,7 @@ describe('burn summary archive integration (#82)', () => {
     process.env['HOME'] = tmpHome;
     process.env['RELAYBURN_HOME'] = tmpRelay;
     delete process.env['RELAYBURN_ARCHIVE'];
+    __resetIndexCacheForTesting();
   });
 
   after(async () => {
@@ -176,6 +178,44 @@ describe('burn summary archive integration (#82)', () => {
 
     // The archive should still be missing — we hit the legacy `queryAll` path.
     await assert.rejects(stat(archivePath()), /ENOENT/);
+  });
+
+  it('--agent includes sessions linked by relationship records', async () => {
+    await appendTurns([
+      fakeTurn({ sessionId: 's-parent', messageId: 'parent-1' }),
+      fakeTurn({
+        sessionId: 's-child',
+        messageId: 'child-1',
+        ts: '2026-04-20T00:01:00.000Z',
+        usage: {
+          input: 2000,
+          output: 500,
+          reasoning: 0,
+          cacheRead: 1000,
+          cacheCreate5m: 0,
+          cacheCreate1h: 0,
+        },
+      }),
+    ]);
+    await appendRelationships([
+      {
+        v: 1,
+        source: 'spawn-env',
+        sessionId: 's-child',
+        relatedSessionId: 'ag-parent',
+        relationshipType: 'subagent',
+        agentId: 'ag-child',
+      },
+    ]);
+
+    const out = await captureSummary({
+      json: true,
+      agent: 'ag-parent',
+      'no-archive': true,
+    });
+    assert.equal(out.code, 0);
+    const parsed = JSON.parse(out.stdout) as { turns: number };
+    assert.equal(parsed.turns, 1);
   });
 
   it('RELAYBURN_ARCHIVE=0 env disables the archive path (fallback)', async () => {

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -21,12 +21,18 @@ import {
   buildArchive,
   queryAll,
   queryAllFromArchive,
+  queryRelationships,
   queryUserTurns,
   readContent,
   type Query,
 } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
-import type { ContentRecord, Coverage, UserTurnRecord } from '@relayburn/reader';
+import type {
+  ContentRecord,
+  Coverage,
+  SessionRelationshipRecord,
+  UserTurnRecord,
+} from '@relayburn/reader';
 
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
@@ -42,7 +48,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   if (typeof args.flags['project'] === 'string') q.project = args.flags['project'];
   if (typeof args.flags['session'] === 'string') q.sessionId = args.flags['session'];
   if (typeof args.flags['workflow'] === 'string') q.enrichment = { workflowId: args.flags['workflow'] };
-  if (typeof args.flags['agent'] === 'string') q.enrichment = { ...(q.enrichment ?? {}), agentId: args.flags['agent'] };
+  const agentFilter = typeof args.flags['agent'] === 'string' ? args.flags['agent'] : undefined;
   const providerFilter = parseProviderFilter(args.flags['provider']);
   if (providerFilter instanceof Error) {
     process.stderr.write(providerFilter.message);
@@ -73,7 +79,12 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
 
   const ingestReport = await ingestAll();
   const pricing = await loadPricing();
-  const turns = filterTurnsByProvider(await loadTurns(q, args), providerFilter);
+  const agentSessionIds =
+    agentFilter !== undefined ? await resolveAgentSessionTree(agentFilter) : undefined;
+  const turns = filterTurnsByProvider(
+    filterTurnsByAgent(await loadTurns(q, args), agentFilter, agentSessionIds),
+    providerFilter,
+  );
 
   if (subagentTreeFlag !== undefined) {
     return renderSubagentTreeMode(args, turns, pricing, subagentTreeFlag, q);
@@ -203,6 +214,57 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
 
   process.stdout.write(lines.join('\n'));
   return 0;
+}
+
+async function resolveAgentSessionTree(agentId: string): Promise<Set<string>> {
+  return collectAgentSessionTree(await queryRelationships(), agentId);
+}
+
+function collectAgentSessionTree(
+  relationships: readonly SessionRelationshipRecord[],
+  agentId: string,
+): Set<string> {
+  const byParent = new Map<string, SessionRelationshipRecord[]>();
+  for (const r of relationships) {
+    if (r.relationshipType !== 'subagent') continue;
+    if (typeof r.relatedSessionId !== 'string' || r.relatedSessionId.length === 0) continue;
+    let list = byParent.get(r.relatedSessionId);
+    if (!list) {
+      list = [];
+      byParent.set(r.relatedSessionId, list);
+    }
+    list.push(r);
+  }
+
+  const sessions = new Set<string>();
+  const seenParents = new Set<string>();
+  const queue = [agentId];
+  while (queue.length > 0) {
+    const parent = queue.shift()!;
+    if (seenParents.has(parent)) continue;
+    seenParents.add(parent);
+    for (const child of byParent.get(parent) ?? []) {
+      sessions.add(child.sessionId);
+      queue.push(child.sessionId);
+      if (typeof child.agentId === 'string' && child.agentId.length > 0) {
+        queue.push(child.agentId);
+      }
+    }
+  }
+  return sessions;
+}
+
+function filterTurnsByAgent(
+  turns: EnrichedTurn[],
+  agentId: string | undefined,
+  sessionIds: Set<string> | undefined,
+): EnrichedTurn[] {
+  if (agentId === undefined) return turns;
+  return turns.filter((t) => {
+    if (t.enrichment['agentId'] === agentId) return true;
+    if (t.enrichment['parentAgentId'] === agentId) return true;
+    return sessionIds?.has(t.sessionId) === true;
+  });
 }
 
 async function loadContentForQuality(

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/ledger`.
 
 ## [Unreleased]
 
+### Added
+
+- Session stamps with `parentAgentId` now append a deduped `spawn-env` relationship record for source-agnostic spawn-tree queries.
+
 ## [0.40.0] - 2026-04-28
 
 ### Added

--- a/packages/ledger/src/ledger.test.ts
+++ b/packages/ledger/src/ledger.test.ts
@@ -118,6 +118,22 @@ describe('ledger', () => {
     assert.deepEqual(b.enrichment, {});
   });
 
+  it('emits a spawn-env relationship when a session stamp carries parentAgentId', async () => {
+    await stamp(
+      { sessionId: 's-child' },
+      { agentId: 'ag-child', parentAgentId: 'ag-parent', harness: 'codex' },
+    );
+    const got = await queryRelationships();
+    assert.equal(got.length, 1);
+    const rel = got[0]!;
+    assert.equal(rel.source, 'spawn-env');
+    assert.equal(rel.sessionId, 's-child');
+    assert.equal(rel.relatedSessionId, 'ag-parent');
+    assert.equal(rel.relationshipType, 'subagent');
+    assert.equal(rel.agentId, 'ag-child');
+    assert.equal(typeof rel.ts, 'string');
+  });
+
   it('applies messageId stamp only to that one turn', async () => {
     await appendTurns([
       fakeTurn({ sessionId: 's-A', messageId: 'm1' }),

--- a/packages/ledger/src/writer.ts
+++ b/packages/ledger/src/writer.ts
@@ -197,5 +197,47 @@ export async function stamp(
     selector,
     enrichment,
   };
-  await appendLines([line]);
+  const relationship = spawnEnvRelationshipFromStamp(line);
+  if (!relationship) {
+    await appendLines([line]);
+    return;
+  }
+
+  const idx = await loadIndex();
+  const id = relationshipIdHash(relationship);
+  if (idx.ids.has(id)) {
+    await appendLines([line]);
+    return;
+  }
+  idx.ids.add(id);
+  await appendLines([
+    line,
+    {
+      v: 1,
+      kind: 'relationship',
+      record: relationship,
+    },
+  ]);
+  await appendHashes([id], []);
+}
+
+function spawnEnvRelationshipFromStamp(
+  line: StampLine,
+): SessionRelationshipRecord | null {
+  const sessionId = line.selector.sessionId;
+  if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
+  const parentAgentId = line.enrichment['parentAgentId'];
+  if (typeof parentAgentId !== 'string' || parentAgentId.length === 0) return null;
+
+  const relationship: SessionRelationshipRecord = {
+    v: 1,
+    source: 'spawn-env',
+    sessionId,
+    relatedSessionId: parentAgentId,
+    relationshipType: 'subagent',
+    ts: line.ts,
+  };
+  const agentId = line.enrichment['agentId'];
+  if (typeof agentId === 'string' && agentId.length > 0) relationship.agentId = agentId;
+  return relationship;
 }

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/reader`.
 
 ## [Unreleased]
 
+### Changed
+
+- Claude and OpenCode subagent relationship rows now identify native parent-signal sources separately from parser root/session records.
+
 ## [0.42.0] - 2026-04-28
 
 ### Added

--- a/packages/reader/src/claude.test.ts
+++ b/packages/reader/src/claude.test.ts
@@ -181,6 +181,7 @@ describe('parseClaudeSession', () => {
 
     // Outer subagent: parent is the main session id.
     assert.equal(outer.agentId, 'u-sub1-user');
+    assert.equal(outer.source, 'native-claude');
     assert.equal(outer.parentToolUseId, 'toolu_outer');
     assert.equal(outer.relatedSessionId, '55555555-5555-5555-5555-555555555555');
     assert.equal(outer.description, 'Research the codebase');
@@ -1053,4 +1054,3 @@ describe('parseClaudeSession fork / continuation relationships (#112)', () => {
     await rm(dir, { recursive: true, force: true });
   });
 });
-

--- a/packages/reader/src/claude.ts
+++ b/packages/reader/src/claude.ts
@@ -982,7 +982,7 @@ function collectSubagentRelationships(
     seen.add(agentId);
     const row: SessionRelationshipRecord = {
       v: 1,
-      source: 'claude-code',
+      source: 'native-claude',
       sessionId: t.sessionId,
       relationshipType: 'subagent',
       agentId,

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -12,6 +12,7 @@ export type {
   ContentToolUse,
   ContentToolResult,
   ContentStoreMode,
+  RelationshipSourceKind,
   RelationshipType,
   SessionRelationshipRecord,
   ToolResultStatus,

--- a/packages/reader/src/opencode.test.ts
+++ b/packages/reader/src/opencode.test.ts
@@ -750,7 +750,7 @@ describe('parseOpencodeSession execution graph (#42 / #93)', () => {
     const subRows = relationships.filter((r) => r.relationshipType === 'subagent');
     assert.equal(subRows.length, 1, 'exactly one subagent row');
     const sub = subRows[0]!;
-    assert.equal(sub.source, 'opencode');
+    assert.equal(sub.source, 'native-opencode');
     assert.equal(sub.sessionId, 'ses_child', 'row is keyed on the child');
     assert.equal(sub.relatedSessionId, 'ses_multi', 'parent session id mirrored to relatedSessionId');
     const root = relationships.find((r) => r.relationshipType === 'root');

--- a/packages/reader/src/opencode.ts
+++ b/packages/reader/src/opencode.ts
@@ -436,7 +436,7 @@ function buildOpencodeRelationships(
   if (typeof session.parentID === 'string' && session.parentID.length > 0) {
     const sub: SessionRelationshipRecord = {
       v: 1,
-      source: 'opencode',
+      source: 'native-opencode',
       sessionId: session.id,
       relatedSessionId: session.parentID,
       relationshipType: 'subagent',

--- a/packages/reader/src/types.ts
+++ b/packages/reader/src/types.ts
@@ -6,6 +6,12 @@ export type SourceKind =
   | 'openai-api'
   | 'gemini-api';
 
+export type RelationshipSourceKind =
+  | SourceKind
+  | 'spawn-env'
+  | 'native-claude'
+  | 'native-opencode';
+
 export interface Usage {
   input: number;
   output: number;
@@ -220,7 +226,7 @@ export type RelationshipType = 'root' | 'continuation' | 'fork' | 'subagent';
 
 export interface SessionRelationshipRecord {
   v: 1;
-  source: SourceKind;
+  source: RelationshipSourceKind;
   // The session this row is "about". For a root, this is the session itself.
   // For a subagent / fork / continuation, this is the *child* session — i.e.
   // the one that was spawned, forked, or continued.


### PR DESCRIPTION
## Summary
- Emit spawn-env SessionRelationshipRecord rows from parentAgentId stamps.
- Label Claude/OpenCode native subagent relationships and use relationship rows for summary --agent trees.
- Add burn diagnose drift counts plus --explain-drift details.

## Tests
- pnpm run test:ts
- node --test --test-reporter=spec packages/ledger/dist/ledger.test.js packages/cli/dist/commands/diagnose.test.js packages/cli/dist/commands/summary.test.js packages/reader/dist/claude.test.js packages/reader/dist/opencode.test.js

Closes #103
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
