### PR TITLE
Surface execution graph in diagnose

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ You can override per-call via `costForUsage(usage, model, pricing, { reasoningMo
 
 ```
 burn summary [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--provider <p>]
-             [--by-provider | --by-tool | --by-subagent-type | --subagent-tree <session-id>]
+             [--by-provider | --by-tool | --by-subagent-type | --by-relationship[=subagent] | --subagent-tree <session-id>]
 burn waste [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--provider <p>]
 burn compare <model_a,model_b[,...]> [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--fidelity <class>] [--include-partial] [--json|--csv]
 burn run <claude|codex|opencode>  [--tag k=v ...] [-- <harness args>]

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@relayburn/cli`.
 ### Added
 
 - `burn diagnose` now reports spawn-env/native relationship drift, with `--explain-drift` for per-session details.
+- `burn diagnose <session>` now surfaces session relationships and tool-result chronology from the execution graph.
 - `burn ingest --runtime claude` now records hook-path tool-result events for Claude `PreToolUse`, `PostToolUse`, `SubagentStop`, and tool-tied `Notification` payloads.
 - `burn summary --by-relationship` now rolls up cost and turn metrics by persisted session relationship type, with `--by-relationship=subagent` for subagent-type detail.
 - `burn watch --opencode-stream` can subscribe to OpenCode's local SSE endpoint and wake ingest immediately on session/message events while polling remains the fallback.

--- a/packages/cli/src/commands/diagnose.test.ts
+++ b/packages/cli/src/commands/diagnose.test.ts
@@ -8,9 +8,16 @@ import {
   __resetIndexCacheForTesting,
   appendContent,
   appendRelationships,
+  appendToolResultEvents,
   appendTurns,
 } from '@relayburn/ledger';
-import type { ContentRecord, SourceKind, TurnRecord } from '@relayburn/reader';
+import type {
+  ContentRecord,
+  SessionRelationshipRecord,
+  SourceKind,
+  ToolResultEventRecord,
+  TurnRecord,
+} from '@relayburn/reader';
 
 import { runDiagnose } from './diagnose.js';
 
@@ -84,6 +91,41 @@ function toolResultContent(opts: {
       toolUseId: opts.toolUseId,
       content: 'ok',
     },
+  };
+}
+
+function fakeRelationship(
+  overrides: Partial<SessionRelationshipRecord> = {},
+): SessionRelationshipRecord {
+  return {
+    v: 1,
+    source: 'native-claude',
+    sessionId: 's-1',
+    relationshipType: 'root',
+    ts: '2026-04-20T00:00:01.000Z',
+    ...overrides,
+  };
+}
+
+function fakeToolResultEvent(
+  overrides: Partial<ToolResultEventRecord> & {
+    sessionId: string;
+    toolUseId: string;
+    eventIndex: number;
+  },
+): ToolResultEventRecord {
+  const { sessionId, toolUseId, eventIndex, ...rest } = overrides;
+  return {
+    v: 1,
+    source: 'claude-code',
+    sessionId,
+    toolUseId,
+    eventIndex,
+    ts: `2026-04-20T00:02:${String(eventIndex).padStart(2, '0')}.000Z`,
+    status: 'completed',
+    eventSource: 'tool_result',
+    contentLength: 2,
+    ...rest,
   };
 }
 
@@ -494,6 +536,158 @@ describe('burn diagnose aggregate (#79)', () => {
     });
     assert.equal(out.code, 1);
     assert.match(out.stderr, /no turns found for session does-not-exist/);
+  });
+
+  it('renders relationship rows and linked tool-result chronology for a session', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'diag-parent',
+        messageId: 'diag-parent-1',
+      }),
+      fakeTurn({
+        sessionId: 'diag-child',
+        messageId: 'diag-child-1',
+        ts: '2026-04-20T00:03:00.000Z',
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({
+        sessionId: 'diag-parent',
+        relationshipType: 'root',
+      }),
+      fakeRelationship({
+        sessionId: 'diag-child',
+        relatedSessionId: 'diag-parent',
+        relationshipType: 'subagent',
+        parentToolUseId: 'tool-spawn',
+        agentId: 'agent-review',
+        subagentType: 'code-reviewer',
+        description: 'inspect execution graph',
+      }),
+    ]);
+    await appendToolResultEvents([
+      fakeToolResultEvent({
+        sessionId: 'diag-parent',
+        toolUseId: 'tool-spawn',
+        eventIndex: 0,
+        status: 'errored',
+        contentLength: 120,
+      }),
+      fakeToolResultEvent({
+        sessionId: 'diag-parent',
+        toolUseId: 'tool-spawn',
+        eventIndex: 1,
+        status: 'errored',
+        contentLength: 128,
+      }),
+      fakeToolResultEvent({
+        sessionId: 'diag-parent',
+        toolUseId: 'tool-spawn',
+        eventIndex: 2,
+        status: 'completed',
+        contentLength: 80,
+      }),
+      fakeToolResultEvent({
+        sessionId: 'diag-child',
+        toolUseId: 'child-read',
+        eventIndex: 0,
+        status: 'errored',
+        contentLength: 64,
+      }),
+    ]);
+
+    const out = await captureDiagnose({
+      flags: {},
+      tags: {},
+      positional: ['diag-parent'],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    assert.match(out.stdout, /tool results: 1 of 2 tool calls errored across 2 linked sessions/);
+    assert.match(out.stdout, /Session relationships/);
+    assert.match(out.stdout, /diag-child/);
+    assert.match(out.stdout, /subagent/);
+    assert.match(out.stdout, /code-reviewer/);
+    assert.match(out.stdout, /tool-spawn/);
+    assert.match(out.stdout, /inspect execution graph/);
+    assert.match(out.stdout, /Tool result chronology/);
+    assert.match(out.stdout, /errored \(2x\)/);
+    assert.match(out.stdout, /child-read/);
+  });
+
+  it('adds graph arrays to diagnose --json', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'diag-json',
+        messageId: 'diag-json-1',
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({
+        sessionId: 'diag-json',
+        relationshipType: 'root',
+      }),
+    ]);
+    await appendToolResultEvents([
+      fakeToolResultEvent({
+        sessionId: 'diag-json',
+        toolUseId: 'json-read',
+        eventIndex: 0,
+        status: 'completed',
+        contentLength: 42,
+      }),
+    ]);
+
+    const out = await captureDiagnose({
+      flags: { json: true },
+      tags: {},
+      positional: ['diag-json'],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    const parsed = JSON.parse(out.stdout) as {
+      relationships: SessionRelationshipRecord[];
+      toolResultEvents: ToolResultEventRecord[];
+      toolResultStatusBySession: Array<{
+        sessionId: string;
+        toolCalls: number;
+        completed: number;
+      }>;
+    };
+    assert.equal(parsed.relationships.length, 1);
+    assert.equal(parsed.relationships[0]!.relationshipType, 'root');
+    assert.equal(parsed.toolResultEvents.length, 1);
+    assert.equal(parsed.toolResultEvents[0]!.toolUseId, 'json-read');
+    assert.deepEqual(parsed.toolResultStatusBySession, [
+      {
+        sessionId: 'diag-json',
+        toolCalls: 1,
+        completed: 1,
+        errored: 0,
+        cancelled: 0,
+        unknown: 0,
+      },
+    ]);
+  });
+
+  it('keeps the human per-session output unchanged when no graph rows exist', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'diag-empty-graph',
+        messageId: 'diag-empty-graph-1',
+      }),
+    ]);
+
+    const out = await captureDiagnose({
+      flags: {},
+      tags: {},
+      positional: ['diag-empty-graph'],
+      passthrough: [],
+    });
+    assert.equal(out.code, 0);
+    assert.doesNotMatch(out.stdout, /Session relationships/);
+    assert.doesNotMatch(out.stdout, /Tool result chronology/);
+    assert.doesNotMatch(out.stdout, /tool results:/);
   });
 
   it('renders an empty-ledger note when there are no adapter sessions at all', async () => {

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -12,6 +12,7 @@ import {
   queryAll,
   queryCompactions,
   queryRelationships,
+  queryToolResultEvents,
   queryUserTurns,
   readContent,
 } from '@relayburn/ledger';
@@ -19,6 +20,7 @@ import type {
   ContentRecord,
   SessionRelationshipRecord,
   SourceKind,
+  ToolResultEventRecord,
   TurnRecord,
   UserTurnRecord,
 } from '@relayburn/reader';
@@ -41,6 +43,18 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
     return 1;
   }
   const compactions = await queryCompactions({ sessionId });
+  const relationships = await queryRelationships({ sessionId });
+  const graphSessionIds = collectGraphSessionIds(sessionId, relationships);
+  const eventBatches = await Promise.all(
+    [...graphSessionIds].map((sid) => queryToolResultEvents({ sessionId: sid })),
+  );
+  const toolResultEvents = sortToolResultEvents(
+    eventBatches.reduce<ToolResultEventRecord[]>((out, batch) => {
+      out.push(...batch);
+      return out;
+    }, []),
+  );
+  const toolResultStatusBySession = summarizeToolResultStatuses(toolResultEvents);
 
   const contentRecords: ContentRecord[] = await readContent({ sessionId });
   const contentBySession = new Map<string, ContentRecord[]>();
@@ -75,6 +89,9 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
           topFiles: files,
           topBashes: bashes,
           topSubagents: subagents,
+          relationships,
+          toolResultEvents,
+          toolResultStatusBySession,
         },
         null,
         2,
@@ -89,6 +106,9 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
   out.push('');
   out.push(`session: ${sessionId}`);
   out.push(`turns: ${formatInt(turns.length)}`);
+  if (toolResultStatusBySession.length > 0) {
+    out.push(renderToolResultStatusLine(toolResultStatusBySession));
+  }
   if (totals) {
     out.push(
       `cost: ${formatUsd(totals.grandCost)} (attributed ${formatUsd(totals.attributedCost)}, unattributed ${formatUsd(totals.unattributedCost)})`,
@@ -105,6 +125,17 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
   out.push('');
 
   const scoped = filterPatterns(patterns, sessionId);
+
+  if (relationships.length > 0) {
+    out.push('Session relationships');
+    out.push(renderRelationships(relationships));
+    out.push('');
+  }
+  if (toolResultEvents.length > 0) {
+    out.push('Tool result chronology');
+    out.push(renderToolResultChronology(toolResultEvents));
+    out.push('');
+  }
 
   out.push('Retry loops');
   out.push(renderRetries(scoped.retryLoops));
@@ -173,6 +204,186 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
 
   process.stdout.write(out.join('\n'));
   return 0;
+}
+
+const DASH = '—';
+const RELATIONSHIP_ORDER = new Map<string, number>([
+  ['root', 0],
+  ['subagent', 1],
+  ['continuation', 2],
+  ['fork', 3],
+]);
+
+interface ToolResultStatusSummary {
+  sessionId: string;
+  toolCalls: number;
+  completed: number;
+  errored: number;
+  cancelled: number;
+  unknown: number;
+}
+
+function collectGraphSessionIds(
+  sessionId: string,
+  relationships: readonly SessionRelationshipRecord[],
+): Set<string> {
+  const out = new Set<string>([sessionId]);
+  for (const r of relationships) {
+    out.add(r.sessionId);
+    if (r.relatedSessionId) out.add(r.relatedSessionId);
+  }
+  return out;
+}
+
+function sortToolResultEvents(
+  events: readonly ToolResultEventRecord[],
+): ToolResultEventRecord[] {
+  return [...events].sort((a, b) => {
+    const session = a.sessionId.localeCompare(b.sessionId);
+    if (session !== 0) return session;
+    const tool = a.toolUseId.localeCompare(b.toolUseId);
+    if (tool !== 0) return tool;
+    return a.eventIndex - b.eventIndex;
+  });
+}
+
+function summarizeToolResultStatuses(
+  events: readonly ToolResultEventRecord[],
+): ToolResultStatusSummary[] {
+  const bySession = new Map<string, Map<string, ToolResultEventRecord[]>>();
+  for (const event of events) {
+    let byTool = bySession.get(event.sessionId);
+    if (!byTool) {
+      byTool = new Map();
+      bySession.set(event.sessionId, byTool);
+    }
+    const bucket = byTool.get(event.toolUseId);
+    if (bucket) bucket.push(event);
+    else byTool.set(event.toolUseId, [event]);
+  }
+
+  const out: ToolResultStatusSummary[] = [];
+  for (const [sessionId, byTool] of bySession) {
+    const row: ToolResultStatusSummary = {
+      sessionId,
+      toolCalls: 0,
+      completed: 0,
+      errored: 0,
+      cancelled: 0,
+      unknown: 0,
+    };
+    for (const toolEvents of byTool.values()) {
+      row.toolCalls++;
+      const status = terminalToolStatus(toolEvents);
+      row[status]++;
+    }
+    out.push(row);
+  }
+  return out.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
+}
+
+function terminalToolStatus(
+  events: readonly ToolResultEventRecord[],
+): 'completed' | 'errored' | 'cancelled' | 'unknown' {
+  const sorted = sortToolResultEvents(events);
+  const latest = sorted[sorted.length - 1];
+  switch (latest?.status) {
+    case 'completed':
+    case 'errored':
+    case 'cancelled':
+      return latest.status;
+    default:
+      return 'unknown';
+  }
+}
+
+function renderToolResultStatusLine(
+  summaries: readonly ToolResultStatusSummary[],
+): string {
+  const totals = summaries.reduce<ToolResultStatusSummary>(
+    (acc, row) => {
+      acc.toolCalls += row.toolCalls;
+      acc.completed += row.completed;
+      acc.errored += row.errored;
+      acc.cancelled += row.cancelled;
+      acc.unknown += row.unknown;
+      return acc;
+    },
+    {
+      sessionId: '',
+      toolCalls: 0,
+      completed: 0,
+      errored: 0,
+      cancelled: 0,
+      unknown: 0,
+    },
+  );
+  const callWord = totals.toolCalls === 1 ? 'tool call' : 'tool calls';
+  const sessionSuffix =
+    summaries.length > 1 ? ` across ${formatInt(summaries.length)} linked sessions` : '';
+  return `tool results: ${formatInt(totals.errored)} of ${formatInt(totals.toolCalls)} ${callWord} errored${sessionSuffix} (completed ${formatInt(totals.completed)}, cancelled ${formatInt(totals.cancelled)}, unknown ${formatInt(totals.unknown)})`;
+}
+
+function renderRelationships(
+  relationships: readonly SessionRelationshipRecord[],
+): string {
+  const sorted = [...relationships].sort((a, b) => {
+    const aOrder = RELATIONSHIP_ORDER.get(a.relationshipType) ?? 99;
+    const bOrder = RELATIONSHIP_ORDER.get(b.relationshipType) ?? 99;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    const session = a.sessionId.localeCompare(b.sessionId);
+    if (session !== 0) return session;
+    return (a.ts ?? '').localeCompare(b.ts ?? '');
+  });
+  return table([
+    ['session', 'type', 'related', 'source', 'subagentType', 'parentToolUseId', 'description'],
+    ...sorted.map((r) => [
+      truncate(r.sessionId, 24),
+      r.relationshipType,
+      truncate(r.relatedSessionId ?? DASH, 24),
+      r.source,
+      truncate(r.subagentType ?? DASH, 24),
+      truncate(r.parentToolUseId ?? DASH, 24),
+      truncate(r.description ?? DASH, 36),
+    ]),
+  ]);
+}
+
+function renderToolResultChronology(
+  events: readonly ToolResultEventRecord[],
+): string {
+  const errorCounts = new Map<string, number>();
+  for (const event of events) {
+    if (event.status !== 'errored') continue;
+    const key = toolEventKey(event);
+    errorCounts.set(key, (errorCounts.get(key) ?? 0) + 1);
+  }
+  return table([
+    ['toolUseId', 'session', 'event', 'ts', 'status', 'eventSource', 'contentLength'],
+    ...sortToolResultEvents(events).map((event) => [
+      truncate(event.toolUseId, 24),
+      truncate(event.sessionId, 24),
+      formatInt(event.eventIndex),
+      truncate(event.ts ?? DASH, 24),
+      renderToolEventStatus(event, errorCounts.get(toolEventKey(event)) ?? 0),
+      event.eventSource,
+      event.contentLength === undefined ? DASH : formatInt(event.contentLength),
+    ]),
+  ]);
+}
+
+function toolEventKey(event: ToolResultEventRecord): string {
+  return `${event.sessionId}\0${event.toolUseId}`;
+}
+
+function renderToolEventStatus(
+  event: ToolResultEventRecord,
+  erroredEventsForTool: number,
+): string {
+  if (event.status === 'errored' && erroredEventsForTool > 1) {
+    return `errored (${formatInt(erroredEventsForTool)}x)`;
+  }
+  return event.status;
 }
 
 function filterPatterns(patterns: PatternsResult, sessionId: string): PatternsResult {


### PR DESCRIPTION
## Summary
- Surface SessionRelationshipRecord rows and ToolResultEventRecord chronology in burn diagnose <session>, including JSON arrays and terminal status rollups.
- Add burn summary --by-relationship with text and JSON aggregation by relationship type.
- Update CLI help, README usage, changelog, and coverage for populated and empty graph cases.

## Tests
- pnpm run build
- node --test --test-reporter=spec packages/cli/dist/commands/diagnose.test.js packages/cli/dist/commands/summary.test.js
- pnpm run test

Closes #111
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
