### PR TITLE
Add burn summary --by-relationship

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@relayburn/cli`.
 ### Added
 
 - `burn ingest --runtime claude` now records hook-path tool-result events for Claude `PreToolUse`, `PostToolUse`, `SubagentStop`, and tool-tied `Notification` payloads.
+- `burn summary --by-relationship` now rolls up cost and turn metrics by persisted session relationship type, with `--by-relationship=subagent` for subagent-type detail.
 - `burn watch --opencode-stream` can subscribe to OpenCode's local SSE endpoint and wake ingest immediately on session/message events while polling remains the fallback.
 
 ### Changed

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,7 +22,7 @@ const HELP = `burn — token usage & cost attribution for agent CLIs
 
 Usage:
   burn summary       [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--provider <p>] [--quality]
-                     [--by-provider | --by-tool | --by-subagent-type | --subagent-tree <session-id>] [--no-archive]
+                     [--by-provider | --by-tool | --by-subagent-type | --by-relationship[=subagent] | --subagent-tree <session-id>] [--no-archive]
                      (mode flags are mutually exclusive; --by-tool emits tool | calls | attributedCost)
   burn waste         [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--provider <p>] [--all] [--json]
                      [--patterns[=retries,failures,compaction,reverts]] [--findings]
@@ -44,6 +44,7 @@ Examples:
   burn summary --by-provider --provider synthetic
   burn summary --subagent-tree <session-id>
   burn summary --by-subagent-type --since 7d
