### PR TITLE
Add direct OpenCode stream ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 - `burn watch --opencode-stream` now ingests stream-owned OpenCode sessions directly at completed tool-call grain while keeping file ingest as the fallback.
 
+### Fixed
+
+- OpenCode stream cursor progress now survives concurrent file-ingest fallback saves.
+
 ## [0.45.0] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Added
+
+- `burn watch --opencode-stream` now ingests stream-owned OpenCode sessions directly at completed tool-call grain while keeping file ingest as the fallback.
+
 ## [0.45.0] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For passive ingest without a wrapper, run:
 burn watch [--interval <ms>] [--opencode-stream] [--opencode-url <url>]
 ```
 
-`burn watch` scans Claude, Codex, and OpenCode stores in the foreground and uses the same cursor + dedup path as the reporting commands. `--opencode-stream` also subscribes to OpenCode's local SSE endpoint (`http://127.0.0.1:4096/event` by default, or `OPENCODE_SERVER_URL`) and wakes the same ingest loop on session/message events; polling remains enabled as the fallback. If the server uses Basic auth, `OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD` are forwarded. `burn watch --daemon` is reserved but not implemented yet.
+`burn watch` scans Claude, Codex, and OpenCode stores in the foreground and uses the same cursor + dedup path as the reporting commands. `--opencode-stream` also subscribes to OpenCode's local SSE endpoint (`http://127.0.0.1:4096/event` by default, or `OPENCODE_SERVER_URL`) and ingests sessions observed from creation directly from the stream at completed tool-call grain; polling remains enabled as the fallback for already-running sessions, missed events, and drift checks. If the server uses Basic auth, `OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD` are forwarded. `burn watch --daemon` is reserved but not implemented yet.
 
 ### Spawner env-var contract (workflow / agent attribution)
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Added
+
+- `burn watch --opencode-stream` now writes direct stream-derived OpenCode records for sessions observed from creation, including completed tool-call events and stream cursor high-watermarks.
+
 ## [0.45.0] - 2026-04-29
 
 ### Fixed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `@relayburn/cli`.
 
 - `burn watch --opencode-stream` now writes direct stream-derived OpenCode records for sessions observed from creation, including completed tool-call events and stream cursor high-watermarks.
 
+### Fixed
+
+- `burn watch --opencode-stream` now preserves stream cursor progress when polling fallback saves file-ingest cursors concurrently.
+
 ## [0.45.0] - 2026-04-29
 
 ### Fixed

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -18,7 +18,7 @@ import {
   loadConfig,
   loadCursors,
   queryToolResultEvents,
-  saveCursors,
+  saveCursorChanges,
   withLock,
 } from '@relayburn/ledger';
 import type { ClaudeCursor } from '@relayburn/ledger';
