### PR TITLE
Unify derived-state rebuild commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ A **content sidecar** (enabled by default) stores the full conversation separate
 
 Content is stored because it meaningfully strengthens several attribution and diagnostic paths — tool-call sizing becomes exact (no delta estimation), outcome inference gets a real signal, CLAUDE.md adherence checking becomes possible, and waste patterns can surface the specific error text that caused a retry loop rather than just a count.
 
-Retention defaults to 90 days for the sidecar, forever for the main ledger. Configure via `RELAYBURN_CONTENT_TTL_DAYS`. Prune is **source-aware**: a sidecar whose upstream session file (`~/.claude/projects/…`, `~/.codex/sessions/…`, `~/.local/share/opencode/storage/…`) still exists is left in place, because `burn rebuild --content` can rederive it. Run `burn content prune --force` (or set `RELAYBURN_PRUNE_FORCE=1`) to delete recoverable sidecars anyway.
+Retention defaults to 90 days for the sidecar, forever for the main ledger. Configure via `RELAYBURN_CONTENT_TTL_DAYS`. Prune is **source-aware**: a sidecar whose upstream session file (`~/.claude/projects/…`, `~/.codex/sessions/…`, `~/.local/share/opencode/storage/…`) still exists is left in place, because `burn rebuild content` can rederive it. Run `burn content prune --force` (or set `RELAYBURN_PRUNE_FORCE=1`) to delete recoverable sidecars anyway.
 
 Three content modes:
 