+  burn summary --by-relationship --since 7d
   burn summary --by-tool --since 7d
   burn waste --since 7d
   burn waste --patterns --since 7d

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -431,6 +431,7 @@ describe('burn summary --by-relationship (#114)', () => {
     ]);
     await appendRelationships([
       fakeRelationship({
+        source: 'native-claude',
         sessionId: 'rel-subonly',
         relationshipType: 'subagent',
         agentId: 'agent-review',
@@ -456,6 +457,54 @@ describe('burn summary --by-relationship (#114)', () => {
     assert.equal(payload.relationships[0]!.sessionCount, 1);
     assert.equal(payload.relationships[0]!.turnCount, 1);
     assert.equal(typeof payload.relationships[0]!.totalCost, 'number');
+  });
+
+  it('joins spawn-env child-session relationships to turns without subagent metadata', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'rel-spawn-child',
+        messageId: 'rel-spawn-child-1',
+        source: 'codex',
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({
+        source: 'spawn-env',
+        sessionId: 'rel-spawn-child',
+        relationshipType: 'subagent',
+        relatedSessionId: 'rel-spawn-parent',
+        agentId: 'agent-spawn-child',
+        subagentType: 'worker',
+      }),
+    ]);
+
+    const out = await captureSummary({ 'by-relationship': 'subagent', json: true });
+    assert.equal(out.code, 0);
+    const payload = JSON.parse(out.stdout) as {
+      relationships: Array<{ relationshipType: string; turnCount: number }>;
+      subagentTypes: Array<{
+        subagentType: string;
+        invocations: number;
+        turns: number;
+        totalCost: number;
+        medianCost: number;
+        p95Cost: number;
+        meanCost: number;
+      }>;
+    };
+    assert.equal(payload.relationships[0]!.relationshipType, 'subagent');
+    assert.equal(payload.relationships[0]!.turnCount, 1);
+    assert.deepEqual(payload.subagentTypes, [
+      {
+        subagentType: 'worker',
+        invocations: 1,
+        turns: 1,
+        totalCost: payload.subagentTypes[0]!.totalCost,
+        medianCost: payload.subagentTypes[0]!.medianCost,
+        p95Cost: payload.subagentTypes[0]!.p95Cost,
+        meanCost: payload.subagentTypes[0]!.meanCost,
+      },
+    ]);
   });
 
   it('--by-relationship=subagent renders the subagent type breakdown', async () => {
@@ -497,6 +546,7 @@ describe('burn summary --by-relationship (#114)', () => {
     ]);
     await appendRelationships([
       fakeRelationship({
+        source: 'native-claude',
         sessionId: 'rel-types',
         relationshipType: 'subagent',
         agentId: 'agent-explore-1',
@@ -504,6 +554,7 @@ describe('burn summary --by-relationship (#114)', () => {
         subagentType: 'Explore',
       }),
       fakeRelationship({
+        source: 'native-claude',
         sessionId: 'rel-types',
         relationshipType: 'subagent',
         agentId: 'agent-explore-2',
@@ -511,6 +562,7 @@ describe('burn summary --by-relationship (#114)', () => {
         subagentType: 'Explore',
       }),
       fakeRelationship({
+        source: 'native-claude',
         sessionId: 'rel-types',
         relationshipType: 'subagent',
         agentId: 'agent-review-1',

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -2,16 +2,22 @@ import { strict as assert } from 'node:assert';
 import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { after, beforeEach, describe, it } from 'node:test';
+import { after, afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
+  appendRelationships,
   appendUserTurns,
   appendTurns,
   archivePath,
   stamp,
   __resetIndexCacheForTesting,
 } from '@relayburn/ledger';
-import type { Fidelity, TurnRecord, UserTurnRecord } from '@relayburn/reader';
+import type {
+  Fidelity,
+  SessionRelationshipRecord,
+  TurnRecord,
+  UserTurnRecord,
+} from '@relayburn/reader';
 
 import { runSummary } from './summary.js';
 
@@ -48,6 +54,19 @@ function fakeUserTurn(overrides: Partial<UserTurnRecord> = {}): UserTurnRecord {
     precedingMessageId: 'msg-1',
     followingMessageId: 'msg-2',
     blocks: [],
+    ...overrides,
+  };
+}
+
+function fakeRelationship(
+  overrides: Partial<SessionRelationshipRecord> = {},
+): SessionRelationshipRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    sessionId: 's-1',
+    relationshipType: 'root',
+    ts: '2026-04-20T00:00:00.000Z',
     ...overrides,
   };
 }
@@ -219,6 +238,263 @@ describe('burn summary archive integration (#82)', () => {
       return idx >= 0 ? s.slice(idx) : s;
     };
     assert.equal(stripPreamble(archiveOut.stdout), stripPreamble(ledgerOut.stdout));
+  });
+});
+
+describe('burn summary --by-relationship (#114)', () => {
+  let tmpHome: string;
+  let tmpRelay: string;
+  const originalHome = process.env['HOME'];
+  const originalRelay = process.env['RELAYBURN_HOME'];
+  const originalArchive = process.env['RELAYBURN_ARCHIVE'];
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-summary-rel-home-'));
+    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-summary-rel-relay-'));
+    process.env['HOME'] = tmpHome;
+    process.env['RELAYBURN_HOME'] = tmpRelay;
+    process.env['RELAYBURN_ARCHIVE'] = '0';
+    __resetIndexCacheForTesting();
+  });
+
+  afterEach(async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(tmpRelay, { recursive: true, force: true });
+  });
+
+  after(async () => {
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+    else delete process.env['HOME'];
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    if (originalArchive !== undefined) process.env['RELAYBURN_ARCHIVE'] = originalArchive;
+    else delete process.env['RELAYBURN_ARCHIVE'];
+  });
+
+  it('renders a relationship table for all four relationship types', async () => {
+    await appendTurns([
+      fakeTurn({ sessionId: 'rel-root', messageId: 'rel-root-1' }),
+      fakeTurn({
+        sessionId: 'rel-root',
+        messageId: 'rel-sub-1',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        subagent: {
+          isSidechain: true,
+          agentId: 'agent-explore',
+          parentAgentId: 'rel-root',
+          subagentType: 'Explore',
+        },
+      }),
+      fakeTurn({
+        sessionId: 'rel-cont',
+        messageId: 'rel-cont-1',
+        ts: '2026-04-20T00:02:00.000Z',
+      }),
+      fakeTurn({
+        sessionId: 'rel-fork',
+        messageId: 'rel-fork-1',
+        ts: '2026-04-20T00:03:00.000Z',
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({ sessionId: 'rel-root', relationshipType: 'root' }),
+      fakeRelationship({
+        sessionId: 'rel-root',
+        relationshipType: 'subagent',
+        agentId: 'agent-explore',
+        relatedSessionId: 'rel-root',
+        subagentType: 'Explore',
+      }),
+      fakeRelationship({
+        sessionId: 'rel-cont',
+        relationshipType: 'continuation',
+        relatedSessionId: 'rel-parent',
+      }),
+      fakeRelationship({
+        sessionId: 'rel-fork',
+        relationshipType: 'fork',
+        relatedSessionId: 'rel-source',
+        sourceSessionId: 'rel-source',
+      }),
+    ]);
+
+    const out = await captureSummary({ 'by-relationship': true });
+    assert.equal(out.code, 0);
+    assert.match(
+      out.stdout,
+      /relationshipType\s+sessionCount\s+turnCount\s+total\s+median\s+p95\s+mean/,
+    );
+    assert.match(out.stdout, /root\s+1\s+1\s+\$/);
+    assert.match(out.stdout, /continuation\s+1\s+1\s+\$/);
+    assert.match(out.stdout, /fork\s+1\s+1\s+\$/);
+    assert.match(out.stdout, /subagent\s+1\s+1\s+\$/);
+  });
+
+  it('--json emits a stable relationships block', async () => {
+    await appendTurns([
+      fakeTurn({ sessionId: 'rel-json-root', messageId: 'rel-json-root-1' }),
+      fakeTurn({
+        sessionId: 'rel-json-cont',
+        messageId: 'rel-json-cont-1',
+        ts: '2026-04-20T00:01:00.000Z',
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({ sessionId: 'rel-json-root', relationshipType: 'root' }),
+      fakeRelationship({
+        sessionId: 'rel-json-cont',
+        relationshipType: 'continuation',
+        relatedSessionId: 'rel-json-parent',
+      }),
+    ]);
+
+    const out = await captureSummary({ 'by-relationship': true, json: true });
+    assert.equal(out.code, 0);
+    interface Payload {
+      relationships: Array<{
+        relationshipType: string;
+        count: number;
+        sessionCount: number;
+        turnCount: number;
+        totalCost: number;
+        medianCost: number;
+        p95Cost: number;
+        meanCost: number;
+      }>;
+    }
+    const payload = JSON.parse(out.stdout) as Payload;
+    assert.deepEqual(
+      payload.relationships.map((r) => r.relationshipType),
+      ['root', 'continuation'],
+    );
+    assert.equal(payload.relationships[0]!.count, 1);
+    assert.equal(payload.relationships[0]!.sessionCount, 1);
+    assert.equal(payload.relationships[0]!.turnCount, 1);
+    assert.equal(typeof payload.relationships[0]!.totalCost, 'number');
+    assert.equal(typeof payload.relationships[0]!.medianCost, 'number');
+    assert.equal(typeof payload.relationships[0]!.p95Cost, 'number');
+    assert.equal(typeof payload.relationships[0]!.meanCost, 'number');
+  });
+
+  it('can aggregate a subagent-only slice', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'rel-subonly',
+        messageId: 'rel-subonly-1',
+        subagent: {
+          isSidechain: true,
+          agentId: 'agent-review',
+          parentAgentId: 'rel-subonly',
+          subagentType: 'code-reviewer',
+        },
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({
+        sessionId: 'rel-subonly',
+        relationshipType: 'subagent',
+        agentId: 'agent-review',
+        relatedSessionId: 'rel-subonly',
+        subagentType: 'code-reviewer',
+      }),
+    ]);
+
+    const out = await captureSummary({ 'by-relationship': true, json: true });
+    assert.equal(out.code, 0);
+    const payload = JSON.parse(out.stdout) as {
+      relationships: Array<{
+        relationshipType: string;
+        count: number;
+        sessionCount: number;
+        turnCount: number;
+        totalCost: number;
+      }>;
+    };
+    assert.equal(payload.relationships.length, 1);
+    assert.equal(payload.relationships[0]!.relationshipType, 'subagent');
+    assert.equal(payload.relationships[0]!.count, 1);
+    assert.equal(payload.relationships[0]!.sessionCount, 1);
+    assert.equal(payload.relationships[0]!.turnCount, 1);
+    assert.equal(typeof payload.relationships[0]!.totalCost, 'number');
+  });
+
+  it('--by-relationship=subagent renders the subagent type breakdown', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'rel-types',
+        messageId: 'rel-types-1',
+        subagent: {
+          isSidechain: true,
+          agentId: 'agent-explore-1',
+          parentAgentId: 'rel-types',
+          subagentType: 'Explore',
+        },
+      }),
+      fakeTurn({
+        sessionId: 'rel-types',
+        messageId: 'rel-types-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        subagent: {
+          isSidechain: true,
+          agentId: 'agent-explore-2',
+          parentAgentId: 'rel-types',
+          subagentType: 'Explore',
+        },
+      }),
+      fakeTurn({
+        sessionId: 'rel-types',
+        messageId: 'rel-types-3',
+        turnIndex: 2,
+        ts: '2026-04-20T00:02:00.000Z',
+        subagent: {
+          isSidechain: true,
+          agentId: 'agent-review-1',
+          parentAgentId: 'rel-types',
+          subagentType: 'code-reviewer',
+        },
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({
+        sessionId: 'rel-types',
+        relationshipType: 'subagent',
+        agentId: 'agent-explore-1',
+        relatedSessionId: 'rel-types',
+        subagentType: 'Explore',
+      }),
+      fakeRelationship({
+        sessionId: 'rel-types',
+        relationshipType: 'subagent',
+        agentId: 'agent-explore-2',
+        relatedSessionId: 'rel-types',
+        subagentType: 'Explore',
+      }),
+      fakeRelationship({
+        sessionId: 'rel-types',
+        relationshipType: 'subagent',
+        agentId: 'agent-review-1',
+        relatedSessionId: 'rel-types',
+        subagentType: 'code-reviewer',
+      }),
+    ]);
+
+    const out = await captureSummary({ 'by-relationship': 'subagent' });
+    assert.equal(out.code, 0);
+    assert.match(
+      out.stdout,
+      /subagentType\s+invocations\s+turns\s+total\s+median\s+p95\s+mean/,
+    );
+    assert.match(out.stdout, /Explore\s+2\s+2\s+\$/);
+    assert.match(out.stdout, /code-reviewer\s+1\s+1\s+\$/);
+  });
+
+  it('prints a clear message when no relationship rows match the slice', async () => {
+    await appendTurns([fakeTurn({ sessionId: 'rel-empty', messageId: 'rel-empty-1' })]);
+    const out = await captureSummary({ 'by-relationship': true });
+    assert.equal(out.code, 0);
+    assert.match(out.stdout, /no SessionRelationshipRecord rows found for the matched slice/);
   });
 });
 