@@ -471,6 +471,7 @@ async function ingestClaudeTranscript(
 
   const cfg = await loadConfig();
   const cursors = await loadCursors();
+  const before = structuredClone(cursors) as typeof cursors;
   const prior = cursors[file];
   const priorClaude = prior?.kind === 'claude' ? prior : undefined;
   const rotated =
@@ -482,7 +483,7 @@ async function ingestClaudeTranscript(
 
   if (!rotated && startOffset >= st.size) {
     priorClaude.mtimeMs = st.mtimeMs;
-    await saveCursors(cursors);
+    await saveCursorChanges(before, cursors);
     return;
   }
 
@@ -520,7 +521,7 @@ async function ingestClaudeTranscript(
   };
   if (lastUserText) next.lastUserText = lastUserText;
   cursors[file] = next;
-  await saveCursors(cursors);
+  await saveCursorChanges(before, cursors);
 
   if (!opts.quiet && turns.length > 0) {
     process.stderr.write(`[burn] ingested ${turns.length} turns from ${file}\n`);

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -2,6 +2,19 @@ import type { ParsedArgs } from '../args.js';
 import { formatInt } from '../format.js';
 import { ingestAll, type IngestReport } from '../ingest.js';
 import { startOpencodeEventStream } from '../opencode-stream.js';
+import { resolvePendingStampsForSession } from '../pending-stamps.js';
+import { createOpencodeStreamIngestor } from '@relayburn/reader';
+import {
+  appendContent,
+  appendRelationships,
+  appendToolResultEvents,
+  appendTurns,
+  appendUserTurns,
+  loadConfig,
+  loadCursors,
+  updateCursors,
+  type OpencodeStreamCursor,
+} from '@relayburn/ledger';
 
 const WATCH_HELP = `burn watch — foreground incremental ingest
 
@@ -74,27 +87,84 @@ export async function runWatch(args: ParsedArgs): Promise<number> {
   });
   const stream =
     args.flags['opencode-stream'] === true
-      ? startOpencodeEventStream({
-          ...opencodeStreamFlags(args),
-          onOpen(url) {
-            process.stderr.write(`[burn] watch: OpenCode event stream ${url}\n`);
-          },
-          onIngestHint() {
-            void controller.tick();
-          },
-          onError(err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            process.stderr.write(
-              `[burn] watch: OpenCode event stream unavailable (${msg}); polling continues\n`,
-            );
-          },
-        })
+      ? await startDirectOpencodeStream(args, controller)
       : undefined;
 
   await waitForStopSignal();
   if (stream) await stream.stop();
   await controller.stop();
   return 0;
+}
+
+async function startDirectOpencodeStream(
+  args: ParsedArgs,
+  controller: WatchController,
+): Promise<ReturnType<typeof startOpencodeEventStream>> {
+  const streamFlags = opencodeStreamFlags(args);
+  const cursorKey = `opencode-stream:${streamFlags.baseUrl ?? process.env['OPENCODE_SERVER_URL'] ?? 'http://127.0.0.1:4096'}:${streamFlags.global === true ? 'global' : 'project'}`;
+  const cursors = await loadCursors();
+  const prior = cursors[cursorKey]?.kind === 'opencode-stream'
+    ? (cursors[cursorKey] as OpencodeStreamCursor)
+    : undefined;
+  const config = await loadConfig();
+  const ingestorOpts: Parameters<typeof createOpencodeStreamIngestor>[0] = {
+    contentMode: config.content.store,
+  };
+  if (prior !== undefined) ingestorOpts.cursor = prior;
+  const ingestor = await createOpencodeStreamIngestor(ingestorOpts);
+  const streamOpts: Parameters<typeof startOpencodeEventStream>[0] = {
+    ...streamFlags,
+    onOpen(url) {
+      process.stderr.write(`[burn] watch: OpenCode event stream ${url}\n`);
+    },
+    async onEvent(event, payload) {
+      const result = await ingestor.ingest(payload, event.id);
+      if (result.turns.length > 0) {
+        const stamped = new Set<string>();
+        for (const turn of result.turns) {
+          if (stamped.has(turn.sessionId)) continue;
+          stamped.add(turn.sessionId);
+          const candidate: Parameters<typeof resolvePendingStampsForSession>[0] = {
+            harness: 'opencode',
+            sessionId: turn.sessionId,
+            sessionMtimeMs: Date.now(),
+          };
+          if (turn.project !== undefined) candidate.cwd = turn.project;
+          await resolvePendingStampsForSession(candidate);
+        }
+        await appendTurns(result.turns);
+      }
+      if (result.content.length > 0) await appendContent(result.content);
+      if (result.relationships.length > 0) await appendRelationships(result.relationships);
+      if (result.toolResultEvents.length > 0) {
+        await appendToolResultEvents(result.toolResultEvents);
+      }
+      if (result.userTurns.length > 0) await appendUserTurns(result.userTurns);
+      await updateCursors((map) => {
+        map[cursorKey] = { kind: 'opencode-stream', ...result.cursor };
+      });
+      if (result.turns.length > 0) {
+        process.stderr.write(
+          renderWatchReport({
+            scannedSessions: 0,
+            ingestedSessions: 1,
+            appendedTurns: result.turns.length,
+          }),
+        );
+      }
+    },
+    onIngestHint() {
+      void controller.tick();
+    },
+    onError(err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[burn] watch: OpenCode event stream unavailable (${msg}); polling continues\n`,
+      );
+    },
+  };
+  if (prior?.lastEventId !== undefined) streamOpts.lastEventId = prior.lastEventId;
+  return startOpencodeEventStream(streamOpts);
 }
 
 export async function runWatchTick(): Promise<IngestReport> {

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -29,7 +29,7 @@ import {
   loadConfig,
   loadCursors,
   queryUserTurns,
-  saveCursors,
+  saveCursorChanges,
   type ClaudeCursor,
   type CodexCursor,
   type FileCursor,
@@ -116,36 +116,39 @@ export function setIngestGapWriter(write: (msg: string) => void): (msg: string) 
 export async function ingestClaudeProjects(): Promise<IngestReport> {
   await cleanupStalePendingStamps();
   const cursors = await loadCursors();
+  const before = cloneCursors(cursors);
   const report = emptyReport();
   const contentMode = await resolveContentMode();
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   await ingestClaudeInto(cursors, report, contentMode, gap);
   emitGapWarning('claude', contentMode, gap, moduleGapState);
-  await saveCursors(cursors);
+  await saveCursorChanges(before, cursors);
   return report;
 }
 
 export async function ingestCodexSessions(): Promise<IngestReport> {
   await cleanupStalePendingStamps();
   const cursors = await loadCursors();
+  const before = cloneCursors(cursors);
   const report = emptyReport();
   const contentMode = await resolveContentMode();
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   await ingestCodexInto(cursors, report, contentMode, gap);
   emitGapWarning('codex', contentMode, gap, moduleGapState);
-  await saveCursors(cursors);
+  await saveCursorChanges(before, cursors);
   return report;
 }
 
 export async function ingestOpencodeSessions(): Promise<IngestReport> {
   await cleanupStalePendingStamps();
   const cursors = await loadCursors();
+  const before = cloneCursors(cursors);
   const report = emptyReport();
   const contentMode = await resolveContentMode();
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   await ingestOpencodeInto(cursors, report, contentMode, gap);
   emitGapWarning('opencode', contentMode, gap, moduleGapState);
-  await saveCursors(cursors);
+  await saveCursorChanges(before, cursors);
   return report;
 }
 
@@ -180,6 +183,7 @@ export async function ingestClaudeSession(cwd: string, sessionId: string): Promi
   if (userTurns.length > 0) await appendUserTurns(userTurns);
 
   const cursors = await loadCursors();
+  const before = cloneCursors(cursors);
   const cursor: ClaudeCursor = {
     kind: 'claude',
     inode: st.ino,
@@ -187,7 +191,7 @@ export async function ingestClaudeSession(cwd: string, sessionId: string): Promi
     mtimeMs: st.mtimeMs,
   };
   cursors[file] = cursor;
-  await saveCursors(cursors);
+  await saveCursorChanges(before, cursors);
 
   return { scannedSessions: 1, ingestedSessions: 1, appendedTurns: turns.length };
 }
@@ -195,6 +199,7 @@ export async function ingestClaudeSession(cwd: string, sessionId: string): Promi
 export async function ingestAll(): Promise<IngestReport> {
   await cleanupStalePendingStamps();
   const cursors = await loadCursors();
+  const before = cloneCursors(cursors);
   const report = emptyReport();
   const contentMode = await resolveContentMode();
   const claudeGap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
@@ -206,7 +211,7 @@ export async function ingestAll(): Promise<IngestReport> {
   emitGapWarning('claude', contentMode, claudeGap, moduleGapState);
   emitGapWarning('codex', contentMode, codexGap, moduleGapState);
   emitGapWarning('opencode', contentMode, opencodeGap, moduleGapState);
-  await saveCursors(cursors);
+  await saveCursorChanges(before, cursors);
   return report;
 }
 
@@ -589,6 +594,10 @@ async function ingestOpencodeInto(
 
 function emptyReport(): IngestReport {
   return { scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 };
+}
+
+function cloneCursors(cursors: Record<string, FileCursor>): Record<string, FileCursor> {
+  return structuredClone(cursors) as Record<string, FileCursor>;
 }
 
 export interface ReingestContentReport {

--- a/packages/cli/src/opencode-stream.test.ts
+++ b/packages/cli/src/opencode-stream.test.ts
@@ -31,8 +31,9 @@ describe('opencode event stream helpers', () => {
     const headers = buildOpencodeEventHeaders({
       OPENCODE_SERVER_USERNAME: 'alice',
       OPENCODE_SERVER_PASSWORD: 'secret',
-    });
+    }, { lastEventId: 'evt_1' });
     assert.equal(headers['Accept'], 'text/event-stream');
+    assert.equal(headers['Last-Event-ID'], 'evt_1');
     assert.equal(headers['Authorization'], 'Basic YWxpY2U6c2VjcmV0');
   });
 
@@ -64,9 +65,14 @@ describe('opencode event stream helpers', () => {
 
   it('consumes an SSE stream and calls onIngestHint for session/message events', async () => {
     let requestedUrl = '';
+    let requestedLastEventId = '';
     const wakeTypes: string[] = [];
-    const fetchImpl = async (url: string): Promise<FetchResponseLike> => {
+    const fetchImpl = async (
+      url: string,
+      init: { headers: Record<string, string> },
+    ): Promise<FetchResponseLike> => {
       requestedUrl = url;
+      requestedLastEventId = init.headers['Last-Event-ID'] ?? '';
       return responseFromChunks([
         'data: {"type":"server.connected","properties":{}}\n\n',
         'data: {"type":"message.part.updated","properties":{"sessionID":"ses_1"}}\n\n',
@@ -76,6 +82,7 @@ describe('opencode event stream helpers', () => {
 
     const report = await consumeOpencodeEventStream({
       baseUrl: 'http://localhost:4096',
+      lastEventId: 'evt_prev',
       fetchImpl,
       env: {},
       onIngestHint(payload) {
@@ -85,6 +92,7 @@ describe('opencode event stream helpers', () => {
     });
 
     assert.equal(requestedUrl, 'http://localhost:4096/event');
+    assert.equal(requestedLastEventId, 'evt_prev');
     assert.deepEqual(report, { events: 3, wakeups: 2 });
     assert.deepEqual(wakeTypes, ['message.part.updated', 'session.updated']);
   });

--- a/packages/cli/src/opencode-stream.ts
+++ b/packages/cli/src/opencode-stream.ts
@@ -26,11 +26,12 @@ export type FetchLike = (
 export interface ConsumeOpencodeEventStreamOptions {
   baseUrl?: string;
   global?: boolean;
+  lastEventId?: string;
   fetchImpl?: FetchLike;
   signal?: AbortSignal;
   env?: NodeJS.ProcessEnv;
-  onEvent?: (event: SseEvent, payload: unknown) => void;
-  onIngestHint?: (payload: unknown) => void;
+  onEvent?: (event: SseEvent, payload: unknown) => void | Promise<void>;
+  onIngestHint?: (payload: unknown) => void | Promise<void>;
 }
 
 export interface OpencodeEventStreamController {
@@ -59,8 +60,12 @@ export function resolveOpencodeEventUrl(
 
 export function buildOpencodeEventHeaders(
   env: NodeJS.ProcessEnv = process.env,
+  opts: { lastEventId?: string } = {},
 ): Record<string, string> {
   const headers: Record<string, string> = { Accept: 'text/event-stream' };
+  if (opts.lastEventId !== undefined && opts.lastEventId.length > 0) {
+    headers['Last-Event-ID'] = opts.lastEventId;
+  }
   const password = env['OPENCODE_SERVER_PASSWORD'];
   if (password !== undefined && password.length > 0) {
     const username = env['OPENCODE_SERVER_USERNAME'] || 'opencode';
@@ -133,8 +138,10 @@ export async function consumeOpencodeEventStream(
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
   const env = opts.env ?? process.env;
   const url = resolveOpencodeEventUrl(opts.baseUrl, resolveUrlOptions(opts.global, env));
+  const headerOpts: { lastEventId?: string } = {};
+  if (opts.lastEventId !== undefined) headerOpts.lastEventId = opts.lastEventId;
   const response = await fetchImpl(url, {
-    headers: buildOpencodeEventHeaders(env),
+    headers: buildOpencodeEventHeaders(env, headerOpts),
     ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
   });
   if (!response.ok) {
@@ -163,10 +170,10 @@ export async function consumeOpencodeEventStream(
       if (!parsed) continue;
       const payload = parseEventPayload(parsed.data);
       events++;
-      opts.onEvent?.(parsed, payload);
+      await opts.onEvent?.(parsed, payload);
       if (isOpencodeIngestHint(payload)) {
         wakeups++;
-        opts.onIngestHint?.(payload);
+        await opts.onIngestHint?.(payload);
       }
     }
   }
@@ -176,10 +183,10 @@ export async function consumeOpencodeEventStream(
   if (trailing) {
     const payload = parseEventPayload(trailing.data);
     events++;
-    opts.onEvent?.(trailing, payload);
+    await opts.onEvent?.(trailing, payload);
     if (isOpencodeIngestHint(payload)) {
       wakeups++;
-      opts.onIngestHint?.(payload);
+      await opts.onIngestHint?.(payload);
     }
   }
 

--- a/packages/cli/src/pending-stamps.ts
+++ b/packages/cli/src/pending-stamps.ts
@@ -36,7 +36,7 @@ export interface PendingStampWriteResult {
 export interface PendingStampSessionCandidate {
   harness: PendingStampHarness;
   sessionId: string;
-  sessionPath: string;
+  sessionPath?: string;
   sessionMtimeMs?: number;
   cwd?: string;
 }
@@ -185,7 +185,7 @@ function pendingStampMatches(
   candidate: PendingStampSessionCandidate,
 ): boolean {
   if (record.harness !== candidate.harness) return false;
-  if (record.sessionDirHint !== undefined) {
+  if (record.sessionDirHint !== undefined && candidate.sessionPath !== undefined) {
     const rel = path.relative(record.sessionDirHint, path.resolve(candidate.sessionPath));
     if (rel.startsWith('..') || path.isAbsolute(rel)) return false;
   }

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/ledger`.
 
 ## [Unreleased]
 
+### Added
+
+- Added an atomic cursor change-save helper so writers can persist only the cursor keys they touched.
+
 ### Changed
 
 - Content sidecars now skip exact duplicate records so live stream ingest and file fallback can overlap without double-counting content blocks.

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/ledger`.
 
 ## [Unreleased]
 
+### Changed
+
+- Content sidecars now skip exact duplicate records so live stream ingest and file fallback can overlap without double-counting content blocks.
+
 ## [0.45.0] - 2026-04-29
 
 ### Changed

--- a/packages/ledger/src/content.test.ts
+++ b/packages/ledger/src/content.test.ts
@@ -79,6 +79,16 @@ describe('content sidecar', () => {
     assert.equal(got[1]!.toolUse!.name, 'Bash');
   });
 
+  it('deduplicates identical records when stream and file ingest overlap', async () => {
+    const rec = record({ sessionId: 's-dedupe', messageId: 'm-dedupe' });
+    await appendContent([rec]);
+    await appendContent([rec]);
+
+    const got = await readContent({ sessionId: 's-dedupe' });
+    assert.equal(got.length, 1);
+    assert.equal(got[0]!.text, 'hello world');
+  });
+
   it('filters by messageId', async () => {
     await appendContent([
       record({ sessionId: 's-X', messageId: 'a' }),

--- a/packages/ledger/src/content.ts
+++ b/packages/ledger/src/content.ts
@@ -70,8 +70,22 @@ async function appendSessionContent(
   records: ContentRecord[],
 ): Promise<void> {
   const file = contentFilePath(sessionId);
-  const payload = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
   await withLock(`content.${sessionId}`, async () => {
+    const lines = records.map((r) => JSON.stringify(r));
+    let existing = new Set<string>();
+    try {
+      const raw = await readFile(file, 'utf8');
+      existing = new Set(raw.split('\n').filter((line) => line.length > 0));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    const fresh = lines.filter((line) => {
+      if (existing.has(line)) return false;
+      existing.add(line);
+      return true;
+    });
+    if (fresh.length === 0) return;
+    const payload = fresh.join('\n') + '\n';
     await appendFile(file, payload, { encoding: 'utf8' });
   });
 }

--- a/packages/ledger/src/cursors.test.ts
+++ b/packages/ledger/src/cursors.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { after, before, beforeEach, describe, it } from 'node:test';
 
-import { loadCursors, saveCursors } from './cursors.js';
+import {
+  type FileCursor,
+  loadCursors,
+  saveCursorChanges,
+  saveCursors,
+  updateCursors,
+} from './cursors.js';
 import { cursorsPath } from './paths.js';
 import { withLock } from './lock.js';
 
@@ -95,5 +101,45 @@ describe('cursors', () => {
     const raw = await readFile(cursorsPath(), 'utf8');
     const parsed = JSON.parse(raw);
     assert.ok(parsed.files['/a'].kind === 'codex');
+  });
+
+  it('saves only changed cursor keys so concurrent stream cursor updates survive', async () => {
+    const streamKey = 'opencode-stream:http://127.0.0.1:4096:project';
+    const before: Record<string, FileCursor> = {
+      '/abs/a.jsonl': { kind: 'claude', inode: 1, offsetBytes: 100, mtimeMs: 100 },
+      [streamKey]: {
+        kind: 'opencode-stream',
+        lastEventId: '1',
+        emittedMessageIds: ['m1'],
+        emittedToolEventIds: [],
+      },
+    };
+    const after = structuredClone(before);
+    after['/abs/a.jsonl'] = {
+      kind: 'claude',
+      inode: 1,
+      offsetBytes: 200,
+      mtimeMs: 200,
+    };
+
+    await saveCursors(before);
+    await updateCursors((map) => {
+      map[streamKey] = {
+        kind: 'opencode-stream',
+        lastEventId: '2',
+        emittedMessageIds: ['m1', 'm2'],
+        emittedToolEventIds: ['tool:0'],
+      };
+    });
+    await saveCursorChanges(before, after);
+
+    const got = await loadCursors();
+    assert.deepEqual(got['/abs/a.jsonl'], after['/abs/a.jsonl']);
+    assert.deepEqual(got[streamKey], {
+      kind: 'opencode-stream',
+      lastEventId: '2',
+      emittedMessageIds: ['m1', 'm2'],
+      emittedToolEventIds: ['tool:0'],
+    });
   });
 });

--- a/packages/ledger/src/cursors.ts
+++ b/packages/ledger/src/cursors.ts
@@ -1,7 +1,11 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import type { CodexLastCompletedTurn, PersistedUserTurnSlot } from '@relayburn/reader';
+import type {
+  CodexLastCompletedTurn,
+  OpencodeStreamCursorState,
+  PersistedUserTurnSlot,
+} from '@relayburn/reader';
 
 import { withLock } from './lock.js';
 import { cursorsPath } from './paths.js';
@@ -40,7 +44,11 @@ export interface OpencodeCursor {
   seenMessageIds: string[];
 }
 
-export type FileCursor = ClaudeCursor | CodexCursor | OpencodeCursor;
+export interface OpencodeStreamCursor extends OpencodeStreamCursorState {
+  kind: 'opencode-stream';
+}
+
+export type FileCursor = ClaudeCursor | CodexCursor | OpencodeCursor | OpencodeStreamCursor;
 
 interface CursorsFile {
   files: Record<string, FileCursor>;
@@ -65,6 +73,30 @@ export async function saveCursors(map: Record<string, FileCursor>): Promise<void
   const payload: CursorsFile = { files: map };
   const tmpPath = `${finalPath}.tmp`;
   await withLock('cursors', async () => {
+    await writeFile(tmpPath, JSON.stringify(payload, null, 2), 'utf8');
+    await rename(tmpPath, finalPath);
+  });
+}
+
+export async function updateCursors(
+  mutate: (map: Record<string, FileCursor>) => void | Promise<void>,
+): Promise<void> {
+  const finalPath = cursorsPath();
+  await mkdir(path.dirname(finalPath), { recursive: true });
+  const tmpPath = `${finalPath}.tmp`;
+  await withLock('cursors', async () => {
+    let map: Record<string, FileCursor> = {};
+    try {
+      const raw = await readFile(finalPath, 'utf8');
+      const parsed = JSON.parse(raw) as CursorsFile;
+      if (parsed && typeof parsed === 'object' && parsed.files && typeof parsed.files === 'object') {
+        map = parsed.files;
+      }
+    } catch {
+      map = {};
+    }
+    await mutate(map);
+    const payload: CursorsFile = { files: map };
     await writeFile(tmpPath, JSON.stringify(payload, null, 2), 'utf8');
     await rename(tmpPath, finalPath);
   });

--- a/packages/ledger/src/cursors.ts
+++ b/packages/ledger/src/cursors.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 
 import type {
   CodexLastCompletedTurn,
@@ -75,6 +76,36 @@ export async function saveCursors(map: Record<string, FileCursor>): Promise<void
   await withLock('cursors', async () => {
     await writeFile(tmpPath, JSON.stringify(payload, null, 2), 'utf8');
     await rename(tmpPath, finalPath);
+  });
+}
+
+export async function saveCursorChanges(
+  before: Record<string, FileCursor>,
+  after: Record<string, FileCursor>,
+): Promise<void> {
+  const changedKeys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const changes: Array<{ key: string; cursor?: FileCursor }> = [];
+  for (const key of changedKeys) {
+    const prior = before[key];
+    const next = after[key];
+    if (next === undefined) {
+      if (prior !== undefined) changes.push({ key });
+      continue;
+    }
+    if (prior === undefined || !isDeepStrictEqual(prior, next)) {
+      changes.push({ key, cursor: next });
+    }
+  }
+  if (changes.length === 0) return;
+
+  await updateCursors((map) => {
+    for (const change of changes) {
+      if (change.cursor === undefined) {
+        delete map[change.key];
+      } else {
+        map[change.key] = change.cursor;
+      }
+    }
   });
 }
 

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -77,7 +77,7 @@ export {
 } from './schema.js';
 export { loadHwm, saveHwm } from './hwm.js';
 export type { HwmEntry, HwmMap } from './hwm.js';
-export { loadCursors, saveCursors, updateCursors } from './cursors.js';
+export { loadCursors, saveCursorChanges, saveCursors, updateCursors } from './cursors.js';
 export type {
   FileCursor,
   ClaudeCursor,

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -77,8 +77,14 @@ export {
 } from './schema.js';
 export { loadHwm, saveHwm } from './hwm.js';
 export type { HwmEntry, HwmMap } from './hwm.js';
-export { loadCursors, saveCursors } from './cursors.js';
-export type { FileCursor, ClaudeCursor, CodexCursor, OpencodeCursor } from './cursors.js';
+export { loadCursors, saveCursors, updateCursors } from './cursors.js';
+export type {
+  FileCursor,
+  ClaudeCursor,
+  CodexCursor,
+  OpencodeCursor,
+  OpencodeStreamCursor,
+} from './cursors.js';
 export { withLock } from './lock.js';
 export {
   rebuildIndex,

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@relayburn/reader`.
 
 ## [Unreleased]
 
+### Added
+
+- OpenCode stream events can now be normalized into turn, content, user-turn, relationship, and tool-result event records for stream-owned sessions.
+
+### Changed
+
+- OpenCode tool-result events now include a conservative per-tool share of the assistant turn's usage when turn-level usage is available.
+
 ## [0.45.0] - 2026-04-29
 
 ### Added

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to `@relayburn/reader`.
 
 - OpenCode tool-result events now include a conservative per-tool share of the assistant turn's usage when turn-level usage is available.
 
+### Fixed
+
+- OpenCode stream ingestion now keeps tool-result event indexes stable across repeated flushes and clears buffered parts for deleted sessions.
+
 ## [0.45.0] - 2026-04-29
 
 ### Added

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -63,5 +63,12 @@ export type {
   ParseOpencodeIncrementalOptions,
   ParseOpencodeIncrementalResult,
 } from './opencode.js';
+export { createOpencodeStreamIngestor } from './opencode-stream.js';
+export type {
+  OpencodeStreamCursorState,
+  OpencodeStreamIngestOptions,
+  OpencodeStreamIngestResult,
+  OpencodeStreamIngestor,
+} from './opencode-stream.js';
 export { resolveProject, canonicalizeRemoteUrl, parseGitConfig } from './git.js';
 export type { ResolvedProject } from './git.js';

--- a/packages/reader/src/opencode-stream.test.ts
+++ b/packages/reader/src/opencode-stream.test.ts
@@ -173,6 +173,159 @@ describe('opencode stream ingestor', () => {
     assert.equal(result.turns.length, 0);
   });
 
+  it('does not duplicate tool events when an earlier assistant finalizes later', async () => {
+    const ingestor = await createOpencodeStreamIngestor({ tokenizer: 'heuristic' });
+    await ingestor.ingest({
+      type: 'session.created',
+      properties: { info: { id: 'ses_out_of_order', directory: '/tmp/project' } },
+    });
+    await ingestor.ingest({
+      type: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_asst_1',
+          sessionID: 'ses_out_of_order',
+          role: 'assistant',
+          time: { created: 100 },
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4-5',
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'part_tool_1',
+          sessionID: 'ses_out_of_order',
+          messageID: 'msg_asst_1',
+          type: 'tool',
+          callID: 'tool_1',
+          tool: 'bash',
+          state: { input: { command: 'one' }, output: 'one\n' },
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_asst_2',
+          sessionID: 'ses_out_of_order',
+          role: 'assistant',
+          time: { created: 200 },
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4-5',
+          tokens: { input: 2, output: 2 },
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'part_tool_2',
+          sessionID: 'ses_out_of_order',
+          messageID: 'msg_asst_2',
+          type: 'tool',
+          callID: 'tool_2',
+          tool: 'bash',
+          state: { input: { command: 'two' }, output: 'two\n' },
+        },
+      },
+    });
+
+    const first = await ingestor.ingest({
+      type: 'session.idle',
+      properties: { sessionID: 'ses_out_of_order' },
+    });
+    assert.deepEqual(
+      first.toolResultEvents.map((e) => [e.toolUseId, e.eventIndex]),
+      [['tool_2', 0]],
+    );
+
+    await ingestor.ingest({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'part_step_1',
+          sessionID: 'ses_out_of_order',
+          messageID: 'msg_asst_1',
+          type: 'step-finish',
+          reason: 'end_turn',
+          tokens: { input: 1, output: 1 },
+        },
+      },
+    });
+
+    const second = await ingestor.ingest({
+      type: 'session.idle',
+      properties: { sessionID: 'ses_out_of_order' },
+    });
+    assert.deepEqual(
+      second.toolResultEvents.map((e) => [e.toolUseId, e.eventIndex]),
+      [['tool_1', 1]],
+    );
+    assert.equal(
+      second.toolResultEvents.some((e) => e.toolUseId === 'tool_2'),
+      false,
+      'already emitted later assistant tool must not be re-emitted with a shifted eventIndex',
+    );
+    assert.equal(second.cursor.nextToolEventIndexBySession?.['ses_out_of_order'], 2);
+  });
+
+  it('drops buffered parts for deleted sessions', async () => {
+    const ingestor = await createOpencodeStreamIngestor({ tokenizer: 'heuristic' });
+    await ingestor.ingest({
+      type: 'session.created',
+      properties: { info: { id: 'ses_deleted', directory: '/tmp/project' } },
+    });
+    await ingestor.ingest({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'part_old_tool',
+          sessionID: 'ses_deleted',
+          messageID: 'msg_reused',
+          type: 'tool',
+          callID: 'old_tool',
+          tool: 'bash',
+          state: { input: { command: 'old' }, output: 'old\n' },
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'session.deleted',
+      properties: { sessionID: 'ses_deleted' },
+    });
+    await ingestor.ingest({
+      type: 'session.created',
+      properties: { info: { id: 'ses_deleted', directory: '/tmp/project' } },
+    });
+    await ingestor.ingest({
+      type: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_reused',
+          sessionID: 'ses_deleted',
+          role: 'assistant',
+          time: { created: 300 },
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4-5',
+          tokens: { input: 1, output: 1 },
+        },
+      },
+    });
+
+    const result = await ingestor.ingest({
+      type: 'session.idle',
+      properties: { sessionID: 'ses_deleted' },
+    });
+    assert.equal(result.turns.length, 1);
+    assert.equal(result.turns[0]!.toolCalls.length, 0);
+    assert.equal(result.toolResultEvents.length, 0);
+  });
+
   it('matches file-derived OpenCode records for the same completed session', async () => {
     const file = sessionFile('with-tool', 'ses_tool');
     const expected = await parseOpencodeSession(file, {

--- a/packages/reader/src/opencode-stream.test.ts
+++ b/packages/reader/src/opencode-stream.test.ts
@@ -1,0 +1,258 @@
+import { strict as assert } from 'node:assert';
+import { readFile, readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createOpencodeStreamIngestor } from './opencode-stream.js';
+import { parseOpencodeSession } from './opencode.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.resolve(__dirname, '..', '..', '..', 'tests', 'fixtures', 'opencode');
+
+function sessionFile(fixture: string, sessionId: string): string {
+  return path.join(FIXTURES, fixture, 'storage', 'session', 'global', `${sessionId}.json`);
+}
+
+describe('opencode stream ingestor', () => {
+  it('normalizes a stream-owned OpenCode session into burn records on idle', async () => {
+    const ingestor = await createOpencodeStreamIngestor({
+      contentMode: 'full',
+      tokenizer: 'heuristic',
+    });
+
+    await ingestor.ingest(
+      {
+        type: 'session.created',
+        properties: { info: { id: 'ses_stream', directory: '/tmp/project' } },
+      },
+      '1',
+    );
+    await ingestor.ingest({
+      type: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_stream_user',
+          sessionID: 'ses_stream',
+          role: 'user',
+          time: { created: 1_777_000_000_000 },
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'prt_user_text',
+          sessionID: 'ses_stream',
+          messageID: 'msg_stream_user',
+          type: 'text',
+          text: 'list files',
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_stream_asst',
+          sessionID: 'ses_stream',
+          role: 'assistant',
+          time: { created: 1_777_000_001_000 },
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4-5',
+          path: { cwd: '/tmp/project' },
+          tokens: {
+            input: 10,
+            output: 20,
+            reasoning: 0,
+            cache: { read: 5, write: 7 },
+          },
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'prt_asst_tool',
+          sessionID: 'ses_stream',
+          messageID: 'msg_stream_asst',
+          type: 'tool',
+          callID: 'toolu_bash_1',
+          tool: 'bash',
+          state: {
+            status: 'completed',
+            input: { command: 'ls' },
+            output: 'a.ts\n',
+          },
+        },
+      },
+    });
+    await ingestor.ingest({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'prt_step_finish',
+          sessionID: 'ses_stream',
+          messageID: 'msg_stream_asst',
+          type: 'step-finish',
+          reason: 'end_turn',
+          tokens: {
+            input: 10,
+            output: 20,
+            reasoning: 0,
+            cache: { read: 5, write: 7 },
+          },
+        },
+      },
+    });
+
+    const result = await ingestor.ingest(
+      {
+        type: 'session.idle',
+        properties: { sessionID: 'ses_stream' },
+      },
+      '7',
+    );
+
+    assert.equal(result.turns.length, 1);
+    assert.equal(result.turns[0]!.messageId, 'msg_stream_asst');
+    assert.equal(result.turns[0]!.turnIndex, 0);
+    assert.equal(result.turns[0]!.toolCalls[0]!.name, 'bash');
+    assert.equal(result.turns[0]!.toolCalls[0]!.target, 'ls');
+    assert.deepEqual(result.turns[0]!.usage, {
+      input: 10,
+      output: 20,
+      reasoning: 0,
+      cacheRead: 5,
+      cacheCreate5m: 7,
+      cacheCreate1h: 0,
+    });
+
+    assert.equal(result.toolResultEvents.length, 1);
+    const event = result.toolResultEvents[0]!;
+    assert.equal(event.toolUseId, 'toolu_bash_1');
+    assert.equal(event.eventIndex, 0);
+    assert.equal(event.usageAttribution, 'single-tool-turn');
+    assert.equal(event.usage?.input, 10);
+    assert.equal(event.contentLength, 'a.ts\n'.length);
+
+    assert.equal(result.content.filter((c) => c.kind === 'tool_result').length, 1);
+    assert.equal(result.content.filter((c) => c.kind === 'text').length, 1);
+    assert.equal(result.userTurns.length, 1);
+    assert.equal(result.userTurns[0]!.blocks[0]!.kind, 'text');
+    assert.equal(result.cursor.lastEventId, '7');
+
+    const secondIdle = await ingestor.ingest({
+      type: 'session.idle',
+      properties: { sessionID: 'ses_stream' },
+    });
+    assert.equal(secondIdle.turns.length, 0);
+    assert.equal(secondIdle.toolResultEvents.length, 0);
+  });
+
+  it('does not emit direct records for sessions that predate the stream', async () => {
+    const ingestor = await createOpencodeStreamIngestor({ contentMode: 'full' });
+    await ingestor.ingest({
+      type: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_existing_asst',
+          sessionID: 'ses_existing',
+          role: 'assistant',
+          time: { created: 1 },
+          tokens: { input: 1, output: 1 },
+        },
+      },
+    });
+    const result = await ingestor.ingest({
+      type: 'session.idle',
+      properties: { sessionID: 'ses_existing' },
+    });
+    assert.equal(result.turns.length, 0);
+  });
+
+  it('matches file-derived OpenCode records for the same completed session', async () => {
+    const file = sessionFile('with-tool', 'ses_tool');
+    const expected = await parseOpencodeSession(file, {
+      contentMode: 'full',
+      tokenizer: 'heuristic',
+    });
+    const ingestor = await createOpencodeStreamIngestor({
+      contentMode: 'full',
+      tokenizer: 'heuristic',
+    });
+
+    const result = await replayFixture(ingestor, 'with-tool', 'ses_tool');
+    assert.equal(result.turns.length, expected.turns.length);
+    assert.equal(result.turns[0]!.messageId, expected.turns[0]!.messageId);
+    assert.deepEqual(result.turns[0]!.usage, expected.turns[0]!.usage);
+    assert.deepEqual(
+      result.turns[0]!.toolCalls.map((t) => [t.id, t.name, t.target]),
+      expected.turns[0]!.toolCalls.map((t) => [t.id, t.name, t.target]),
+    );
+    assert.deepEqual(
+      result.toolResultEvents.map((e) => [
+        e.toolUseId,
+        e.eventIndex,
+        e.status,
+        e.usageAttribution,
+        e.usage?.input,
+      ]),
+      expected.toolResultEvents.map((e) => [
+        e.toolUseId,
+        e.eventIndex,
+        e.status,
+        e.usageAttribution,
+        e.usage?.input,
+      ]),
+    );
+    assert.equal(
+      result.content.filter((c) => c.kind === 'tool_result').length,
+      expected.content.filter((c) => c.kind === 'tool_result').length,
+    );
+  });
+});
+
+async function replayFixture(
+  ingestor: Awaited<ReturnType<typeof createOpencodeStreamIngestor>>,
+  fixture: string,
+  sessionId: string,
+) {
+  const storage = path.join(FIXTURES, fixture, 'storage');
+  const session = await readJson(path.join(storage, 'session', 'global', `${sessionId}.json`));
+  await ingestor.ingest({ type: 'session.created', properties: { info: session } });
+
+  const messageDir = path.join(storage, 'message', sessionId);
+  const messages = await Promise.all(
+    (await readdir(messageDir))
+      .filter((name) => name.endsWith('.json'))
+      .map((name) => readJson(path.join(messageDir, name))),
+  );
+  messages.sort((a, b) => Number(a.time?.created ?? 0) - Number(b.time?.created ?? 0));
+  for (const message of messages) {
+    await ingestor.ingest({ type: 'message.updated', properties: { info: message } });
+    const partDir = path.join(storage, 'part', String(message.id));
+    let partNames: string[];
+    try {
+      partNames = await readdir(partDir);
+    } catch {
+      partNames = [];
+    }
+    const parts = await Promise.all(
+      partNames
+        .filter((name) => name.endsWith('.json'))
+        .map((name) => readJson(path.join(partDir, name))),
+    );
+    parts.sort((a, b) => String(a.id ?? '').localeCompare(String(b.id ?? '')));
+    for (const part of parts) {
+      await ingestor.ingest({ type: 'message.part.updated', properties: { part } });
+    }
+  }
+  return ingestor.ingest({ type: 'session.idle', properties: { sessionID: sessionId } });
+}
+
+async function readJson(file: string): Promise<Record<string, any>> {
+  return JSON.parse(await readFile(file, 'utf8')) as Record<string, any>;
+}

--- a/packages/reader/src/opencode-stream.ts
+++ b/packages/reader/src/opencode-stream.ts
@@ -1,0 +1,880 @@
+import { classifyActivity } from './classifier.js';
+import { makeFidelity, EMPTY_COVERAGE } from './fidelity.js';
+import { argsHash, contentHash } from './hash.js';
+import { resolveProject } from './git.js';
+import type {
+  ContentRecord,
+  ContentStoreMode,
+  Coverage,
+  Fidelity,
+  SessionRelationshipRecord,
+  Subagent,
+  ToolCall,
+  ToolResultEventRecord,
+  TurnRecord,
+  Usage,
+  UserTurnBlock,
+  UserTurnRecord,
+} from './types.js';
+import {
+  createUserTurnTokenCounter,
+  makeTextBlock,
+  makeToolResultBlock,
+  type UserTurnTokenCounter,
+  type UserTurnTokenizer,
+} from './userTurn.js';
+
+interface SessionInfo {
+  id: string;
+  parentID?: string;
+  directory?: string;
+}
+
+interface MessageTokens {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cache?: {
+    read?: number;
+    write?: number;
+  };
+}
+
+interface AssistantMessage {
+  id: string;
+  sessionID: string;
+  role: 'assistant';
+  time: { created: number };
+  providerID?: string;
+  modelID?: string;
+  path?: { cwd?: string };
+  tokens?: MessageTokens;
+}
+
+interface UserMessage {
+  id: string;
+  sessionID: string;
+  role: 'user';
+  time: { created: number };
+}
+
+interface ToolPart {
+  id?: string;
+  sessionID?: string;
+  messageID?: string;
+  type: 'tool';
+  callID?: string;
+  tool?: string;
+  state?: {
+    input?: Record<string, unknown>;
+    status?: string;
+    metadata?: { exit?: number; [k: string]: unknown };
+    output?: unknown;
+    [k: string]: unknown;
+  };
+}
+
+interface StepFinishPart {
+  id?: string;
+  sessionID?: string;
+  messageID?: string;
+  type: 'step-finish';
+  reason?: string;
+  tokens?: MessageTokens;
+}
+
+interface TextPart {
+  id?: string;
+  sessionID?: string;
+  messageID?: string;
+  type: 'text';
+  text?: string;
+  synthetic?: boolean;
+}
+
+type Part =
+  | ToolPart
+  | StepFinishPart
+  | TextPart
+  | { id?: string; sessionID?: string; messageID?: string; type: string; [k: string]: unknown };
+
+export interface OpencodeStreamCursorState {
+  lastEventId?: string;
+  emittedMessageIds?: string[];
+  emittedToolEventIds?: string[];
+}
+
+export interface OpencodeStreamIngestOptions {
+  contentMode?: ContentStoreMode;
+  tokenizer?: UserTurnTokenizer;
+  cursor?: OpencodeStreamCursorState;
+}
+
+export interface OpencodeStreamIngestResult {
+  turns: TurnRecord[];
+  content: ContentRecord[];
+  relationships: SessionRelationshipRecord[];
+  toolResultEvents: ToolResultEventRecord[];
+  userTurns: UserTurnRecord[];
+  cursor: OpencodeStreamCursorState;
+}
+
+export interface OpencodeStreamIngestor {
+  ingest(payload: unknown, eventId?: string): Promise<OpencodeStreamIngestResult>;
+  snapshotCursor(): OpencodeStreamCursorState;
+}
+
+interface NormalizedEvent {
+  type: string;
+  properties: Record<string, unknown>;
+}
+
+export async function createOpencodeStreamIngestor(
+  options: OpencodeStreamIngestOptions = {},
+): Promise<OpencodeStreamIngestor> {
+  const tokenCounter = await createUserTurnTokenCounter(options.tokenizer);
+  return new Ingestor(options, tokenCounter);
+}
+
+class Ingestor implements OpencodeStreamIngestor {
+  private readonly contentMode: ContentStoreMode;
+  private readonly tokenCounter: UserTurnTokenCounter;
+  private readonly sessions = new Map<string, SessionInfo>();
+  private readonly streamOwnedSessions = new Set<string>();
+  private readonly messages = new Map<string, AssistantMessage | UserMessage>();
+  private readonly partsByMessage = new Map<string, Map<string, Part>>();
+  private readonly emittedMessageIds: Set<string>;
+  private readonly emittedToolEventIds: Set<string>;
+  private lastEventId: string | undefined;
+
+  constructor(options: OpencodeStreamIngestOptions, tokenCounter: UserTurnTokenCounter) {
+    this.contentMode = options.contentMode ?? 'full';
+    this.tokenCounter = tokenCounter;
+    this.emittedMessageIds = new Set(options.cursor?.emittedMessageIds ?? []);
+    this.emittedToolEventIds = new Set(options.cursor?.emittedToolEventIds ?? []);
+    this.lastEventId = options.cursor?.lastEventId;
+  }
+
+  async ingest(payload: unknown, eventId?: string): Promise<OpencodeStreamIngestResult> {
+    if (eventId !== undefined && eventId.length > 0) this.lastEventId = eventId;
+    const ev = normalizeEvent(payload);
+    const flush = new Set<string>();
+    if (ev) {
+      switch (ev.type) {
+        case 'session.created':
+          this.updateSession(ev.properties);
+          {
+            const id = sessionIdFromInfo(ev.properties['info']);
+            if (id) this.streamOwnedSessions.add(id);
+          }
+          break;
+        case 'session.updated':
+          this.updateSession(ev.properties);
+          break;
+        case 'session.deleted':
+          {
+            const id = sessionIdFromInfo(ev.properties['info']) ?? stringProp(ev.properties, 'sessionID');
+            if (id) this.dropSession(id);
+          }
+          break;
+        case 'message.updated':
+          this.updateMessage(ev.properties);
+          break;
+        case 'message.part.updated':
+          this.updatePart(ev.properties);
+          break;
+        case 'message.part.removed':
+          this.removePart(ev.properties);
+          break;
+        case 'session.idle':
+          {
+            const id = stringProp(ev.properties, 'sessionID');
+            if (id) flush.add(id);
+          }
+          break;
+        case 'session.status':
+          if (isIdleStatus(ev.properties['status'])) {
+            const id = stringProp(ev.properties, 'sessionID');
+            if (id) flush.add(id);
+          }
+          break;
+      }
+    }
+    return this.flush(flush);
+  }
+
+  snapshotCursor(): OpencodeStreamCursorState {
+    const cursor: OpencodeStreamCursorState = {
+      emittedMessageIds: [...this.emittedMessageIds],
+      emittedToolEventIds: [...this.emittedToolEventIds],
+    };
+    if (this.lastEventId !== undefined) cursor.lastEventId = this.lastEventId;
+    return cursor;
+  }
+
+  private updateSession(properties: Record<string, unknown>): void {
+    const raw = properties['info'];
+    if (!raw || typeof raw !== 'object') return;
+    const rec = raw as Record<string, unknown>;
+    if (typeof rec.id !== 'string') return;
+    const session: SessionInfo = { id: rec.id };
+    if (typeof rec.parentID === 'string') session.parentID = rec.parentID;
+    if (typeof rec.directory === 'string') session.directory = rec.directory;
+    this.sessions.set(session.id, session);
+  }
+
+  private updateMessage(properties: Record<string, unknown>): void {
+    const raw = properties['info'];
+    if (!raw || typeof raw !== 'object') return;
+    const rec = raw as Record<string, unknown>;
+    if (isCompleteAssistantLike(rec)) {
+      if (!this.streamOwnedSessions.has(rec.sessionID)) return;
+      this.messages.set(rec.id, rec as unknown as AssistantMessage);
+    } else if (isCompleteUserLike(rec)) {
+      if (!this.streamOwnedSessions.has(rec.sessionID)) return;
+      this.messages.set(rec.id, rec as unknown as UserMessage);
+    }
+  }
+
+  private updatePart(properties: Record<string, unknown>): void {
+    const raw = properties['part'];
+    if (!raw || typeof raw !== 'object') return;
+    const part = raw as Part;
+    if (typeof part.sessionID !== 'string' || typeof part.messageID !== 'string') return;
+    if (!this.streamOwnedSessions.has(part.sessionID)) return;
+    const id = typeof part.id === 'string' && part.id.length > 0 ? part.id : partKey(part);
+    let bucket = this.partsByMessage.get(part.messageID);
+    if (!bucket) {
+      bucket = new Map();
+      this.partsByMessage.set(part.messageID, bucket);
+    }
+    bucket.set(id, part);
+  }
+
+  private removePart(properties: Record<string, unknown>): void {
+    const messageID = stringProp(properties, 'messageID');
+    const partID = stringProp(properties, 'partID');
+    const sessionID = stringProp(properties, 'sessionID');
+    if (!messageID || !partID || !sessionID) return;
+    if (!this.streamOwnedSessions.has(sessionID)) return;
+    this.partsByMessage.get(messageID)?.delete(partID);
+  }
+
+  private dropSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+    this.streamOwnedSessions.delete(sessionId);
+    for (const [id, message] of this.messages.entries()) {
+      if (message.sessionID === sessionId) this.messages.delete(id);
+    }
+  }
+
+  private async flush(sessionIds: Set<string>): Promise<OpencodeStreamIngestResult> {
+    const turns: TurnRecord[] = [];
+    const content: ContentRecord[] = [];
+    const relationships: SessionRelationshipRecord[] = [];
+    const toolResultEvents: ToolResultEventRecord[] = [];
+    const userTurns: UserTurnRecord[] = [];
+
+    for (const sessionId of sessionIds) {
+      if (!this.streamOwnedSessions.has(sessionId)) continue;
+      const session = this.sessions.get(sessionId) ?? { id: sessionId };
+      const assistants = [...this.messages.values()]
+        .filter((m): m is AssistantMessage => m.role === 'assistant' && m.sessionID === sessionId)
+        .sort((a, b) => a.time.created - b.time.created);
+      const users = [...this.messages.values()]
+        .filter((m): m is UserMessage => m.role === 'user' && m.sessionID === sessionId)
+        .sort((a, b) => a.time.created - b.time.created);
+      relationships.push(...buildRelationships(session, assistants));
+
+      const allToolEvents = collectToolResultEventsForSession(sessionId, assistants, (messageId) =>
+        this.partsFor(messageId),
+      );
+      for (const ev of allToolEvents) {
+        const key = toolEventKey(ev);
+        if (this.emittedToolEventIds.has(key)) continue;
+        this.emittedToolEventIds.add(key);
+        toolResultEvents.push(ev);
+      }
+
+      for (let i = 0; i < assistants.length; i++) {
+        const m = assistants[i]!;
+        if (this.emittedMessageIds.has(m.id)) continue;
+        const parts = this.partsFor(m.id);
+        if (!isFinalAssistant(m, parts)) continue;
+        const prev = i > 0 ? assistants[i - 1]! : undefined;
+        const userMsg = findPrecedingUser(users, m.time.created);
+        const userMsgForGap =
+          userMsg && (!prev || userMsg.time.created > prev.time.created) ? userMsg : undefined;
+        const userTurn = buildUserTurnRecord(
+          sessionId,
+          prev,
+          m,
+          userMsgForGap,
+          prev ? this.partsFor(prev.id) : [],
+          userMsgForGap ? this.partsFor(userMsgForGap.id) : [],
+          this.tokenCounter,
+        );
+        if (userTurn) userTurns.push(userTurn);
+
+        const { toolCalls, filesTouched, erroredCallIds } = extractToolsAndFiles(parts);
+        const usage = toUsage(m.tokens);
+        const record = buildTurnRecord(
+          session,
+          m,
+          i,
+          parts,
+          toolCalls,
+          filesTouched,
+          erroredCallIds,
+          usage,
+          userMsg ? extractTextParts(this.partsFor(userMsg.id), { includeSynthetic: false }).join('\n') : '',
+        );
+        turns.push(record);
+        this.emittedMessageIds.add(m.id);
+        if (this.contentMode === 'full') {
+          if (userMsg) {
+            const userTs = new Date(userMsg.time.created).toISOString();
+            for (const t of extractTextParts(this.partsFor(userMsg.id), { includeSynthetic: false })) {
+              content.push({
+                v: 1,
+                source: 'opencode',
+                sessionId,
+                messageId: userMsg.id,
+                ts: userTs,
+                role: 'user',
+                kind: 'text',
+                text: t,
+              });
+            }
+          }
+          content.push(...extractAssistantContent(parts, sessionId, m.id, record.ts));
+        }
+      }
+    }
+
+    return {
+      turns,
+      content,
+      relationships,
+      toolResultEvents,
+      userTurns,
+      cursor: this.snapshotCursor(),
+    };
+  }
+
+  private partsFor(messageId: string): Part[] {
+    const bucket = this.partsByMessage.get(messageId);
+    if (!bucket) return [];
+    return [...bucket.values()].sort((a, b) =>
+      (a.id ?? '') < (b.id ?? '') ? -1 : (a.id ?? '') > (b.id ?? '') ? 1 : 0,
+    );
+  }
+}
+
+function normalizeEvent(payload: unknown): NormalizedEvent | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const rec = payload as Record<string, unknown>;
+  const nested = rec['payload'];
+  if (nested && typeof nested === 'object') return normalizeEvent(nested);
+  const type = rec['type'];
+  if (typeof type !== 'string') return null;
+  const properties = rec['properties'];
+  return {
+    type,
+    properties:
+      properties && typeof properties === 'object'
+        ? (properties as Record<string, unknown>)
+        : {},
+  };
+}
+
+function sessionIdFromInfo(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const id = (raw as Record<string, unknown>)['id'];
+  return typeof id === 'string' ? id : undefined;
+}
+
+function stringProp(rec: Record<string, unknown>, key: string): string | undefined {
+  const value = rec[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isIdleStatus(raw: unknown): boolean {
+  if (raw === 'idle') return true;
+  if (!raw || typeof raw !== 'object') return false;
+  return (raw as Record<string, unknown>)['type'] === 'idle';
+}
+
+function isCompleteAssistantLike(rec: Record<string, unknown>): rec is Record<string, unknown> & AssistantMessage {
+  return (
+    rec['role'] === 'assistant' &&
+    typeof rec['id'] === 'string' &&
+    typeof rec['sessionID'] === 'string' &&
+    typeof (rec['time'] as { created?: unknown } | undefined)?.created === 'number'
+  );
+}
+
+function isCompleteUserLike(rec: Record<string, unknown>): rec is Record<string, unknown> & UserMessage {
+  return (
+    rec['role'] === 'user' &&
+    typeof rec['id'] === 'string' &&
+    typeof rec['sessionID'] === 'string' &&
+    typeof (rec['time'] as { created?: unknown } | undefined)?.created === 'number'
+  );
+}
+
+function partKey(part: Part): string {
+  return `${part.messageID ?? ''}:${part.type}:${JSON.stringify(part).length}`;
+}
+
+function isFinalAssistant(m: AssistantMessage, parts: Part[]): boolean {
+  return m.tokens !== undefined || parts.some((p) => p.type === 'step-finish');
+}
+
+function buildRelationships(
+  session: SessionInfo,
+  assistants: AssistantMessage[],
+): SessionRelationshipRecord[] {
+  const firstTs =
+    assistants.length > 0 ? new Date(assistants[0]!.time.created).toISOString() : undefined;
+  const root: SessionRelationshipRecord = {
+    v: 1,
+    source: 'opencode',
+    sessionId: session.id,
+    relationshipType: 'root',
+  };
+  if (firstTs !== undefined) root.ts = firstTs;
+  const out = [root];
+  if (typeof session.parentID === 'string' && session.parentID.length > 0) {
+    const sub: SessionRelationshipRecord = {
+      v: 1,
+      source: 'native-opencode',
+      sessionId: session.id,
+      relatedSessionId: session.parentID,
+      relationshipType: 'subagent',
+    };
+    if (firstTs !== undefined) sub.ts = firstTs;
+    out.push(sub);
+  }
+  return out;
+}
+
+function collectToolResultEventsForSession(
+  sessionId: string,
+  assistants: AssistantMessage[],
+  partsFor: (messageId: string) => Part[],
+): ToolResultEventRecord[] {
+  const out: ToolResultEventRecord[] = [];
+  const callIndexCounters = new Map<string, number>();
+  let eventIndex = 0;
+  for (const m of assistants) {
+    const parts = partsFor(m.id);
+    if (!isFinalAssistant(m, parts)) continue;
+    const terminalTools = parts.filter(isTerminalToolPart);
+    const turnUsage = toUsage(m.tokens);
+    const usageShare =
+      terminalTools.length > 0 ? divideUsage(turnUsage, terminalTools.length) : undefined;
+    const usageAttribution =
+      terminalTools.length === 1
+        ? 'single-tool-turn'
+        : terminalTools.length > 1
+          ? 'even-split-turn'
+          : undefined;
+    for (const tp of terminalTools) {
+      const state = tp.state!;
+      const isError = isFailedTool(tp);
+      const callIndex = callIndexCounters.get(tp.callID) ?? 0;
+      callIndexCounters.set(tp.callID, callIndex + 1);
+      const record: ToolResultEventRecord = {
+        v: 1,
+        source: 'opencode',
+        sessionId,
+        messageId: m.id,
+        toolUseId: tp.callID,
+        callIndex,
+        eventIndex: eventIndex++,
+        ts: new Date(m.time.created).toISOString(),
+        status: isError ? 'errored' : 'completed',
+        eventSource: 'tool_result',
+      };
+      if (isError) record.isError = true;
+      if (usageShare !== undefined) {
+        record.usage = usageShare;
+        if (usageAttribution !== undefined) record.usageAttribution = usageAttribution;
+      }
+      const measured = measureToolOutput(state.output);
+      if (measured.length !== undefined) record.contentLength = measured.length;
+      if (measured.hash !== undefined) record.contentHash = measured.hash;
+      out.push(record);
+    }
+  }
+  return out;
+}
+
+function toolEventKey(ev: ToolResultEventRecord): string {
+  return `${ev.sessionId}|${ev.toolUseId}|${ev.eventIndex}`;
+}
+
+function buildTurnRecord(
+  session: SessionInfo,
+  m: AssistantMessage,
+  turnIndex: number,
+  parts: Part[],
+  toolCalls: ToolCall[],
+  filesTouched: string[],
+  erroredCallIds: Set<string>,
+  usage: Usage,
+  userText: string,
+): TurnRecord {
+  const model = buildModel(m.providerID, m.modelID);
+  const project = m.path?.cwd ?? session.directory;
+  let usageCoverage = coverageFromTokens(m.tokens);
+  for (const sf of stepFinishTokens(parts)) {
+    usageCoverage = mergeUsageCoverage(usageCoverage, coverageFromTokens(sf));
+  }
+  const record: TurnRecord = {
+    v: 1,
+    source: 'opencode',
+    sessionId: m.sessionID,
+    messageId: m.id,
+    turnIndex,
+    ts: new Date(m.time.created).toISOString(),
+    model,
+    usage,
+    toolCalls,
+    fidelity: buildFidelity(usageCoverage),
+  };
+  if (project !== undefined) {
+    const resolved = resolveProject(project);
+    record.project = resolved.project;
+    if (resolved.projectKey !== undefined) record.projectKey = resolved.projectKey;
+  }
+  if (filesTouched.length > 0) record.filesTouched = filesTouched;
+  if (session.parentID) {
+    const sub: Subagent = { isSidechain: true };
+    record.subagent = sub;
+  }
+  const stopReason = lastStepFinishReason(parts);
+  if (stopReason !== undefined) record.stopReason = stopReason;
+  const assistantText = extractAssistantText(parts);
+  const hasFailedTool = toolCalls.some((tc) => erroredCallIds.has(tc.id));
+  const classified = classifyActivity({
+    toolCalls,
+    text: [userText, assistantText].filter((s) => s.length > 0).join('\n'),
+    hasFailedTool,
+    reasoningTokens: usage.reasoning,
+  });
+  record.activity = classified.activity;
+  record.retries = classified.retries;
+  record.hasEdits = classified.hasEdits;
+  return record;
+}
+
+function buildUserTurnRecord(
+  sessionId: string,
+  prev: AssistantMessage | undefined,
+  next: AssistantMessage,
+  userMsg: UserMessage | undefined,
+  prevParts: Part[],
+  userParts: Part[],
+  tokenCounter: UserTurnTokenCounter,
+): UserTurnRecord | undefined {
+  const blocks: UserTurnBlock[] = [];
+  if (prev) {
+    for (const p of prevParts) {
+      if (!isTerminalToolPart(p)) continue;
+      const isError = isFailedTool(p);
+      blocks.push(makeToolResultBlock(p.callID, p.state?.output ?? '', isError, tokenCounter));
+    }
+  }
+  let ts = userMsg ? new Date(userMsg.time.created).toISOString() : '';
+  for (const text of extractTextParts(userParts, { includeSynthetic: true })) {
+    blocks.push(makeTextBlock(text, tokenCounter));
+  }
+  if (blocks.length === 0) return undefined;
+  if (!ts) ts = new Date(next.time.created).toISOString();
+  const userUuid = userMsg ? userMsg.id : `${sessionId}:${prev?.id ?? 'start'}->${next.id}`;
+  const record: UserTurnRecord = {
+    v: 1,
+    source: 'opencode',
+    sessionId,
+    userUuid,
+    ts,
+    blocks,
+    followingMessageId: next.id,
+  };
+  if (prev) record.precedingMessageId = prev.id;
+  return record;
+}
+
+function extractToolsAndFiles(parts: Part[]): {
+  toolCalls: ToolCall[];
+  filesTouched: string[];
+  erroredCallIds: Set<string>;
+} {
+  const toolCalls: ToolCall[] = [];
+  const seen = new Set<string>();
+  const files = new Set<string>();
+  const erroredCallIds = new Set<string>();
+  for (const p of parts) {
+    if (p.type !== 'tool') continue;
+    const tp = p as ToolPart;
+    if (typeof tp.callID !== 'string' || typeof tp.tool !== 'string') continue;
+    if (seen.has(tp.callID)) continue;
+    seen.add(tp.callID);
+    const input = tp.state?.input ?? {};
+    const call: ToolCall = {
+      id: tp.callID,
+      name: tp.tool,
+      argsHash: argsHash(input),
+    };
+    const target = pickTarget(tp.tool, input);
+    if (target !== undefined) call.target = target;
+    if (tp.tool === 'skill') {
+      const skillName = input.skill ?? input.name ?? input.skill_name;
+      if (typeof skillName === 'string') call.skillName = skillName;
+    }
+    toolCalls.push(call);
+    if (target !== undefined && isFileTool(tp.tool)) files.add(target);
+    if (isFailedTool(tp)) erroredCallIds.add(tp.callID);
+  }
+  return { toolCalls, filesTouched: [...files], erroredCallIds };
+}
+
+function extractAssistantContent(
+  parts: Part[],
+  sessionId: string,
+  messageId: string,
+  ts: string,
+): ContentRecord[] {
+  const out: ContentRecord[] = [];
+  for (const p of parts) {
+    if (p.type === 'text') {
+      const tp = p as TextPart;
+      if (tp.synthetic === true) continue;
+      if (typeof tp.text === 'string' && tp.text.length > 0) {
+        out.push({
+          v: 1,
+          source: 'opencode',
+          sessionId,
+          messageId,
+          ts,
+          role: 'assistant',
+          kind: 'text',
+          text: tp.text,
+        });
+      }
+      continue;
+    }
+    if (p.type === 'tool') {
+      const tp = p as ToolPart;
+      if (typeof tp.callID !== 'string' || typeof tp.tool !== 'string') continue;
+      const input = tp.state?.input ?? {};
+      out.push({
+        v: 1,
+        source: 'opencode',
+        sessionId,
+        messageId,
+        ts,
+        role: 'assistant',
+        kind: 'tool_use',
+        toolUse: { id: tp.callID, name: tp.tool, input },
+      });
+      const state = tp.state;
+      if (state && Object.prototype.hasOwnProperty.call(state, 'output')) {
+        const result: ContentRecord = {
+          v: 1,
+          source: 'opencode',
+          sessionId,
+          messageId,
+          ts,
+          role: 'tool_result',
+          kind: 'tool_result',
+          toolResult: { toolUseId: tp.callID, content: state.output ?? '' },
+        };
+        if (isFailedTool(tp)) result.toolResult!.isError = true;
+        out.push(result);
+      }
+    }
+  }
+  return out;
+}
+
+function extractTextParts(parts: Part[], opts: { includeSynthetic: boolean }): string[] {
+  const out: string[] = [];
+  for (const p of parts) {
+    if (p.type !== 'text') continue;
+    const tp = p as TextPart;
+    if (!opts.includeSynthetic && tp.synthetic === true) continue;
+    if (typeof tp.text === 'string' && tp.text.length > 0) out.push(tp.text);
+  }
+  return out;
+}
+
+function isTerminalToolPart(p: Part): p is ToolPart & { callID: string } {
+  if (p.type !== 'tool') return false;
+  const tp = p as ToolPart;
+  if (typeof tp.callID !== 'string' || tp.callID.length === 0) return false;
+  const state = tp.state;
+  return !!state && Object.prototype.hasOwnProperty.call(state, 'output');
+}
+
+function isFailedTool(tp: ToolPart): boolean {
+  const state = tp.state;
+  if (!state) return false;
+  if (state.status === 'error') return true;
+  const exit = state.metadata?.exit;
+  if (typeof exit === 'number' && exit !== 0) return true;
+  return false;
+}
+
+function extractAssistantText(parts: Part[]): string {
+  return extractTextParts(parts, { includeSynthetic: false }).join('\n');
+}
+
+function findPrecedingUser(users: UserMessage[], tsCreated: number): UserMessage | undefined {
+  let best: UserMessage | undefined;
+  for (const u of users) {
+    if (u.time.created <= tsCreated) best = u;
+    else break;
+  }
+  return best;
+}
+
+function pickTarget(name: string, input: Record<string, unknown>): string | undefined {
+  const s = (k: string): string | undefined => {
+    const v = input[k];
+    return typeof v === 'string' ? v : undefined;
+  };
+  switch (name) {
+    case 'read':
+    case 'write':
+    case 'edit':
+      return s('filePath') ?? s('file_path') ?? s('path');
+    case 'bash':
+      return s('command');
+    case 'grep':
+    case 'glob':
+      return s('pattern');
+    case 'webfetch':
+      return s('url');
+    case 'task':
+      return s('subagent_type') ?? s('description') ?? s('prompt');
+    default:
+      return s('filePath') ?? s('file_path') ?? s('path') ?? s('url') ?? s('command');
+  }
+}
+
+function isFileTool(name: string): boolean {
+  return name === 'read' || name === 'write' || name === 'edit';
+}
+
+function lastStepFinishReason(parts: Part[]): string | undefined {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const p = parts[i]!;
+    if (p.type === 'step-finish') {
+      const sf = p as StepFinishPart;
+      if (typeof sf.reason === 'string') return sf.reason;
+    }
+  }
+  return undefined;
+}
+
+function stepFinishTokens(parts: Part[]): MessageTokens[] {
+  const out: MessageTokens[] = [];
+  for (const p of parts) {
+    if (p.type !== 'step-finish') continue;
+    const sf = p as StepFinishPart;
+    if (sf.tokens) out.push(sf.tokens);
+  }
+  return out;
+}
+
+function buildModel(providerID: string | undefined, modelID: string | undefined): string {
+  if (providerID && modelID) return `${providerID}/${modelID}`;
+  return modelID ?? providerID ?? '';
+}
+
+function toUsage(t: MessageTokens | undefined): Usage {
+  const input = t?.input ?? 0;
+  const output = t?.output ?? 0;
+  const reasoning = t?.reasoning ?? 0;
+  const cacheRead = t?.cache?.read ?? 0;
+  const cacheWrite = t?.cache?.write ?? 0;
+  return {
+    input,
+    output,
+    reasoning,
+    cacheRead,
+    cacheCreate5m: cacheWrite,
+    cacheCreate1h: 0,
+  };
+}
+
+function divideUsage(usage: Usage, divisor: number): Usage {
+  if (divisor <= 1) return { ...usage };
+  return {
+    input: usage.input / divisor,
+    output: usage.output / divisor,
+    reasoning: usage.reasoning / divisor,
+    cacheRead: usage.cacheRead / divisor,
+    cacheCreate5m: usage.cacheCreate5m / divisor,
+    cacheCreate1h: usage.cacheCreate1h / divisor,
+  };
+}
+
+type OpencodeUsageCoverage = Pick<
+  Coverage,
+  | 'hasInputTokens'
+  | 'hasOutputTokens'
+  | 'hasReasoningTokens'
+  | 'hasCacheReadTokens'
+  | 'hasCacheCreateTokens'
+>;
+
+function coverageFromTokens(t: MessageTokens | undefined): OpencodeUsageCoverage {
+  return {
+    hasInputTokens: t?.input !== undefined,
+    hasOutputTokens: t?.output !== undefined,
+    hasReasoningTokens: t?.reasoning !== undefined,
+    hasCacheReadTokens: t?.cache?.read !== undefined,
+    hasCacheCreateTokens: t?.cache?.write !== undefined,
+  };
+}
+
+function mergeUsageCoverage(
+  a: OpencodeUsageCoverage,
+  b: OpencodeUsageCoverage,
+): OpencodeUsageCoverage {
+  return {
+    hasInputTokens: a.hasInputTokens || b.hasInputTokens,
+    hasOutputTokens: a.hasOutputTokens || b.hasOutputTokens,
+    hasReasoningTokens: a.hasReasoningTokens || b.hasReasoningTokens,
+    hasCacheReadTokens: a.hasCacheReadTokens || b.hasCacheReadTokens,
+    hasCacheCreateTokens: a.hasCacheCreateTokens || b.hasCacheCreateTokens,
+  };
+}
+
+function buildFidelity(usageCoverage: OpencodeUsageCoverage): Fidelity {
+  const coverage: Coverage = {
+    ...EMPTY_COVERAGE,
+    ...usageCoverage,
+    hasToolCalls: true,
+    hasToolResultEvents: true,
+    hasSessionRelationships: true,
+    hasRawContent: true,
+  };
+  return makeFidelity('per-turn', coverage);
+}
+
+function measureToolOutput(output: unknown): { length?: number; hash?: string } {
+  if (typeof output === 'string') return { length: output.length, hash: contentHash(output) };
+  if (output === undefined || output === null) return {};
+  try {
+    const serialized = JSON.stringify(output);
+    if (typeof serialized !== 'string') return {};
+    return { length: serialized.length, hash: contentHash(serialized) };
+  } catch {
+    return {};
+  }
+}

--- a/packages/reader/src/opencode-stream.ts
+++ b/packages/reader/src/opencode-stream.ts
@@ -102,6 +102,7 @@ export interface OpencodeStreamCursorState {
   lastEventId?: string;
   emittedMessageIds?: string[];
   emittedToolEventIds?: string[];
+  nextToolEventIndexBySession?: Record<string, number>;
 }
 
 export interface OpencodeStreamIngestOptions {
@@ -129,6 +130,11 @@ interface NormalizedEvent {
   properties: Record<string, unknown>;
 }
 
+interface ToolResultEventCandidate {
+  key: string;
+  record: Omit<ToolResultEventRecord, 'eventIndex'>;
+}
+
 export async function createOpencodeStreamIngestor(
   options: OpencodeStreamIngestOptions = {},
 ): Promise<OpencodeStreamIngestor> {
@@ -145,6 +151,7 @@ class Ingestor implements OpencodeStreamIngestor {
   private readonly partsByMessage = new Map<string, Map<string, Part>>();
   private readonly emittedMessageIds: Set<string>;
   private readonly emittedToolEventIds: Set<string>;
+  private readonly nextToolEventIndexBySession = new Map<string, number>();
   private lastEventId: string | undefined;
 
   constructor(options: OpencodeStreamIngestOptions, tokenCounter: UserTurnTokenCounter) {
@@ -153,6 +160,21 @@ class Ingestor implements OpencodeStreamIngestor {
     this.emittedMessageIds = new Set(options.cursor?.emittedMessageIds ?? []);
     this.emittedToolEventIds = new Set(options.cursor?.emittedToolEventIds ?? []);
     this.lastEventId = options.cursor?.lastEventId;
+    for (const [sessionId, next] of Object.entries(
+      options.cursor?.nextToolEventIndexBySession ?? {},
+    )) {
+      if (Number.isFinite(next) && next >= 0) {
+        this.nextToolEventIndexBySession.set(sessionId, next);
+      }
+    }
+    if (options.cursor?.nextToolEventIndexBySession === undefined) {
+      for (const [sessionId, next] of deriveNextToolEventIndexBySession(
+        options.cursor?.emittedToolEventIds ?? [],
+      )) {
+        const current = this.nextToolEventIndexBySession.get(sessionId) ?? 0;
+        if (next > current) this.nextToolEventIndexBySession.set(sessionId, next);
+      }
+    }
   }
 
   async ingest(payload: unknown, eventId?: string): Promise<OpencodeStreamIngestResult> {
@@ -209,6 +231,11 @@ class Ingestor implements OpencodeStreamIngestor {
       emittedToolEventIds: [...this.emittedToolEventIds],
     };
     if (this.lastEventId !== undefined) cursor.lastEventId = this.lastEventId;
+    if (this.nextToolEventIndexBySession.size > 0) {
+      cursor.nextToolEventIndexBySession = Object.fromEntries(
+        this.nextToolEventIndexBySession.entries(),
+      );
+    }
     return cursor;
   }
 
@@ -263,8 +290,20 @@ class Ingestor implements OpencodeStreamIngestor {
   private dropSession(sessionId: string): void {
     this.sessions.delete(sessionId);
     this.streamOwnedSessions.delete(sessionId);
+    const deletedMessageIds = new Set<string>();
     for (const [id, message] of this.messages.entries()) {
-      if (message.sessionID === sessionId) this.messages.delete(id);
+      if (message.sessionID === sessionId) {
+        deletedMessageIds.add(id);
+        this.messages.delete(id);
+      }
+    }
+    for (const [messageId, bucket] of this.partsByMessage.entries()) {
+      if (
+        deletedMessageIds.has(messageId) ||
+        [...bucket.values()].some((part) => part.sessionID === sessionId)
+      ) {
+        this.partsByMessage.delete(messageId);
+      }
     }
   }
 
@@ -286,14 +325,26 @@ class Ingestor implements OpencodeStreamIngestor {
         .sort((a, b) => a.time.created - b.time.created);
       relationships.push(...buildRelationships(session, assistants));
 
-      const allToolEvents = collectToolResultEventsForSession(sessionId, assistants, (messageId) =>
-        this.partsFor(messageId),
+      const toolEventCandidates = collectToolResultEventCandidatesForSession(
+        sessionId,
+        assistants,
+        (messageId) => this.partsFor(messageId),
       );
-      for (const ev of allToolEvents) {
-        const key = toolEventKey(ev);
+      let nextToolEventIndex = this.nextToolEventIndexBySession.get(sessionId) ?? 0;
+      let emittedAnyToolEvent = false;
+      for (const candidate of toolEventCandidates) {
+        const key = candidate.key;
         if (this.emittedToolEventIds.has(key)) continue;
         this.emittedToolEventIds.add(key);
+        const ev: ToolResultEventRecord = {
+          ...candidate.record,
+          eventIndex: nextToolEventIndex++,
+        };
         toolResultEvents.push(ev);
+        emittedAnyToolEvent = true;
+      }
+      if (emittedAnyToolEvent) {
+        this.nextToolEventIndexBySession.set(sessionId, nextToolEventIndex);
       }
 
       for (let i = 0; i < assistants.length; i++) {
@@ -459,14 +510,13 @@ function buildRelationships(
   return out;
 }
 
-function collectToolResultEventsForSession(
+function collectToolResultEventCandidatesForSession(
   sessionId: string,
   assistants: AssistantMessage[],
   partsFor: (messageId: string) => Part[],
-): ToolResultEventRecord[] {
-  const out: ToolResultEventRecord[] = [];
+): ToolResultEventCandidate[] {
+  const out: ToolResultEventCandidate[] = [];
   const callIndexCounters = new Map<string, number>();
-  let eventIndex = 0;
   for (const m of assistants) {
     const parts = partsFor(m.id);
     if (!isFinalAssistant(m, parts)) continue;
@@ -485,14 +535,13 @@ function collectToolResultEventsForSession(
       const isError = isFailedTool(tp);
       const callIndex = callIndexCounters.get(tp.callID) ?? 0;
       callIndexCounters.set(tp.callID, callIndex + 1);
-      const record: ToolResultEventRecord = {
+      const record: Omit<ToolResultEventRecord, 'eventIndex'> = {
         v: 1,
         source: 'opencode',
         sessionId,
         messageId: m.id,
         toolUseId: tp.callID,
         callIndex,
-        eventIndex: eventIndex++,
         ts: new Date(m.time.created).toISOString(),
         status: isError ? 'errored' : 'completed',
         eventSource: 'tool_result',
@@ -505,14 +554,35 @@ function collectToolResultEventsForSession(
       const measured = measureToolOutput(state.output);
       if (measured.length !== undefined) record.contentLength = measured.length;
       if (measured.hash !== undefined) record.contentHash = measured.hash;
-      out.push(record);
+      out.push({ key: toolEventKey(sessionId, m.id, tp, callIndex), record });
     }
   }
   return out;
 }
 
-function toolEventKey(ev: ToolResultEventRecord): string {
-  return `${ev.sessionId}|${ev.toolUseId}|${ev.eventIndex}`;
+function toolEventKey(
+  sessionId: string,
+  messageId: string,
+  part: ToolPart & { callID: string },
+  callIndex: number,
+): string {
+  const partId = typeof part.id === 'string' && part.id.length > 0 ? part.id : undefined;
+  return `${sessionId}|${messageId}|${part.callID}|${partId ?? callIndex}`;
+}
+
+function deriveNextToolEventIndexBySession(keys: readonly string[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const key of keys) {
+    const first = key.indexOf('|');
+    const last = key.lastIndexOf('|');
+    if (first <= 0 || last <= first) continue;
+    const maybeIndex = Number.parseInt(key.slice(last + 1), 10);
+    if (!Number.isFinite(maybeIndex) || maybeIndex < 0) continue;
+    const sessionId = key.slice(0, first);
+    const current = out.get(sessionId) ?? 0;
+    if (maybeIndex + 1 > current) out.set(sessionId, maybeIndex + 1);
+  }
+  return out;
 }
 
 function buildTurnRecord(

--- a/packages/reader/src/opencode.test.ts
+++ b/packages/reader/src/opencode.test.ts
@@ -912,6 +912,8 @@ describe('parseOpencodeSession execution graph (#42 / #93)', () => {
       assert.equal(ok.callIndex, 0);
       assert.equal(ok.eventIndex, 0);
       assert.equal(ok.ts, new Date(1_777_000_000_000).toISOString());
+      assert.equal(ok.usageAttribution, 'even-split-turn');
+      assert.equal(ok.usage?.input, 5 / 3);
 
       const errStatus = byId.get('call_err_status')!;
       assert.equal(errStatus.status, 'errored', 'state.status=error → errored');

--- a/packages/reader/src/opencode.ts
+++ b/packages/reader/src/opencode.ts
@@ -280,6 +280,7 @@ export async function parseOpencodeSessionIncremental(
       m.sessionID,
       m.id,
       new Date(m.time.created).toISOString(),
+      usage,
       toolResultEvents,
       callIndexCounters,
       nextEventIndex,
@@ -376,17 +377,25 @@ function collectOpencodeToolResultEvents(
   sessionId: string,
   messageId: string,
   ts: string,
+  turnUsage: Usage,
   out: ToolResultEventRecord[],
   callIndexCounters: Map<string, number>,
   startEventIndex: number,
 ): number {
   let nextIndex = startEventIndex;
+  const terminalTools = parts.filter(isTerminalToolPart);
+  const usageShare =
+    terminalTools.length > 0 ? divideUsage(turnUsage, terminalTools.length) : undefined;
+  const usageAttribution =
+    terminalTools.length === 1
+      ? 'single-tool-turn'
+      : terminalTools.length > 1
+        ? 'even-split-turn'
+        : undefined;
   for (const p of parts) {
-    if (p.type !== 'tool') continue;
-    const tp = p as ToolPart;
-    if (typeof tp.callID !== 'string' || tp.callID.length === 0) continue;
-    const state = tp.state;
-    if (!state || !Object.prototype.hasOwnProperty.call(state, 'output')) continue;
+    if (!isTerminalToolPart(p)) continue;
+    const tp = p;
+    const state = tp.state!;
     const isError = isFailedTool(tp);
     const callIndex = callIndexCounters.get(tp.callID) ?? 0;
     callIndexCounters.set(tp.callID, callIndex + 1);
@@ -403,12 +412,36 @@ function collectOpencodeToolResultEvents(
       eventSource: 'tool_result',
     };
     if (isError) record.isError = true;
+    if (usageShare !== undefined) {
+      record.usage = usageShare;
+      if (usageAttribution !== undefined) record.usageAttribution = usageAttribution;
+    }
     const measured = measureOpencodeToolOutput(state.output);
     if (measured.length !== undefined) record.contentLength = measured.length;
     if (measured.hash !== undefined) record.contentHash = measured.hash;
     out.push(record);
   }
   return nextIndex;
+}
+
+function isTerminalToolPart(p: Part): p is ToolPart & { callID: string } {
+  if (p.type !== 'tool') return false;
+  const tp = p as ToolPart;
+  if (typeof tp.callID !== 'string' || tp.callID.length === 0) return false;
+  const state = tp.state;
+  return !!state && Object.prototype.hasOwnProperty.call(state, 'output');
+}
+
+function divideUsage(usage: Usage, divisor: number): Usage {
+  if (divisor <= 1) return { ...usage };
+  return {
+    input: usage.input / divisor,
+    output: usage.output / divisor,
+    reasoning: usage.reasoning / divisor,
+    cacheRead: usage.cacheRead / divisor,
+    cacheCreate5m: usage.cacheCreate5m / divisor,
+    cacheCreate1h: usage.cacheCreate1h / divisor,
+  };
 }
 
 function measureOpencodeToolOutput(output: unknown): { length?: number; hash?: string } {

--- a/packages/reader/src/types.ts
+++ b/packages/reader/src/types.ts
@@ -304,6 +304,13 @@ export interface ToolResultEventRecord {
   contentHash?: string;
   isError?: boolean;
 
+  // Optional per-tool-call share of the assistant turn's usage. Some sources
+  // expose usage only at the completed assistant-message / step boundary, not
+  // per individual tool. When present, this is the parser's conservative
+  // allocation of that turn-level usage onto the terminal tool-result events.
+  usage?: Usage;
+  usageAttribution?: 'single-tool-turn' | 'even-split-turn';
+
   // For tool calls that spawn a subagent (Agent / Task / spawn_agent), the
   // child session id once the spawn resolves.
   subagentSessionId?: string;


### PR DESCRIPTION
Closes #92

Summary:
- Add a reader-level OpenCode stream ingestor that normalizes SSE events into turns, content, user turns, relationships, and tool-result events for sessions observed from session.created.
- Wire burn watch --opencode-stream to append stream-derived records, persist the Last-Event-ID cursor, and keep file polling as the fallback/drift path.
- Add conservative per-tool usage attribution for OpenCode tool-result events and content sidecar dedupe for stream/file overlap.
- Keep already-running sessions on file fallback to avoid stream event-index drift.

Tests:
- pnpm run build
- pnpm run test
- node --test --test-reporter=spec packages/reader/dist/opencode-stream.test.js packages/reader/dist/opencode.test.js packages/cli/dist/opencode-stream.test.js packages/ledger/dist/content.test.js
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
