### PR TITLE
Use tool-result events for waste pattern detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ### Changed
 
+- `burn waste --patterns` now bases retry and failure findings on persisted tool-result chronology when available, while preserving legacy fallback behavior.
 - Spawn-env and native sidechain attribution now share session relationship records, and `burn diagnose --explain-drift` surfaces sessions where they disagree.
 - Provider-aware CLI rendering now uses shared analyze helpers for effective-provider resolution and aggregation.
 - Per-tool cost attribution now uses persisted user-turn block sizes in summary and waste reports, with rebuild backfill for historical sessions.

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `@relayburn/analyze`.
 
 ### Changed
 
+- `detectPatterns()` now uses persisted tool-result event chronology for retry and failure detection, with legacy `toolCalls[].isError` fallback when graph rows are absent.
 - Waste attribution now prefers persisted user-turn block sizes over content sidecar estimates before falling back to even-split attribution.
 
 ## [0.42.0] - 2026-04-28

--- a/packages/analyze/src/findings.test.ts
+++ b/packages/analyze/src/findings.test.ts
@@ -260,6 +260,7 @@ describe('findings — findingsFromPatterns rolls up the full PatternsResult', (
       sessionId: SESSION,
       retryLoopCount: 1,
       failureRunCount: 1,
+      cancellationRunCount: 0,
       consecutiveFailureMax: 3,
       compactionCount: 1,
       editRevertCount: 1,
@@ -272,6 +273,7 @@ describe('findings — findingsFromPatterns rolls up the full PatternsResult', (
     };
     const result: PatternsResult = {
       retryLoops: [baseRetryLoop],
+      cancelledRuns: [],
       failureRuns: [
         {
           sessionId: SESSION,

--- a/packages/analyze/src/findings.ts
+++ b/packages/analyze/src/findings.ts
@@ -10,10 +10,12 @@
 // `WasteAction`s instead of scraping strings.
 
 import type {
+  CancellationRun,
   CompactionLoss,
   EditHeavySession,
   EditRevertCycle,
   FailureRun,
+  PatternEventSource,
   PatternsResult,
   RetryLoop,
   SkillPruningProtection,
@@ -48,8 +50,8 @@ export interface EstimatedSavings {
 
 export interface WasteFinding {
   // Stable kind tag. Matches the `--patterns` flag value where applicable
-  // (`retry-loop`, `failure-run`, `compaction-loss`, `edit-revert`,
-  // `edit-heavy`, `skill-recall-dup`, `skill-pruning-protection`,
+  // (`retry-loop`, `failure-run`, `cancellation-run`, `compaction-loss`,
+  // `edit-revert`, `edit-heavy`, `skill-recall-dup`, `skill-pruning-protection`,
   // `system-prompt-tax`). New detectors should pick a kebab-case noun.
   kind: string;
   severity: WasteSeverity;
@@ -58,6 +60,8 @@ export interface WasteFinding {
   detail: string;
   estimatedSavings: EstimatedSavings;
   actions: WasteAction[];
+  // Present for graph-backed retry/failure/cancellation findings.
+  eventSource?: PatternEventSource;
 }
 
 // Severity tiers driven by `usdPerSession`. Consistent across detectors so
@@ -90,7 +94,7 @@ export function retryLoopToFinding(loop: RetryLoop): WasteFinding {
   // append it to the title so the report is actionable at a glance ("4×
   // Bash retries" → "4× Bash retries: 'npm ERR! code ENOENT'").
   const titleSuffix = loop.errorSignature ? `: '${loop.errorSignature}'` : '';
-  return {
+  const finding: WasteFinding = {
     kind: 'retry-loop',
     severity: severityFromUsd(loop.cost),
     sessionId: loop.sessionId,
@@ -102,6 +106,8 @@ export function retryLoopToFinding(loop: RetryLoop): WasteFinding {
     estimatedSavings: { usdPerSession: loop.cost },
     actions: [diagnoseAction(loop.sessionId)],
   };
+  if (loop.eventSource !== undefined) finding.eventSource = loop.eventSource;
+  return finding;
 }
 
 export function failureRunToFinding(run: FailureRun): WasteFinding {
@@ -114,7 +120,7 @@ export function failureRunToFinding(run: FailureRun): WasteFinding {
         run.errorSignatures.map((s) => `${s.tool}='${s.firstLine}'`).join('; ') +
         '.'
       : '';
-  return {
+  const finding: WasteFinding = {
     kind: 'failure-run',
     severity: severityFromUsd(run.cost),
     sessionId: run.sessionId,
@@ -126,6 +132,24 @@ export function failureRunToFinding(run: FailureRun): WasteFinding {
       `recovering or asking for help.${sigDetail}`,
     estimatedSavings: { usdPerSession: run.cost },
     actions: [diagnoseAction(run.sessionId)],
+  };
+  if (run.eventSource !== undefined) finding.eventSource = run.eventSource;
+  return finding;
+}
+
+export function cancellationRunToFinding(run: CancellationRun): WasteFinding {
+  const toolList = run.toolsInvolved.join(', ');
+  return {
+    kind: 'cancellation-run',
+    severity: severityFromUsd(run.cost),
+    sessionId: run.sessionId,
+    title: `Cancellation run: ${run.length} cancelled tool call${run.length === 1 ? '' : 's'}`,
+    detail:
+      `Turns ${run.startTurnIndex}-${run.endTurnIndex} ended with cancelled ` +
+      `tool/subagent status (${toolList}). Cumulative turn cost ${fmtUsd(run.cost)}.`,
+    estimatedSavings: { usdPerSession: run.cost },
+    actions: [diagnoseAction(run.sessionId)],
+    eventSource: run.eventSource,
   };
 }
 
@@ -266,6 +290,7 @@ export function findingsFromPatterns(result: PatternsResult): WasteFinding[] {
   const findings: WasteFinding[] = [];
   for (const r of result.retryLoops) findings.push(retryLoopToFinding(r));
   for (const f of result.failureRuns) findings.push(failureRunToFinding(f));
+  for (const c of result.cancelledRuns) findings.push(cancellationRunToFinding(c));
   for (const c of result.compactions) findings.push(compactionLossToFinding(c));
   for (const e of result.editReverts) findings.push(editRevertToFinding(e));
   for (const e of result.editHeavySessions) findings.push(editHeavyToFinding(e));

--- a/packages/analyze/src/index.ts
+++ b/packages/analyze/src/index.ts
@@ -33,11 +33,13 @@ export type {
 } from './subagent-tree.js';
 export { detectPatterns } from './patterns.js';
 export type {
+  CancellationRun,
   CompactionLoss,
   DetectPatternsOptions,
   EditHeavySession,
   EditRevertCycle,
   FailureRun,
+  PatternEventSource,
   PatternsResult,
   RetryLoop,
   SessionPatternSummary,
@@ -46,6 +48,7 @@ export type {
   SystemPromptTax,
 } from './patterns.js';
 export {
+  cancellationRunToFinding,
   compactionLossToFinding,
   editHeavyToFinding,
   editRevertToFinding,

--- a/packages/analyze/src/patterns.test.ts
+++ b/packages/analyze/src/patterns.test.ts
@@ -8,6 +8,7 @@ import type {
   CompactionEvent,
   ContentRecord,
   ToolCall,
+  ToolResultEventRecord,
   TurnRecord,
   UserTurnRecord,
 } from '@relayburn/reader';
@@ -39,6 +40,22 @@ function turn(overrides: Partial<TurnRecord> & { sessionId: string; messageId: s
   };
 }
 
+function event(
+  overrides: Partial<ToolResultEventRecord> & {
+    sessionId: string;
+    toolUseId: string;
+    eventIndex: number;
+    status: ToolResultEventRecord['status'];
+  },
+): ToolResultEventRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    eventSource: 'tool_result',
+    ...overrides,
+  };
+}
+
 describe('detectPatterns — retry loops', () => {
   it('reports one retry-loop of length 4 for 4 consecutive identical failing Bash calls', async () => {
     const pricing = await loadBuiltinPricing();
@@ -51,6 +68,23 @@ describe('detectPatterns — retry loops', () => {
     assert.equal(loop.startTurnIndex, 0);
     assert.equal(loop.endTurnIndex, 3);
     assert.ok(loop.cost > 0, 'cost should be nonzero (sum of retry-turn costs)');
+  });
+
+  it('reports the same retry loop from ToolResultEventRecord chronology and annotates eventSource', async () => {
+    const pricing = await loadBuiltinPricing();
+    const { turns, toolResultEvents } = await parseClaudeSession(
+      path.join(FIXTURES, 'retry-loop.jsonl'),
+    );
+    const legacy = detectPatterns(turns, { pricing });
+    const graph = detectPatterns(turns, { pricing, toolResultEvents });
+    assert.equal(graph.retryLoops.length, 1);
+    assert.equal(graph.failureRuns.length, 0);
+    const graphLoop = graph.retryLoops[0]!;
+    assert.equal(graphLoop.eventSource, 'tool_result');
+    assert.deepEqual(
+      { ...graphLoop, eventSource: undefined },
+      { ...legacy.retryLoops[0]!, eventSource: undefined },
+    );
   });
 
   it('does not trigger on 2 consecutive failures (below threshold)', async () => {
@@ -75,6 +109,29 @@ describe('detectPatterns — retry loops', () => {
     ];
     const result = detectPatterns(turns, { pricing });
     assert.equal(result.retryLoops.length, 0);
+  });
+
+  it('mixes graph-backed sessions with legacy fallback sessions', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = [
+      turn({ sessionId: 'graph', messageId: 'g1', turnIndex: 0, toolCalls: [tc('g1', 'Bash', 'same')] }),
+      turn({ sessionId: 'graph', messageId: 'g2', turnIndex: 1, toolCalls: [tc('g2', 'Bash', 'same')] }),
+      turn({ sessionId: 'graph', messageId: 'g3', turnIndex: 2, toolCalls: [tc('g3', 'Bash', 'same')] }),
+      turn({ sessionId: 'fallback', messageId: 'f1', turnIndex: 0, toolCalls: [tc('f1', 'Bash', 'same', { isError: true })] }),
+      turn({ sessionId: 'fallback', messageId: 'f2', turnIndex: 1, toolCalls: [tc('f2', 'Bash', 'same', { isError: true })] }),
+      turn({ sessionId: 'fallback', messageId: 'f3', turnIndex: 2, toolCalls: [tc('f3', 'Bash', 'same', { isError: true })] }),
+    ];
+    const toolResultEvents = [
+      event({ sessionId: 'graph', toolUseId: 'g1', eventIndex: 0, status: 'errored' }),
+      event({ sessionId: 'graph', toolUseId: 'g2', eventIndex: 1, status: 'errored' }),
+      event({ sessionId: 'graph', toolUseId: 'g3', eventIndex: 2, status: 'errored' }),
+    ];
+
+    const result = detectPatterns(turns, { pricing, toolResultEvents });
+    assert.equal(result.retryLoops.length, 2);
+    const bySession = new Map(result.retryLoops.map((loop) => [loop.sessionId, loop]));
+    assert.equal(bySession.get('graph')!.eventSource, 'tool_result');
+    assert.equal(bySession.get('fallback')!.eventSource, undefined);
   });
 });
 
@@ -110,6 +167,48 @@ describe('detectPatterns — consecutive failure runs', () => {
     const result = detectPatterns(turns, { pricing });
     assert.equal(result.retryLoops.length, 1, 'retry loop reported');
     assert.equal(result.failureRuns.length, 0, 'same-key streak is NOT a failure run');
+  });
+
+  it('counts chained subagent_notification errors even when toolCalls have no isError flag', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = [
+      turn({ sessionId: 's', messageId: 'm1', turnIndex: 0, toolCalls: [tc('a1', 'Agent', 'agent:one')] }),
+      turn({ sessionId: 's', messageId: 'm2', turnIndex: 1, toolCalls: [tc('a2', 'Agent', 'agent:two')] }),
+      turn({ sessionId: 's', messageId: 'm3', turnIndex: 2, toolCalls: [tc('a3', 'Agent', 'agent:three')] }),
+    ];
+    const toolResultEvents = [
+      event({ sessionId: 's', toolUseId: 'a1', eventIndex: 0, status: 'errored', eventSource: 'subagent_notification' }),
+      event({ sessionId: 's', toolUseId: 'a2', eventIndex: 1, status: 'errored', eventSource: 'subagent_notification' }),
+      event({ sessionId: 's', toolUseId: 'a3', eventIndex: 2, status: 'errored', eventSource: 'subagent_notification' }),
+    ];
+
+    const result = detectPatterns(turns, { pricing, toolResultEvents });
+    assert.equal(result.failureRuns.length, 1);
+    assert.equal(result.failureRuns[0]!.length, 3);
+    assert.equal(result.failureRuns[0]!.eventSource, 'subagent_notification');
+  });
+});
+
+describe('detectPatterns — cancelled graph events', () => {
+  it('keeps cancellations out of retry/failure detectors and reports them separately', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = [
+      turn({ sessionId: 's', messageId: 'm1', turnIndex: 0, toolCalls: [tc('c1', 'Bash', 'same', { isError: true })] }),
+      turn({ sessionId: 's', messageId: 'm2', turnIndex: 1, toolCalls: [tc('c2', 'Bash', 'same', { isError: true })] }),
+      turn({ sessionId: 's', messageId: 'm3', turnIndex: 2, toolCalls: [tc('c3', 'Bash', 'same', { isError: true })] }),
+    ];
+    const toolResultEvents = [
+      event({ sessionId: 's', toolUseId: 'c1', eventIndex: 0, status: 'cancelled' }),
+      event({ sessionId: 's', toolUseId: 'c2', eventIndex: 1, status: 'cancelled' }),
+      event({ sessionId: 's', toolUseId: 'c3', eventIndex: 2, status: 'cancelled' }),
+    ];
+
+    const result = detectPatterns(turns, { pricing, toolResultEvents });
+    assert.equal(result.retryLoops.length, 0);
+    assert.equal(result.failureRuns.length, 0);
+    assert.equal(result.cancelledRuns.length, 1);
+    assert.equal(result.cancelledRuns[0]!.length, 3);
+    assert.equal(result.cancelledRuns[0]!.eventSource, 'tool_result');
   });
 });
 
@@ -257,6 +356,7 @@ describe('detectPatterns — defensive', () => {
     const result = detectPatterns([], { pricing, compactions: [] as CompactionEvent[] });
     assert.deepEqual(result.retryLoops, []);
     assert.deepEqual(result.failureRuns, []);
+    assert.deepEqual(result.cancelledRuns, []);
     assert.deepEqual(result.compactions, []);
     assert.deepEqual(result.editReverts, []);
     assert.deepEqual(result.sessionSummaries, []);

--- a/packages/analyze/src/patterns.ts
+++ b/packages/analyze/src/patterns.ts
@@ -4,6 +4,8 @@ import type {
   ContentToolResult,
   SourceKind,
   ToolCall,
+  ToolResultEventRecord,
+  ToolResultEventSource,
   TurnRecord,
   UserTurnRecord,
 } from '@relayburn/reader';
@@ -12,10 +14,14 @@ import { countRetries, normalizeToolName } from '@relayburn/reader';
 import { costForTurn, costForUsage } from './cost.js';
 import type { PricingTable } from './pricing.js';
 
-// Retry loops: ≥ 3 strictly-consecutive tool calls that share (toolName,
-// argsHash) and all carry tool_result.is_error=true. The flattened tool-call
-// stream is what matters — a different tool (or different args) interleaved
-// between two candidates breaks the streak, even within the same turn.
+export type PatternEventSource = ToolResultEventSource | 'mixed';
+
+// Retry loops: ≥ 3 strictly-consecutive failed tool attempts that share
+// (toolName, argsHash). ToolResultEventRecord chronology is the primary
+// signal; sessions with no graph events fall back to toolCalls[].isError.
+// The flattened tool-call/event stream is what matters — a different tool
+// (or different args) interleaved between two candidates breaks the streak,
+// even within the same turn.
 export interface RetryLoop {
   sessionId: string;
   tool: string;
@@ -36,6 +42,8 @@ export interface RetryLoop {
   // when no content was supplied or none of the retry tool_uses had a
   // matching tool_result in the sidecar.
   errorSignature?: string;
+  // Present when this finding came from ToolResultEventRecord chronology.
+  eventSource?: PatternEventSource;
 }
 
 // Consecutive tool failures: ≥ 3 consecutive errored tool results using
@@ -55,6 +63,21 @@ export interface FailureRun {
   // the sidecar are omitted. Absent when no content was supplied or no
   // signatures could be extracted.
   errorSignatures?: Array<{ tool: string; firstLine: string }>;
+  // Present when this finding came from ToolResultEventRecord chronology.
+  eventSource?: PatternEventSource;
+}
+
+// Cancelled tool/subagent runs are separated from retry/failure patterns:
+// an interrupted Bash or abandoned subagent is not the same thing as an
+// errored attempt, but it is still useful graph-backed chronology.
+export interface CancellationRun {
+  sessionId: string;
+  length: number;
+  startTurnIndex: number;
+  endTurnIndex: number;
+  toolsInvolved: string[];
+  cost: number;
+  eventSource: PatternEventSource;
 }
 
 export interface CompactionLoss {
@@ -178,6 +201,7 @@ export interface SessionPatternSummary {
   sessionId: string;
   retryLoopCount: number;
   failureRunCount: number;
+  cancellationRunCount: number;
   consecutiveFailureMax: number;
   compactionCount: number;
   editRevertCount: number;
@@ -192,6 +216,7 @@ export interface SessionPatternSummary {
 export interface PatternsResult {
   retryLoops: RetryLoop[];
   failureRuns: FailureRun[];
+  cancelledRuns: CancellationRun[];
   compactions: CompactionLoss[];
   editReverts: EditRevertCycle[];
   skillRecallDups: SkillRecallDup[];
@@ -212,6 +237,11 @@ export interface DetectPatternsOptions {
   // (error signatures, compacted-window summaries, edit previews). Detectors
   // run identically without it — only the enrichment fields are absent.
   contentBySession?: Map<string, ContentRecord[]> | undefined;
+  // Tool-result / subagent / queue / progress chronology. When supplied for a
+  // session, retry/failure/cancellation detectors use it instead of
+  // reconstructing status from TurnRecord.toolCalls[].isError. Sessions with
+  // no matching events keep the legacy fallback path.
+  toolResultEvents?: ToolResultEventRecord[] | undefined;
 }
 
 const MIN_RETRY_LEN = 3;
@@ -246,9 +276,11 @@ export function detectPatterns(
   opts: DetectPatternsOptions,
 ): PatternsResult {
   const bySession = groupBySession(turns);
+  const eventsBySession = groupToolResultEventsBySession(opts.toolResultEvents);
 
   const retryLoops: RetryLoop[] = [];
   const failureRuns: FailureRun[] = [];
+  const cancelledRuns: CancellationRun[] = [];
   const editReverts: EditRevertCycle[] = [];
   const skillRecallDups: SkillRecallDup[] = [];
   const skillPruningProtection: SkillPruningProtection[] = [];
@@ -258,10 +290,26 @@ export function detectPatterns(
   for (const [sessionId, sessionTurns] of bySession) {
     sessionTurns.sort((a, b) => a.turnIndex - b.turnIndex);
     const contentIndex = buildContentIndex(opts.contentBySession?.get(sessionId));
-    retryLoops.push(...detectRetryLoopsForSession(sessionId, sessionTurns, opts.pricing, contentIndex));
-    failureRuns.push(
-      ...detectFailureRunsForSession(sessionId, sessionTurns, opts.pricing, contentIndex),
-    );
+    const sessionEvents = eventsBySession.get(sessionId) ?? [];
+    if (sessionEvents.length > 0) {
+      const graphPatterns = detectGraphStatusPatternsForSession(
+        sessionId,
+        sessionTurns,
+        sessionEvents,
+        opts.pricing,
+        contentIndex,
+      );
+      retryLoops.push(...graphPatterns.retryLoops);
+      failureRuns.push(...graphPatterns.failureRuns);
+      cancelledRuns.push(...graphPatterns.cancelledRuns);
+    } else {
+      retryLoops.push(
+        ...detectRetryLoopsForSession(sessionId, sessionTurns, opts.pricing, contentIndex),
+      );
+      failureRuns.push(
+        ...detectFailureRunsForSession(sessionId, sessionTurns, opts.pricing, contentIndex),
+      );
+    }
     editReverts.push(...detectEditRevertsForSession(sessionId, sessionTurns, opts.pricing, contentIndex));
     skillRecallDups.push(...detectSkillRecallDupsForSession(sessionId, sessionTurns, opts.pricing));
     skillPruningProtection.push(...detectSkillPruningProtectionForSession(sessionId, sessionTurns, opts.pricing));
@@ -276,6 +324,7 @@ export function detectPatterns(
   return {
     retryLoops,
     failureRuns,
+    cancelledRuns,
     compactions,
     editReverts,
     skillRecallDups,
@@ -285,6 +334,7 @@ export function detectPatterns(
     sessionSummaries: buildSummaries(
       retryLoops,
       failureRuns,
+      cancelledRuns,
       compactions,
       editReverts,
       skillRecallDups,
@@ -308,6 +358,22 @@ function groupBySession(turns: TurnRecord[]): Map<string, TurnRecord[]> {
   return by;
 }
 
+function groupToolResultEventsBySession(
+  events: ToolResultEventRecord[] | undefined,
+): Map<string, ToolResultEventRecord[]> {
+  const by = new Map<string, ToolResultEventRecord[]>();
+  if (!events) return by;
+  for (const event of events) {
+    let list = by.get(event.sessionId);
+    if (!list) {
+      list = [];
+      by.set(event.sessionId, list);
+    }
+    list.push(event);
+  }
+  return by;
+}
+
 interface ToolCallRef {
   turn: TurnRecord;
   call: ToolCall;
@@ -317,6 +383,148 @@ function flattenToolCalls(turns: TurnRecord[]): ToolCallRef[] {
   const out: ToolCallRef[] = [];
   for (const turn of turns) {
     for (const call of turn.toolCalls) out.push({ turn, call });
+  }
+  return out;
+}
+
+interface ToolResultEventRef {
+  event: ToolResultEventRecord;
+  turn: TurnRecord | undefined;
+  call: ToolCall | undefined;
+  tool: string;
+  target: string | undefined;
+  argsHash: string | undefined;
+  turnIndex: number;
+}
+
+interface GraphStatusPatterns {
+  retryLoops: RetryLoop[];
+  failureRuns: FailureRun[];
+  cancelledRuns: CancellationRun[];
+}
+
+function detectGraphStatusPatternsForSession(
+  sessionId: string,
+  turns: TurnRecord[],
+  events: ToolResultEventRecord[],
+  pricing: PricingTable,
+  contentIndex: ContentIndex | null,
+): GraphStatusPatterns {
+  const terminalRefs = buildTerminalEventRefs(sessionId, turns, events);
+  return {
+    retryLoops: detectGraphRetryLoopsForSession(sessionId, terminalRefs, pricing, contentIndex),
+    failureRuns: detectGraphFailureRunsForSession(sessionId, terminalRefs, pricing, contentIndex),
+    cancelledRuns: detectGraphCancellationRunsForSession(sessionId, terminalRefs, pricing),
+  };
+}
+
+function buildTerminalEventRefs(
+  sessionId: string,
+  turns: TurnRecord[],
+  events: ToolResultEventRecord[],
+): ToolResultEventRef[] {
+  const byToolUseId = new Map<string, ToolCallRef>();
+  const turnByMessageId = new Map<string, TurnRecord>();
+  for (const turn of turns) {
+    turnByMessageId.set(turn.messageId, turn);
+    for (const call of turn.toolCalls) byToolUseId.set(call.id, { turn, call });
+  }
+
+  // Collapse progress/fanout rows to the final observed status for each
+  // toolUseId. A trailing `running` row means no terminal status landed yet,
+  // so it is excluded below.
+  const terminalByToolUseId = new Map<string, ToolResultEventRecord>();
+  for (const event of [...events].sort(compareToolResultEvents)) {
+    if (event.sessionId !== sessionId) continue;
+    terminalByToolUseId.set(event.toolUseId, event);
+  }
+
+  const out: ToolResultEventRef[] = [];
+  for (const event of [...terminalByToolUseId.values()].sort(compareToolResultEvents)) {
+    if (event.status === 'running') continue;
+    const callRef = byToolUseId.get(event.toolUseId);
+    const turn = callRef?.turn ?? findTurnForEvent(event, turns, turnByMessageId);
+    out.push({
+      event,
+      turn,
+      call: callRef?.call,
+      tool: displayToolName(event, callRef?.call),
+      target: callRef?.call.target,
+      argsHash: callRef?.call.argsHash,
+      turnIndex: turn?.turnIndex ?? event.eventIndex,
+    });
+  }
+  return out;
+}
+
+function compareToolResultEvents(
+  a: ToolResultEventRecord,
+  b: ToolResultEventRecord,
+): number {
+  if (a.eventIndex !== b.eventIndex) return a.eventIndex - b.eventIndex;
+  const ts = (a.ts ?? '').localeCompare(b.ts ?? '');
+  if (ts !== 0) return ts;
+  return a.toolUseId.localeCompare(b.toolUseId);
+}
+
+function findTurnForEvent(
+  event: ToolResultEventRecord,
+  turns: TurnRecord[],
+  turnByMessageId: Map<string, TurnRecord>,
+): TurnRecord | undefined {
+  if (event.messageId) {
+    const byMessage = turnByMessageId.get(event.messageId);
+    if (byMessage) return byMessage;
+  }
+  if (!event.ts) return undefined;
+  let best: TurnRecord | undefined;
+  for (const turn of turns) {
+    if (turn.ts <= event.ts) {
+      best = turn;
+      continue;
+    }
+    if (!best) return turn;
+    break;
+  }
+  return best;
+}
+
+function displayToolName(
+  event: ToolResultEventRecord,
+  call: ToolCall | undefined,
+): string {
+  if (call) return call.name;
+  switch (event.eventSource) {
+    case 'subagent_notification':
+      return 'Subagent';
+    case 'function_call_output':
+      return 'FunctionCall';
+    case 'queue_event':
+      return 'QueueEvent';
+    case 'progress_event':
+      return 'ProgressEvent';
+    case 'tool_result':
+      return 'Tool';
+  }
+}
+
+function coalesceEventSource(refs: ToolResultEventRef[]): PatternEventSource {
+  const sources = new Set(refs.map((r) => r.event.eventSource));
+  return sources.size === 1 ? refs[0]!.event.eventSource : 'mixed';
+}
+
+function dedupDefinedTurns(refs: ToolResultEventRef[]): TurnRecord[] {
+  const turns: TurnRecord[] = [];
+  for (const ref of refs) {
+    if (ref.turn) turns.push(ref.turn);
+  }
+  return dedupTurns(turns);
+}
+
+function eventRefsToToolCallRefs(refs: ToolResultEventRef[]): ToolCallRef[] {
+  const out: ToolCallRef[] = [];
+  for (const ref of refs) {
+    if (ref.turn && ref.call) out.push({ turn: ref.turn, call: ref.call });
   }
   return out;
 }
@@ -430,6 +638,143 @@ function sumCostForTurns(turns: TurnRecord[], pricing: PricingTable): number {
     if (c) sum += c.total;
   }
   return sum;
+}
+
+function detectGraphRetryLoopsForSession(
+  sessionId: string,
+  refs: ToolResultEventRef[],
+  pricing: PricingTable,
+  contentIndex: ContentIndex | null,
+): RetryLoop[] {
+  const loops: RetryLoop[] = [];
+  let streak: ToolResultEventRef[] = [];
+
+  const commit = (): void => {
+    if (streak.length < MIN_RETRY_LEN) return;
+    const first = streak[0]!;
+    const last = streak[streak.length - 1]!;
+    const contributingTurns = dedupDefinedTurns(streak);
+    const loop: RetryLoop = {
+      sessionId,
+      tool: first.tool,
+      target: first.target,
+      argsHash: first.argsHash!,
+      attempts: streak.length,
+      startTurnIndex: first.turnIndex,
+      endTurnIndex: last.turnIndex,
+      cost: sumCostForTurns(contributingTurns, pricing),
+      eventSource: coalesceEventSource(streak),
+    };
+    const sig = retryLoopSignature(eventRefsToToolCallRefs(streak), contentIndex);
+    if (sig !== undefined) loop.errorSignature = sig;
+    loops.push(loop);
+  };
+
+  for (const ref of refs) {
+    if (ref.event.status !== 'errored' || !ref.call || !ref.argsHash) {
+      commit();
+      streak = [];
+      continue;
+    }
+    if (streak.length === 0) {
+      streak = [ref];
+      continue;
+    }
+    const head = streak[0]!;
+    if (head.tool === ref.tool && head.argsHash === ref.argsHash) {
+      streak.push(ref);
+    } else {
+      commit();
+      streak = [ref];
+    }
+  }
+  commit();
+  return loops;
+}
+
+function detectGraphFailureRunsForSession(
+  sessionId: string,
+  refs: ToolResultEventRef[],
+  pricing: PricingTable,
+  contentIndex: ContentIndex | null,
+): FailureRun[] {
+  const runs: FailureRun[] = [];
+  let streak: ToolResultEventRef[] = [];
+
+  const commit = (): void => {
+    if (streak.length < MIN_FAILURE_RUN_LEN) return;
+    const keys = new Set(streak.map(statusPatternKey));
+    const hasNonToolResult = streak.some((r) => r.event.eventSource !== 'tool_result');
+    // A same-(tool,args) tool_result run is a retry loop. Non-tool_result
+    // terminal events (notably subagent notifications) remain failure runs:
+    // they represent child invocations ending badly, not a parent retry loop.
+    if (keys.size < 2 && !hasNonToolResult) return;
+    const first = streak[0]!;
+    const last = streak[streak.length - 1]!;
+    const tools = Array.from(new Set(streak.map((r) => r.tool)));
+    const run: FailureRun = {
+      sessionId,
+      length: streak.length,
+      startTurnIndex: first.turnIndex,
+      endTurnIndex: last.turnIndex,
+      toolsInvolved: tools,
+      cost: sumCostForTurns(dedupDefinedTurns(streak), pricing),
+      eventSource: coalesceEventSource(streak),
+    };
+    const sigs = failureRunSignatures(eventRefsToToolCallRefs(streak), contentIndex);
+    if (sigs.length > 0) run.errorSignatures = sigs;
+    runs.push(run);
+  };
+
+  for (const ref of refs) {
+    if (ref.event.status === 'errored') {
+      streak.push(ref);
+    } else {
+      commit();
+      streak = [];
+    }
+  }
+  commit();
+  return runs;
+}
+
+function detectGraphCancellationRunsForSession(
+  sessionId: string,
+  refs: ToolResultEventRef[],
+  pricing: PricingTable,
+): CancellationRun[] {
+  const runs: CancellationRun[] = [];
+  let streak: ToolResultEventRef[] = [];
+
+  const commit = (): void => {
+    if (streak.length === 0) return;
+    const first = streak[0]!;
+    const last = streak[streak.length - 1]!;
+    runs.push({
+      sessionId,
+      length: streak.length,
+      startTurnIndex: first.turnIndex,
+      endTurnIndex: last.turnIndex,
+      toolsInvolved: Array.from(new Set(streak.map((r) => r.tool))),
+      cost: sumCostForTurns(dedupDefinedTurns(streak), pricing),
+      eventSource: coalesceEventSource(streak),
+    });
+  };
+
+  for (const ref of refs) {
+    if (ref.event.status === 'cancelled') {
+      streak.push(ref);
+    } else {
+      commit();
+      streak = [];
+    }
+  }
+  commit();
+  return runs;
+}
+
+function statusPatternKey(ref: ToolResultEventRef): string {
+  return `${ref.tool}|${ref.argsHash ?? ref.event.toolUseId}`;
 }
 
 function detectRetryLoopsForSession(
@@ -974,6 +1319,7 @@ function dedupTurns(turns: TurnRecord[]): TurnRecord[] {
 function buildSummaries(
   retryLoops: RetryLoop[],
   failureRuns: FailureRun[],
+  cancelledRuns: CancellationRun[],
   compactions: CompactionLoss[],
   editReverts: EditRevertCycle[],
   skillRecallDups: SkillRecallDup[],
@@ -989,6 +1335,7 @@ function buildSummaries(
         sessionId,
         retryLoopCount: 0,
         failureRunCount: 0,
+        cancellationRunCount: 0,
         consecutiveFailureMax: 0,
         compactionCount: 0,
         editRevertCount: 0,
@@ -1014,6 +1361,11 @@ function buildSummaries(
     row.failureRunCount++;
     if (f.length > row.consecutiveFailureMax) row.consecutiveFailureMax = f.length;
     row.totalPatternCost += f.cost;
+  }
+  for (const c of cancelledRuns) {
+    const row = get(c.sessionId);
+    row.cancellationRunCount++;
+    row.totalPatternCost += c.cost;
   }
   for (const c of compactions) {
     const row = get(c.sessionId);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `@relayburn/cli`.
 
 ### Changed
 
+- `burn waste --patterns` now reads tool-result event chronology for retry, failure, and cancellation findings, including graph-backed `eventSource` in JSON output.
 - `burn summary --agent` now includes sessions linked by relationship records, not only turns stamped with the agent id.
 - Provider filters and `burn summary --by-provider` now use the shared analyze provider resolver.
 - `burn summary --by-tool` now uses persisted user-turn block sizes for proportional attribution and reports each JSON row's attribution method.

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -73,6 +73,7 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
     compactions,
     userTurnsBySession,
     contentBySession,
+    toolResultEvents,
   });
   const files = aggregateByFile(attribution.attributions).slice(0, 5);
   const bashes = aggregateByBash(attribution.attributions).slice(0, 5);
@@ -116,7 +117,7 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
   }
   if (summary) {
     out.push(
-      `patterns: ${summary.retryLoopCount} retry-loops, ${summary.failureRunCount} failure-runs (max ${summary.consecutiveFailureMax}), ${summary.compactionCount} compactions, ${summary.editRevertCount} edit-reverts, ${summary.editHeavyCount} edit-heavy, ${summary.skillRecallDupCount} skill-recall-dups, ${summary.skillPruningProtectionCount} skill-pruning, ${summary.systemPromptTaxCount} system-prompt-tax`,
+      `patterns: ${summary.retryLoopCount} retry-loops, ${summary.failureRunCount} failure-runs (max ${summary.consecutiveFailureMax}), ${summary.cancellationRunCount} cancellations, ${summary.compactionCount} compactions, ${summary.editRevertCount} edit-reverts, ${summary.editHeavyCount} edit-heavy, ${summary.skillRecallDupCount} skill-recall-dups, ${summary.skillPruningProtectionCount} skill-pruning, ${summary.systemPromptTaxCount} system-prompt-tax`,
     );
     out.push(`pattern cost: ${formatUsd(summary.totalPatternCost)}`);
   } else {
@@ -142,6 +143,9 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
   out.push('');
   out.push('Consecutive failure runs');
   out.push(renderFailures(scoped.failureRuns));
+  out.push('');
+  out.push('Cancelled tool/subagent runs');
+  out.push(renderCancellations(scoped.cancelledRuns));
   out.push('');
   out.push('Compaction events');
   out.push(renderCompactions(scoped.compactions));
@@ -390,6 +394,7 @@ function filterPatterns(patterns: PatternsResult, sessionId: string): PatternsRe
   return {
     retryLoops: patterns.retryLoops.filter((r) => r.sessionId === sessionId),
     failureRuns: patterns.failureRuns.filter((r) => r.sessionId === sessionId),
+    cancelledRuns: patterns.cancelledRuns.filter((r) => r.sessionId === sessionId),
     compactions: patterns.compactions.filter((r) => r.sessionId === sessionId),
     editReverts: patterns.editReverts.filter((r) => r.sessionId === sessionId),
     skillRecallDups: patterns.skillRecallDups.filter((r) => r.sessionId === sessionId),
@@ -422,6 +427,20 @@ function renderFailures(runs: PatternsResult['failureRuns']): string {
       String(r.length),
       `${r.startTurnIndex}–${r.endTurnIndex}`,
       truncate(r.toolsInvolved.join(', '), 40),
+      formatUsd(r.cost),
+    ]),
+  ]);
+}
+
+function renderCancellations(runs: PatternsResult['cancelledRuns']): string {
+  if (runs.length === 0) return '  (none)';
+  return table([
+    ['length', 'turns', 'tools', 'source', 'cost'],
+    ...runs.map((r) => [
+      String(r.length),
+      `${r.startTurnIndex}–${r.endTurnIndex}`,
+      truncate(r.toolsInvolved.join(', '), 40),
+      r.eventSource,
       formatUsd(r.cost),
     ]),
   ]);

--- a/packages/cli/src/commands/waste.test.ts
+++ b/packages/cli/src/commands/waste.test.ts
@@ -10,7 +10,7 @@ import type {
   WasteResult,
 } from '@relayburn/analyze';
 import type { EnrichedTurn } from '@relayburn/ledger';
-import type { Coverage, Fidelity, SourceKind } from '@relayburn/reader';
+import type { Coverage, Fidelity, SourceKind, ToolResultEventRecord } from '@relayburn/reader';
 
 import {
   ATTRIBUTION_REQUIRED,
@@ -268,6 +268,22 @@ function makeTurn(
   };
 }
 
+function makeToolResultEvent(
+  overrides: Partial<ToolResultEventRecord> & {
+    sessionId: string;
+    toolUseId: string;
+    eventIndex: number;
+    status: ToolResultEventRecord['status'];
+  },
+): ToolResultEventRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    eventSource: 'tool_result',
+    ...overrides,
+  };
+}
+
 function args(flags: Record<string, string | true> = {}): ParsedArgs {
   return { flags, tags: {}, positional: [], passthrough: [] };
 }
@@ -424,15 +440,10 @@ describe('describeExcluded / source clauses (#100)', () => {
 });
 
 describe('PATTERN_REQUIRED prerequisites (#100)', () => {
-  it('matches the spec: retries/failures need tool-result events; reverts needs raw content', () => {
-    assert.deepEqual([...PATTERN_REQUIRED.retries].sort(), [
-      'hasToolCalls',
-      'hasToolResultEvents',
-    ]);
-    assert.deepEqual([...PATTERN_REQUIRED.failures].sort(), [
-      'hasToolCalls',
-      'hasToolResultEvents',
-    ]);
+  it('matches the spec: retries/failures can fall back to tool-call errors; reverts needs raw content', () => {
+    assert.deepEqual([...PATTERN_REQUIRED.retries].sort(), ['hasToolCalls']);
+    assert.deepEqual([...PATTERN_REQUIRED.failures].sort(), ['hasToolCalls']);
+    assert.deepEqual([...PATTERN_REQUIRED.cancellations].sort(), ['hasToolCalls']);
     assert.deepEqual([...PATTERN_REQUIRED.reverts].sort(), [
       'hasRawContent',
       'hasToolCalls',
@@ -450,8 +461,10 @@ describe('resolvePatternSelection', () => {
 
   it('returns all detectors when the flag is bare (true)', () => {
     const set = resolvePatternSelection(true);
-    // 8 inherited + ghost-surface (#166) + tool-output-bloat (#168) = 10.
-    assert.equal(set.size, 10);
+    // 8 inherited + cancellations (#113) + ghost-surface (#166) +
+    // tool-output-bloat (#168) = 11.
+    assert.equal(set.size, 11);
+    assert.ok(set.has('cancellations'));
     assert.ok(set.has('ghost-surface'));
     assert.ok(set.has('tool-output-bloat'));
   });
@@ -640,8 +653,8 @@ describe('runPatternsMode — fidelity refusal (#100)', () => {
     assert.equal(result, 2);
     assert.equal(stdout, '');
     assert.match(stderr, /burn waste --patterns: no selected detectors can run/);
-    assert.match(stderr, /retries: 1\/1 turns lack tool-call records \+ tool-result events/);
-    assert.match(stderr, /failures: 1\/1 turns lack tool-call records \+ tool-result events/);
+    assert.match(stderr, /retries: 1\/1 turns lack tool-call records/);
+    assert.match(stderr, /failures: 1\/1 turns lack tool-call records/);
     assert.match(stderr, /codex/);
   });
 
@@ -695,7 +708,7 @@ describe('runPatternsMode — fidelity refusal (#100)', () => {
       (d: { kind: string }) => d.kind === 'retries',
     );
     assert.ok(retries, 'retries detector reported');
-    assert.deepEqual(retries.required.sort(), ['hasToolCalls', 'hasToolResultEvents']);
+    assert.deepEqual(retries.required.sort(), ['hasToolCalls']);
     assert.equal(retries.refused, true);
     assert.equal(retries.analyzed, 0);
     assert.equal(retries.excluded, 1);
@@ -707,10 +720,10 @@ describe('runPatternsMode — fidelity refusal (#100)', () => {
 describe('runPatternsMode — per-detector partial exclusion (#100)', () => {
   it('names the missing coverage flag per detector when a source is excluded', async () => {
     const pricing = await loadBuiltinPricing();
-    // Three claude turns with full fidelity; two codex turns with partial
-    // fidelity (no tool-result events). Selecting --patterns retries,failures
-    // should analyze only the claude turns and emit a per-detector notice
-    // naming the missing prereq.
+    // Three claude turns with full fidelity; two codex turns without
+    // tool-call records. Selecting --patterns retries,failures should analyze
+    // only the claude turns and emit a per-detector notice naming the missing
+    // prereq.
     const turns: EnrichedTurn[] = [];
     for (let i = 0; i < 3; i++) {
       turns.push(
@@ -730,7 +743,10 @@ describe('runPatternsMode — per-detector partial exclusion (#100)', () => {
           messageId: `b${i}`,
           turnIndex: i,
           source: 'codex',
-          fidelity: fidelityWith('partial', 'per-turn', { hasToolResultEvents: false }),
+          fidelity: fidelityWith('partial', 'per-turn', {
+            hasToolCalls: false,
+            hasToolResultEvents: false,
+          }),
         }),
       );
     }
@@ -741,9 +757,9 @@ describe('runPatternsMode — per-detector partial exclusion (#100)', () => {
     assert.equal(result, 0);
     assert.equal(stderr, '');
     // Per-detector lines should mention the missing prereq + source.
-    assert.match(stdout, /retries: analyzed 3 of 5 turns; 2 excluded \(needs tool-call records \+ tool-result events;/);
-    assert.match(stdout, /failures: analyzed 3 of 5 turns; 2 excluded \(needs tool-call records \+ tool-result events;/);
-    assert.match(stdout, /missing tool-result events/);
+    assert.match(stdout, /retries: analyzed 3 of 5 turns; 2 excluded \(needs tool-call records;/);
+    assert.match(stdout, /failures: analyzed 3 of 5 turns; 2 excluded \(needs tool-call records;/);
+    assert.match(stdout, /missing tool-call records/);
     assert.match(stdout, /\(codex\)/);
   });
 
@@ -762,7 +778,10 @@ describe('runPatternsMode — per-detector partial exclusion (#100)', () => {
         messageId: 'b1',
         turnIndex: 0,
         source: 'codex',
-        fidelity: fidelityWith('partial', 'per-turn', { hasToolResultEvents: false }),
+        fidelity: fidelityWith('partial', 'per-turn', {
+          hasToolCalls: false,
+          hasToolResultEvents: false,
+        }),
       }),
     ];
     const selected = new Set(['retries', 'failures', 'reverts'] as const);
@@ -778,15 +797,15 @@ describe('runPatternsMode — per-detector partial exclusion (#100)', () => {
       (d: { kind: string }) => d.kind === 'reverts',
     );
     assert.ok(retries && reverts);
-    assert.deepEqual(retries.required.sort(), ['hasToolCalls', 'hasToolResultEvents']);
+    assert.deepEqual(retries.required.sort(), ['hasToolCalls']);
     assert.deepEqual(reverts.required.sort(), ['hasRawContent', 'hasToolCalls']);
-    // The codex turn here passes reverts (it has hasRawContent + hasToolCalls
-    // by default in fullCoverage()) but fails retries.
+    // The codex turn here lacks tool-call records, so it fails both retries
+    // and reverts.
     assert.equal(retries.excluded, 1);
     assert.equal(retries.excludedBySource[0].source, 'codex');
     assert.deepEqual(
       retries.excludedBySource[0].missingCoverage.sort(),
-      ['hasToolResultEvents'],
+      ['hasToolCalls'],
     );
   });
 
@@ -944,5 +963,92 @@ describe('runPatternsMode — per-detector partial exclusion (#100)', () => {
     );
     assert.equal(compaction.refused, false);
     assert.equal(compaction.analyzed, 3);
+  });
+
+  it('JSON mode annotates graph-backed retry findings with eventSource (#113)', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns: EnrichedTurn[] = [
+      makeTurn({
+        sessionId: 's',
+        messageId: 'm0',
+        turnIndex: 0,
+        source: 'claude-code',
+        toolCalls: [{ id: 'u0', name: 'Bash', argsHash: 'same' }],
+      }),
+      makeTurn({
+        sessionId: 's',
+        messageId: 'm1',
+        turnIndex: 1,
+        source: 'claude-code',
+        toolCalls: [{ id: 'u1', name: 'Bash', argsHash: 'same' }],
+      }),
+      makeTurn({
+        sessionId: 's',
+        messageId: 'm2',
+        turnIndex: 2,
+        source: 'claude-code',
+        toolCalls: [{ id: 'u2', name: 'Bash', argsHash: 'same' }],
+      }),
+    ];
+    const toolResultEvents = [
+      makeToolResultEvent({ sessionId: 's', toolUseId: 'u0', eventIndex: 0, status: 'errored' }),
+      makeToolResultEvent({ sessionId: 's', toolUseId: 'u1', eventIndex: 1, status: 'errored' }),
+      makeToolResultEvent({ sessionId: 's', toolUseId: 'u2', eventIndex: 2, status: 'errored' }),
+    ];
+    const selected = new Set(['retries'] as const);
+    const { stdout } = await captureStdio(() =>
+      runPatternsMode(args({ json: true }), turns, pricing, [], selected, {
+        toolResultEvents,
+      }),
+    );
+
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.retryLoops[0].eventSource, 'tool_result');
+    assert.equal(payload.findings[0].eventSource, 'tool_result');
+  });
+
+  it('JSON mode separates cancelled graph events from retry/failure output (#113)', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns: EnrichedTurn[] = [
+      makeTurn({
+        sessionId: 's',
+        messageId: 'm0',
+        turnIndex: 0,
+        source: 'claude-code',
+        toolCalls: [{ id: 'u0', name: 'Bash', argsHash: 'same', isError: true }],
+      }),
+      makeTurn({
+        sessionId: 's',
+        messageId: 'm1',
+        turnIndex: 1,
+        source: 'claude-code',
+        toolCalls: [{ id: 'u1', name: 'Bash', argsHash: 'same', isError: true }],
+      }),
+      makeTurn({
+        sessionId: 's',
+        messageId: 'm2',
+        turnIndex: 2,
+        source: 'claude-code',
+        toolCalls: [{ id: 'u2', name: 'Bash', argsHash: 'same', isError: true }],
+      }),
+    ];
+    const toolResultEvents = [
+      makeToolResultEvent({ sessionId: 's', toolUseId: 'u0', eventIndex: 0, status: 'cancelled' }),
+      makeToolResultEvent({ sessionId: 's', toolUseId: 'u1', eventIndex: 1, status: 'cancelled' }),
+      makeToolResultEvent({ sessionId: 's', toolUseId: 'u2', eventIndex: 2, status: 'cancelled' }),
+    ];
+    const selected = new Set(['retries', 'failures'] as const);
+    const { stdout } = await captureStdio(() =>
+      runPatternsMode(args({ json: true }), turns, pricing, [], selected, {
+        toolResultEvents,
+      }),
+    );
+
+    const payload = JSON.parse(stdout);
+    assert.deepEqual(payload.retryLoops, []);
+    assert.deepEqual(payload.failureRuns, []);
+    assert.equal(payload.cancelledRuns.length, 1);
+    assert.equal(payload.cancelledRuns[0].eventSource, 'tool_result');
+    assert.equal(payload.findings[0].kind, 'cancellation-run');
   });
 });

--- a/packages/cli/src/commands/waste.ts
+++ b/packages/cli/src/commands/waste.ts
@@ -3,6 +3,7 @@ import {
   aggregateByFile,
   aggregateBySubagent,
   attributeWaste,
+  cancellationRunToFinding,
   compactionLossToFinding,
   detectGhostSurface,
   detectPatterns,
@@ -57,7 +58,7 @@ import type { ParsedArgs } from '../args.js';
 import { filterTurnsByProvider, parseProviderFilter } from '../provider.js';
 
 const DEFAULT_TOP_N = 10;
-const PATTERN_KINDS = ['retries', 'failures', 'compaction', 'reverts', 'edit-heavy', 'opencode-skill-recall', 'opencode-skill-pruning', 'opencode-system-prompt', 'ghost-surface', 'tool-output-bloat'] as const;
+const PATTERN_KINDS = ['retries', 'failures', 'cancellations', 'compaction', 'reverts', 'edit-heavy', 'opencode-skill-recall', 'opencode-skill-pruning', 'opencode-system-prompt', 'ghost-surface', 'tool-output-bloat'] as const;
 type PatternKind = (typeof PATTERN_KINDS)[number];
 
 // When even-split sessions reach this fraction of the matched set, the
@@ -207,7 +208,7 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
     const compactions = selected.has('compaction')
       ? (await queryCompactions(q)).filter((c) => sessionIds.has(c.sessionId))
       : [];
-    return runPatternsMode(args, turns, pricing, compactions, selected);
+    return runPatternsMode(args, turns, pricing, compactions, selected, { query: q });
   }
 
   return runWasteAttribution(args, turns, pricing);
@@ -562,8 +563,9 @@ export const PATTERN_REQUIRED: Record<
   Exclude<PatternKind, 'compaction' | 'ghost-surface' | 'tool-output-bloat'>,
   ReadonlyArray<keyof Coverage>
 > = {
-  retries: ['hasToolCalls', 'hasToolResultEvents'],
-  failures: ['hasToolCalls', 'hasToolResultEvents'],
+  retries: ['hasToolCalls'],
+  failures: ['hasToolCalls'],
+  cancellations: ['hasToolCalls'],
   reverts: ['hasToolCalls', 'hasRawContent'],
   // Edit-heavy only needs the tool-call stream (counts of read vs edit).
   // tool_result is not consulted, so `hasToolResultEvents` isn't required.
@@ -589,12 +591,20 @@ interface PatternDetectorCoverage {
   refused: boolean;
 }
 
+export interface PatternsModeDeps {
+  // Tests can inject a fixture slice; production loads from the ledger using
+  // `query` and then filters to the selected turn sessions.
+  toolResultEvents?: ToolResultEventRecord[];
+  query?: Query;
+}
+
 export async function runPatternsMode(
   args: ParsedArgs,
   turns: EnrichedTurn[],
   pricing: Awaited<ReturnType<typeof loadPricing>>,
   compactions: Awaited<ReturnType<typeof queryCompactions>>,
   selected: Set<PatternKind>,
+  deps: PatternsModeDeps = {},
 ): Promise<number> {
   const total = turns.length;
   const fidelityAll = summarizeFidelity(turns);
@@ -675,6 +685,7 @@ export async function runPatternsMode(
             turnsAnalyzed: 0,
             retryLoops: [],
             failureRuns: [],
+            cancelledRuns: [],
             compactions: [],
             editReverts: [],
             editHeavySessions: [],
@@ -706,6 +717,7 @@ export async function runPatternsMode(
   // Run each enabled detector on its own filtered slice.
   let retryLoops: PatternsResult['retryLoops'] = [];
   let failureRuns: PatternsResult['failureRuns'] = [];
+  let cancelledRuns: PatternsResult['cancelledRuns'] = [];
   let compactionLosses: PatternsResult['compactions'] = [];
   let editReverts: PatternsResult['editReverts'] = [];
   let skillRecallDups: PatternsResult['skillRecallDups'] = [];
@@ -733,13 +745,48 @@ export async function runPatternsMode(
     ? await loadContentBySession(perDetector, enrichableDetectors)
     : undefined;
 
+  const needToolResultEvents =
+    selected.has('retries') || selected.has('failures') || selected.has('cancellations');
+  const toolResultEvents = needToolResultEvents
+    ? (deps.toolResultEvents ?? await loadToolResultEventsForTurns(turns, deps.query))
+    : undefined;
+
   if (selected.has('retries')) {
-    const r = detectPatterns(perDetector.get('retries')!, { pricing, userTurnsBySession, contentBySession });
+    const r = detectPatterns(perDetector.get('retries')!, {
+      pricing,
+      userTurnsBySession,
+      contentBySession,
+      toolResultEvents,
+    });
     retryLoops = r.retryLoops;
   }
   if (selected.has('failures')) {
-    const r = detectPatterns(perDetector.get('failures')!, { pricing, userTurnsBySession, contentBySession });
+    const r = detectPatterns(perDetector.get('failures')!, {
+      pricing,
+      userTurnsBySession,
+      contentBySession,
+      toolResultEvents,
+    });
     failureRuns = r.failureRuns;
+  }
+  if (selected.has('cancellations')) {
+    const r = detectPatterns(perDetector.get('cancellations')!, {
+      pricing,
+      userTurnsBySession,
+      contentBySession,
+      toolResultEvents,
+    });
+    cancelledRuns = r.cancelledRuns;
+  } else if (selected.has('retries') || selected.has('failures')) {
+    const statusTurns =
+      perDetector.get('retries') ?? perDetector.get('failures') ?? [];
+    const r = detectPatterns(statusTurns, {
+      pricing,
+      userTurnsBySession,
+      contentBySession,
+      toolResultEvents,
+    });
+    cancelledRuns = r.cancelledRuns;
   }
   if (selected.has('compaction')) {
     const r = detectPatterns(perDetector.get('compaction')!, { pricing, compactions, userTurnsBySession, contentBySession });
@@ -780,7 +827,7 @@ export async function runPatternsMode(
     // Signal B inputs: stream `tool_result_events` from the ledger. We pass
     // the full TurnRecord set so the detector can join tool_use_ids back to
     // tool names + price the carry cost at the correct model rate.
-    const toolResultEvents = await loadToolResultEventsForTurns(turns);
+    const toolResultEvents = await loadToolResultEventsForTurns(turns, deps.query);
     toolOutputBloats = detectToolOutputBloat({
       settings,
       toolResultEvents,
@@ -808,6 +855,7 @@ export async function runPatternsMode(
   sessionSummaries = buildSessionSummaries(
     retryLoops,
     failureRuns,
+    cancelledRuns,
     compactionLosses,
     editReverts,
     skillRecallDups,
@@ -830,6 +878,7 @@ export async function runPatternsMode(
   const findings: WasteFinding[] = sortFindings([
     ...retryLoops.map(retryLoopToFinding),
     ...failureRuns.map(failureRunToFinding),
+    ...cancelledRuns.map(cancellationRunToFinding),
     ...compactionLosses.map(compactionLossToFinding),
     ...editReverts.map(editRevertToFinding),
     ...editHeavySessions.map(editHeavyToFinding),
@@ -847,6 +896,7 @@ export async function runPatternsMode(
           turnsAnalyzed: analyzedCount,
           retryLoops,
           failureRuns,
+          cancelledRuns,
           compactions: compactionLosses,
           editReverts,
           skillRecallDups,
@@ -902,6 +952,11 @@ export async function runPatternsMode(
   if (selected.has('failures')) {
     out.push('Consecutive tool-failure runs (≥3 distinct tools failing in sequence)');
     out.push(renderFailureTable(failureRuns, limit));
+    out.push('');
+  }
+  if (selected.has('cancellations') || cancelledRuns.length > 0) {
+    out.push('Cancelled tool/subagent runs');
+    out.push(renderCancellationTable(cancelledRuns, limit));
     out.push('');
   }
   if (selected.has('compaction')) {
@@ -999,6 +1054,7 @@ function formatPerDetectorNotice(
 function buildSessionSummaries(
   retryLoops: PatternsResult['retryLoops'],
   failureRuns: PatternsResult['failureRuns'],
+  cancelledRuns: PatternsResult['cancelledRuns'],
   compactions: PatternsResult['compactions'],
   editReverts: PatternsResult['editReverts'],
   skillRecallDups: PatternsResult['skillRecallDups'],
@@ -1014,6 +1070,7 @@ function buildSessionSummaries(
         sessionId,
         retryLoopCount: 0,
         failureRunCount: 0,
+        cancellationRunCount: 0,
         consecutiveFailureMax: 0,
         compactionCount: 0,
         editRevertCount: 0,
@@ -1039,6 +1096,11 @@ function buildSessionSummaries(
     row.failureRunCount++;
     if (f.length > row.consecutiveFailureMax) row.consecutiveFailureMax = f.length;
     row.totalPatternCost += f.cost;
+  }
+  for (const c of cancelledRuns) {
+    const row = get(c.sessionId);
+    row.cancellationRunCount++;
+    row.totalPatternCost += c.cost;
   }
   for (const c of compactions) {
     const row = get(c.sessionId);
@@ -1106,6 +1168,25 @@ function renderFailureTable(runs: PatternsResult['failureRuns'], limit: number):
       String(r.length),
       `${r.startTurnIndex}–${r.endTurnIndex}`,
       truncate(r.toolsInvolved.join(', '), 40),
+      formatUsd(r.cost),
+    ]);
+  }
+  return table(rows);
+}
+
+function renderCancellationTable(runs: PatternsResult['cancelledRuns'], limit: number): string {
+  if (runs.length === 0) return '  (none)';
+  const rows: string[][] = [
+    ['session', 'length', 'turns', 'tools', 'source', 'cost'],
+  ];
+  const slice = [...runs].sort((a, b) => b.cost - a.cost).slice(0, limit);
+  for (const r of slice) {
+    rows.push([
+      r.sessionId.slice(0, 8),
+      String(r.length),
+      `${r.startTurnIndex}–${r.endTurnIndex}`,
+      truncate(r.toolsInvolved.join(', '), 40),
+      r.eventSource,
       formatUsd(r.cost),
     ]);
   }
@@ -1315,17 +1396,18 @@ async function loadContentBySession(
   return out;
 }
 
-// Pull every `ToolResultEventRecord` whose session appears in `turns`. Used
-// only by `tool-output-bloat`; we filter post-query rather than issuing one
-// per session so we avoid N round-trips on large slices. The ledger reader
-// streams a single pass over the JSONL file regardless.
+// Pull every `ToolResultEventRecord` whose session appears in `turns`.
+// Pattern graph detectors and tool-output-bloat both use this. We filter
+// post-query rather than issuing one per session so we avoid N round-trips on
+// large slices; the ledger reader streams a single pass over the JSONL file.
 async function loadToolResultEventsForTurns(
   turns: EnrichedTurn[],
+  q: Query = {},
 ): Promise<ToolResultEventRecord[]> {
   if (turns.length === 0) return [];
   const sessionIds = new Set<string>();
   for (const t of turns) sessionIds.add(t.sessionId);
-  const events = await queryToolResultEvents({});
+  const events = await queryToolResultEvents(q);
   return events.filter((e) => sessionIds.has(e.sessionId));
 }
 


### PR DESCRIPTION
## Summary
- Use ToolResultEventRecord chronology for retry, failure, and cancellation pattern detection, with per-session legacy fallback.
- Surface graph eventSource in JSON findings and cancellation buckets.
- Thread tool-result events through waste/diagnose and update coverage gating.

## Tests
- pnpm run build
- pnpm run test

Closes #113
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