@@ -613,7 +889,7 @@ describe('burn summary per-cell fidelity (#136)', () => {
     assert.equal(out.code, 2);
     assert.match(
       out.stderr,
-      /--by-tool cannot be combined with --by-provider\/--by-subagent-type\/--subagent-tree/,
+      /--by-tool cannot be combined with --by-provider\/--by-subagent-type\/--by-relationship\/--subagent-tree/,
     );
   });
 
@@ -622,14 +898,14 @@ describe('burn summary per-cell fidelity (#136)', () => {
     assert.equal(byType.code, 2);
     assert.match(
       byType.stderr,
-      /--by-provider cannot be combined with --by-subagent-type\/--subagent-tree/,
+      /--by-provider cannot be combined with --by-subagent-type\/--by-relationship\/--subagent-tree/,
     );
 
     const tree = await captureSummary({ 'by-provider': true, 'subagent-tree': 's-1' });
     assert.equal(tree.code, 2);
     assert.match(
       tree.stderr,
-      /--by-provider cannot be combined with --by-subagent-type\/--subagent-tree/,
+      /--by-provider cannot be combined with --by-subagent-type\/--by-relationship\/--subagent-tree/,
     );
   });
 

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -21,12 +21,19 @@ import {
   buildArchive,
   queryAll,
   queryAllFromArchive,
+  queryRelationships,
   queryUserTurns,
   readContent,
   type Query,
 } from '@relayburn/ledger';
 import type { EnrichedTurn } from '@relayburn/ledger';
