### PR TITLE
Fix Codex session_meta id hint reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Fixed
+
+- `burn rebuild --content` now fast-skips renamed Codex rollout files using their embedded session metadata.
+
 ## [0.43.0] - 2026-04-29
 
 ### Changed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Fixed
+
+- `burn rebuild --content` now fast-skips renamed Codex rollout files using their first-line `session_meta` session id.
+
 ## [0.44.0] - 2026-04-29
 
 ### Changed

--- a/packages/cli/src/ingest.test.ts
+++ b/packages/cli/src/ingest.test.ts
@@ -291,6 +291,28 @@ describe('ingest forwards UserTurnRecord into the ledger (#94)', () => {
       'tool_result user-turn block should be persisted for sized attribution',
     );
   });
+
+  it('rebuild --content skips renamed Codex rollouts using session_meta ids', async () => {
+    const sessionId = 'sess_codex_renamed_rebuild_skip';
+    await writeCodexSession(
+      tmpHome,
+      'renamed-codex-rebuild',
+      codexSessionWithUserTurnBridgeChunks(sessionId).join(''),
+    );
+
+    await ingestCodexSessions();
+    const sizeBefore = (await stat(ledgerPath())).size;
+
+    const report = await reingestMissingContent();
+    const sizeAfter = (await stat(ledgerPath())).size;
+
+    assert.equal(report.scannedFiles, 1);
+    assert.equal(report.skippedExisting, 1);
+    assert.equal(report.reingestedSessions, 0);
+    assert.equal(report.appendedContent, 0);
+    assert.equal(report.appendedUserTurns, 0);
+    assert.equal(sizeAfter, sizeBefore, 'ledger must not grow for already-covered renamed rollouts');
+  });
 });
 
 describe('pending stamp ingest', () => {
@@ -392,6 +414,21 @@ describe('pending stamp ingest', () => {
     );
 
     assert.equal(await deriveCodexSessionId(file), 'sess_from_meta');
+  });
+
+  it('derives a codex session id from a canonical filename without reading the file', async () => {
+    const sessionId = '11111111-2222-3333-4444-555555555555';
+    const file = path.join(
+      tmpHome,
+      '.codex',
+      'sessions',
+      '2026',
+      '04',
+      '24',
+      `rollout-2026-04-24T00-00-00-000Z-${sessionId}.jsonl`,
+    );
+
+    assert.equal(await deriveCodexSessionId(file), sessionId);
   });
 });
 

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -1,4 +1,4 @@
-import { open, readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
@@ -7,6 +7,7 @@ import {
   parseClaudeSessionIncremental,
   parseCodexSessionIncremental,
   parseOpencodeSessionIncremental,
+  readCodexSessionIdHint,
   reconcileClaudeSessionRelationships,
 } from '@relayburn/reader';
 import type {
@@ -763,49 +764,15 @@ async function appendReingestedDerivedRecords(
 
 // Codex filenames are `rollout-<timestamp>-<uuid>.jsonl` where the UUID is the
 // session id. Extract it for a cheap skip check before parsing. If the pattern
-// doesn't match, return null and fall back to post-filtering.
+// doesn't match, peek at Codex's first-line session_meta hint before falling
+// back to post-filtering.
 export async function deriveCodexSessionId(file: string): Promise<string | null> {
   const base = path.basename(file, '.jsonl');
   const m = base.match(
     /([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/,
   );
   if (m) return m[1]!;
-  return readCodexSessionMetaId(file);
-}
-
-async function readCodexSessionMetaId(file: string): Promise<string | null> {
-  // session_meta is always the first JSONL line, so an 8 KB prefix is more
-  // than enough — avoids loading multi-MB rollouts during rebuild --content
-  // (#125 review).
-  let raw: string;
-  try {
-    const handle = await open(file, 'r');
-    try {
-      const buf = Buffer.alloc(8192);
-      const { bytesRead } = await handle.read(buf, 0, buf.length, 0);
-      raw = buf.subarray(0, bytesRead).toString('utf8');
-    } finally {
-      await handle.close();
-    }
-  } catch {
-    return null;
-  }
-  for (const line of raw.split(/\r?\n/, 20)) {
-    const text = line.trim();
-    if (!text) continue;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(text);
-    } catch {
-      continue;
-    }
-    if (!parsed || typeof parsed !== 'object') continue;
-    const rec = parsed as { type?: unknown; payload?: unknown };
-    if (rec.type !== 'session_meta' || !rec.payload || typeof rec.payload !== 'object') continue;
-    const id = (rec.payload as { id?: unknown }).id;
-    return typeof id === 'string' && id.length > 0 ? id : null;
-  }
-  return null;
+  return readCodexSessionIdHint(file);
 }
 
 async function listDirs(parent: string): Promise<string[]> {

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/reader`.
 
 ## [Unreleased]
 
+### Added
+
+- Added `readCodexSessionIdHint()` for cheap Codex first-line `session_meta` session-id discovery.
+
 ## [0.43.0] - 2026-04-29
 
 ### Changed

--- a/packages/reader/src/codex.test.ts
+++ b/packages/reader/src/codex.test.ts
@@ -4,10 +4,78 @@ import { fileURLToPath } from 'node:url';
 import * as path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { parseCodexSession, parseCodexSessionIncremental } from './codex.js';
+import {
+  parseCodexSession,
+  parseCodexSessionIncremental,
+  readCodexSessionIdHint,
+} from './codex.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.resolve(__dirname, '..', '..', '..', 'tests', 'fixtures', 'codex');
+
+describe('readCodexSessionIdHint', () => {
+  it('returns the session_meta id from the first JSONL line', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-codex-hint-'));
+    try {
+      const file = path.join(tmp, 'renamed-rollout.jsonl');
+      await writeFile(
+        file,
+        JSON.stringify({
+          timestamp: '2026-04-20T00:00:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'sess_hint_1',
+            cwd: '/tmp/project',
+            timestamp: '2026-04-20T00:00:00.000Z',
+          },
+        }) + '\n',
+        'utf8',
+      );
+
+      assert.equal(await readCodexSessionIdHint(file), 'sess_hint_1');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when the first JSONL line is malformed', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-codex-hint-bad-'));
+    try {
+      const file = path.join(tmp, 'renamed-rollout.jsonl');
+      await writeFile(
+        file,
+        [
+          '{"type":"session_meta","payload":',
+          JSON.stringify({ type: 'session_meta', payload: { id: 'sess_second_line' } }),
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+
+      assert.equal(await readCodexSessionIdHint(file), null);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for an empty file', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const tmp = await mkdtemp(path.join(tmpdir(), 'burn-codex-hint-empty-'));
+    try {
+      const file = path.join(tmp, 'empty.jsonl');
+      await writeFile(file, '', 'utf8');
+
+      assert.equal(await readCodexSessionIdHint(file), null);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('parseCodexSession', () => {
   it('parses a simple one-turn session', async () => {

--- a/packages/reader/src/codex.ts
+++ b/packages/reader/src/codex.ts
@@ -107,6 +107,12 @@ interface SessionMetaPayload {
   continued_from_session_id?: string;
 }
 
+function sessionMetaPayloadId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const id = (payload as SessionMetaPayload).id;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
 interface TurnContextPayload {
   turn_id?: string;
   cwd?: string;
@@ -309,6 +315,37 @@ export async function parseCodexSession(
   return { turns, content, events, userTurns, relationships, toolResultEvents };
 }
 
+export async function readCodexSessionIdHint(filePath: string): Promise<string | null> {
+  try {
+    const handle = await open(filePath, 'r');
+    try {
+      const buf = Buffer.alloc(8192);
+      const { bytesRead } = await handle.read(buf, 0, buf.length, 0);
+      if (bytesRead === 0) return null;
+
+      const raw = buf.subarray(0, bytesRead).toString('utf8');
+      const newline = raw.indexOf('\n');
+      const firstLine = (newline === -1 ? raw : raw.slice(0, newline)).replace(/\r$/, '').trim();
+      if (!firstLine) return null;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(firstLine);
+      } catch {
+        return null;
+      }
+      if (!parsed || typeof parsed !== 'object') return null;
+      const rec = parsed as { type?: unknown; payload?: unknown };
+      if (rec.type !== 'session_meta') return null;
+      return sessionMetaPayloadId(rec.payload);
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
 export async function parseCodexSessionIncremental(
   filePath: string,
   options: ParseCodexIncrementalOptions = {},
@@ -448,7 +485,8 @@ export async function parseCodexSessionIncremental(
 
     if (rec.type === 'session_meta') {
       const sp = payload as SessionMetaPayload;
-      if (typeof sp.id === 'string') sessionId = sp.id;
+      const metaSessionId = sessionMetaPayloadId(payload);
+      if (metaSessionId) sessionId = metaSessionId;
       if (typeof sp.cwd === 'string') {
         sessionCwd = sp.cwd;
         if (openTurn && openTurn.project === undefined) openTurn.project = sp.cwd;

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -41,7 +41,11 @@ export type {
   ClaudeRelationshipEvidence,
   ReconcileClaudeRelationshipsInput,
 } from './claude.js';
-export { parseCodexSession, parseCodexSessionIncremental } from './codex.js';
+export {
+  parseCodexSession,
+  parseCodexSessionIncremental,
+  readCodexSessionIdHint,
+} from './codex.js';
 export type {
   ParseCodexOptions,
   ParseCodexResult,


### PR DESCRIPTION
## Summary
- export a reader-side readCodexSessionIdHint() helper for first-line Codex session_meta ids
- make CLI Codex session-id derivation delegate to the shared reader helper after the filename fast path
- cover malformed/empty hints, canonical filename fast path, and renamed rollout rebuild skipping

## Tests
- pnpm run build
- pnpm run test

Closes #96
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
