### PR TITLE
Use enriched approxTokens from user-turn blocks in tool-output-bloat detector

### DIFF
--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to `@relayburn/analyze`.
 
 ### Changed
 
-- `detectToolOutputBloat` now reads cl100k `approxTokens` from user-turn `tool_result` blocks (content-sidecar enrichment from #2/#86) instead of deriving tokens from `contentLength` via the bytes/4 heuristic. Events without matching enriched blocks (e.g. legacy ledgers) fall back to the bytes/4 path. Net effect on findings: real text-heavy tool output is sized roughly the same; highly compressible payloads (large repetitive logs, base64 dumps) score lower in token terms and may slip below the 15k threshold — re-tune `DEFAULT_BLOAT_TOKEN_THRESHOLD` if your sessions are dominated by such content.
+- `detectToolOutputBloat` now sizes oversized tool output via cl100k token counts from user-turn enrichment, with a bytes/4 fallback for legacy ledgers. Highly compressible payloads (repetitive logs, base64 dumps) score lower in tokens and may slip below the 15k default threshold.
+
+### Fixed
+
+- `detectObservedBloat` no longer double-counts a tool call when its `tool_result` is followed by a `subagent_notification` (or other non-carrier event) sharing the same `toolUseId`. Non-carrier events are now sized by their own `contentLength` instead of inheriting the carrier's enriched token count.
 
 ## [0.44.0] - 2026-04-29
 

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `@relayburn/analyze`.
 
 ### Changed
 
-- `detectToolOutputBloat` now uses enriched `approxTokens` from user-turn blocks instead of deriving from `contentLength`, with fallback for legacy data.
+- `detectToolOutputBloat` now reads cl100k `approxTokens` from user-turn `tool_result` blocks (content-sidecar enrichment from #2/#86) instead of deriving tokens from `contentLength` via the bytes/4 heuristic. Events without matching enriched blocks (e.g. legacy ledgers) fall back to the bytes/4 path. Net effect on findings: real text-heavy tool output is sized roughly the same; highly compressible payloads (large repetitive logs, base64 dumps) score lower in token terms and may slip below the 15k threshold — re-tune `DEFAULT_BLOAT_TOKEN_THRESHOLD` if your sessions are dominated by such content.
 
 ## [0.44.0] - 2026-04-29
 

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/analyze`.
 
 ## [Unreleased]
 
+### Changed
+
+- `detectToolOutputBloat` now uses enriched `approxTokens` from user-turn blocks instead of deriving from `contentLength`, with fallback for legacy data.
+
 ## [0.44.0] - 2026-04-29
 
 ### Changed

--- a/packages/analyze/src/tool-output-bloat.test.ts
+++ b/packages/analyze/src/tool-output-bloat.test.ts
@@ -600,20 +600,44 @@ describe('detectStaticConfigBloat — settings.json fixture', () => {
 });
 
 describe('detectObservedBloat — cross-harness fixtures (#168 acceptance)', () => {
-  it('flags Claude Bash oversized output from a real session fixture', async () => {
+  it('flags Claude Bash oversized output from a real session fixture (enriched path)', async () => {
     const pricing = await loadBuiltinPricing();
     const fixture = path.join(FIXTURES_ROOT, 'claude', 'oversized-bash-output.jsonl');
     const parsed = await parseClaudeSession(fixture);
-    // Old fixture doesn't have enriched user-turn blocks, so we pass empty userTurns
-    // and rely on the contentLength fallback. The unit tests above cover the
-    // enriched data path.
+    // Pass `parsed.userTurns` so the detector exercises the enriched
+    // `approxTokens` path used in production. The fixture's tool_result is
+    // 80,000 repeated 'x' chars, which cl100k tokenizes to ~10k tokens (vs
+    // 20k under the bytes/4 heuristic) — repeated single-char content is
+    // pathologically compressible by BPE. Use a lower threshold so the
+    // assertion still trips; the synthetic content is what makes the floor
+    // unrealistic, not the detector logic.
+    const out = detectObservedBloat({
+      toolResultEvents: parsed.toolResultEvents,
+      userTurns: parsed.userTurns,
+      turns: parsed.turns,
+      pricing,
+      threshold: 5_000,
+    });
+    assert.equal(out.length, 1, 'expected one bloat bucket');
+    assert.equal(out[0]!.source, 'claude-code');
+    assert.equal(out[0]!.toolName, 'Bash');
+    assert.ok(out[0]!.evidencedMaxOutput > 5_000);
+  });
+
+  it('flags Claude Bash oversized output via the contentLength fallback (legacy ledgers)', async () => {
+    const pricing = await loadBuiltinPricing();
+    const fixture = path.join(FIXTURES_ROOT, 'claude', 'oversized-bash-output.jsonl');
+    const parsed = await parseClaudeSession(fixture);
+    // Simulates a ledger written before #2/#86 landed, where
+    // `tool_result_events` carry `contentLength` but no matching enriched
+    // user-turn record exists. The detector should fall back to bytes/4.
     const out = detectObservedBloat({
       toolResultEvents: parsed.toolResultEvents,
       userTurns: [],
       turns: parsed.turns,
       pricing,
     });
-    assert.equal(out.length, 1, 'expected one bloat bucket');
+    assert.equal(out.length, 1, 'expected one bloat bucket via fallback');
     assert.equal(out[0]!.source, 'claude-code');
     assert.equal(out[0]!.toolName, 'Bash');
     assert.ok(out[0]!.evidencedMaxOutput >= DEFAULT_BLOAT_TOKEN_THRESHOLD);
@@ -623,12 +647,15 @@ describe('detectObservedBloat — cross-harness fixtures (#168 acceptance)', () 
     const pricing = await loadBuiltinPricing();
     const fixture = path.join(FIXTURES_ROOT, 'codex', 'oversized-shell-output.jsonl');
     const parsed = await parseCodexSession(fixture);
-    // Old fixture doesn't have enriched user-turn blocks, so we pass empty userTurns
-    // and rely on the contentLength fallback. The unit tests above cover the
-    // enriched data path.
+    // The Codex reader doesn't emit `UserTurnRecord`s for this fixture's
+    // shape (rollout JSONL with `function_call_output` items lacks the
+    // boundary cues the user-turn synthesis needs), so `parsed.userTurns`
+    // is empty here and the detector falls through to the `contentLength`
+    // fallback. Passing `parsed.userTurns` rather than a hardcoded `[]`
+    // keeps the test honest if the reader gains user-turn coverage later.
     const out = detectObservedBloat({
       toolResultEvents: parsed.toolResultEvents,
-      userTurns: [],
+      userTurns: parsed.userTurns,
       turns: parsed.turns,
       pricing,
     });

--- a/packages/analyze/src/tool-output-bloat.test.ts
+++ b/packages/analyze/src/tool-output-bloat.test.ts
@@ -10,6 +10,7 @@ import type {
   ToolCall,
   ToolResultEventRecord,
   TurnRecord,
+  UserTurnRecord,
 } from '@relayburn/reader';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -45,13 +46,25 @@ function turn(o: Partial<TurnRecord> & { sessionId: string; messageId: string; t
 }
 
 function evt(
-  o: Partial<ToolResultEventRecord> & { sessionId: string; toolUseId: string; eventIndex: number; contentLength: number },
+  o: Partial<ToolResultEventRecord> & { sessionId: string; toolUseId: string; eventIndex: number },
 ): ToolResultEventRecord {
   return {
     v: 1,
     source: 'claude-code',
     eventSource: 'tool_result',
     status: 'completed',
+    ...o,
+  };
+}
+
+function userTurn(
+  o: Partial<UserTurnRecord> & { sessionId: string; userUuid: string },
+): UserTurnRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    ts: '2026-04-20T00:00:00.500Z',
+    blocks: [],
     ...o,
   };
 }
@@ -211,14 +224,23 @@ describe('loadClaudeSettings — filesystem loader', () => {
 describe('detectObservedBloat — Signal B', () => {
   it('flags Claude Bash tool_result events above the 15k-token threshold', async () => {
     const pricing = await loadBuiltinPricing();
-    // 80,000 bytes ≈ 20,000 tokens — well above the 15k threshold.
+    // 20,000 tokens — well above the 15k threshold.
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 80_000, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 80_000, approxTokens: 20_000 }],
+      }),
     ];
     const turns = [
       turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
     ];
-    const out = detectObservedBloat({ toolResultEvents: events, turns, pricing });
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
     assert.equal(out.length, 1);
     const b = out[0]!;
     assert.equal(b.kind, 'observed-bloat');
@@ -232,34 +254,66 @@ describe('detectObservedBloat — Signal B', () => {
 
   it('does NOT flag below the threshold', async () => {
     const pricing = await loadBuiltinPricing();
-    // 40,000 bytes ≈ 10,000 tokens — under threshold.
+    // 10,000 tokens — under threshold.
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 40_000, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 40_000, approxTokens: 10_000 }],
+      }),
     ];
     const turns = [
       turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
     ];
-    const out = detectObservedBloat({ toolResultEvents: events, turns, pricing });
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
     assert.equal(out.length, 0);
   });
 
   it('aggregates multiple oversized events into one (source, toolName) bucket', async () => {
     const pricing = await loadBuiltinPricing();
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 80_000, messageId: 'm1' }),
-      evt({ sessionId: 's2', toolUseId: 'tu_b', eventIndex: 0, contentLength: 100_000, messageId: 'm2' }),
-      evt({ sessionId: 's3', toolUseId: 'tu_c', eventIndex: 0, contentLength: 120_000, messageId: 'm3' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
+      evt({ sessionId: 's2', toolUseId: 'tu_b', eventIndex: 0, messageId: 'm2' }),
+      evt({ sessionId: 's3', toolUseId: 'tu_c', eventIndex: 0, messageId: 'm3' }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 80_000, approxTokens: 20_000 }],
+      }),
+      userTurn({
+        sessionId: 's2',
+        userUuid: 'u2',
+        precedingMessageId: 'm2',
+        followingMessageId: 'm3',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_b', byteLen: 100_000, approxTokens: 25_000 }],
+      }),
+      userTurn({
+        sessionId: 's3',
+        userUuid: 'u3',
+        precedingMessageId: 'm3',
+        followingMessageId: 'm4',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_c', byteLen: 120_000, approxTokens: 30_000 }],
+      }),
     ];
     const turns = [
       turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
       turn({ sessionId: 's2', messageId: 'm2', turnIndex: 0, toolCalls: [tc('tu_b', 'Bash')] }),
       turn({ sessionId: 's3', messageId: 'm3', turnIndex: 0, toolCalls: [tc('tu_c', 'Bash')] }),
     ];
-    const out = detectObservedBloat({ toolResultEvents: events, turns, pricing });
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
     assert.equal(out.length, 1);
     const b = out[0]!;
     assert.equal(b.occurrenceCount, 3);
-    assert.equal(b.evidencedMaxOutput, 30_000); // ceil(120_000 / 4)
+    assert.equal(b.evidencedMaxOutput, 30_000);
     assert.equal(b.evidence.length, 3);
   });
 
@@ -267,14 +321,13 @@ describe('detectObservedBloat — Signal B', () => {
     const pricing = await loadBuiltinPricing();
     const events = [
       // Claude Bash
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 80_000, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
       // Codex shell
       evt({
         source: 'codex',
         sessionId: 's2',
         toolUseId: 'call_b',
         eventIndex: 0,
-        contentLength: 90_000,
         messageId: 'm2',
       }),
       // OpenCode bash
@@ -283,8 +336,32 @@ describe('detectObservedBloat — Signal B', () => {
         sessionId: 's3',
         toolUseId: 'opc_c',
         eventIndex: 0,
-        contentLength: 85_000,
         messageId: 'm3',
+      }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 80_000, approxTokens: 20_000 }],
+      }),
+      userTurn({
+        source: 'codex',
+        sessionId: 's2',
+        userUuid: 'u2',
+        precedingMessageId: 'm2',
+        followingMessageId: 'm3',
+        blocks: [{ kind: 'tool_result', toolUseId: 'call_b', byteLen: 90_000, approxTokens: 22_500 }],
+      }),
+      userTurn({
+        source: 'opencode',
+        sessionId: 's3',
+        userUuid: 'u3',
+        precedingMessageId: 'm3',
+        followingMessageId: 'm4',
+        blocks: [{ kind: 'tool_result', toolUseId: 'opc_c', byteLen: 85_000, approxTokens: 21_250 }],
       }),
     ];
     const turns: TurnRecord[] = [
@@ -304,7 +381,7 @@ describe('detectObservedBloat — Signal B', () => {
         toolCalls: [tc('opc_c', 'bash')],
       }),
     ];
-    const out = detectObservedBloat({ toolResultEvents: events, turns, pricing });
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
     // Three distinct (source, toolName) buckets — Claude Bash, Codex shell
     // (normalizes to Bash), OpenCode bash (normalizes to Bash) all get their
     // own row, keyed by source. Cross-harness aggregation under the
@@ -315,30 +392,40 @@ describe('detectObservedBloat — Signal B', () => {
     for (const b of out) assert.equal(b.toolName, 'Bash');
   });
 
-  it('skips events without contentLength', async () => {
+  it('skips events without matching user-turn blocks', async () => {
     const pricing = await loadBuiltinPricing();
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 0, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
     ];
+    const userTurns: UserTurnRecord[] = [];
     const turns = [
       turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
     ];
-    const out = detectObservedBloat({ toolResultEvents: events, turns, pricing });
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
     assert.equal(out.length, 0);
   });
 
   it('honors a custom threshold', async () => {
     const pricing = await loadBuiltinPricing();
-    // 4,000 bytes = 1,000 tokens — under default 15k but over a 500-token threshold.
+    // 1,000 tokens — under default 15k but over a 500-token threshold.
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 4_000, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 4_000, approxTokens: 1_000 }],
+      }),
     ];
     const turns = [
       turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
     ];
-    const def = detectObservedBloat({ toolResultEvents: events, turns, pricing });
+    const def = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
     assert.equal(def.length, 0);
-    const tight = detectObservedBloat({ toolResultEvents: events, turns, pricing, threshold: 500 });
+    const tight = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing, threshold: 500 });
     assert.equal(tight.length, 1);
     assert.equal(tight[0]!.evidencedMaxOutput, 1000);
   });
@@ -346,10 +433,19 @@ describe('detectObservedBloat — Signal B', () => {
   it('falls back to <unknown> when the tool_use_id has no matching turn', async () => {
     const pricing = await loadBuiltinPricing();
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'orphan', eventIndex: 0, contentLength: 80_000, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'orphan', eventIndex: 0, messageId: 'm1' }),
     ];
-    // No turns supplied — the lookup misses.
-    const out = detectObservedBloat({ toolResultEvents: events, turns: [], pricing });
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'orphan', byteLen: 80_000, approxTokens: 20_000 }],
+      }),
+    ];
+    // No turns supplied — the tool name lookup misses.
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns: [], pricing });
     assert.equal(out.length, 1);
     assert.equal(out[0]!.toolName, '<unknown>');
     // Without a model we still emit the bucket but cost is 0.
@@ -368,7 +464,16 @@ describe('detectToolOutputBloat — orchestration', () => {
       { path: '/u/.claude/settings.json', settings: { env: { [BASH_MAX_OUTPUT_ENV_KEY]: '80000' } } },
     ];
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 80_000, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 80_000, approxTokens: 20_000 }],
+      }),
     ];
     const turns = [
       turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
@@ -376,6 +481,7 @@ describe('detectToolOutputBloat — orchestration', () => {
     const out = detectToolOutputBloat({
       settings,
       toolResultEvents: events,
+      userTurns,
       turns,
       pricing,
     });
@@ -397,12 +503,21 @@ describe('detectToolOutputBloat — orchestration', () => {
   it('runs only Signal B when no settings are supplied', async () => {
     const pricing = await loadBuiltinPricing();
     const events = [
-      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, contentLength: 80_000, messageId: 'm1' }),
+      evt({ sessionId: 's1', toolUseId: 'tu_a', eventIndex: 0, messageId: 'm1' }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 80_000, approxTokens: 20_000 }],
+      }),
     ];
     const turns = [
       turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
     ];
-    const out = detectToolOutputBloat({ toolResultEvents: events, turns, pricing });
+    const out = detectToolOutputBloat({ toolResultEvents: events, userTurns, turns, pricing });
     assert.equal(out.length, 1);
     assert.equal(out[0]!.kind, 'observed-bloat');
   });
@@ -489,8 +604,12 @@ describe('detectObservedBloat — cross-harness fixtures (#168 acceptance)', () 
     const pricing = await loadBuiltinPricing();
     const fixture = path.join(FIXTURES_ROOT, 'claude', 'oversized-bash-output.jsonl');
     const parsed = await parseClaudeSession(fixture);
+    // Old fixture doesn't have enriched user-turn blocks, so we pass empty userTurns
+    // and rely on the contentLength fallback. The unit tests above cover the
+    // enriched data path.
     const out = detectObservedBloat({
       toolResultEvents: parsed.toolResultEvents,
+      userTurns: [],
       turns: parsed.turns,
       pricing,
     });
@@ -504,8 +623,12 @@ describe('detectObservedBloat — cross-harness fixtures (#168 acceptance)', () 
     const pricing = await loadBuiltinPricing();
     const fixture = path.join(FIXTURES_ROOT, 'codex', 'oversized-shell-output.jsonl');
     const parsed = await parseCodexSession(fixture);
+    // Old fixture doesn't have enriched user-turn blocks, so we pass empty userTurns
+    // and rely on the contentLength fallback. The unit tests above cover the
+    // enriched data path.
     const out = detectObservedBloat({
       toolResultEvents: parsed.toolResultEvents,
+      userTurns: [],
       turns: parsed.turns,
       pricing,
     });
@@ -524,7 +647,7 @@ describe('detectObservedBloat — cross-harness fixtures (#168 acceptance)', () 
     // tests/fixtures/opencode/<scenario>/storage/...). Re-creating that for
     // the bloat case yields no extra detector coverage beyond what synthetic
     // ToolResultEventRecords already provide — the detector branches purely
-    // on `source` + `contentLength`. Synthesize the records inline and
+    // on `source` + `approxTokens`. Synthesize the records inline and
     // assert the same cross-harness contract the issue calls out.
     const pricing = await loadBuiltinPricing();
     const events: ToolResultEventRecord[] = [
@@ -533,8 +656,17 @@ describe('detectObservedBloat — cross-harness fixtures (#168 acceptance)', () 
         sessionId: 'ses_bloat',
         toolUseId: 'opc_bash_1',
         eventIndex: 0,
-        contentLength: 80_000,
         messageId: 'msg_bloat',
+      }),
+    ];
+    const userTurns: UserTurnRecord[] = [
+      userTurn({
+        source: 'opencode',
+        sessionId: 'ses_bloat',
+        userUuid: 'u_bloat',
+        precedingMessageId: 'msg_bloat',
+        followingMessageId: 'msg_bloat_next',
+        blocks: [{ kind: 'tool_result', toolUseId: 'opc_bash_1', byteLen: 80_000, approxTokens: 20_000 }],
       }),
     ];
     const turns: TurnRecord[] = [
@@ -546,7 +678,7 @@ describe('detectObservedBloat — cross-harness fixtures (#168 acceptance)', () 
         toolCalls: [tc('opc_bash_1', 'bash')],
       }),
     ];
-    const out = detectObservedBloat({ toolResultEvents: events, turns, pricing });
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
     assert.equal(out.length, 1);
     assert.equal(out[0]!.source, 'opencode');
     // OpenCode `bash` (lowercase) normalizes to canonical `Bash`.

--- a/packages/analyze/src/tool-output-bloat.test.ts
+++ b/packages/analyze/src/tool-output-bloat.test.ts
@@ -451,6 +451,56 @@ describe('detectObservedBloat — Signal B', () => {
     // Without a model we still emit the bucket but cost is 0.
     assert.equal(out[0]!.cost, 0);
   });
+
+  it('does not double-count when one tool call emits a tool_result + subagent_notification', async () => {
+    const pricing = await loadBuiltinPricing();
+    // One carrier (`tool_result`) plus a non-carrier `subagent_notification`
+    // sharing the same toolUseId — Claude reader emits this shape when a
+    // sidechain wraps up. The enriched approxTokens belongs to the
+    // tool_result payload only; the notification is a small status update
+    // that happens to share the toolUseId. Without the carrier filter, the
+    // enrichment lookup hands the notification the carrier's full token
+    // count and we'd count the same payload twice.
+    const events = [
+      evt({
+        sessionId: 's1',
+        toolUseId: 'tu_a',
+        eventIndex: 0,
+        callIndex: 0,
+        messageId: 'm1',
+        eventSource: 'tool_result',
+      }),
+      evt({
+        sessionId: 's1',
+        toolUseId: 'tu_a',
+        eventIndex: 1,
+        callIndex: 1,
+        messageId: 'm1',
+        eventSource: 'subagent_notification',
+        contentLength: 200,
+      }),
+    ];
+    const userTurns = [
+      userTurn({
+        sessionId: 's1',
+        userUuid: 'u1',
+        precedingMessageId: 'm1',
+        followingMessageId: 'm2',
+        blocks: [{ kind: 'tool_result', toolUseId: 'tu_a', byteLen: 80_000, approxTokens: 20_000 }],
+      }),
+    ];
+    const turns = [
+      turn({ sessionId: 's1', messageId: 'm1', turnIndex: 0, toolCalls: [tc('tu_a', 'Bash')] }),
+    ];
+    const out = detectObservedBloat({ toolResultEvents: events, userTurns, turns, pricing });
+    assert.equal(out.length, 1);
+    assert.equal(
+      out[0]!.occurrenceCount,
+      1,
+      'subagent_notification must not inherit the carrier event\'s enriched approxTokens',
+    );
+    assert.equal(out[0]!.evidencedMaxOutput, 20_000);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/analyze/src/tool-output-bloat.ts
+++ b/packages/analyze/src/tool-output-bloat.ts
@@ -243,16 +243,20 @@ export function detectStaticConfigBloat(
 // ---------------------------------------------------------------------------
 
 export interface DetectObservedBloatOptions {
-  // Cross-harness tool-result events.
+  // Cross-harness tool-result events. Each event is sized via
+  // `sizeEventTokens`: enrichment-first for carriers, `contentLength`
+  // fallback otherwise. Events with neither are dropped.
   toolResultEvents: ToolResultEventRecord[];
-  // User turn records with enriched content-sidecar data. Used to:
-  //   1. Look up `toolName` for each event (joined by `tool_use_id`).
-  //   2. Look up `approxTokens` from tool_result blocks (content-sidecar enrichment).
-  //   3. Look up the model that consumed the next turn so we can price the
-  //      oversized cache-input ride at the correct rate.
-  // Tests can pass an empty array — the detector falls back to "Unknown"
-  // tool names and a zero cost in that case (the bucket still emits).
+  // User-turn records carrying per-call cl100k `approxTokens` on
+  // `tool_result` blocks (content-sidecar enrichment from #2/#86). Joined
+  // to carrier events by `(source|sessionId|toolUseId)`. Pass `[]` to
+  // force the `bytesToTokens(contentLength)` fallback (legacy ledgers).
   userTurns: UserTurnRecord[];
+  // Turn records keyed alongside the events. Used to look up `toolName`
+  // (joined by `tool_use_id`) and the model that consumed the next turn
+  // so we can price the oversized cache-input ride at the correct rate.
+  // Tests can pass an empty array — the detector falls back to "<unknown>"
+  // tool names and a zero cost in that case (the bucket still emits).
   turns: TurnRecord[];
   pricing: PricingTable;
   // Token threshold for "oversized". Defaults to
@@ -328,6 +332,38 @@ function priceCarryCost(tokens: number, model: string, pricing: PricingTable): n
   return (tokens / 1_000_000) * rate.input;
 }
 
+// `tool_result` (Claude/Anthropic) and `function_call_output` (Codex) are the
+// canonical "carrier" events for a tool call — each represents the single
+// payload returned to the model. Other event types (`subagent_notification`,
+// `queue_event`, `progress_event`) can share the same `toolUseId` with a
+// carrier but carry their own independent payloads (status updates, progress
+// fanout). The user-turn enrichment is keyed by `toolUseId` and represents
+// the carrier's tokens — applying it to non-carrier events would attribute
+// the carrier's bytes to every notification and double-count the bucket.
+function isCarrierEvent(e: ToolResultEventRecord): boolean {
+  return e.eventSource === 'tool_result' || e.eventSource === 'function_call_output';
+}
+
+// Per-event token size. Carrier events prefer the user-turn enrichment
+// (cl100k accuracy from #2/#86) and fall back to `bytesToTokens(contentLength)`
+// for legacy ledgers without enrichment. Non-carrier events always size by
+// their own `contentLength` so they don't inherit the carrier's payload.
+// Returns `undefined` when the event has no usable size (drop it).
+function sizeEventTokens(
+  e: ToolResultEventRecord,
+  lookup: ToolUseLookup,
+): number | undefined {
+  if (isCarrierEvent(e)) {
+    const useKey = `${e.source}|${e.sessionId}|${e.toolUseId}`;
+    const enriched = lookup.approxTokensByUseId.get(useKey);
+    if (enriched !== undefined) return enriched;
+  }
+  if (typeof e.contentLength === 'number' && e.contentLength > 0) {
+    return bytesToTokens(e.contentLength);
+  }
+  return undefined;
+}
+
 export function detectObservedBloat(
   opts: DetectObservedBloatOptions,
 ): ToolOutputBloat[] {
@@ -344,13 +380,7 @@ export function detectObservedBloat(
   // 15k floor only.
   const allTokens: number[] = [];
   for (const e of events) {
-    const useKey = `${e.source}|${e.sessionId}|${e.toolUseId}`;
-    let tokens = lookup.approxTokensByUseId.get(useKey);
-    if (tokens === undefined && typeof e.contentLength === 'number' && e.contentLength > 0) {
-      // Fallback to contentLength when enriched data is not available
-      // (e.g., old fixtures without user-turn enrichment).
-      tokens = bytesToTokens(e.contentLength);
-    }
+    const tokens = sizeEventTokens(e, lookup);
     if (tokens !== undefined && tokens > 0) allTokens.push(tokens);
   }
   const p95 = allTokens.length >= P95_SAMPLE_FLOOR ? percentile(allTokens, 95) : 0;
@@ -367,13 +397,9 @@ export function detectObservedBloat(
   }
   const buckets = new Map<string, Bucket>();
   for (const e of events) {
-    const useKey = `${e.source}|${e.sessionId}|${e.toolUseId}`;
-    let tokens = lookup.approxTokensByUseId.get(useKey);
-    if (tokens === undefined && typeof e.contentLength === 'number' && e.contentLength > 0) {
-      // Fallback to contentLength when enriched data is not available
-      tokens = bytesToTokens(e.contentLength);
-    }
+    const tokens = sizeEventTokens(e, lookup);
     if (tokens === undefined || tokens === 0 || tokens <= threshold) continue;
+    const useKey = `${e.source}|${e.sessionId}|${e.toolUseId}`;
     const rawName = lookup.toolNameByUseId.get(useKey);
     const toolName = rawName ? normalizeToolName(rawName) : '<unknown>';
     const bucketKey = `${e.source}|${toolName}`;

--- a/packages/analyze/src/tool-output-bloat.ts
+++ b/packages/analyze/src/tool-output-bloat.ts
@@ -17,9 +17,12 @@
 //
 // Both signals emit the same `ToolOutputBloat` shape so the CLI can render a
 // single severity-ranked list. `cost` is the rough USD waste attributed to
-// carrying the oversized payload — Signal B uses per-call `approxTokens` from
-// user-turn blocks (content-sidecar enrichment), while Signal A uses the
-// `bytes/4` heuristic for character-unit config values.
+// carrying the oversized payload — Signal B uses per-call cl100k
+// `approxTokens` from user-turn `tool_result` blocks (content-sidecar
+// enrichment from #2/#86), with a `bytes/4` fallback when an event has no
+// matching enriched block (e.g. ledgers written before the enrichment
+// landed). Signal A continues to use `bytes/4` for the character-unit
+// config values.
 
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
@@ -280,12 +283,17 @@ function buildLookup(userTurns: UserTurnRecord[], turns: TurnRecord[]): ToolUseL
   const approxTokensByUseId = new Map<string, number>();
   const modelByMessageId = new Map<string, string>();
 
-  // Build approxTokens lookup from user-turn blocks (content-sidecar enrichment)
+  // Build approxTokens lookup from user-turn blocks (content-sidecar
+  // enrichment). Skip blocks with `approxTokens <= 0`: a non-positive value
+  // means the block was either truly empty (skip) or the enrichment is
+  // malformed (let the per-event `contentLength` fallback take over). Either
+  // way, leaving the entry out of the map yields the right behavior.
   for (const userTurn of userTurns) {
     for (const block of userTurn.blocks) {
       if (block.kind !== 'tool_result' || !block.toolUseId) continue;
+      if (block.approxTokens <= 0) continue;
       const key = `${userTurn.source}|${userTurn.sessionId}|${block.toolUseId}`;
-      approxTokensByUseId.set(key, Math.max(0, block.approxTokens));
+      approxTokensByUseId.set(key, block.approxTokens);
     }
   }
 

--- a/packages/analyze/src/tool-output-bloat.ts
+++ b/packages/analyze/src/tool-output-bloat.ts
@@ -17,8 +17,9 @@
 //
 // Both signals emit the same `ToolOutputBloat` shape so the CLI can render a
 // single severity-ranked list. `cost` is the rough USD waste attributed to
-// carrying the oversized payload — bytes-to-tokens is via the `bytes/4`
-// heuristic (issue #107) until #57 lands a precise byte→token rule.
+// carrying the oversized payload — Signal B uses per-call `approxTokens` from
+// user-turn blocks (content-sidecar enrichment), while Signal A uses the
+// `bytes/4` heuristic for character-unit config values.
 
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
@@ -29,6 +30,7 @@ import {
   type SourceKind,
   type ToolResultEventRecord,
   type TurnRecord,
+  type UserTurnRecord,
 } from '@relayburn/reader';
 
 import { lookupModelRate } from './cost.js';
@@ -62,10 +64,9 @@ const DEFAULT_MIN_OCCURRENCES = 1;
 // single-session debug ledger still surfaces oversized events.
 const P95_SAMPLE_FLOOR = 20;
 
-// bytes → tokens heuristic. Cancels exactly with the bytes/4 used elsewhere
-// in the codebase (`bytesToApproxTokens` in reader/userTurn.ts; issue #107).
-// TODO(#57): once the content-sidecar enrichment lands, prefer the per-call
-// `byteLen`/`approxTokens` rather than re-deriving from `contentLength`.
+// bytes → tokens heuristic. Used by Signal A for character-unit config values.
+// Matches the `bytes/4` heuristic used elsewhere in the codebase
+// (`bytesToApproxTokens` in reader/userTurn.ts).
 function bytesToTokens(bytes: number): number {
   if (bytes <= 0) return 0;
   return Math.ceil(bytes / BYTES_PER_TOKEN);
@@ -239,16 +240,16 @@ export function detectStaticConfigBloat(
 // ---------------------------------------------------------------------------
 
 export interface DetectObservedBloatOptions {
-  // Cross-harness tool-result events. Required field is `contentLength`
-  // (substrate from #42); events without a content length are skipped — we
-  // can't size them.
+  // Cross-harness tool-result events.
   toolResultEvents: ToolResultEventRecord[];
-  // Turn records keyed alongside the events. Used to:
+  // User turn records with enriched content-sidecar data. Used to:
   //   1. Look up `toolName` for each event (joined by `tool_use_id`).
-  //   2. Look up the model that consumed the next turn so we can price the
+  //   2. Look up `approxTokens` from tool_result blocks (content-sidecar enrichment).
+  //   3. Look up the model that consumed the next turn so we can price the
   //      oversized cache-input ride at the correct rate.
   // Tests can pass an empty array — the detector falls back to "Unknown"
   // tool names and a zero cost in that case (the bucket still emits).
+  userTurns: UserTurnRecord[];
   turns: TurnRecord[];
   pricing: PricingTable;
   // Token threshold for "oversized". Defaults to
@@ -267,13 +268,28 @@ interface ToolUseLookup {
   // harnesses (unlikely but possible — Codex `call_*`, Claude UUIDs) don't
   // overwrite each other.
   toolNameByUseId: Map<string, string>;
+  // `(source|sessionId|toolUseId)` -> approxTokens from user-turn blocks.
+  // Populated from content-sidecar enrichment; falls back to 0 when missing.
+  approxTokensByUseId: Map<string, number>;
   // `(source|sessionId|messageId)` -> model. Same dedupe rationale.
   modelByMessageId: Map<string, string>;
 }
 
-function buildLookup(turns: TurnRecord[]): ToolUseLookup {
+function buildLookup(userTurns: UserTurnRecord[], turns: TurnRecord[]): ToolUseLookup {
   const toolNameByUseId = new Map<string, string>();
+  const approxTokensByUseId = new Map<string, number>();
   const modelByMessageId = new Map<string, string>();
+
+  // Build approxTokens lookup from user-turn blocks (content-sidecar enrichment)
+  for (const userTurn of userTurns) {
+    for (const block of userTurn.blocks) {
+      if (block.kind !== 'tool_result' || !block.toolUseId) continue;
+      const key = `${userTurn.source}|${userTurn.sessionId}|${block.toolUseId}`;
+      approxTokensByUseId.set(key, Math.max(0, block.approxTokens));
+    }
+  }
+
+  // Build tool name and model lookups from turn records
   for (const t of turns) {
     modelByMessageId.set(`${t.source}|${t.sessionId}|${t.messageId}`, t.model);
     for (const call of t.toolCalls) {
@@ -281,7 +297,7 @@ function buildLookup(turns: TurnRecord[]): ToolUseLookup {
       toolNameByUseId.set(`${t.source}|${t.sessionId}|${call.id}`, call.name);
     }
   }
-  return { toolNameByUseId, modelByMessageId };
+  return { toolNameByUseId, approxTokensByUseId, modelByMessageId };
 }
 
 // p95 of an array of numbers. Empty array → 0.
@@ -307,10 +323,10 @@ function priceCarryCost(tokens: number, model: string, pricing: PricingTable): n
 export function detectObservedBloat(
   opts: DetectObservedBloatOptions,
 ): ToolOutputBloat[] {
-  const events = opts.toolResultEvents.filter((e) => typeof e.contentLength === 'number' && e.contentLength > 0);
+  const events = opts.toolResultEvents;
   if (events.length === 0) return [];
 
-  const lookup = buildLookup(opts.turns);
+  const lookup = buildLookup(opts.userTurns, opts.turns);
   const minOccurrences = opts.minOccurrences ?? DEFAULT_MIN_OCCURRENCES;
 
   // Compute the threshold: max(default, p95 across all events). The p95 only
@@ -320,7 +336,14 @@ export function detectObservedBloat(
   // 15k floor only.
   const allTokens: number[] = [];
   for (const e of events) {
-    allTokens.push(bytesToTokens(e.contentLength!));
+    const useKey = `${e.source}|${e.sessionId}|${e.toolUseId}`;
+    let tokens = lookup.approxTokensByUseId.get(useKey);
+    if (tokens === undefined && typeof e.contentLength === 'number' && e.contentLength > 0) {
+      // Fallback to contentLength when enriched data is not available
+      // (e.g., old fixtures without user-turn enrichment).
+      tokens = bytesToTokens(e.contentLength);
+    }
+    if (tokens !== undefined && tokens > 0) allTokens.push(tokens);
   }
   const p95 = allTokens.length >= P95_SAMPLE_FLOOR ? percentile(allTokens, 95) : 0;
   const threshold = opts.threshold ?? Math.max(DEFAULT_BLOAT_TOKEN_THRESHOLD, p95);
@@ -336,9 +359,13 @@ export function detectObservedBloat(
   }
   const buckets = new Map<string, Bucket>();
   for (const e of events) {
-    const tokens = bytesToTokens(e.contentLength!);
-    if (tokens <= threshold) continue;
     const useKey = `${e.source}|${e.sessionId}|${e.toolUseId}`;
+    let tokens = lookup.approxTokensByUseId.get(useKey);
+    if (tokens === undefined && typeof e.contentLength === 'number' && e.contentLength > 0) {
+      // Fallback to contentLength when enriched data is not available
+      tokens = bytesToTokens(e.contentLength);
+    }
+    if (tokens === undefined || tokens === 0 || tokens <= threshold) continue;
     const rawName = lookup.toolNameByUseId.get(useKey);
     const toolName = rawName ? normalizeToolName(rawName) : '<unknown>';
     const bucketKey = `${e.source}|${toolName}`;
@@ -408,6 +435,7 @@ export interface DetectToolOutputBloatOptions {
   settings?: LoadedClaudeSettings[];
   // Signal B inputs.
   toolResultEvents?: ToolResultEventRecord[];
+  userTurns?: UserTurnRecord[];
   turns?: TurnRecord[];
   pricing: PricingTable;
   // Shared tunables (apply to both signals).
@@ -431,6 +459,7 @@ export function detectToolOutputBloat(
     out.push(
       ...detectObservedBloat({
         toolResultEvents: opts.toolResultEvents,
+        userTurns: opts.userTurns ?? [],
         turns: opts.turns ?? [],
         pricing: opts.pricing,
         ...(opts.threshold !== undefined ? { threshold: opts.threshold } : {}),

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Changed
+
+- `burn waste --patterns tool-output-bloat` now sizes oversized tool output via cl100k token counts from user-turn enrichment instead of bytes/4 estimates. Findings on highly compressible payloads (repetitive logs, base64 dumps) may shift below the 15k default threshold.
+
 ## [0.45.0] - 2026-04-29
 
 ### Fixed

--- a/packages/cli/src/commands/waste.ts
+++ b/packages/cli/src/commands/waste.ts
@@ -727,9 +727,13 @@ export async function runPatternsMode(
   let toolOutputBloats: ToolOutputBloat[] = [];
   let sessionSummaries: PatternsResult['sessionSummaries'] = [];
 
-  // Load user turns if the system-prompt detector is selected (needs first
-  // user message size to estimate the system prompt / skill catalog tax).
-  const needUserTurns = selected.has('opencode-system-prompt');
+  // Load user turns when any detector that consumes them is selected:
+  //   - opencode-system-prompt: needs first user message size to estimate the
+  //     system prompt / skill catalog tax.
+  //   - tool-output-bloat: joins per-call `approxTokens` from user-turn
+  //     `tool_result` blocks for cl100k-accurate sizing of oversized output.
+  const needUserTurns =
+    selected.has('opencode-system-prompt') || selected.has('tool-output-bloat');
   const userTurnsBySession = needUserTurns
     ? await loadUserTurnsBySession(perDetector)
     : undefined;
@@ -827,15 +831,16 @@ export async function runPatternsMode(
     // Signal B inputs: stream `tool_result_events` from the ledger. We pass
     // the full TurnRecord set so the detector can join tool_use_ids back to
     // tool names + price the carry cost at the correct model rate. We also
-    // pass userTurns for enriched approxTokens from the content-sidecar.
+    // pass userTurns so the detector can join per-call cl100k `approxTokens`
+    // from the content-sidecar enrichment instead of re-deriving from
+    // `contentLength`. The map is loaded once at the top of the function and
+    // reused across detectors — flatten its values here since the detector
+    // keys lookups by `(source|sessionId|toolUseId)` and doesn't need the
+    // per-session structure preserved.
     const toolResultEvents = await loadToolResultEventsForTurns(turns, deps.query);
-    const userTurnsBySession = await loadUserTurnsBySession(
-      new Map([['tool-output-bloat', turns]]),
-    );
-    const allUserTurns: UserTurnRecord[] = [];
-    for (const sessionTurns of userTurnsBySession.values()) {
-      allUserTurns.push(...sessionTurns);
-    }
+    const allUserTurns: UserTurnRecord[] = userTurnsBySession
+      ? [...userTurnsBySession.values()].flat()
+      : [];
     toolOutputBloats = detectToolOutputBloat({
       settings,
       toolResultEvents,

--- a/packages/cli/src/commands/waste.ts
+++ b/packages/cli/src/commands/waste.ts
@@ -826,11 +826,20 @@ export async function runPatternsMode(
 
     // Signal B inputs: stream `tool_result_events` from the ledger. We pass
     // the full TurnRecord set so the detector can join tool_use_ids back to
-    // tool names + price the carry cost at the correct model rate.
+    // tool names + price the carry cost at the correct model rate. We also
+    // pass userTurns for enriched approxTokens from the content-sidecar.
     const toolResultEvents = await loadToolResultEventsForTurns(turns, deps.query);
+    const userTurnsBySession = await loadUserTurnsBySession(
+      new Map([['tool-output-bloat', turns]]),
+    );
+    const allUserTurns: UserTurnRecord[] = [];
+    for (const sessionTurns of userTurnsBySession.values()) {
+      allUserTurns.push(...sessionTurns);
+    }
     toolOutputBloats = detectToolOutputBloat({
       settings,
       toolResultEvents,
+      userTurns: allUserTurns,
       turns,
       pricing,
     });


### PR DESCRIPTION
## Summary
- Updated `detectToolOutputBloat` to use enriched `approxTokens` from user-turn blocks instead of deriving from `contentLength`
- Removed outdated TODO comment referencing issue #57 (which is now closed)
- Added fallback to `contentLength` for legacy data compatibility
- Updated CLI waste command to load and pass userTurns
- Updated all tests to use the new API

#### Test plan
- All existing tests pass
- Unit tests verify the enriched data path with synthetic userTurn blocks
- Fixture tests verify backward compatibility with contentLength fallback
- Build succeeds with no TypeScript errors

Generated with [Devin](https://cli.devin.ai/docs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