-import type { ContentRecord, Coverage, UserTurnRecord } from '@relayburn/reader';
+import type {
+  ContentRecord,
+  Coverage,
+  RelationshipType,
+  SessionRelationshipRecord,
+  UserTurnRecord,
+} from '@relayburn/reader';
 
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
@@ -51,22 +58,47 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
 
   const subagentTreeFlag = args.flags['subagent-tree'];
   const subagentTypeFlag = args.flags['by-subagent-type'] === true;
+  const relationshipFlag = args.flags['by-relationship'];
+  const byRelationship = relationshipFlag !== undefined;
   const byProvider = args.flags['by-provider'] === true;
   const byTool = args.flags['by-tool'] === true;
+  if (
+    relationshipFlag !== undefined &&
+    relationshipFlag !== true &&
+    relationshipFlag !== 'subagent'
+  ) {
+    process.stderr.write('burn: --by-relationship accepts only the optional value "subagent"\n');
+    return 2;
+  }
 
   // Mode exclusivity: each "mode flag" produces its own output shape; combining
   // them silently would surprise the caller (we'd pick one and drop the rest).
   // Subagent flags already implicitly assume one-axis-at-a-time; --by-tool
   // makes that explicit.
-  if (byTool && (byProvider || subagentTypeFlag || subagentTreeFlag !== undefined)) {
+  if (
+    byTool &&
+    (byProvider || subagentTypeFlag || byRelationship || subagentTreeFlag !== undefined)
+  ) {
     process.stderr.write(
-      'burn: --by-tool cannot be combined with --by-provider/--by-subagent-type/--subagent-tree\n',
+      'burn: --by-tool cannot be combined with --by-provider/--by-subagent-type/--by-relationship/--subagent-tree\n',
     );
     return 2;
   }
-  if (byProvider && (subagentTypeFlag || subagentTreeFlag !== undefined)) {
+  if (byProvider && (subagentTypeFlag || byRelationship || subagentTreeFlag !== undefined)) {
     process.stderr.write(
-      'burn: --by-provider cannot be combined with --by-subagent-type/--subagent-tree\n',
+      'burn: --by-provider cannot be combined with --by-subagent-type/--by-relationship/--subagent-tree\n',
+    );
+    return 2;
+  }
+  if (subagentTypeFlag && (byRelationship || subagentTreeFlag !== undefined)) {
+    process.stderr.write(
+      'burn: --by-subagent-type cannot be combined with --by-relationship/--subagent-tree\n',
+    );
+    return 2;
+  }
+  if (byRelationship && subagentTreeFlag !== undefined) {
+    process.stderr.write(
+      'burn: --by-relationship cannot be combined with --subagent-tree\n',
     );
     return 2;
   }
@@ -80,6 +112,9 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   }
   if (subagentTypeFlag) {
     return renderSubagentTypeMode(args, turns, pricing);
+  }
+  if (byRelationship) {
+    return renderRelationshipMode(args, turns, pricing, q, relationshipFlag);
   }
   if (byTool) {
     return renderByToolMode(args, ingestReport, turns, pricing);
@@ -592,6 +627,104 @@ function renderSubagentTypeMode(
   return 0;
 }
 
+async function renderRelationshipMode(
+  args: ParsedArgs,
+  turns: EnrichedTurn[],
+  pricing: Parameters<typeof costForTurn>[1],
+  q: Query,
+  flag: string | true,
+): Promise<number> {
+  const relationships = await queryRelationships(relationshipQueryForTurnSlice(q));
+  const matches = matchRelationshipsToTurns(relationships, turns, pricing);
+  const stats = aggregateRelationshipStats(matches);
+
+  if (flag === 'subagent') {
+    return renderRelationshipSubagentMode(args, stats, matches);
+  }
+
+  if (stats.length === 0) {
+    return renderNoRelationships(args);
+  }
+
+  if (args.flags['json'] === true) {
+    process.stdout.write(JSON.stringify({ relationships: stats }, null, 2) + '\n');
+    return 0;
+  }
+
+  const out: string[] = [];
+  out.push('');
+  out.push(`relationships: ${formatInt(stats.reduce((sum, s) => sum + s.sessionCount, 0))}`);
+  out.push('');
+  const rows: string[][] = [
+    ['relationshipType', 'sessionCount', 'turnCount', 'total', 'median', 'p95', 'mean'],
+  ];
+  for (const s of stats) {
+    rows.push([
+      s.relationshipType,
+      formatInt(s.sessionCount),
+      formatInt(s.turnCount),
+      formatUsd(s.totalCost),
+      formatUsd(s.medianCost),
+      formatUsd(s.p95Cost),
+      formatUsd(s.meanCost),
+    ]);
+  }
+  out.push(table(rows));
+  out.push('');
+  process.stdout.write(out.join('\n'));
+  return 0;
+}
+
+function renderRelationshipSubagentMode(
+  args: ParsedArgs,
+  stats: RelationshipStats[],
+  matches: RelationshipMatch[],
+): number {
+  const subagentStats = aggregateRelationshipSubagentStats(matches);
+  if (subagentStats.length === 0) {
+    return renderNoRelationships(args);
+  }
+
+  if (args.flags['json'] === true) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          relationships: stats.filter((s) => s.relationshipType === 'subagent'),
+          subagentTypes: subagentStats,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+
+  const out: string[] = [];
+  out.push('');
+  out.push(
+    `subagent invocations: ${formatInt(subagentStats.reduce((a, s) => a + s.invocations, 0))}`,
+  );
+  out.push('');
+  const rows: string[][] = [
+    ['subagentType', 'invocations', 'turns', 'total', 'median', 'p95', 'mean'],
+  ];
+  for (const s of subagentStats) {
+    rows.push([
+      s.subagentType,
+      formatInt(s.invocations),
+      formatInt(s.turns),
+      formatUsd(s.totalCost),
+      formatUsd(s.medianCost),
+      formatUsd(s.p95Cost),
+      formatUsd(s.meanCost),
+    ]);
+  }
+  out.push(table(rows));
+  out.push('');
+  process.stdout.write(out.join('\n'));
+  return 0;
+}
+
 function renderTree(root: SubagentTreeNode): string[] {
   const out: string[] = [];
   out.push(renderNodeLine(root, ''));
@@ -706,6 +839,15 @@ function buildPerCellFidelity(
 
 const PARTIAL_MARK = '*';
 const DASH = '—';
+const NO_RELATIONSHIPS_MESSAGE =
+  'no SessionRelationshipRecord rows found for the matched slice; ingest a session with execution-graph wiring or run `burn rebuild` once relationship backfill is available';
+
+const RELATIONSHIP_ORDER: RelationshipType[] = [
+  'root',
+  'continuation',
+  'fork',
+  'subagent',
+];
 
 function renderFidelityNotice(f: FidelitySummary): string | undefined {
   // Returns undefined when every classified turn is full fidelity *and* no
@@ -727,6 +869,24 @@ function renderFidelityNotice(f: FidelitySummary): string | undefined {
   if (f.byClass.partial > 0) parts.push(`${f.byClass.partial} partial`);
   if (f.unknown > 0) parts.push(`${f.unknown} unknown`);
   return `fidelity: ${parts.join(' / ')} (use --json for per-field coverage)`;
+}
+
+function renderNoRelationships(args: ParsedArgs): number {
+  if (args.flags['json'] === true) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          relationships: [],
+          message: NO_RELATIONSHIPS_MESSAGE,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(`${NO_RELATIONSHIPS_MESSAGE}\n`);
+  }
+  return 0;
 }
 
 /**
@@ -799,6 +959,243 @@ function aggregateTurns(
     }
   }
   return [...byModel.values()].sort((a, b) => b.cost.total - a.cost.total);
+}
+
+function relationshipQueryForTurnSlice(q: Query): Query {
+  // Project/workflow/agent/provider filters have already been applied to the
+  // turn slice. Let matching turns, not relationship timestamps, define the
+  // slice so an old root row can still classify a recent turn in the same
+  // session.
+  const out: Query = {};
+  if (q.sessionId !== undefined) out.sessionId = q.sessionId;
+  if (q.source !== undefined) out.source = q.source;
+  return out;
+}
+
+interface RelationshipTurnIndex {
+  allBySession: Map<string, EnrichedTurn[]>;
+  mainBySession: Map<string, EnrichedTurn[]>;
+  sidechainBySession: Map<string, EnrichedTurn[]>;
+  subagentBySessionAgent: Map<string, EnrichedTurn[]>;
+}
+
+interface RelationshipMatch {
+  source: SessionRelationshipRecord['source'];
+  relationshipType: RelationshipType;
+  sessionId: string;
+  subagentType?: string;
+  turnCount: number;
+  cost: number;
+}
+
+interface RelationshipStats {
+  relationshipType: RelationshipType;
+  count: number;
+  sessionCount: number;
+  turnCount: number;
+  totalCost: number;
+  medianCost: number;
+  p95Cost: number;
+  meanCost: number;
+}
+
+interface RelationshipSubagentStats {
+  subagentType: string;
+  invocations: number;
+  turns: number;
+  totalCost: number;
+  medianCost: number;
+  p95Cost: number;
+  meanCost: number;
+}
+
+function matchRelationshipsToTurns(
+  relationships: SessionRelationshipRecord[],
+  turns: EnrichedTurn[],
+  pricing: Parameters<typeof costForTurn>[1],
+): RelationshipMatch[] {
+  const index = buildRelationshipTurnIndex(turns);
+  const out: RelationshipMatch[] = [];
+  const seen = new Set<string>();
+  for (const r of relationships) {
+    const key = relationshipInstanceKey(r);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const matchedTurns = turnsForRelationship(r, index);
+    if (matchedTurns.length === 0) continue;
+    const match: RelationshipMatch = {
+      source: r.source,
+      relationshipType: r.relationshipType,
+      sessionId: r.sessionId,
+      turnCount: matchedTurns.length,
+      cost: matchedTurns.reduce((sum, t) => sum + (costForTurn(t, pricing)?.total ?? 0), 0),
+    };
+    const subagentType = relationshipSubagentType(r, matchedTurns);
+    if (subagentType !== undefined) match.subagentType = subagentType;
+    out.push(match);
+  }
+  return out;
+}
+
+function buildRelationshipTurnIndex(turns: EnrichedTurn[]): RelationshipTurnIndex {
+  const allBySession = new Map<string, EnrichedTurn[]>();
+  const mainBySession = new Map<string, EnrichedTurn[]>();
+  const sidechainBySession = new Map<string, EnrichedTurn[]>();
+  const subagentBySessionAgent = new Map<string, EnrichedTurn[]>();
+  for (const turn of turns) {
+    const key = sourceSessionKey(turn.source, turn.sessionId);
+    pushMap(allBySession, key, turn);
+    if (isMainThreadTurn(turn)) pushMap(mainBySession, key, turn);
+    if (turn.subagent?.isSidechain) pushMap(sidechainBySession, key, turn);
+    const agentId = turn.subagent?.agentId;
+    if (agentId !== undefined && agentId.length > 0) {
+      pushMap(
+        subagentBySessionAgent,
+        sourceSessionAgentKey(turn.source, turn.sessionId, agentId),
+        turn,
+      );
+    }
+  }
+  return { allBySession, mainBySession, sidechainBySession, subagentBySessionAgent };
+}
+
+function turnsForRelationship(
+  r: SessionRelationshipRecord,
+  index: RelationshipTurnIndex,
+): EnrichedTurn[] {
+  const sessionKey = sourceSessionKey(r.source, r.sessionId);
+  switch (r.relationshipType) {
+    case 'root':
+      return index.mainBySession.get(sessionKey) ?? [];
+    case 'subagent': {
+      if (r.agentId !== undefined && r.agentId.length > 0) {
+        const direct = index.subagentBySessionAgent.get(
+          sourceSessionAgentKey(r.source, r.sessionId, r.agentId),
+        );
+        if (direct !== undefined && direct.length > 0) return direct;
+        // Some sources model a spawned agent as its own session and do not
+        // annotate the child turns with `subagent`. In that shape the
+        // relationship row's sessionId/agentId is the only join key.
+        if (r.sessionId === r.agentId) return index.allBySession.get(sessionKey) ?? [];
+      }
+      return index.sidechainBySession.get(sessionKey) ?? [];
+    }
+    case 'continuation':
+    case 'fork':
+      return index.allBySession.get(sessionKey) ?? [];
+  }
+}
+
+function aggregateRelationshipStats(matches: RelationshipMatch[]): RelationshipStats[] {
+  const byType = new Map<RelationshipType, Map<string, { turns: number; cost: number }>>();
+  for (const match of matches) {
+    let bySession = byType.get(match.relationshipType);
+    if (!bySession) {
+      bySession = new Map();
+      byType.set(match.relationshipType, bySession);
+    }
+    const key = sourceSessionKey(match.source, match.sessionId);
+    const current = bySession.get(key) ?? { turns: 0, cost: 0 };
+    current.turns += match.turnCount;
+    current.cost += match.cost;
+    bySession.set(key, current);
+  }
+
+  const out: RelationshipStats[] = [];
+  for (const relationshipType of RELATIONSHIP_ORDER) {
+    const bySession = byType.get(relationshipType);
+    if (!bySession || bySession.size === 0) continue;
+    const costs = [...bySession.values()].map((v) => v.cost).sort((a, b) => a - b);
+    const totalCost = costs.reduce((sum, n) => sum + n, 0);
+    const sessionCount = bySession.size;
+    out.push({
+      relationshipType,
+      count: sessionCount,
+      sessionCount,
+      turnCount: [...bySession.values()].reduce((sum, v) => sum + v.turns, 0),
+      totalCost,
+      medianCost: percentile(costs, 0.5),
+      p95Cost: percentile(costs, 0.95),
+      meanCost: sessionCount > 0 ? totalCost / sessionCount : 0,
+    });
+  }
+  return out;
+}
+
+function aggregateRelationshipSubagentStats(
+  matches: RelationshipMatch[],
+): RelationshipSubagentStats[] {
+  const byType = new Map<string, { turns: number; total: number; costs: number[] }>();
+  for (const match of matches) {
+    if (match.relationshipType !== 'subagent') continue;
+    const type = match.subagentType ?? '(unknown)';
+    const current = byType.get(type) ?? { turns: 0, total: 0, costs: [] };
+    current.turns += match.turnCount;
+    current.total += match.cost;
+    current.costs.push(match.cost);
+    byType.set(type, current);
+  }
+  const out: RelationshipSubagentStats[] = [];
+  for (const [subagentType, agg] of byType) {
+    agg.costs.sort((a, b) => a - b);
+    out.push({
+      subagentType,
+      invocations: agg.costs.length,
+      turns: agg.turns,
+      totalCost: agg.total,
+      medianCost: percentile(agg.costs, 0.5),
+      p95Cost: percentile(agg.costs, 0.95),
+      meanCost: agg.costs.length > 0 ? agg.total / agg.costs.length : 0,
+    });
+  }
+  return out.sort((a, b) => b.totalCost - a.totalCost);
+}
+
+function relationshipSubagentType(
+  relationship: SessionRelationshipRecord,
+  turns: EnrichedTurn[],
+): string | undefined {
+  if (relationship.subagentType !== undefined) return relationship.subagentType;
+  for (const turn of turns) {
+    if (turn.subagent?.subagentType !== undefined) return turn.subagent.subagentType;
+  }
+  return undefined;
+}
+
+function relationshipInstanceKey(r: SessionRelationshipRecord): string {
+  return [
+    r.source,
+    r.relationshipType,
+    r.sessionId,
+    r.relatedSessionId ?? '',
+    r.agentId ?? '',
+    r.parentToolUseId ?? '',
+  ].join('\0');
+}
+
+function sourceSessionKey(source: string, sessionId: string): string {
+  return `${source}\0${sessionId}`;
+}
+
+function sourceSessionAgentKey(source: string, sessionId: string, agentId: string): string {
+  return `${source}\0${sessionId}\0${agentId}`;
+}
+
+function isMainThreadTurn(turn: EnrichedTurn): boolean {
+  const sub = turn.subagent;
+  return !sub || !sub.isSidechain || sub.agentId === turn.sessionId;
+}
+
+function pushMap<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const list = map.get(key);
+  if (list) list.push(value);
+  else map.set(key, [value]);
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const rank = Math.min(sorted.length - 1, Math.max(0, Math.ceil(p * sorted.length) - 1));
+  return sorted[rank]!;
 }
 
 // A turn whose record predates #41 has no `coverage` map; the long-standing

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -1036,7 +1036,6 @@ interface RelationshipTurnIndex {
 }
 
 interface RelationshipMatch {
-  source: SessionRelationshipRecord['source'];
   relationshipType: RelationshipType;
   sessionId: string;
   subagentType?: string;
@@ -1080,7 +1079,6 @@ function matchRelationshipsToTurns(
     const matchedTurns = turnsForRelationship(r, index);
     if (matchedTurns.length === 0) continue;
     const match: RelationshipMatch = {
-      source: r.source,
       relationshipType: r.relationshipType,
       sessionId: r.sessionId,
       turnCount: matchedTurns.length,
@@ -1099,17 +1097,12 @@ function buildRelationshipTurnIndex(turns: EnrichedTurn[]): RelationshipTurnInde
   const sidechainBySession = new Map<string, EnrichedTurn[]>();
   const subagentBySessionAgent = new Map<string, EnrichedTurn[]>();
   for (const turn of turns) {
-    const key = sourceSessionKey(turn.source, turn.sessionId);
-    pushMap(allBySession, key, turn);
-    if (isMainThreadTurn(turn)) pushMap(mainBySession, key, turn);
-    if (turn.subagent?.isSidechain) pushMap(sidechainBySession, key, turn);
+    pushMap(allBySession, turn.sessionId, turn);
+    if (isMainThreadTurn(turn)) pushMap(mainBySession, turn.sessionId, turn);
+    if (turn.subagent?.isSidechain) pushMap(sidechainBySession, turn.sessionId, turn);
     const agentId = turn.subagent?.agentId;
     if (agentId !== undefined && agentId.length > 0) {
-      pushMap(
-        subagentBySessionAgent,
-        sourceSessionAgentKey(turn.source, turn.sessionId, agentId),
-        turn,
-      );
+      pushMap(subagentBySessionAgent, sessionAgentKey(turn.sessionId, agentId), turn);
     }
   }
   return { allBySession, mainBySession, sidechainBySession, subagentBySessionAgent };
@@ -1119,26 +1112,26 @@ function turnsForRelationship(
   r: SessionRelationshipRecord,
   index: RelationshipTurnIndex,
 ): EnrichedTurn[] {
-  const sessionKey = sourceSessionKey(r.source, r.sessionId);
   switch (r.relationshipType) {
     case 'root':
-      return index.mainBySession.get(sessionKey) ?? [];
+      return index.mainBySession.get(r.sessionId) ?? [];
     case 'subagent': {
       if (r.agentId !== undefined && r.agentId.length > 0) {
-        const direct = index.subagentBySessionAgent.get(
-          sourceSessionAgentKey(r.source, r.sessionId, r.agentId),
-        );
+        const direct = index.subagentBySessionAgent.get(sessionAgentKey(r.sessionId, r.agentId));
         if (direct !== undefined && direct.length > 0) return direct;
         // Some sources model a spawned agent as its own session and do not
         // annotate the child turns with `subagent`. In that shape the
         // relationship row's sessionId/agentId is the only join key.
-        if (r.sessionId === r.agentId) return index.allBySession.get(sessionKey) ?? [];
+        if (r.sessionId === r.agentId) return index.allBySession.get(r.sessionId) ?? [];
       }
-      return index.sidechainBySession.get(sessionKey) ?? [];
+      const sidechain = index.sidechainBySession.get(r.sessionId);
+      if (sidechain !== undefined && sidechain.length > 0) return sidechain;
+      if (r.source === 'spawn-env') return index.allBySession.get(r.sessionId) ?? [];
+      return [];
     }
     case 'continuation':
     case 'fork':
-      return index.allBySession.get(sessionKey) ?? [];
+      return index.allBySession.get(r.sessionId) ?? [];
   }
 }
 
@@ -1150,11 +1143,10 @@ function aggregateRelationshipStats(matches: RelationshipMatch[]): RelationshipS
       bySession = new Map();
       byType.set(match.relationshipType, bySession);
     }
-    const key = sourceSessionKey(match.source, match.sessionId);
-    const current = bySession.get(key) ?? { turns: 0, cost: 0 };
+    const current = bySession.get(match.sessionId) ?? { turns: 0, cost: 0 };
     current.turns += match.turnCount;
     current.cost += match.cost;
-    bySession.set(key, current);
+    bySession.set(match.sessionId, current);
   }
 
   const out: RelationshipStats[] = [];
@@ -1229,12 +1221,8 @@ function relationshipInstanceKey(r: SessionRelationshipRecord): string {
   ].join('\0');
 }
 
-function sourceSessionKey(source: string, sessionId: string): string {
-  return `${source}\0${sessionId}`;
-}
-
-function sourceSessionAgentKey(source: string, sessionId: string, agentId: string): string {
-  return `${source}\0${sessionId}\0${agentId}`;
+function sessionAgentKey(sessionId: string, agentId: string): string {
+  return `${sessionId}\0${agentId}`;
 }
 
 function isMainThreadTurn(turn: EnrichedTurn): boolean {


### PR DESCRIPTION
Closes #114

Summary:
- Adds burn summary --by-relationship table and JSON output for SessionRelationshipRecord rows.
- Adds burn summary --by-relationship=subagent for subagent type detail.
- Covers full relationship, subagent-only, JSON, subgrouping, and empty-slice behavior.

Tests:
- pnpm run build
- node --test --test-reporter=spec packages/cli/dist/commands/summary.test.js
- pnpm run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
