### PR TITLE
Use relationship graph for subagent trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Changed
+
+- `burn summary --subagent-tree` now renders persisted session relationship graphs while preserving legacy subagent-tree output for older data.
+
 ## [0.45.0] - 2026-04-29
 
 ### Added

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/analyze`.
 
 ## [Unreleased]
 
+### Changed
+
+- `buildSubagentTree()` now consumes `SessionRelationshipRecord` graphs when available, with legacy `TurnRecord.subagent` fallback and per-node `relationshipType`.
+
 ## [0.44.0] - 2026-04-29
 
 ### Changed

--- a/packages/analyze/src/subagent-tree.test.ts
+++ b/packages/analyze/src/subagent-tree.test.ts
@@ -1,7 +1,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import type { Subagent, TurnRecord } from '@relayburn/reader';
+import type {
+  SessionRelationshipRecord,
+  Subagent,
+  TurnRecord,
+} from '@relayburn/reader';
 
 import { loadBuiltinPricing } from './pricing.js';
 import { aggregateSubagentTypeStats, buildSubagentTree } from './subagent-tree.js';
@@ -11,7 +15,7 @@ function turn(
 ): TurnRecord {
   const base: TurnRecord = {
     v: 1,
-    source: 'claude-code',
+    source: overrides.source ?? 'claude-code',
     sessionId: overrides.sessionId,
     messageId: overrides.messageId,
     turnIndex: overrides.turnIndex ?? 0,
@@ -33,6 +37,17 @@ function turn(
 
 function sub(fields: Partial<Subagent>): Subagent {
   return { isSidechain: true, ...fields };
+}
+
+function relationship(
+  overrides: Partial<SessionRelationshipRecord> & { sessionId: string },
+): SessionRelationshipRecord {
+  return {
+    v: 1,
+    source: 'native-claude',
+    relationshipType: 'root',
+    ...overrides,
+  };
 }
 
 describe('buildSubagentTree', () => {
@@ -133,6 +148,106 @@ describe('buildSubagentTree', () => {
     const root = trees.get(sessionId)!;
     assert.equal(root.children.length, 1);
     assert.equal(root.children[0]!.label, '(unresolved)');
+    assert.equal(root.children[0]!.selfTurns, 1);
+  });
+
+  it('builds the same Claude tree from SessionRelationshipRecord rows', async () => {
+    const pricing = await loadBuiltinPricing();
+    const sessionId = 'sess-graph';
+    const turns: TurnRecord[] = [
+      turn({ sessionId, messageId: 'm1', model: 'claude-sonnet-4-6', turnIndex: 0 }),
+      turn({
+        sessionId,
+        messageId: 'o1',
+        model: 'claude-haiku-4-5',
+        turnIndex: 1,
+        subagent: sub({
+          agentId: 'u-outer',
+          parentAgentId: sessionId,
+          subagentType: 'Explore',
+          description: 'Research',
+          parentToolUseId: 'toolu_outer',
+        }),
+      }),
+      turn({
+        sessionId,
+        messageId: 'i1',
+        model: 'claude-haiku-4-5',
+        turnIndex: 2,
+        subagent: sub({
+          agentId: 'u-inner',
+          parentAgentId: 'u-outer',
+          subagentType: 'code-reviewer',
+          parentToolUseId: 'toolu_inner',
+        }),
+      }),
+    ];
+    const relationships: SessionRelationshipRecord[] = [
+      relationship({ sessionId, source: 'claude-code', relationshipType: 'root' }),
+      relationship({
+        sessionId,
+        relationshipType: 'subagent',
+        relatedSessionId: sessionId,
+        agentId: 'u-outer',
+        subagentType: 'Explore',
+        description: 'Research',
+        parentToolUseId: 'toolu_outer',
+      }),
+      relationship({
+        sessionId,
+        relationshipType: 'subagent',
+        relatedSessionId: 'u-outer',
+        agentId: 'u-inner',
+        subagentType: 'code-reviewer',
+        parentToolUseId: 'toolu_inner',
+      }),
+    ];
+
+    const legacy = buildSubagentTree(turns, { pricing }).get(sessionId)!;
+    const graph = buildSubagentTree(turns, { pricing, relationships }).get(sessionId)!;
+    assert.deepEqual(graph, legacy);
+    assert.equal(graph.relationshipType, 'root');
+    assert.equal(graph.children[0]!.relationshipType, 'subagent');
+  });
+
+  it('joins child-session relationship rows to turns without per-turn subagent metadata', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns: TurnRecord[] = [
+      turn({
+        source: 'codex',
+        sessionId: 'parent-session',
+        messageId: 'parent-1',
+        model: 'gpt-5.1-codex',
+      }),
+      turn({
+        source: 'codex',
+        sessionId: 'agent-child',
+        messageId: 'child-1',
+        model: 'gpt-5.1-codex',
+      }),
+    ];
+    const relationships: SessionRelationshipRecord[] = [
+      relationship({
+        source: 'codex',
+        sessionId: 'parent-session',
+        relationshipType: 'root',
+      }),
+      relationship({
+        source: 'codex',
+        sessionId: 'agent-child',
+        relationshipType: 'subagent',
+        relatedSessionId: 'parent-session',
+        agentId: 'agent-child',
+        subagentType: 'worker',
+      }),
+    ];
+
+    const root = buildSubagentTree(turns, { pricing, relationships }).get('parent-session')!;
+    assert.equal(root.selfTurns, 1);
+    assert.equal(root.cumulativeTurns, 2);
+    assert.equal(root.children.length, 1);
+    assert.equal(root.children[0]!.label, 'worker');
+    assert.equal(root.children[0]!.relationshipType, 'subagent');
     assert.equal(root.children[0]!.selfTurns, 1);
   });
 });

--- a/packages/analyze/src/subagent-tree.test.ts
+++ b/packages/analyze/src/subagent-tree.test.ts
@@ -221,7 +221,7 @@ describe('buildSubagentTree', () => {
       }),
       turn({
         source: 'codex',
-        sessionId: 'agent-child',
+        sessionId: 'child-session',
         messageId: 'child-1',
         model: 'gpt-5.1-codex',
       }),
@@ -234,7 +234,7 @@ describe('buildSubagentTree', () => {
       }),
       relationship({
         source: 'codex',
-        sessionId: 'agent-child',
+        sessionId: 'child-session',
         relationshipType: 'subagent',
         relatedSessionId: 'parent-session',
         agentId: 'agent-child',
@@ -247,8 +247,35 @@ describe('buildSubagentTree', () => {
     assert.equal(root.cumulativeTurns, 2);
     assert.equal(root.children.length, 1);
     assert.equal(root.children[0]!.label, 'worker');
+    assert.equal(root.children[0]!.nodeId, 'child-session');
     assert.equal(root.children[0]!.relationshipType, 'subagent');
     assert.equal(root.children[0]!.selfTurns, 1);
+  });
+
+  it('does not alias native sidechain session roots onto agent ids when turns lack subagent fields', async () => {
+    const pricing = await loadBuiltinPricing();
+    const sessionId = 'partial-claude';
+    const turns: TurnRecord[] = [
+      turn({ sessionId, messageId: 'main-1', model: 'claude-sonnet-4-6' }),
+    ];
+    const relationships: SessionRelationshipRecord[] = [
+      relationship({ sessionId, source: 'claude-code', relationshipType: 'root' }),
+      relationship({
+        sessionId,
+        relationshipType: 'subagent',
+        relatedSessionId: sessionId,
+        agentId: 'u-outer',
+        subagentType: 'Explore',
+      }),
+    ];
+
+    const root = buildSubagentTree(turns, { pricing, relationships }).get(sessionId)!;
+    assert.equal(root.nodeId, sessionId);
+    assert.equal(root.label, 'main');
+    assert.equal(root.selfTurns, 1);
+    assert.equal(root.children.length, 1);
+    assert.equal(root.children[0]!.nodeId, 'u-outer');
+    assert.equal(root.children[0]!.selfTurns, 0);
   });
 });
 

--- a/packages/analyze/src/subagent-tree.ts
+++ b/packages/analyze/src/subagent-tree.ts
@@ -1,4 +1,8 @@
-import type { TurnRecord } from '@relayburn/reader';
+import type {
+  RelationshipType,
+  SessionRelationshipRecord,
+  TurnRecord,
+} from '@relayburn/reader';
 
 import { costForTurn } from './cost.js';
 import type { PricingTable } from './pricing.js';
@@ -11,6 +15,9 @@ export interface SubagentTreeNode {
   // '(unknown)' for sidechain turns whose tree fields couldn't be resolved
   // from passive data.
   label: string;
+  // Relationship edge that introduced this node. The main-thread root is
+  // `root`; legacy TurnRecord.subagent fallback nodes are `subagent`.
+  relationshipType: RelationshipType;
   // Agent/Task subagent_type from the spawning tool input, when known.
   subagentType?: string;
   // Agent/Task description from the spawning tool input, when known.
@@ -31,11 +38,15 @@ export interface SubagentTreeNode {
 
 export interface BuildSubagentTreeOptions {
   pricing: PricingTable;
+  relationships?: readonly SessionRelationshipRecord[];
 }
 
 // Build per-session subagent trees. Each session produces one tree whose root
 // represents the main thread (non-sidechain turns). Children are subagent
 // invocations grouped by `subagent.agentId`, nested by `parentAgentId`.
+// When SessionRelationshipRecord rows are provided, they are the primary tree
+// substrate and TurnRecord.subagent is used only to attach turn costs and fill
+// legacy gaps.
 //
 // Sessions with sidechain turns whose tree fields are absent (e.g. incomplete
 // incremental ingest) still emit a tree; those turns attach to a synthetic
@@ -43,6 +54,16 @@ export interface BuildSubagentTreeOptions {
 export function buildSubagentTree(
   turns: TurnRecord[],
   opts: BuildSubagentTreeOptions,
+): Map<string, SubagentTreeNode> {
+  if (opts.relationships && opts.relationships.length > 0) {
+    return buildRelationshipTrees(turns, opts.relationships, opts.pricing);
+  }
+  return buildLegacySubagentTrees(turns, opts.pricing);
+}
+
+function buildLegacySubagentTrees(
+  turns: TurnRecord[],
+  pricing: PricingTable,
 ): Map<string, SubagentTreeNode> {
   const bySession = new Map<string, TurnRecord[]>();
   for (const t of turns) {
@@ -56,7 +77,7 @@ export function buildSubagentTree(
 
   const out = new Map<string, SubagentTreeNode>();
   for (const [sessionId, sessionTurns] of bySession) {
-    const root = buildSessionTree(sessionId, sessionTurns, opts.pricing);
+    const root = buildSessionTree(sessionId, sessionTurns, pricing);
     out.set(sessionId, root);
   }
   return out;
@@ -64,6 +85,294 @@ export function buildSubagentTree(
 
 interface MutableNode extends SubagentTreeNode {
   children: MutableNode[];
+}
+
+interface GraphState {
+  aliasById: Map<string, string>;
+  nodeById: Map<string, MutableNode>;
+  modelsByNode: Map<string, Set<string>>;
+  parentByNode: Map<string, string>;
+}
+
+function buildRelationshipTrees(
+  turns: TurnRecord[],
+  relationships: readonly SessionRelationshipRecord[],
+  pricing: PricingTable,
+): Map<string, SubagentTreeNode> {
+  const state: GraphState = {
+    aliasById: buildRelationshipAliases(turns, relationships),
+    nodeById: new Map(),
+    modelsByNode: new Map(),
+    parentByNode: new Map(),
+  };
+
+  for (const r of relationships) {
+    const id = canonicalId(state, relationshipNodeId(r));
+    const node = ensureNode(state, id, labelForRelationship(r), r.relationshipType);
+    applyRelationshipMetadata(node, r);
+    if (r.relationshipType === 'root' || r.relatedSessionId === undefined) continue;
+    const parentId = canonicalId(state, r.relatedSessionId);
+    ensureNode(state, parentId, parentId, 'root');
+    if (!state.parentByNode.has(id)) state.parentByNode.set(id, parentId);
+  }
+
+  addLegacySubagentGaps(state, turns);
+  ensureTurnSessionRoots(state, turns);
+  attachGraphChildren(state);
+  attachTurnCosts(state, turns, pricing);
+
+  const out = new Map<string, SubagentTreeNode>();
+  const childIds = collectAttachedChildIds(state);
+  for (const [id, node] of state.nodeById) {
+    if (childIds.has(id)) continue;
+    finalizeTree(state, node);
+    out.set(id, node);
+  }
+  return out;
+}
+
+function buildRelationshipAliases(
+  turns: readonly TurnRecord[],
+  relationships: readonly SessionRelationshipRecord[],
+): Map<string, string> {
+  const sessionsWithNativeSidechains = new Set<string>();
+  for (const t of turns) {
+    if (t.subagent?.agentId) sessionsWithNativeSidechains.add(t.sessionId);
+  }
+
+  const aliases = new Map<string, string>();
+  for (const r of relationships) {
+    if (r.relationshipType !== 'subagent' || r.agentId === undefined) {
+      aliases.set(r.sessionId, r.sessionId);
+    }
+  }
+  for (const r of relationships) {
+    if (r.relationshipType !== 'subagent') continue;
+    if (r.agentId === undefined) {
+      aliases.set(r.sessionId, r.sessionId);
+      continue;
+    }
+    aliases.set(r.agentId, r.agentId);
+    // Claude sidechains live inside the parent file session, so their
+    // relationship row has sessionId=<root session>, agentId=<sidechain id>,
+    // and turns already carry subagent.agentId. Child-session sources such as
+    // Codex/OpenCode have no per-turn subagent field, so alias their session
+    // id to the graph node when the session is not a native sidechain holder.
+    if (!sessionsWithNativeSidechains.has(r.sessionId)) aliases.set(r.sessionId, r.agentId);
+  }
+  return aliases;
+}
+
+function relationshipNodeId(r: SessionRelationshipRecord): string {
+  if (r.relationshipType === 'subagent') return r.agentId ?? r.sessionId;
+  return r.sessionId;
+}
+
+function canonicalId(state: GraphState, id: string): string {
+  return state.aliasById.get(id) ?? id;
+}
+
+function ensureNode(
+  state: GraphState,
+  id: string,
+  label: string,
+  relationshipType: RelationshipType,
+): MutableNode {
+  let node = state.nodeById.get(id);
+  if (!node) {
+    node = {
+      nodeId: id,
+      label,
+      relationshipType,
+      models: [],
+      selfTurns: 0,
+      selfCost: 0,
+      cumulativeTurns: 0,
+      cumulativeCost: 0,
+      depth: -1,
+      children: [],
+    };
+    state.nodeById.set(id, node);
+    state.modelsByNode.set(id, new Set());
+  }
+  return node;
+}
+
+function labelForRelationship(r: SessionRelationshipRecord): string {
+  if (r.relationshipType === 'root') return 'main';
+  if (r.relationshipType === 'subagent') return r.subagentType ?? '(unknown)';
+  return r.sessionId;
+}
+
+function applyRelationshipMetadata(node: MutableNode, r: SessionRelationshipRecord): void {
+  if (r.relationshipType === 'root') {
+    if (node.relationshipType === 'root') node.label = 'main';
+    return;
+  }
+
+  node.relationshipType = r.relationshipType;
+  node.label = labelForRelationship(r);
+  if (r.subagentType !== undefined) node.subagentType = r.subagentType;
+  if (r.description !== undefined) node.description = r.description;
+}
+
+function addLegacySubagentGaps(state: GraphState, turns: readonly TurnRecord[]): void {
+  for (const t of turns) {
+    const sub = t.subagent;
+    if (!sub?.agentId) continue;
+    const id = canonicalId(state, sub.agentId);
+    const node = ensureNode(
+      state,
+      id,
+      sub.subagentType ?? '(unknown)',
+      'subagent',
+    );
+    if (node.relationshipType === 'root') node.relationshipType = 'subagent';
+    if (node.label === '(unknown)' && sub.subagentType !== undefined) {
+      node.label = sub.subagentType;
+    }
+    if (node.subagentType === undefined && sub.subagentType !== undefined) {
+      node.subagentType = sub.subagentType;
+    }
+    if (node.description === undefined && sub.description !== undefined) {
+      node.description = sub.description;
+    }
+    if (state.parentByNode.has(id)) continue;
+    const parentId = canonicalId(state, sub.parentAgentId ?? t.sessionId);
+    state.parentByNode.set(id, parentId);
+  }
+}
+
+function ensureTurnSessionRoots(state: GraphState, turns: readonly TurnRecord[]): void {
+  for (const t of turns) {
+    const id = canonicalId(state, t.sessionId);
+    const node = ensureNode(state, id, 'main', 'root');
+    if (node.relationshipType === 'root') node.label = 'main';
+  }
+  for (const parentId of state.parentByNode.values()) {
+    ensureNode(state, parentId, parentId, 'root');
+  }
+}
+
+function attachGraphChildren(state: GraphState): void {
+  for (const [id, parentId] of state.parentByNode) {
+    const node = state.nodeById.get(id);
+    if (!node) continue;
+    const resolvedParentId = resolveGraphParent(id, parentId, state.parentByNode);
+    if (resolvedParentId === undefined) continue;
+    const parent = state.nodeById.get(resolvedParentId);
+    if (!parent) continue;
+    if (!parent.children.includes(node)) parent.children.push(node);
+  }
+}
+
+function collectAttachedChildIds(state: GraphState): Set<string> {
+  const out = new Set<string>();
+  for (const node of state.nodeById.values()) {
+    for (const child of node.children) out.add(child.nodeId);
+  }
+  return out;
+}
+
+function attachTurnCosts(
+  state: GraphState,
+  turns: readonly TurnRecord[],
+  pricing: PricingTable,
+): void {
+  const unresolvedByParent = new Map<string, MutableNode>();
+  for (const t of turns) {
+    const cost = costForTurn(t, pricing)?.total ?? 0;
+    const sub = t.subagent;
+    if (sub && !sub.agentId) {
+      const parentId = canonicalId(state, t.sessionId);
+      let unresolved = unresolvedByParent.get(parentId);
+      if (!unresolved) {
+        unresolved = ensureNode(
+          state,
+          `${parentId}:__unresolved`,
+          '(unresolved)',
+          'subagent',
+        );
+        state.parentByNode.set(unresolved.nodeId, parentId);
+        const parent = state.nodeById.get(parentId);
+        if (parent && !parent.children.includes(unresolved)) parent.children.push(unresolved);
+        unresolvedByParent.set(parentId, unresolved);
+      }
+      addTurnToNode(state, unresolved.nodeId, t, cost);
+      continue;
+    }
+
+    const id = sub?.agentId ? canonicalId(state, sub.agentId) : canonicalId(state, t.sessionId);
+    ensureNode(state, id, sub?.subagentType ?? 'main', sub ? 'subagent' : 'root');
+    addTurnToNode(state, id, t, cost);
+  }
+}
+
+function addTurnToNode(
+  state: GraphState,
+  id: string,
+  turn: TurnRecord,
+  cost: number,
+): void {
+  const node = state.nodeById.get(id);
+  if (!node) return;
+  node.selfTurns++;
+  node.selfCost += cost;
+  if (turn.model) {
+    let models = state.modelsByNode.get(id);
+    if (!models) {
+      models = new Set();
+      state.modelsByNode.set(id, models);
+    }
+    models.add(turn.model);
+  }
+}
+
+function finalizeTree(state: GraphState, root: MutableNode): void {
+  const queue: Array<{ node: MutableNode; depth: number }> = [{ node: root, depth: 0 }];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const { node, depth } = queue.shift()!;
+    if (seen.has(node.nodeId)) continue;
+    seen.add(node.nodeId);
+    node.depth = depth;
+    for (const child of node.children) {
+      queue.push({ node: child, depth: depth + 1 });
+    }
+  }
+
+  foldCumulative(root);
+  assignModelArrays(state, root);
+  sortTree(root);
+}
+
+function assignModelArrays(state: GraphState, root: MutableNode): void {
+  const queue: MutableNode[] = [root];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    if (seen.has(node.nodeId)) continue;
+    seen.add(node.nodeId);
+    const models = state.modelsByNode.get(node.nodeId);
+    if (models) node.models = [...models].sort();
+    for (const child of node.children) queue.push(child);
+  }
+}
+
+function resolveGraphParent(
+  id: string,
+  parentId: string,
+  parentByNode: Map<string, string>,
+): string | undefined {
+  if (parentId === id) return undefined;
+  const seen = new Set<string>([id]);
+  let cursor = parentId;
+  while (parentByNode.has(cursor)) {
+    if (seen.has(cursor)) return undefined;
+    seen.add(cursor);
+    cursor = parentByNode.get(cursor)!;
+  }
+  return parentId;
 }
 
 function buildSessionTree(
@@ -74,6 +383,7 @@ function buildSessionTree(
   const root: MutableNode = {
     nodeId: sessionId,
     label: 'main',
+    relationshipType: 'root',
     models: [],
     selfTurns: 0,
     selfCost: 0,
@@ -109,6 +419,7 @@ function buildSessionTree(
         unresolved = {
           nodeId: `${sessionId}:__unresolved`,
           label: '(unresolved)',
+          relationshipType: 'subagent',
           models: [],
           selfTurns: 0,
           selfCost: 0,
@@ -130,6 +441,7 @@ function buildSessionTree(
       node = {
         nodeId: agentId,
         label: t.subagent.subagentType ?? '(unknown)',
+        relationshipType: 'subagent',
         models: [],
         selfTurns: 0,
         selfCost: 0,

--- a/packages/analyze/src/subagent-tree.ts
+++ b/packages/analyze/src/subagent-tree.ts
@@ -139,12 +139,18 @@ function buildRelationshipAliases(
   for (const t of turns) {
     if (t.subagent?.agentId) sessionsWithNativeSidechains.add(t.sessionId);
   }
+  for (const r of relationships) {
+    if (
+      r.relationshipType === 'subagent' &&
+      r.relatedSessionId === r.sessionId
+    ) {
+      sessionsWithNativeSidechains.add(r.sessionId);
+    }
+  }
 
   const aliases = new Map<string, string>();
   for (const r of relationships) {
-    if (r.relationshipType !== 'subagent' || r.agentId === undefined) {
-      aliases.set(r.sessionId, r.sessionId);
-    }
+    aliases.set(r.sessionId, r.sessionId);
   }
   for (const r of relationships) {
     if (r.relationshipType !== 'subagent') continue;
@@ -152,13 +158,15 @@ function buildRelationshipAliases(
       aliases.set(r.sessionId, r.sessionId);
       continue;
     }
-    aliases.set(r.agentId, r.agentId);
     // Claude sidechains live inside the parent file session, so their
     // relationship row has sessionId=<root session>, agentId=<sidechain id>,
     // and turns already carry subagent.agentId. Child-session sources such as
-    // Codex/OpenCode have no per-turn subagent field, so alias their session
-    // id to the graph node when the session is not a native sidechain holder.
-    if (!sessionsWithNativeSidechains.has(r.sessionId)) aliases.set(r.sessionId, r.agentId);
+    // Codex/OpenCode keep turns under the child session id, so the agent id
+    // aliases to the session id while the session id remains addressable.
+    aliases.set(
+      r.agentId,
+      sessionsWithNativeSidechains.has(r.sessionId) ? r.agentId : r.sessionId,
+    );
   }
   return aliases;
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Changed
+
+- `burn summary --subagent-tree` now reads persisted session relationships, including child-session subagents and fork/continuation annotations.
+
 ## [0.45.0] - 2026-04-29
 
 ### Fixed

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -589,6 +589,148 @@ describe('burn summary --by-relationship (#114)', () => {
   });
 });
 
+describe('burn summary --subagent-tree relationships (#109)', () => {
+  let tmpHome: string;
+  let tmpRelay: string;
+  const originalHome = process.env['HOME'];
+  const originalRelay = process.env['RELAYBURN_HOME'];
+  const originalArchive = process.env['RELAYBURN_ARCHIVE'];
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-summary-tree-home-'));
+    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-summary-tree-relay-'));
+    process.env['HOME'] = tmpHome;
+    process.env['RELAYBURN_HOME'] = tmpRelay;
+    process.env['RELAYBURN_ARCHIVE'] = '0';
+    __resetIndexCacheForTesting();
+  });
+
+  afterEach(async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(tmpRelay, { recursive: true, force: true });
+  });
+
+  after(async () => {
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+    else delete process.env['HOME'];
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    if (originalArchive !== undefined) process.env['RELAYBURN_ARCHIVE'] = originalArchive;
+    else delete process.env['RELAYBURN_ARCHIVE'];
+  });
+
+  it('--json includes relationshipType and renders child-session subagents', async () => {
+    await appendTurns([
+      fakeTurn({
+        source: 'codex',
+        sessionId: 'tree-parent',
+        messageId: 'tree-parent-1',
+        model: 'gpt-5.1-codex',
+      }),
+      fakeTurn({
+        source: 'codex',
+        sessionId: 'tree-child',
+        messageId: 'tree-child-1',
+        model: 'gpt-5.1-codex',
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({
+        source: 'codex',
+        sessionId: 'tree-parent',
+        relationshipType: 'root',
+      }),
+      fakeRelationship({
+        source: 'codex',
+        sessionId: 'tree-child',
+        relationshipType: 'subagent',
+        relatedSessionId: 'tree-parent',
+        agentId: 'tree-child',
+        subagentType: 'worker',
+      }),
+    ]);
+
+    const out = await captureSummary({
+      'subagent-tree': 'tree-parent',
+      json: true,
+      'no-archive': true,
+    });
+    assert.equal(out.code, 0);
+    const payload = JSON.parse(out.stdout) as {
+      relationshipType: string;
+      selfTurns: number;
+      cumulativeTurns: number;
+      children: Array<{
+        label: string;
+        relationshipType: string;
+        selfTurns: number;
+      }>;
+    };
+    assert.equal(payload.relationshipType, 'root');
+    assert.equal(payload.selfTurns, 1);
+    assert.equal(payload.cumulativeTurns, 2);
+    assert.equal(payload.children[0]!.label, 'worker');
+    assert.equal(payload.children[0]!.relationshipType, 'subagent');
+    assert.equal(payload.children[0]!.selfTurns, 1);
+  });
+
+  it('falls back to TurnRecord.subagent when no relationship rows exist', async () => {
+    await appendTurns([
+      fakeTurn({ sessionId: 'tree-legacy', messageId: 'tree-legacy-1' }),
+      fakeTurn({
+        sessionId: 'tree-legacy',
+        messageId: 'tree-legacy-sub-1',
+        turnIndex: 1,
+        subagent: {
+          isSidechain: true,
+          agentId: 'legacy-agent',
+          parentAgentId: 'tree-legacy',
+          subagentType: 'Explore',
+        },
+      }),
+    ]);
+
+    const out = await captureSummary({
+      'subagent-tree': 'tree-legacy',
+      json: true,
+      'no-archive': true,
+    });
+    assert.equal(out.code, 0);
+    const payload = JSON.parse(out.stdout) as {
+      children: Array<{ label: string; relationshipType: string; selfTurns: number }>;
+    };
+    assert.equal(payload.children[0]!.label, 'Explore');
+    assert.equal(payload.children[0]!.relationshipType, 'subagent');
+    assert.equal(payload.children[0]!.selfTurns, 1);
+  });
+
+  it('annotates non-subagent relationship nodes in text output', async () => {
+    await appendTurns([
+      fakeTurn({ sessionId: 'tree-root', messageId: 'tree-root-1' }),
+      fakeTurn({
+        sessionId: 'tree-fork',
+        messageId: 'tree-fork-1',
+        ts: '2026-04-20T00:01:00.000Z',
+      }),
+    ]);
+    await appendRelationships([
+      fakeRelationship({ sessionId: 'tree-root', relationshipType: 'root' }),
+      fakeRelationship({
+        sessionId: 'tree-fork',
+        relationshipType: 'fork',
+        relatedSessionId: 'tree-root',
+      }),
+    ]);
+
+    const out = await captureSummary({
+      'subagent-tree': 'tree-root',
+      'no-archive': true,
+    });
+    assert.equal(out.code, 0);
+    assert.match(out.stdout, /tree-fork \[fork\]/);
+  });
+});
+
 describe('burn summary per-cell fidelity (#136)', () => {
   let tmpHome: string;
   let tmpRelay: string;

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -629,7 +629,7 @@ describe('burn summary --subagent-tree relationships (#109)', () => {
       }),
       fakeTurn({
         source: 'codex',
-        sessionId: 'tree-child',
+        sessionId: 'tree-child-session',
         messageId: 'tree-child-1',
         model: 'gpt-5.1-codex',
       }),
@@ -642,10 +642,10 @@ describe('burn summary --subagent-tree relationships (#109)', () => {
       }),
       fakeRelationship({
         source: 'codex',
-        sessionId: 'tree-child',
+        sessionId: 'tree-child-session',
         relationshipType: 'subagent',
         relatedSessionId: 'tree-parent',
-        agentId: 'tree-child',
+        agentId: 'tree-child-agent',
         subagentType: 'worker',
       }),
     ]);
@@ -661,6 +661,7 @@ describe('burn summary --subagent-tree relationships (#109)', () => {
       selfTurns: number;
       cumulativeTurns: number;
       children: Array<{
+        nodeId: string;
         label: string;
         relationshipType: string;
         selfTurns: number;
@@ -669,9 +670,27 @@ describe('burn summary --subagent-tree relationships (#109)', () => {
     assert.equal(payload.relationshipType, 'root');
     assert.equal(payload.selfTurns, 1);
     assert.equal(payload.cumulativeTurns, 2);
+    assert.equal(payload.children[0]!.nodeId, 'tree-child-session');
     assert.equal(payload.children[0]!.label, 'worker');
     assert.equal(payload.children[0]!.relationshipType, 'subagent');
     assert.equal(payload.children[0]!.selfTurns, 1);
+
+    const childOut = await captureSummary({
+      'subagent-tree': 'tree-child-session',
+      json: true,
+      'no-archive': true,
+    });
+    assert.equal(childOut.code, 0);
+    const childPayload = JSON.parse(childOut.stdout) as {
+      nodeId: string;
+      label: string;
+      relationshipType: string;
+      selfTurns: number;
+    };
+    assert.equal(childPayload.nodeId, 'tree-child-session');
+    assert.equal(childPayload.label, 'worker');
+    assert.equal(childPayload.relationshipType, 'subagent');
+    assert.equal(childPayload.selfTurns, 1);
   });
 
   it('falls back to TurnRecord.subagent when no relationship rows exist', async () => {

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -42,6 +42,7 @@ import {
   filterTurnsByProvider,
   parseProviderFilter,
 } from '../provider.js';
+import type { ProviderFilter } from '../provider.js';
 
 export async function runSummary(args: ParsedArgs): Promise<number> {
   const q: Query = {};
@@ -107,15 +108,23 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   const pricing = await loadPricing();
   const agentSessionIds =
     agentFilter !== undefined ? await resolveAgentSessionTree(agentFilter) : undefined;
-  const turnQuery = subagentTreeFlag !== undefined ? queryWithoutSession(q) : q;
+  if (subagentTreeFlag !== undefined) {
+    return renderSubagentTreeMode(
+      args,
+      pricing,
+      subagentTreeFlag,
+      q,
+      agentFilter,
+      agentSessionIds,
+      providerFilter,
+    );
+  }
+
   const turns = filterTurnsByProvider(
-    filterTurnsByAgent(await loadTurns(turnQuery, args), agentFilter, agentSessionIds),
+    filterTurnsByAgent(await loadTurns(q, args), agentFilter, agentSessionIds),
     providerFilter,
   );
 
-  if (subagentTreeFlag !== undefined) {
-    return renderSubagentTreeMode(args, turns, pricing, subagentTreeFlag, q);
-  }
   if (subagentTypeFlag) {
     return renderSubagentTypeMode(args, turns, pricing);
   }
@@ -383,10 +392,12 @@ type ModelRow = UsageCostAggregateRow;
 
 async function renderSubagentTreeMode(
   args: ParsedArgs,
-  turns: EnrichedTurn[],
   pricing: Parameters<typeof costForTurn>[1],
   flag: string | true,
   q: Query,
+  agentFilter: string | undefined,
+  agentSessionIds: Set<string> | undefined,
+  providerFilter: ProviderFilter | undefined,
 ): Promise<number> {
   // Accept either `--subagent-tree <id>` or `--subagent-tree` with --session.
   const sessionId = typeof flag === 'string' ? flag : q.sessionId;
@@ -394,7 +405,15 @@ async function renderSubagentTreeMode(
     process.stderr.write('burn: --subagent-tree requires a session id (positional or --session)\n');
     return 2;
   }
-  const relationships = await queryRelationships();
+  const relationships = await collectSubagentTreeRelationships(sessionId, q);
+  const turns = filterTurnsByProvider(
+    filterTurnsByAgent(
+      await loadSubagentTreeTurns(sessionId, relationships, q, args),
+      agentFilter,
+      agentSessionIds,
+    ),
+    providerFilter,
+  );
   const trees = buildSubagentTree(turns, { pricing, relationships });
   const root = trees.get(sessionId) ?? findTreeNode(trees, sessionId);
   if (!root) {
@@ -414,6 +433,59 @@ async function renderSubagentTreeMode(
   out.push('');
   process.stdout.write(out.join('\n'));
   return 0;
+}
+
+async function collectSubagentTreeRelationships(
+  sessionId: string,
+  q: Query,
+): Promise<SessionRelationshipRecord[]> {
+  const queryBase = relationshipQueryForTurnSlice(q);
+  const out = new Map<string, SessionRelationshipRecord>();
+  const seenIds = new Set<string>();
+  const queue = [sessionId];
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
+    const relationships = await queryRelationships({ ...queryBase, sessionId: id });
+    for (const r of relationships) {
+      out.set(relationshipInstanceKey(r), r);
+      for (const next of relationshipConnectedIds(r)) {
+        if (next.length > 0 && !seenIds.has(next)) queue.push(next);
+      }
+    }
+  }
+
+  return [...out.values()];
+}
+
+function relationshipConnectedIds(r: SessionRelationshipRecord): string[] {
+  const ids = [r.sessionId];
+  if (r.relatedSessionId !== undefined) ids.push(r.relatedSessionId);
+  if (r.agentId !== undefined) ids.push(r.agentId);
+  return ids;
+}
+
+async function loadSubagentTreeTurns(
+  sessionId: string,
+  relationships: readonly SessionRelationshipRecord[],
+  q: Query,
+  args: ParsedArgs,
+): Promise<EnrichedTurn[]> {
+  const sessionIds = new Set<string>([sessionId]);
+  for (const r of relationships) {
+    sessionIds.add(r.sessionId);
+  }
+
+  const byKey = new Map<string, EnrichedTurn>();
+  for (const id of sessionIds) {
+    const turns = await loadTurns({ ...q, sessionId: id }, args);
+    for (const t of turns) {
+      byKey.set(`${t.source}|${t.sessionId}|${t.messageId}`, t);
+    }
+  }
+  return [...byKey.values()];
 }
 
 async function renderByToolMode(
@@ -998,12 +1070,6 @@ async function loadTurns(q: Query, args: ParsedArgs): Promise<EnrichedTurn[]> {
     process.stderr.write(`burn: archive read failed (${msg}); falling back to ledger walk\n`);
     return queryAll(q);
   }
-}
-
-function queryWithoutSession(q: Query): Query {
-  const out: Query = { ...q };
-  delete out.sessionId;
-  return out;
 }
 
 function aggregateByModel(turns: EnrichedTurn[], pricing: Parameters<typeof costForTurn>[1]): ModelRow[] {

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -107,8 +107,9 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   const pricing = await loadPricing();
   const agentSessionIds =
     agentFilter !== undefined ? await resolveAgentSessionTree(agentFilter) : undefined;
+  const turnQuery = subagentTreeFlag !== undefined ? queryWithoutSession(q) : q;
   const turns = filterTurnsByProvider(
-    filterTurnsByAgent(await loadTurns(q, args), agentFilter, agentSessionIds),
+    filterTurnsByAgent(await loadTurns(turnQuery, args), agentFilter, agentSessionIds),
     providerFilter,
   );
 
@@ -380,26 +381,22 @@ const COVERAGE_FLAG: Record<CoverageField, keyof Coverage> = {
 
 type ModelRow = UsageCostAggregateRow;
 
-function renderSubagentTreeMode(
+async function renderSubagentTreeMode(
   args: ParsedArgs,
   turns: EnrichedTurn[],
   pricing: Parameters<typeof costForTurn>[1],
   flag: string | true,
   q: Query,
-): number {
+): Promise<number> {
   // Accept either `--subagent-tree <id>` or `--subagent-tree` with --session.
   const sessionId = typeof flag === 'string' ? flag : q.sessionId;
   if (!sessionId) {
     process.stderr.write('burn: --subagent-tree requires a session id (positional or --session)\n');
     return 2;
   }
-  const sessionTurns = turns.filter((t) => t.sessionId === sessionId);
-  if (sessionTurns.length === 0) {
-    process.stdout.write(`no turns found for session ${sessionId}\n`);
-    return 0;
-  }
-  const trees = buildSubagentTree(sessionTurns, { pricing });
-  const root = trees.get(sessionId);
+  const relationships = await queryRelationships();
+  const trees = buildSubagentTree(turns, { pricing, relationships });
+  const root = trees.get(sessionId) ?? findTreeNode(trees, sessionId);
   if (!root) {
     process.stdout.write(`no turns found for session ${sessionId}\n`);
     return 0;
@@ -781,6 +778,26 @@ function renderRelationshipSubagentMode(
   return 0;
 }
 
+function findTreeNode(
+  trees: ReadonlyMap<string, SubagentTreeNode>,
+  nodeId: string,
+): SubagentTreeNode | undefined {
+  for (const root of trees.values()) {
+    const found = findNode(root, nodeId);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function findNode(node: SubagentTreeNode, nodeId: string): SubagentTreeNode | undefined {
+  if (node.nodeId === nodeId) return node;
+  for (const child of node.children) {
+    const found = findNode(child, nodeId);
+    if (found) return found;
+  }
+  return undefined;
+}
+
 function renderTree(root: SubagentTreeNode): string[] {
   const out: string[] = [];
   out.push(renderNodeLine(root, ''));
@@ -802,10 +819,14 @@ function renderChildren(node: SubagentTreeNode, prefix: string, out: string[]): 
 
 function renderNodeLine(node: SubagentTreeNode, indent: string): string {
   const label = node.label;
+  const relationship =
+    node.relationshipType !== 'root' && node.relationshipType !== 'subagent'
+      ? ` [${node.relationshipType}]`
+      : '';
   const model = node.models.length > 0 ? ` (${node.models.join(', ')})` : '';
   const cost = formatUsd(node.cumulativeCost);
   const turns = `[${formatInt(node.cumulativeTurns)} turn${node.cumulativeTurns === 1 ? '' : 's'}]`;
-  return `${indent}${label}${model}  ${cost}  ${turns}`;
+  return `${indent}${label}${relationship}${model}  ${cost}  ${turns}`;
 }
 
 // Render one token-field cell. Three cases:
@@ -977,6 +998,12 @@ async function loadTurns(q: Query, args: ParsedArgs): Promise<EnrichedTurn[]> {
     process.stderr.write(`burn: archive read failed (${msg}); falling back to ledger walk\n`);
     return queryAll(q);
   }
+}
+
+function queryWithoutSession(q: Query): Query {
+  const out: Query = { ...q };
+  delete out.sessionId;
+  return out;
 }
 
 function aggregateByModel(turns: EnrichedTurn[], pricing: Parameters<typeof costForTurn>[1]): ModelRow[] {


### PR DESCRIPTION
Closes #109

## Summary
- build subagent trees from SessionRelationshipRecord rows when available
- keep TurnRecord.subagent fallback for legacy sessions and partial graph gaps
- include relationshipType in JSON and annotate fork/continuation nodes in text output

## Tests
- pnpm run build
- pnpm run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