@@ -264,6 +264,7 @@ burn waste [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [-
 burn compare <model_a,model_b[,...]> [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--fidelity <class>] [--include-partial] [--json|--csv]
 burn run <claude|codex|opencode>  [--tag k=v ...] [-- <harness args>]
 burn watch   [--interval <ms>] [--once]
+burn rebuild index | classify | content | archive [--full] | all | status [--json]
 ```
 
 Provider filters are applied at query time; raw ledger model strings are not rewritten. `burn summary --by-provider --provider synthetic` groups Synthetic-routed turns under provider `synthetic` while pricing against the normalized model id. Recognized Synthetic model patterns are `hf:*`, `accounts/fireworks/models/*`, and `synthetic/*`.
@@ -295,16 +296,24 @@ By default, `burn compare` only aggregates turns with `usage-only` fidelity or b
 
 Output formats: TTY table (default), `--json` for scripts, `--csv` for spreadsheets. `--json` and `--csv` are mutually exclusive. The `--json` payload includes a `fidelity` block (`{ minimum, excluded, summary }`) computed against the unfiltered slice so consumers can render their own coverage UI.
 
-### `burn rebuild --reclassify` — backfill activity labels on old turns
+### `burn rebuild` — refresh derived state
 
-Ingested turns are classified at write time. If you upgrade burn or a classifier rule changes, already-ingested turns keep the label they had when they were written. Run `burn rebuild --reclassify` to re-run the classifier across the whole ledger using whatever signals are still available (tool calls from the ledger, user prompts and errored tool_results from the content sidecar when present).
+Burn stores a canonical append-only ledger plus rebuildable derived artifacts: the dedup indexes, content sidecars, activity labels, and `archive.sqlite` read model. Use `burn rebuild <target>` to refresh one artifact, or `burn rebuild all` to run content -> index -> classify -> archive.
 
 ```
-burn rebuild --reclassify           # only fills in turns with no activity set
-burn rebuild --reclassify --force   # overwrite every turn's activity
+burn rebuild status                 # index/content/classifier/archive status
+burn rebuild content                # backfill missing content sidecars and user turns
+burn rebuild index                  # rebuild ledger.idx and ledger.content.idx
+burn rebuild classify               # fill in missing activity labels
+burn rebuild classify --force       # overwrite every turn's activity
+burn rebuild archive                # apply the ledger tail to archive.sqlite
+burn rebuild archive --full         # drop and rebuild archive.sqlite from zero
+burn rebuild all                    # content -> index -> classify -> archive
 ```
 
-Default is non-destructive — turns that already have an activity stay as-is, so re-running is safe. `--force` is useful after a rule change when you want the whole ledger to reflect the new rules. The ledger is rewritten atomically under the same lock that `ingest` uses.
+Ingested turns are classified at write time. If you upgrade burn or a classifier rule changes, already-ingested turns keep the label they had when they were written. `burn rebuild classify` re-runs the classifier across the whole ledger using whatever signals are still available (tool calls from the ledger, user prompts and errored tool_results from the content sidecar when present).
+
+Classification rebuilds are non-destructive by default: turns that already have an activity stay as-is. `--force` is useful after a rule change when you want the whole ledger to reflect the new rules. The ledger is rewritten atomically under the same lock that `ingest` uses.
 
 ## Install (local dev)
 

--- a/landscape.md
+++ b/landscape.md
@@ -4,6 +4,8 @@ Reference notes from surveying ten token-usage tools in the Claude Code / multi-
 
 **Burn's meta-goal** (repeated here because it shapes every evaluation below): answer "would the same work cost less on a different model, harness, or tool — in dollars or quota consumption?" Everything in this doc is graded against that question, not against "is this tool well-built."
 
+Burn keeps derived local state deliberately disposable: dedup indexes, content sidecars, activity labels, and the SQLite archive are refreshed through `burn rebuild <target>` rather than separate maintenance verbs.
+
 ## Summary
 
 | # | Project | Stars | Stack | Shape | Load-bearing contribution |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -16,11 +16,13 @@ All notable changes to `@relayburn/cli`.
 
 ### Fixed
 
+- `burn rebuild archive vacuum` now preserves archive space reclamation after the top-level archive command removal.
+- `burn rebuild status` now streams ledger counts instead of materializing all turns.
 - `burn watch --opencode-stream` now preserves stream cursor progress when polling fallback saves file-ingest cursors concurrently.
 
 ### Removed
 
-- Removed the top-level `burn archive` command. Use `burn rebuild archive`, `burn rebuild archive --full`, or `burn rebuild status`.
+- Removed the top-level `burn archive` command. Use `burn rebuild archive`, `burn rebuild archive --full`, `burn rebuild archive vacuum`, or `burn rebuild status`.
 
 ## [0.45.0] - 2026-04-29
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,12 +10,17 @@ All notable changes to `@relayburn/cli`.
 
 ### Changed
 
+- `burn rebuild <target>` now owns derived-state maintenance for indexes, classification, content, archive builds, and status in one command family.
 - `burn waste --patterns tool-output-bloat` now sizes oversized tool output via cl100k token counts from user-turn enrichment instead of bytes/4 estimates. Findings on highly compressible payloads (repetitive logs, base64 dumps) may shift below the 15k default threshold.
 - `burn summary --subagent-tree` now reads persisted session relationships, including child-session subagents and fork/continuation annotations.
 
 ### Fixed
 
 - `burn watch --opencode-stream` now preserves stream cursor progress when polling fallback saves file-ingest cursors concurrently.
+
+### Removed
+
+- Removed the top-level `burn archive` command. Use `burn rebuild archive`, `burn rebuild archive --full`, or `burn rebuild status`.
 
 ## [0.45.0] - 2026-04-29
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { parseArgs } from './args.js';
-import { runArchive } from './commands/archive.js';
 import { runCompare } from './commands/compare.js';
 import { runContent, opportunisticPrune } from './commands/content.js';
 import { runContext } from './commands/context.js';
@@ -36,8 +35,7 @@ Usage:
   burn ingest        --runtime claude [--quiet]     (reads hook payload on stdin)
   burn mcp-server    [--session-id <uuid>]          (stdio MCP server for in-session self-query)
   burn content prune [--days <n>] [--force]
-  burn archive       build | rebuild | status [--json]
-  burn rebuild         --index | --reclassify [--force]
+  burn rebuild       index | classify | content | archive [--full] | all | status [--json]
 
 Examples:
   burn summary --since 24h
@@ -66,10 +64,10 @@ Examples:
   burn watch
   burn watch --opencode-stream
   burn content prune --days 30
-  burn archive status
-  burn archive build
-  burn archive rebuild
-  burn rebuild --reclassify
+  burn rebuild status
+  burn rebuild archive
+  burn rebuild archive --full
+  burn rebuild classify
 
 Provider filters are query-time only. Synthetic-routed models are recognized
 from hf:*, accounts/fireworks/models/*, and synthetic/* model IDs and are
@@ -113,8 +111,6 @@ async function main(): Promise<number> {
       return runMcpServer(args);
     case 'content':
       return runContent(args);
-    case 'archive':
-      return runArchive(args);
     case 'rebuild':
       return runRebuild(args);
     default:

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -35,7 +35,7 @@ Usage:
   burn ingest        --runtime claude [--quiet]     (reads hook payload on stdin)
   burn mcp-server    [--session-id <uuid>]          (stdio MCP server for in-session self-query)
   burn content prune [--days <n>] [--force]
-  burn rebuild       index | classify | content | archive [--full] | all | status [--json]
+  burn rebuild       index | classify | content | archive [--full|--vacuum] | all | status [--json]
 
 Examples:
   burn summary --since 24h
@@ -67,6 +67,7 @@ Examples:
   burn rebuild status
   burn rebuild archive
   burn rebuild archive --full
+  burn rebuild archive vacuum
   burn rebuild classify
 
 Provider filters are query-time only. Synthetic-routed models are recognized

--- a/packages/cli/src/commands/archive.test.ts
+++ b/packages/cli/src/commands/archive.test.ts
@@ -116,7 +116,7 @@ describe('burn rebuild archive/status CLI', () => {
       };
       index: unknown;
       content: unknown;
-      classifier: unknown;
+      classifier: { turns: number; classified: number; missing: number };
     };
     assert.equal(parsed.archive.exists, true);
     assert.equal(parsed.archive.upToDate, true);
@@ -124,7 +124,9 @@ describe('burn rebuild archive/status CLI', () => {
     assert.equal(parsed.archive.rowCounts.sessions, 1);
     assert.ok(parsed.index);
     assert.ok(parsed.content);
-    assert.ok(parsed.classifier);
+    assert.equal(parsed.classifier.turns, 2);
+    assert.equal(parsed.classifier.classified, 0);
+    assert.equal(parsed.classifier.missing, 2);
   });
 
   it('rebuild archive --full is idempotent against the same ledger', async () => {
@@ -144,6 +146,47 @@ describe('burn rebuild archive/status CLI', () => {
       archive: { rowCounts: { turns: number } };
     };
     assert.equal(afterStatus.archive.rowCounts.turns, beforeStatus.archive.rowCounts.turns);
+  });
+
+  it('rebuild archive --vacuum on a missing archive prints a hint and exits 0', async () => {
+    const out = await captureRun({ vacuum: true }, ['archive']);
+    assert.equal(out.code, 0);
+    assert.match(out.stdout, /no archive/);
+    assert.match(out.stdout, /burn rebuild archive/);
+  });
+
+  it('rebuild archive vacuum --json returns the archive vacuum result', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 's-vac-cli',
+        messageId: 'vac-cli-1',
+        ts: '2026-04-23T00:00:00.000Z',
+        usage: {
+          input: 123,
+          output: 45,
+          reasoning: 0,
+          cacheRead: 678,
+          cacheCreate5m: 0,
+          cacheCreate1h: 0,
+        },
+      }),
+    ]);
+    await captureRun({}, ['archive']);
+
+    const out = await captureRun({ json: true }, ['archive', 'vacuum']);
+    assert.equal(out.code, 0);
+    const parsed = JSON.parse(out.stdout) as {
+      existed: boolean;
+      beforeBytes: number;
+      afterBytes: number;
+      reclaimedBytes: number;
+      archivePath: string;
+    };
+    assert.equal(parsed.existed, true);
+    assert.equal(typeof parsed.beforeBytes, 'number');
+    assert.equal(typeof parsed.afterBytes, 'number');
+    assert.equal(typeof parsed.reclaimedBytes, 'number');
+    assert.match(parsed.archivePath, /archive\.sqlite$/);
   });
 
   it('archive status --json surfaces tool_result_events row count', async () => {

--- a/packages/cli/src/commands/archive.test.ts
+++ b/packages/cli/src/commands/archive.test.ts
@@ -7,7 +7,7 @@ import { after, beforeEach, describe, it } from 'node:test';
 import { appendToolResultEvents, appendTurns, stamp } from '@relayburn/ledger';
 import type { ToolResultEventRecord, TurnRecord } from '@relayburn/reader';
 
-import { runArchive } from './archive.js';
+import { runRebuild } from './rebuild.js';
 
 function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
   return {
@@ -56,7 +56,7 @@ async function captureRun(
   }) as typeof process.stderr.write;
   let code: number;
   try {
-    code = await runArchive({ flags, tags: {}, positional, passthrough: [] });
+    code = await runRebuild({ flags, tags: {}, positional, passthrough: [] });
   } finally {
     process.stdout.write = origStdout;
     process.stderr.write = origStderr;
@@ -64,7 +64,7 @@ async function captureRun(
   return { stdout, stderr, code };
 }
 
-describe('burn archive CLI', () => {
+describe('burn rebuild archive/status CLI', () => {
   let tmp: string;
   const originalRelay = process.env['RELAYBURN_HOME'];
 
@@ -79,13 +79,17 @@ describe('burn archive CLI', () => {
     await rm(tmp, { recursive: true, force: true });
   });
 
-  it('archive status reports "not built yet" before the first build', async () => {
+  it('rebuild status reports archive "not built yet" before the first build', async () => {
     const out = await captureRun({}, ['status']);
     assert.equal(out.code, 0);
     assert.match(out.stdout, /not built yet/);
+    assert.match(out.stdout, /index:/);
+    assert.match(out.stdout, /content:/);
+    assert.match(out.stdout, /classifier:/);
+    assert.match(out.stdout, /archive:/);
   });
 
-  it('archive build materializes the ledger and status reflects row counts', async () => {
+  it('rebuild archive materializes the ledger and status reflects row counts', async () => {
     await appendTurns([
       fakeTurn({ sessionId: 's-cli', messageId: 'cli-1' }),
       fakeTurn({
@@ -97,7 +101,7 @@ describe('burn archive CLI', () => {
     ]);
     await stamp({ sessionId: 's-cli' }, { workflowId: 'wf-cli' });
 
-    const buildOut = await captureRun({}, ['build']);
+    const buildOut = await captureRun({}, ['archive']);
     assert.equal(buildOut.code, 0);
     assert.match(buildOut.stdout, /archive build complete/);
     assert.match(buildOut.stdout, /2 turns applied/);
@@ -105,33 +109,41 @@ describe('burn archive CLI', () => {
     const statusOut = await captureRun({ json: true }, ['status']);
     assert.equal(statusOut.code, 0);
     const parsed = JSON.parse(statusOut.stdout) as {
-      exists: boolean;
-      upToDate: boolean;
-      rowCounts: { sessions: number; turns: number };
+      archive: {
+        exists: boolean;
+        upToDate: boolean;
+        rowCounts: { sessions: number; turns: number };
+      };
+      index: unknown;
+      content: unknown;
+      classifier: unknown;
     };
-    assert.equal(parsed.exists, true);
-    assert.equal(parsed.upToDate, true);
-    assert.equal(parsed.rowCounts.turns, 2);
-    assert.equal(parsed.rowCounts.sessions, 1);
+    assert.equal(parsed.archive.exists, true);
+    assert.equal(parsed.archive.upToDate, true);
+    assert.equal(parsed.archive.rowCounts.turns, 2);
+    assert.equal(parsed.archive.rowCounts.sessions, 1);
+    assert.ok(parsed.index);
+    assert.ok(parsed.content);
+    assert.ok(parsed.classifier);
   });
 
-  it('archive rebuild is idempotent against the same ledger', async () => {
+  it('rebuild archive --full is idempotent against the same ledger', async () => {
     await appendTurns([fakeTurn({ sessionId: 's-rb', messageId: 'rb-1' })]);
-    await captureRun({}, ['build']);
+    await captureRun({}, ['archive']);
     const before = await captureRun({ json: true }, ['status']);
     const beforeStatus = JSON.parse(before.stdout) as {
-      rowCounts: { turns: number };
+      archive: { rowCounts: { turns: number } };
     };
 
-    const rebuildOut = await captureRun({}, ['rebuild']);
+    const rebuildOut = await captureRun({ full: true }, ['archive']);
     assert.equal(rebuildOut.code, 0);
     assert.match(rebuildOut.stdout, /rebuilt archive/);
 
     const after = await captureRun({ json: true }, ['status']);
     const afterStatus = JSON.parse(after.stdout) as {
-      rowCounts: { turns: number };
+      archive: { rowCounts: { turns: number } };
     };
-    assert.equal(afterStatus.rowCounts.turns, beforeStatus.rowCounts.turns);
+    assert.equal(afterStatus.archive.rowCounts.turns, beforeStatus.archive.rowCounts.turns);
   });
 
   it('archive status --json surfaces tool_result_events row count', async () => {
@@ -153,14 +165,14 @@ describe('burn archive CLI', () => {
       },
     ];
     await appendToolResultEvents(events);
-    await captureRun({}, ['build']);
+    await captureRun({}, ['archive']);
 
     const statusOut = await captureRun({ json: true }, ['status']);
     assert.equal(statusOut.code, 0);
     const parsed = JSON.parse(statusOut.stdout) as {
-      rowCounts: { toolResultEvents: number };
+      archive: { rowCounts: { toolResultEvents: number } };
     };
-    assert.equal(parsed.rowCounts.toolResultEvents, 1);
+    assert.equal(parsed.archive.rowCounts.toolResultEvents, 1);
 
     const human = await captureRun({}, ['status']);
     assert.match(human.stdout, /tool_result_events:\s+1/);
@@ -215,60 +227,29 @@ describe('burn archive CLI', () => {
         },
       }),
     ]);
-    await captureRun({}, ['build']);
+    await captureRun({}, ['archive']);
     const statusOut = await captureRun({ json: true }, ['status']);
     assert.equal(statusOut.code, 0);
     const parsed = JSON.parse(statusOut.stdout) as {
-      fidelityHistogram: Record<string, number>;
-      rowCounts: { turns: number };
+      archive: {
+        fidelityHistogram: Record<string, number>;
+        rowCounts: { turns: number };
+      };
     };
-    assert.equal(parsed.rowCounts.turns, 2);
-    assert.equal(parsed.fidelityHistogram['full'], 1);
-    assert.equal(parsed.fidelityHistogram['unknown'], 1);
+    assert.equal(parsed.archive.rowCounts.turns, 2);
+    assert.equal(parsed.archive.fidelityHistogram['full'], 1);
+    assert.equal(parsed.archive.fidelityHistogram['unknown'], 1);
   });
 
-  it('archive with no subcommand prints help and exits 0', async () => {
+  it('rebuild with no target prints help and exits 0', async () => {
     const out = await captureRun({}, []);
     assert.equal(out.code, 0);
-    assert.match(out.stdout, /burn archive/);
+    assert.match(out.stdout, /burn rebuild/);
   });
 
-  it('archive vacuum on a missing archive prints a hint and exits 0', async () => {
-    const out = await captureRun({}, ['vacuum']);
-    assert.equal(out.code, 0);
-    assert.match(out.stdout, /no archive at/);
-    assert.match(out.stdout, /burn archive build/);
-  });
-
-  it('archive vacuum --json shape includes before/after/reclaimed bytes', async () => {
-    await appendTurns([fakeTurn({ sessionId: 's-vc', messageId: 'vc-1' })]);
-    await captureRun({}, ['build']);
-    const out = await captureRun({ json: true }, ['vacuum']);
-    assert.equal(out.code, 0);
-    const parsed = JSON.parse(out.stdout) as {
-      existed: boolean;
-      beforeBytes: number;
-      afterBytes: number;
-      reclaimedBytes: number;
-    };
-    assert.equal(parsed.existed, true);
-    assert.equal(typeof parsed.beforeBytes, 'number');
-    assert.equal(typeof parsed.afterBytes, 'number');
-    assert.equal(typeof parsed.reclaimedBytes, 'number');
-    assert.equal(parsed.reclaimedBytes, parsed.beforeBytes - parsed.afterBytes);
-  });
-
-  it('archive vacuum prints a one-line text summary', async () => {
-    await appendTurns([fakeTurn({ sessionId: 's-vt', messageId: 'vt-1' })]);
-    await captureRun({}, ['build']);
-    const out = await captureRun({}, ['vacuum']);
-    assert.equal(out.code, 0);
-    assert.match(out.stdout, /archive: vacuumed .* -> .* \(reclaimed .*\)/);
-  });
-
-  it('archive with unknown subcommand exits non-zero', async () => {
+  it('rebuild with unknown target exits non-zero', async () => {
     const out = await captureRun({}, ['nope']);
     assert.notEqual(out.code, 0);
-    assert.match(out.stderr, /unknown subcommand/);
+    assert.match(out.stderr, /unknown target/);
   });
 });

--- a/packages/cli/src/commands/archive.ts
+++ b/packages/cli/src/commands/archive.ts
@@ -2,66 +2,55 @@ import {
   buildArchive,
   getArchiveStatus,
   rebuildArchive,
-  vacuumArchive,
+  type ArchiveStatus,
   type BuildResult,
 } from '@relayburn/ledger';
 
 import { formatInt } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
-const ARCHIVE_HELP = `burn archive — derived analytics archive (SQLite read model)
+export async function runArchiveBuild(
+  args: ParsedArgs,
+  opts: { full?: boolean } = {},
+): Promise<number> {
+  const result = opts.full ? await rebuildArchive() : await buildArchive();
+  return printArchiveBuildResult(result, args, opts.full ? 'rebuild' : 'build');
+}
 
-Usage:
-  burn archive build       Apply any ledger tail not yet materialized.
-  burn archive rebuild     Drop the archive and rebuild from the ledger.
-  burn archive status      Print schema version, row counts, and sync state.
-  burn archive vacuum      Reclaim free pages via SQLite VACUUM.
-  burn archive --help      Show this help.
-
-The archive is a disposable read model derived from \`ledger.jsonl\`. Deleting
-\`archive.sqlite\` and running \`burn archive rebuild\` always reproduces the
-same state — the ledger remains the canonical event log.
-
-See issue #40 for the broader plan (rewiring read commands onto the archive,
-content-sidecar bridging, full subagent / tool-result event tables).
-`;
-
-export async function runArchive(args: ParsedArgs): Promise<number> {
-  if (args.flags['help'] === true) {
-    process.stdout.write(ARCHIVE_HELP);
+export async function runArchiveStatus(args: ParsedArgs): Promise<number> {
+  const status = await getArchiveStatus();
+  if (args.flags['json'] === true) {
+    process.stdout.write(JSON.stringify(status, null, 2) + '\n');
     return 0;
   }
-  const sub = args.positional[0];
-  switch (sub) {
-    case undefined:
-    case 'help':
-      process.stdout.write(ARCHIVE_HELP);
-      return 0;
-    case 'build':
-      return runBuild(args);
-    case 'rebuild':
-      return runRebuild(args);
-    case 'status':
-      return runStatus(args);
-    case 'vacuum':
-      return runVacuum(args);
-    default:
-      process.stderr.write(`burn archive: unknown subcommand: ${sub}\n\n${ARCHIVE_HELP}`);
-      return 1;
+  process.stdout.write(formatArchiveStatusLines(status).join('\n') + '\n');
+  return 0;
+}
+
+export function formatArchiveStatusLines(status: ArchiveStatus): string[] {
+  const lines: string[] = [];
+  lines.push(`archive: ${status.archivePath}`);
+  if (!status.exists) {
+    lines.push('  status: not built yet - run `burn rebuild archive`');
+    return lines;
   }
+  lines.push(`  schema version: ${status.archiveVersion}`);
+  lines.push(
+    `  ledger cursor: ${formatInt(status.ledgerOffsetBytes)} / ${formatInt(status.ledgerSizeBytes)} bytes` +
+      (status.upToDate ? ' (up to date)' : ' (tail pending)'),
+  );
+  if (status.lastBuiltAt) lines.push(`  last build: ${status.lastBuiltAt}`);
+  if (status.lastRebuildAt) lines.push(`  last full rebuild: ${status.lastRebuildAt}`);
+  lines.push('  rows:');
+  lines.push(`    sessions:           ${formatInt(status.rowCounts.sessions)}`);
+  lines.push(`    turns:              ${formatInt(status.rowCounts.turns)}`);
+  lines.push(`    tool_calls:         ${formatInt(status.rowCounts.toolCalls)}`);
+  lines.push(`    tool_result_events: ${formatInt(status.rowCounts.toolResultEvents)}`);
+  lines.push(`    compactions:        ${formatInt(status.rowCounts.compactions)}`);
+  return lines;
 }
 
-async function runBuild(args: ParsedArgs): Promise<number> {
-  const result = await buildArchive();
-  return printBuildResult(result, args, 'build');
-}
-
-async function runRebuild(args: ParsedArgs): Promise<number> {
-  const result = await rebuildArchive();
-  return printBuildResult(result, args, 'rebuild');
-}
-
-function printBuildResult(
+function printArchiveBuildResult(
   result: BuildResult,
   args: ParsedArgs,
   mode: 'build' | 'rebuild',
@@ -87,69 +76,3 @@ function printBuildResult(
   process.stdout.write(lines.join('\n') + '\n');
   return 0;
 }
-
-async function runStatus(args: ParsedArgs): Promise<number> {
-  const status = await getArchiveStatus();
-  if (args.flags['json'] === true) {
-    process.stdout.write(JSON.stringify(status, null, 2) + '\n');
-    return 0;
-  }
-  const lines: string[] = [];
-  lines.push(`archive: ${status.archivePath}`);
-  if (!status.exists) {
-    lines.push('  status: not built yet — run `burn archive build`');
-    process.stdout.write(lines.join('\n') + '\n');
-    return 0;
-  }
-  lines.push(`  schema version: ${status.archiveVersion}`);
-  lines.push(
-    `  ledger cursor: ${formatInt(status.ledgerOffsetBytes)} / ${formatInt(status.ledgerSizeBytes)} bytes` +
-      (status.upToDate ? ' (up to date)' : ' (tail pending)'),
-  );
-  if (status.lastBuiltAt) lines.push(`  last build: ${status.lastBuiltAt}`);
-  if (status.lastRebuildAt) lines.push(`  last rebuild: ${status.lastRebuildAt}`);
-  lines.push('  rows:');
-  lines.push(`    sessions:           ${formatInt(status.rowCounts.sessions)}`);
-  lines.push(`    turns:              ${formatInt(status.rowCounts.turns)}`);
-  lines.push(`    tool_calls:         ${formatInt(status.rowCounts.toolCalls)}`);
-  lines.push(`    tool_result_events: ${formatInt(status.rowCounts.toolResultEvents)}`);
-  lines.push(`    compactions:        ${formatInt(status.rowCounts.compactions)}`);
-  process.stdout.write(lines.join('\n') + '\n');
-  return 0;
-}
-
-async function runVacuum(args: ParsedArgs): Promise<number> {
-  const result = await vacuumArchive();
-  if (args.flags['json'] === true) {
-    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-    return 0;
-  }
-  if (!result.existed) {
-    process.stdout.write(
-      `archive: no archive at ${result.archivePath} — run \`burn archive build\` first\n`,
-    );
-    return 0;
-  }
-  process.stdout.write(
-    `archive: vacuumed ${formatBytes(result.beforeBytes)} -> ${formatBytes(result.afterBytes)}` +
-      ` (reclaimed ${formatBytes(result.reclaimedBytes)})\n`,
-  );
-  return 0;
-}
-
-function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  const units = ['KB', 'MB', 'GB', 'TB'];
-  let v = n / 1024;
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  const fixed = v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
-  return `${fixed} ${units[i]}`;
-}
-
-// Exported for tests; the `--json` shape includes `fidelityHistogram`
-// (issue #110). Text mode intentionally omits the histogram per the issue
-// scope — JSON-only surfacing for now.

--- a/packages/cli/src/commands/archive.ts
+++ b/packages/cli/src/commands/archive.ts
@@ -2,6 +2,7 @@ import {
   buildArchive,
   getArchiveStatus,
   rebuildArchive,
+  vacuumArchive,
   type ArchiveStatus,
   type BuildResult,
 } from '@relayburn/ledger';
@@ -24,6 +25,25 @@ export async function runArchiveStatus(args: ParsedArgs): Promise<number> {
     return 0;
   }
   process.stdout.write(formatArchiveStatusLines(status).join('\n') + '\n');
+  return 0;
+}
+
+export async function runArchiveVacuum(args: ParsedArgs): Promise<number> {
+  const result = await vacuumArchive();
+  if (args.flags['json'] === true) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  if (!result.existed) {
+    process.stdout.write(
+      `archive: no archive at ${result.archivePath} - run \`burn rebuild archive\` first\n`,
+    );
+    return 0;
+  }
+  process.stdout.write(
+    `archive: vacuumed ${formatBytes(result.beforeBytes)} -> ${formatBytes(result.afterBytes)}` +
+      ` (reclaimed ${formatBytes(result.reclaimedBytes)})\n`,
+  );
   return 0;
 }
 
@@ -75,4 +95,17 @@ function printArchiveBuildResult(
   lines.push(`  ${formatInt(result.scannedBytes)} bytes scanned from ledger tail`);
   process.stdout.write(lines.join('\n') + '\n');
   return 0;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  const fixed = v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
+  return `${fixed} ${units[i]}`;
 }

--- a/packages/cli/src/commands/content.ts
+++ b/packages/cli/src/commands/content.ts
@@ -17,7 +17,7 @@ Flags:
   --days <n>   override retention (number of days, or 'forever' to disable)
   --force      delete sidecars even when the source session file still exists.
                Default behavior keeps recoverable sidecars in place because
-               'burn rebuild --content' can rederive them from the source.
+               'burn rebuild content' can rederive them from the source.
 
 Examples:
   burn content prune
@@ -135,7 +135,7 @@ export async function opportunisticPrune(): Promise<void> {
 //
 // Walk the same source roots that `ingest.ts` uses and build an in-memory
 // Set<sessionId>. Used to answer "is the upstream agent's session file still
-// on disk?" — if yes, the sidecar is recoverable via `burn rebuild --content`
+// on disk?" — if yes, the sidecar is recoverable via `burn rebuild content`
 // and prune should skip it.
 //
 // Cost: one readdir pass per root; ~100ms even on large ledgers. Run

--- a/packages/cli/src/commands/rebuild.ts
+++ b/packages/cli/src/commands/rebuild.ts
@@ -1,14 +1,17 @@
+import { createReadStream } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import * as path from 'node:path';
+import { createInterface } from 'node:readline';
 
 import {
   contentDir,
   getArchiveStatus,
+  isTurnLine,
+  isUserTurnLine,
   isValidSessionId,
   ledgerContentIndexPath,
   ledgerIndexPath,
-  queryAll,
-  queryUserTurns,
+  ledgerPath,
   rebuildIndex,
   reclassifyLedger,
 } from '@relayburn/ledger';
@@ -16,7 +19,7 @@ import {
 import { reingestMissingContent } from '../ingest.js';
 import { formatInt } from '../format.js';
 import type { ParsedArgs } from '../args.js';
-import { formatArchiveStatusLines, runArchiveBuild } from './archive.js';
+import { formatArchiveStatusLines, runArchiveBuild, runArchiveVacuum } from './archive.js';
 
 const REBUILD_HELP = `burn rebuild - rebuild derived ledger artifacts
 
@@ -24,7 +27,8 @@ Usage:
   burn rebuild index
   burn rebuild classify [--force]
   burn rebuild content
-  burn rebuild archive [--full] [--json]
+  burn rebuild archive [--full|--vacuum] [--json]
+  burn rebuild archive vacuum [--json]
   burn rebuild all [--force]
   burn rebuild status [--json]
 
@@ -32,7 +36,8 @@ Targets:
   index     rebuild the sidecar id and content-fingerprint indexes
   classify  re-run the activity classifier on ledger turns
   content   re-parse source session files to populate missing content
-  archive   apply the ledger tail to archive.sqlite; --full rebuilds from zero
+  archive   apply the ledger tail to archive.sqlite; --full rebuilds from zero;
+            --vacuum reclaims unused archive pages
   all       run content, index, classify, then archive
   status    print derived artifact status for index, content, classifier, archive
 
@@ -66,6 +71,20 @@ interface RebuildStatus {
   archive: Awaited<ReturnType<typeof getArchiveStatus>>;
 }
 
+interface ContentSidecarStatus {
+  path: string;
+  exists: boolean;
+  files: number;
+  sessions: number;
+  bytes: number;
+}
+
+interface LedgerDerivedCounts {
+  turns: number;
+  classified: number;
+  userTurns: number;
+}
+
 export async function runRebuild(args: ParsedArgs): Promise<number> {
   if (args.flags['help'] === true) {
     process.stdout.write(REBUILD_HELP);
@@ -85,7 +104,7 @@ export async function runRebuild(args: ParsedArgs): Promise<number> {
     case 'content':
       return runContent();
     case 'archive':
-      return runArchiveBuild(args, { full: args.flags['full'] === true });
+      return runArchiveTarget(args);
     case 'all':
       return runAll(args);
     case 'status':
@@ -94,6 +113,21 @@ export async function runRebuild(args: ParsedArgs): Promise<number> {
       process.stderr.write(`burn rebuild: unknown target: ${target}\n\n${REBUILD_HELP}`);
       return 1;
   }
+}
+
+async function runArchiveTarget(args: ParsedArgs): Promise<number> {
+  const action = args.positional[1];
+  const vacuum = args.flags['vacuum'] === true || action === 'vacuum';
+  if (action !== undefined && action !== 'build' && action !== 'vacuum') {
+    process.stderr.write(`burn rebuild archive: unknown action: ${action}\n\n${REBUILD_HELP}`);
+    return 1;
+  }
+  if (vacuum && args.flags['full'] === true) {
+    process.stderr.write(`burn rebuild archive: --full and --vacuum cannot be combined\n`);
+    return 1;
+  }
+  if (vacuum) return runArchiveVacuum(args);
+  return runArchiveBuild(args, { full: args.flags['full'] === true });
 }
 
 async function runAll(args: ParsedArgs): Promise<number> {
@@ -180,17 +214,21 @@ async function runStatus(args: ParsedArgs): Promise<number> {
 }
 
 async function collectRebuildStatus(): Promise<RebuildStatus> {
-  const [ids, content, contentSidecar, classifier, archive] = await Promise.all([
+  const [ids, content, contentSidecar, ledgerCounts, archive] = await Promise.all([
     indexFileStatus(ledgerIndexPath()),
     indexFileStatus(ledgerContentIndexPath()),
-    contentStatus(),
-    classifierStatus(),
+    contentSidecarStatus(),
+    ledgerDerivedCounts(),
     getArchiveStatus(),
   ]);
   return {
     index: { ids, content },
-    content: contentSidecar,
-    classifier,
+    content: { ...contentSidecar, userTurns: ledgerCounts.userTurns },
+    classifier: {
+      turns: ledgerCounts.turns,
+      classified: ledgerCounts.classified,
+      missing: ledgerCounts.turns - ledgerCounts.classified,
+    },
     archive,
   };
 }
@@ -210,21 +248,19 @@ async function indexFileStatus(filePath: string): Promise<IndexFileStatus> {
   }
 }
 
-async function contentStatus(): Promise<RebuildStatus['content']> {
+async function contentSidecarStatus(): Promise<ContentSidecarStatus> {
   const dir = contentDir();
   let entries: string[];
   try {
     entries = await readdir(dir);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-    const userTurns = await queryUserTurns();
     return {
       path: dir,
       exists: false,
       files: 0,
       sessions: 0,
       bytes: 0,
-      userTurns: userTurns.length,
     };
   }
 
@@ -246,25 +282,48 @@ async function contentStatus(): Promise<RebuildStatus['content']> {
       // Raced with prune; ignore the vanished file.
     }
   }
-  const userTurns = await queryUserTurns();
   return {
     path: dir,
     exists: true,
     files,
     sessions,
     bytes,
-    userTurns: userTurns.length,
   };
 }
 
-async function classifierStatus(): Promise<RebuildStatus['classifier']> {
-  const turns = await queryAll();
-  const classified = turns.filter((t) => typeof t.activity === 'string').length;
-  return {
-    turns: turns.length,
-    classified,
-    missing: turns.length - classified,
-  };
+async function ledgerDerivedCounts(): Promise<LedgerDerivedCounts> {
+  const filePath = ledgerPath();
+  const exists = await stat(filePath)
+    .then((s) => s.isFile())
+    .catch(() => false);
+  if (!exists) return { turns: 0, classified: 0, userTurns: 0 };
+
+  const counts: LedgerDerivedCounts = { turns: 0, classified: 0, userTurns: 0 };
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  });
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (isTurnLine(parsed)) {
+        counts.turns++;
+        if (typeof parsed.record.activity === 'string') counts.classified++;
+      } else if (isUserTurnLine(parsed)) {
+        counts.userTurns++;
+      }
+    }
+  } finally {
+    rl.close();
+  }
+  return counts;
 }
 
 function formatRebuildStatusLines(status: RebuildStatus): string[] {

--- a/packages/cli/src/commands/rebuild.ts
+++ b/packages/cli/src/commands/rebuild.ts
@@ -1,81 +1,326 @@
-import { rebuildIndex, reclassifyLedger } from '@relayburn/ledger';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import {
+  contentDir,
+  getArchiveStatus,
+  isValidSessionId,
+  ledgerContentIndexPath,
+  ledgerIndexPath,
+  queryAll,
+  queryUserTurns,
+  rebuildIndex,
+  reclassifyLedger,
+} from '@relayburn/ledger';
 
 import { reingestMissingContent } from '../ingest.js';
 import { formatInt } from '../format.js';
 import type { ParsedArgs } from '../args.js';
+import { formatArchiveStatusLines, runArchiveBuild } from './archive.js';
 
-const REBUILD_HELP = `burn rebuild — rebuild derived ledger artifacts
+const REBUILD_HELP = `burn rebuild - rebuild derived ledger artifacts
 
 Usage:
-  burn rebuild --index
-  burn rebuild --reclassify [--force]
-  burn rebuild --content
-  burn rebuild --index --reclassify [--force]
+  burn rebuild index
+  burn rebuild classify [--force]
+  burn rebuild content
+  burn rebuild archive [--full] [--json]
+  burn rebuild all [--force]
+  burn rebuild status [--json]
 
-Flags:
-  --index       rebuild the sidecar index
-  --reclassify  re-run the activity classifier on every ledger turn
-  --force       with --reclassify, overwrite activity even if already set
-  --content     re-parse source session files to populate missing content
-                sidecars and user-turn rows. Skips sessions already complete.
-                Does not touch cursors or existing ledger rows.
+Targets:
+  index     rebuild the sidecar id and content-fingerprint indexes
+  classify  re-run the activity classifier on ledger turns
+  content   re-parse source session files to populate missing content
+  archive   apply the ledger tail to archive.sqlite; --full rebuilds from zero
+  all       run content, index, classify, then archive
+  status    print derived artifact status for index, content, classifier, archive
 
 `;
 
-export async function runRebuild(args: ParsedArgs): Promise<number> {
-  const doIndex = args.flags['index'] === true;
-  const doReclassify = args.flags['reclassify'] === true;
-  const doContent = args.flags['content'] === true;
-  const force = args.flags['force'] === true;
+interface IndexFileStatus {
+  path: string;
+  exists: boolean;
+  bytes: number;
+  entries: number;
+}
 
-  if (!doIndex && !doReclassify && !doContent) {
+interface RebuildStatus {
+  index: {
+    ids: IndexFileStatus;
+    content: IndexFileStatus;
+  };
+  content: {
+    path: string;
+    exists: boolean;
+    files: number;
+    sessions: number;
+    bytes: number;
+    userTurns: number;
+  };
+  classifier: {
+    turns: number;
+    classified: number;
+    missing: number;
+  };
+  archive: Awaited<ReturnType<typeof getArchiveStatus>>;
+}
+
+export async function runRebuild(args: ParsedArgs): Promise<number> {
+  if (args.flags['help'] === true) {
     process.stdout.write(REBUILD_HELP);
     return 0;
   }
 
+  const target = args.positional[0];
+  switch (target) {
+    case undefined:
+    case 'help':
+      process.stdout.write(REBUILD_HELP);
+      return 0;
+    case 'index':
+      return runIndex();
+    case 'classify':
+      return runClassify(args);
+    case 'content':
+      return runContent();
+    case 'archive':
+      return runArchiveBuild(args, { full: args.flags['full'] === true });
+    case 'all':
+      return runAll(args);
+    case 'status':
+      return runStatus(args);
+    default:
+      process.stderr.write(`burn rebuild: unknown target: ${target}\n\n${REBUILD_HELP}`);
+      return 1;
+  }
+}
+
+async function runAll(args: ParsedArgs): Promise<number> {
   const lines: string[] = [];
+  await rebuildContent(lines);
+  await rebuildIndexTarget(lines);
+  await rebuildClassify(lines, args.flags['force'] === true);
+  const flags = { ...args.flags };
+  delete flags['json'];
+  const archiveArgs = { ...args, flags };
+  const result = await captureStdout(() => runArchiveBuild(archiveArgs, { full: false }));
+  lines.push(result.stdout.trimEnd());
+  process.stdout.write(lines.filter(Boolean).join('\n') + '\n');
+  return result.code;
+}
 
-  if (doReclassify) {
-    const report = await reclassifyLedger({ force });
-    const unchanged = report.processed - report.changed;
-    lines.push(
-      `reclassified ${formatInt(report.processed)} of ${formatInt(report.scanned)} turns` +
-        ` (${formatInt(report.skipped)} skipped, already classified)`,
-    );
-    lines.push(
-      `  ${formatInt(report.changed)} ended up with a different activity label,` +
-        ` ${formatInt(unchanged)} unchanged`,
-    );
-    if (report.changed > 0) {
-      const changes = Object.entries(report.changedByCategory).sort((a, b) => b[1] - a[1]);
-      for (const [cat, n] of changes) {
-        lines.push(`    → ${cat}: ${formatInt(n)}`);
-      }
-    }
-  }
-
-  if (doContent) {
-    const r = await reingestMissingContent();
-    lines.push(
-      `reingested derived content for ${formatInt(r.reingestedSessions)} sessions` +
-        ` (${formatInt(r.scannedFiles)} files scanned,` +
-        ` ${formatInt(r.skippedExisting)} already complete,` +
-        ` ${formatInt(r.appendedContent)} records appended,` +
-        ` ${formatInt(r.appendedUserTurns)} user turns appended,` +
-        ` ${formatInt(r.failed)} failed)`,
-    );
-  }
-
-  // Rebuild index after reclassify — ids/fingerprints are unchanged by
-  // reclassification today, but doing it together gives users one command for
-  // "fix up my ledger" and guards against future changes where they might.
-  if (doIndex) {
-    const { ids, content } = await rebuildIndex();
-    lines.push(
-      `rebuilt ledger index: ${formatInt(ids)} id hashes, ${formatInt(content)} content fingerprints`,
-    );
-  }
-
+async function runIndex(): Promise<number> {
+  const lines: string[] = [];
+  await rebuildIndexTarget(lines);
   process.stdout.write(lines.join('\n') + '\n');
   return 0;
+}
+
+async function runClassify(args: ParsedArgs): Promise<number> {
+  const lines: string[] = [];
+  await rebuildClassify(lines, args.flags['force'] === true);
+  process.stdout.write(lines.join('\n') + '\n');
+  return 0;
+}
+
+async function runContent(): Promise<number> {
+  const lines: string[] = [];
+  await rebuildContent(lines);
+  process.stdout.write(lines.join('\n') + '\n');
+  return 0;
+}
+
+async function rebuildClassify(lines: string[], force: boolean): Promise<void> {
+  const report = await reclassifyLedger({ force });
+  const unchanged = report.processed - report.changed;
+  lines.push(
+    `reclassified ${formatInt(report.processed)} of ${formatInt(report.scanned)} turns` +
+      ` (${formatInt(report.skipped)} skipped, already classified)`,
+  );
+  lines.push(
+    `  ${formatInt(report.changed)} ended up with a different activity label,` +
+      ` ${formatInt(unchanged)} unchanged`,
+  );
+  if (report.changed > 0) {
+    const changes = Object.entries(report.changedByCategory).sort((a, b) => b[1] - a[1]);
+    for (const [cat, n] of changes) {
+      lines.push(`    -> ${cat}: ${formatInt(n)}`);
+    }
+  }
+}
+
+async function rebuildContent(lines: string[]): Promise<void> {
+  const r = await reingestMissingContent();
+  lines.push(
+    `reingested derived content for ${formatInt(r.reingestedSessions)} sessions` +
+      ` (${formatInt(r.scannedFiles)} files scanned,` +
+      ` ${formatInt(r.skippedExisting)} already complete,` +
+      ` ${formatInt(r.appendedContent)} records appended,` +
+      ` ${formatInt(r.appendedUserTurns)} user turns appended,` +
+      ` ${formatInt(r.failed)} failed)`,
+  );
+}
+
+async function rebuildIndexTarget(lines: string[]): Promise<void> {
+  const { ids, content } = await rebuildIndex();
+  lines.push(
+    `rebuilt ledger index: ${formatInt(ids)} id hashes, ${formatInt(content)} content fingerprints`,
+  );
+}
+
+async function runStatus(args: ParsedArgs): Promise<number> {
+  const status = await collectRebuildStatus();
+  if (args.flags['json'] === true) {
+    process.stdout.write(JSON.stringify(status, null, 2) + '\n');
+    return 0;
+  }
+  process.stdout.write(formatRebuildStatusLines(status).join('\n') + '\n');
+  return 0;
+}
+
+async function collectRebuildStatus(): Promise<RebuildStatus> {
+  const [ids, content, contentSidecar, classifier, archive] = await Promise.all([
+    indexFileStatus(ledgerIndexPath()),
+    indexFileStatus(ledgerContentIndexPath()),
+    contentStatus(),
+    classifierStatus(),
+    getArchiveStatus(),
+  ]);
+  return {
+    index: { ids, content },
+    content: contentSidecar,
+    classifier,
+    archive,
+  };
+}
+
+async function indexFileStatus(filePath: string): Promise<IndexFileStatus> {
+  try {
+    const [raw, st] = await Promise.all([readFile(filePath, 'utf8'), stat(filePath)]);
+    return {
+      path: filePath,
+      exists: st.isFile(),
+      bytes: st.isFile() ? st.size : 0,
+      entries: st.isFile() ? countNonEmptyLines(raw) : 0,
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return { path: filePath, exists: false, bytes: 0, entries: 0 };
+  }
+}
+
+async function contentStatus(): Promise<RebuildStatus['content']> {
+  const dir = contentDir();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    const userTurns = await queryUserTurns();
+    return {
+      path: dir,
+      exists: false,
+      files: 0,
+      sessions: 0,
+      bytes: 0,
+      userTurns: userTurns.length,
+    };
+  }
+
+  let files = 0;
+  let sessions = 0;
+  let bytes = 0;
+  for (const name of entries) {
+    if (!name.endsWith('.jsonl')) continue;
+    const sessionId = name.slice(0, -'.jsonl'.length);
+    if (!isValidSessionId(sessionId)) continue;
+    const full = path.join(dir, name);
+    try {
+      const st = await stat(full);
+      if (!st.isFile()) continue;
+      files++;
+      bytes += st.size;
+      if (st.size > 0) sessions++;
+    } catch {
+      // Raced with prune; ignore the vanished file.
+    }
+  }
+  const userTurns = await queryUserTurns();
+  return {
+    path: dir,
+    exists: true,
+    files,
+    sessions,
+    bytes,
+    userTurns: userTurns.length,
+  };
+}
+
+async function classifierStatus(): Promise<RebuildStatus['classifier']> {
+  const turns = await queryAll();
+  const classified = turns.filter((t) => typeof t.activity === 'string').length;
+  return {
+    turns: turns.length,
+    classified,
+    missing: turns.length - classified,
+  };
+}
+
+function formatRebuildStatusLines(status: RebuildStatus): string[] {
+  const lines: string[] = [];
+  lines.push('derived state:');
+  lines.push('index:');
+  lines.push(`  id index: ${formatIndexFileStatus(status.index.ids, 'hashes')}`);
+  lines.push(`  content index: ${formatIndexFileStatus(status.index.content, 'fingerprints')}`);
+  lines.push('content:');
+  if (!status.content.exists) {
+    lines.push(`  status: not built yet at ${status.content.path}`);
+  } else {
+    lines.push(`  path: ${status.content.path}`);
+  }
+  lines.push(
+    `  sidecars: ${formatInt(status.content.files)} files,` +
+      ` ${formatInt(status.content.sessions)} non-empty sessions,` +
+      ` ${formatInt(status.content.bytes)} bytes`,
+  );
+  lines.push(`  user turns: ${formatInt(status.content.userTurns)} ledger rows`);
+  lines.push('classifier:');
+  lines.push(
+    `  turns: ${formatInt(status.classifier.classified)} classified /` +
+      ` ${formatInt(status.classifier.turns)} total` +
+      (status.classifier.missing > 0
+        ? ` (${formatInt(status.classifier.missing)} missing)`
+        : ' (complete)'),
+  );
+  lines.push(...formatArchiveStatusLines(status.archive));
+  return lines;
+}
+
+function formatIndexFileStatus(status: IndexFileStatus, noun: string): string {
+  if (!status.exists) return `missing at ${status.path}`;
+  return `${formatInt(status.entries)} ${noun}, ${formatInt(status.bytes)} bytes at ${status.path}`;
+}
+
+function countNonEmptyLines(raw: string): number {
+  let count = 0;
+  for (const line of raw.split('\n')) {
+    if (line.trim().length > 0) count++;
+  }
+  return count;
+}
+
+async function captureStdout(fn: () => Promise<number>): Promise<{ code: number; stdout: string }> {
+  const origStdout = process.stdout.write.bind(process.stdout);
+  let stdout = '';
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdout += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const code = await fn();
+    return { code, stdout };
+  } finally {
+    process.stdout.write = origStdout;
+  }
 }

--- a/packages/cli/src/commands/waste.test.ts
+++ b/packages/cli/src/commands/waste.test.ts
@@ -174,7 +174,7 @@ describe('formatWasteReport', () => {
       /⚠ attribution is degraded: 2 of 3 sessions \(66\.7%\) have no sized/,
     );
     // Remediation pointer is present.
-    assert.match(out, /burn rebuild --content/);
+    assert.match(out, /burn rebuild content/);
     assert.match(out, /burn content/);
     // Softened attributed line uses ≈ and the qualifier.
     assert.match(out, /attributed ≈ \$25\.00\s+\(approximate — see above\)/);

--- a/packages/cli/src/commands/waste.ts
+++ b/packages/cli/src/commands/waste.ts
@@ -418,7 +418,7 @@ export function formatWasteReport(input: FormatWasteReportInput): string {
       '  tool-result data, so file / bash / subagent costs for those sessions are approximate',
     );
     out.push(
-      "  (even-split over turn N+1 input/cacheCreate). Run 'burn rebuild --content'",
+      "  (even-split over turn N+1 input/cacheCreate). Run 'burn rebuild content'",
     );
     out.push(
       "  to backfill source-derived sizes, or see 'burn content' for",
@@ -440,7 +440,7 @@ export function formatWasteReport(input: FormatWasteReportInput): string {
       evenSplitSessions.length === result.sessionTotals.length
     ) {
       out.push(
-        'note: no user-turn or content sidecar sizes found — using even-split (initial cost only). Run burn rebuild --content or enable content.store=full to improve attribution.',
+        'note: no user-turn or content sidecar sizes found — using even-split (initial cost only). Run burn rebuild content or enable content.store=full to improve attribution.',
       );
     } else if (evenSplitSessions.length > 0) {
       out.push(

--- a/packages/cli/src/ingest.test.ts
+++ b/packages/cli/src/ingest.test.ts
@@ -256,7 +256,7 @@ describe('ingest forwards UserTurnRecord into the ledger (#94)', () => {
     assert.equal(second.length, 1, 'still one user-turn line after re-ingest');
   });
 
-  it('rebuild --content backfills user-turn rows even when content already exists', async () => {
+  it('rebuild content backfills user-turn rows even when content already exists', async () => {
     const sessionId = '33333333-3333-3333-3333-333333333333';
     await writeClaudeSession(
       tmpHome,
@@ -292,7 +292,7 @@ describe('ingest forwards UserTurnRecord into the ledger (#94)', () => {
     );
   });
 
-  it('rebuild --content skips renamed Codex rollouts using session_meta ids', async () => {
+  it('rebuild content skips renamed Codex rollouts using session_meta ids', async () => {
     const sessionId = 'sess_codex_renamed_rebuild_skip';
     await writeCodexSession(
       tmpHome,

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -610,7 +610,7 @@ export interface ReingestContentReport {
 }
 
 // Re-parse source session files to populate missing content sidecars and
-// user-turn rows. Used by `burn rebuild --content` to fix up historical
+// user-turn rows. Used by `burn rebuild content` to fix up historical
 // sessions ingested before those derived records were written (or where the
 // sidecar was pruned). Does NOT touch cursors, ledger turns, or compactions.
 export async function reingestMissingContent(): Promise<ReingestContentReport> {


### PR DESCRIPTION
Closes #153\n\n## Summary\n- replace the top-level archive command with rebuild targets for index, classify, content, archive, all, and status\n- add unified derived-state status output covering index, content, classifier, and archive state\n- update docs, changelog, and tests for the target-based command shape\n\n## Tests\n- pnpm run build\n- node --test --test-reporter=spec packages/cli/dist/commands/archive.test.js packages/cli/dist/commands/waste.test.js packages/cli/dist/ingest.test.js packages/cli/dist/commands/ingest.test.js\n- pnpm run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
