### PR TITLE
Count Codex shell file reads in edit-heavy detector

### DIFF
--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@relayburn/analyze`.
 ### Changed
 
 - `buildSubagentTree()` now consumes `SessionRelationshipRecord` graphs when available, with legacy `TurnRecord.subagent` fallback and per-node `relationshipType`.
+- Edit-heavy detection now counts Codex `shell`/`exec_command` file reads through `cat`, `head`, and `tail`.
 
 ## [0.44.0] - 2026-04-29
 

--- a/packages/analyze/src/patterns.test.ts
+++ b/packages/analyze/src/patterns.test.ts
@@ -842,9 +842,9 @@ describe('detectPatterns — edit-heavy sessions (cross-harness)', () => {
     assert.equal(result.editHeavySessions.length, 0);
   });
 
-  it('grep / glob / LS / bash do NOT count as reads', async () => {
+  it('grep / glob / LS / Claude Bash do NOT count as reads', async () => {
     const pricing = await loadBuiltinPricing();
-    // 6 edits, plus 5 non-Read tools (Grep/Glob/LS/Bash). Ratio should still
+    // 6 edits, plus non-Read tools (Grep/Glob/LS/Bash). Ratio should still
     // be infinite — reads stay at 0.
     const turns = [
       ...editHeavyTurns('claude-code', 'Edit'),
@@ -852,6 +852,41 @@ describe('detectPatterns — edit-heavy sessions (cross-harness)', () => {
       turn({ sessionId: 's', messageId: 'g2', turnIndex: 7, toolCalls: [tc('g2', 'Glob', 'b')] }),
       turn({ sessionId: 's', messageId: 'g3', turnIndex: 8, toolCalls: [tc('g3', 'LS', 'c')] }),
       turn({ sessionId: 's', messageId: 'g4', turnIndex: 9, toolCalls: [tc('g4', 'Bash', 'cat /etc/hosts')] }),
+    ];
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 1);
+    assert.equal(result.editHeavySessions[0]!.readCount, 0);
+  });
+
+  it('counts Codex shell cat/head/tail file reads in the read:edit ratio', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = [
+      ...editHeavyTurns('codex', 'apply_patch'),
+      turn({ sessionId: 's', messageId: 'r1', turnIndex: 6, source: 'codex' as const, toolCalls: [tc('r1', 'shell', 'a', { target: 'cat package.json' })] }),
+      turn({ sessionId: 's', messageId: 'r2', turnIndex: 7, source: 'codex' as const, toolCalls: [tc('r2', 'exec_command', 'b', { target: 'head -n 20 src/main.ts' })] }),
+    ];
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 0);
+  });
+
+  it('reports a remaining Codex edit-heavy session with one shell file read', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = [
+      ...editHeavyTurns('codex', 'apply_patch'),
+      turn({ sessionId: 's', messageId: 'r1', turnIndex: 6, source: 'codex' as const, toolCalls: [tc('r1', 'exec_command', 'a', { target: 'tail -n 50 src/main.ts' })] }),
+    ];
+    const result = detectPatterns(turns, { pricing });
+    assert.equal(result.editHeavySessions.length, 1);
+    assert.equal(result.editHeavySessions[0]!.readCount, 1);
+    assert.equal(result.editHeavySessions[0]!.ratio, 6);
+  });
+
+  it('does not count unrelated Codex shell commands as reads', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns = [
+      ...editHeavyTurns('codex', 'apply_patch'),
+      turn({ sessionId: 's', messageId: 'b1', turnIndex: 6, source: 'codex' as const, toolCalls: [tc('b1', 'shell', 'a', { target: 'git status' })] }),
+      turn({ sessionId: 's', messageId: 'b2', turnIndex: 7, source: 'codex' as const, toolCalls: [tc('b2', 'exec_command', 'b', { target: 'git log --oneline | head -n 5' })] }),
     ];
     const result = detectPatterns(turns, { pricing });
     assert.equal(result.editHeavySessions.length, 1);

--- a/packages/analyze/src/patterns.ts
+++ b/packages/analyze/src/patterns.ts
@@ -263,13 +263,13 @@ const EDIT_HEAVY_MIN_EDITS = 5;
 
 // Tools whose normalized name (post `normalizeToolName`) counts as a "read of
 // file content" for the purposes of the read:edit ratio. Grep / Glob / LS
-// don't count — they discover files but don't read content. Bash is excluded
-// for the same reason: the model may `cat` via shell, but identifying that
-// from arguments is fragile and would inflate the read count for unrelated
-// shell calls. Keeping the set narrow matches the codeburn intent ("did the
-// model read the file before editing it?").
+// don't count — they discover files but don't read content. Codex also has no
+// dedicated read in some traces; the helper below recognizes its obvious
+// `cat`/`head`/`tail` shell reads without broadening Bash for other harnesses.
 const READ_TOOLS = new Set(['Read', 'NotebookRead']);
 const EDIT_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
+const CODEX_SHELL_NAMES = new Set(['exec_command', 'shell']);
+const CODEX_SHELL_READ_COMMANDS = new Set(['cat', 'head', 'tail']);
 
 export function detectPatterns(
   turns: TurnRecord[],
@@ -1279,7 +1279,7 @@ function detectEditHeavyForSession(
     let turnHasEdit = false;
     for (const call of t.toolCalls) {
       const name = normalizeToolName(call.name);
-      if (READ_TOOLS.has(name)) readCount++;
+      if (isReadForEditHeavy(call, t.source)) readCount++;
       else if (EDIT_TOOLS.has(name)) {
         editCount++;
         turnHasEdit = true;
@@ -1302,6 +1302,86 @@ function detectEditHeavyForSession(
     likelyRetries,
     cost: sumCostForTurns(dedupTurns(editTurns), pricing),
   }];
+}
+
+function isReadForEditHeavy(call: ToolCall, source: SourceKind): boolean {
+  if (READ_TOOLS.has(normalizeToolName(call.name))) return true;
+  return source === 'codex' && isCodexShellFileRead(call);
+}
+
+function isCodexShellFileRead(call: ToolCall): boolean {
+  if (!CODEX_SHELL_NAMES.has(call.name)) return false;
+  if (!call.target) return false;
+  return shellCommandHasFileRead(call.target);
+}
+
+function shellCommandHasFileRead(command: string): boolean {
+  for (const segment of command.split(/(?:&&|\|\||;|\n)/)) {
+    if (shellSegmentStartsWithFileRead(segment)) return true;
+  }
+  return false;
+}
+
+function shellSegmentStartsWithFileRead(segment: string): boolean {
+  const tokens = shellWords(segment);
+  let i = 0;
+  while (i < tokens.length && isShellEnvAssignment(tokens[i]!)) i++;
+  if (i >= tokens.length) return false;
+
+  const command = commandBasename(tokens[i]!);
+  if (!CODEX_SHELL_READ_COMMANDS.has(command)) return false;
+  return hasShellFileOperand(command, tokens.slice(i + 1));
+}
+
+function shellWords(segment: string): string[] {
+  return segment.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+}
+
+function isShellEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+function commandBasename(token: string): string {
+  const unquoted = stripShellQuotes(token);
+  const slash = unquoted.lastIndexOf('/');
+  return slash >= 0 ? unquoted.slice(slash + 1) : unquoted;
+}
+
+function stripShellQuotes(token: string): string {
+  if (token.length >= 2) {
+    const first = token[0];
+    const last = token[token.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
+}
+
+function hasShellFileOperand(command: string, tokens: string[]): boolean {
+  let skipNext = false;
+  for (const raw of tokens) {
+    const token = stripShellQuotes(raw);
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (token === '|' || token === '&&' || token === '||' || token === ';') break;
+    if (/^\d*>/.test(token) || token.startsWith('>')) {
+      if (/^\d*>+$/.test(token) || /^>+$/.test(token)) skipNext = true;
+      continue;
+    }
+    if (token.startsWith('<')) continue;
+    if (token === '-') continue;
+    if ((command === 'head' || command === 'tail') && (token === '-n' || token === '-c' || token === '--lines' || token === '--bytes')) {
+      skipNext = true;
+      continue;
+    }
+    if ((command === 'head' || command === 'tail') && /^[+-]?\d+$/.test(token)) continue;
+    if (token.startsWith('-')) continue;
+    return true;
+  }
+  return false;
 }
 
 function dedupTurns(turns: TurnRecord[]): TurnRecord[] {


### PR DESCRIPTION
## Summary

- Count Codex `shell`/`exec_command` calls that clearly read files through `cat`, `head`, or `tail` as reads for edit-heavy detection.
- Keep Claude/OpenCode Bash behavior unchanged and ignore unrelated Codex shell commands.
- Add focused edit-heavy detector coverage and an analyze changelog entry.

## Tests

- `pnpm run test:ts`

Closes #55
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
