### PR TITLE
Rename attribution surfaces to hotspots and overhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ pnpm run pricing:update   # refresh the vendored models.dev snapshot
 
 Tests run from `dist/` so a stale build will lie. If a test fails unexpectedly, rebuild before debugging.
 
+Terminology note: the old `waste` / `diagnose` CLI and analyze API names are now `hotspots`, and the old `context` / `context advise` surface is now `overhead` / `overhead trim`. Do not add compatibility aliases for the old names.
+
 ## Changelog
 
 Curate `[Unreleased]` in the relevant per-package `packages/*/CHANGELOG.md` as you land PRs — write the entry the way you'd want it to read in a release note. At publish time, the workflow (`.github/workflows/publish.yml`) **promotes** your `[Unreleased]` block verbatim into `## [x.y.z] - DATE` and resets `[Unreleased]` to empty. No double-writing, no post-release hand-editing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ### Changed
 
+- Renamed the attribution surface: `burn hotspots` replaces `burn waste` and per-session `burn diagnose`, while `burn overhead` replaces `burn context`.
 - `burn summary --subagent-tree` now renders persisted session relationship graphs while preserving legacy subagent-tree output for older data.
 
 ### Fixed
@@ -33,7 +34,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `burn waste --patterns` now bases retry and failure findings on persisted tool-result chronology when available, while preserving legacy fallback behavior.
 - Spawn-env and native sidechain attribution now share session relationship records, and `burn diagnose --explain-drift` surfaces sessions where they disagree.
 - Provider-aware CLI rendering now uses shared analyze helpers for effective-provider resolution and aggregation.
-- Per-tool cost attribution now uses persisted user-turn block sizes in summary and waste reports, with rebuild backfill for historical sessions.
+- Per-tool cost attribution now uses persisted user-turn block sizes in summary and hotspots reports, with rebuild backfill for historical sessions.
 
 ## [0.42.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ### Changed
 
-- Renamed the attribution surface: `burn hotspots` replaces `burn waste` and per-session `burn diagnose`, while `burn overhead` replaces `burn context`.
+- Renamed the attribution surface: `burn hotspots` replaces `burn waste` and `burn diagnose`, while `burn overhead` replaces `burn context`.
 - `burn summary --subagent-tree` now renders persisted session relationship graphs while preserving legacy subagent-tree output for older data.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -260,13 +260,20 @@ You can override per-call via `costForUsage(usage, model, pricing, { reasoningMo
 ```
 burn summary [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--provider <p>]
              [--by-provider | --by-tool | --by-subagent-type | --by-relationship[=subagent] | --subagent-tree <session-id>]
-burn waste [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--provider <p>]
+burn hotspots [--since 7d] [--project <path>] [--workflow <id>] [--provider <p>] [--session <id>]
+burn overhead [trim] [--project <path>] [--since 7d] [--kind <claude-md|agents-md>]
 burn compare <model_a,model_b[,...]> [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--fidelity <class>] [--include-partial] [--json|--csv]
 burn run <claude|codex|opencode>  [--tag k=v ...] [-- <harness args>]
 burn watch   [--interval <ms>] [--once]
 ```
 
 Provider filters are applied at query time; raw ledger model strings are not rewritten. `burn summary --by-provider --provider synthetic` groups Synthetic-routed turns under provider `synthetic` while pricing against the normalized model id. Recognized Synthetic model patterns are `hf:*`, `accounts/fireworks/models/*`, and `synthetic/*`.
+
+### Renames from 0.45
+
+`burn hotspots` replaces `burn waste`; `burn hotspots --session <id>` replaces `burn diagnose <id>`. `burn overhead` replaces `burn context`, and `burn overhead trim` replaces `burn context advise`.
+
+For `@relayburn/analyze`, import `attributeHotspots`, `HotspotsResult`, `SessionTotals`, and `HotspotsOptions` from `hotspots`; import `attributeOverhead`, `findOverheadFiles`, `loadOverheadFile`, `OverheadAttribution`, and `buildTrimRecommendations` for the overhead pipeline.
 
 ### `burn compare` — model comparison by observed activity
 
@@ -333,4 +340,4 @@ User overrides go at `$RELAYBURN_HOME/models.dev.json` (or `~/.relayburn/models.
 
 ## Status
 
-v0: Claude Code reader shipped. OpenCode reader in progress. Codex reader scaffolded. Per-tool-call attribution (`burn waste`), CLAUDE.md hot-path analysis, quota-window tracking (`burn limits`), waste-pattern detection, and subagent-tree queries are scoped and tracked as open issues.
+v0: Claude Code reader shipped. OpenCode reader in progress. Codex reader scaffolded. Per-tool-call attribution (`burn hotspots`), CLAUDE.md hot-path analysis, quota-window tracking (`burn limits`), waste-pattern detection, and subagent-tree queries are scoped and tracked as open issues.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ You can override per-call via `costForUsage(usage, model, pricing, { reasoningMo
 ```
 burn summary [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--provider <p>]
              [--by-provider | --by-tool | --by-subagent-type | --by-relationship[=subagent] | --subagent-tree <session-id>]
-burn hotspots [--since 7d] [--project <path>] [--workflow <id>] [--provider <p>] [--session <id>]
+burn hotspots [--since 7d] [--project <path>] [--workflow <id>] [--provider <p>] [--session [id]] [--explain-drift]
 burn overhead [trim] [--project <path>] [--since 7d] [--kind <claude-md|agents-md>]
 burn compare <model_a,model_b[,...]> [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--fidelity <class>] [--include-partial] [--json|--csv]
 burn run <claude|codex|opencode>  [--tag k=v ...] [-- <harness args>]
@@ -271,7 +271,7 @@ Provider filters are applied at query time; raw ledger model strings are not rew
 
 ### Renames from 0.45
 
-`burn hotspots` replaces `burn waste`; `burn hotspots --session <id>` replaces `burn diagnose <id>`. `burn overhead` replaces `burn context`, and `burn overhead trim` replaces `burn context advise`.
+`burn hotspots` replaces `burn waste`; `burn hotspots --session` replaces aggregate `burn diagnose`, including `--explain-drift`, and `burn hotspots --session <id>` replaces `burn diagnose <id>`. `burn overhead` replaces `burn context`, and `burn overhead trim` replaces `burn context advise`.
 
 For `@relayburn/analyze`, import `attributeHotspots`, `HotspotsResult`, `SessionTotals`, and `HotspotsOptions` from `hotspots`; import `attributeOverhead`, `findOverheadFiles`, `loadOverheadFile`, `OverheadAttribution`, and `buildTrimRecommendations` for the overhead pipeline.
 

--- a/landscape.md
+++ b/landscape.md
@@ -305,7 +305,7 @@ Plus **structured fix actions** (`WasteAction = { type: 'paste' | 'command' | 'f
 
 ## Landscape takeaways
 
-1. **Nobody else does per-tool-call attribution.** All 10 tools stop at per-message or per-turn totals. Anthropic returns `usage` at the message level, and every surveyed project treated that as a ceiling. Burn's plan — delta-math fallback (#2), hook-path precise (#7), consumed by `burn waste` (#3) — is novel territory.
+1. **Nobody else does per-tool-call attribution.** All 10 tools stop at per-message or per-turn totals. Anthropic returns `usage` at the message level, and every surveyed project treated that as a ceiling. Burn's plan — delta-math fallback (#2), hook-path precise (#7), consumed by `burn hotspots` (#3) — is novel territory.
 
 2. **Nobody has a workflow/stamp concept.** Burn's `@relayburn/ledger.stamp` API for attributing turns to `workflowId` / `agentId` / `persona` at query time is unique in the landscape. Every competitor aggregates by source-harness or model. This is the primitive that makes cross-harness comparison possible for the meta-goal.
 
@@ -340,7 +340,7 @@ For each filed issue, the project(s) it drew from:
 | Issue | Title | Primary source(s) |
 |---|---|---|
 | #2 | Preserve user-turn block sizes | lazyagent (fallback when hooks unavailable) |
-| #3 | `burn waste` per-tool-call attribution | Original concept |
+| #3 | `burn hotspots` per-tool-call attribution | Original concept |
 | #4 | Incremental cursors + git-canonical project keys | TokenTracker (cursors, git); tokscale (fingerprint dedup, added later) |
 | #5 | `burn limits` quota-window tracking | TokenTracker (endpoints); ccusage (forecasting, added later) |
 | #6 | Outcome/quality signal design | Original concept; prism adherence rejected as primary |

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `@relayburn/analyze`.
 
 ### Changed
 
+- Renamed the public attribution APIs: `attributeHotspots` replaces `attributeWaste`, and `attributeOverhead` / `buildTrimRecommendations` replace the old context and advise names.
 - `detectToolOutputBloat` now sizes oversized tool output via cl100k token counts from user-turn enrichment, with a bytes/4 fallback for legacy ledgers. Highly compressible payloads (repetitive logs, base64 dumps) score lower in tokens and may slip below the 15k default threshold.
 - `buildSubagentTree()` now consumes `SessionRelationshipRecord` graphs when available, with legacy `TurnRecord.subagent` fallback and per-node `relationshipType`.
 - Edit-heavy detection now counts Codex `shell`/`exec_command` file reads through `cat`, `head`, and `tail`.

--- a/packages/analyze/src/claude-md.test.ts
+++ b/packages/analyze/src/claude-md.test.ts
@@ -8,7 +8,7 @@ import type { TurnRecord } from '@relayburn/reader';
 
 import {
   attributeClaudeMd,
-  buildAdviseRecommendations,
+  buildTrimRecommendations,
   findClaudeMdFiles,
   loadClaudeMdFile,
   parseClaudeMd,
@@ -311,7 +311,7 @@ describe('findClaudeMdFiles', () => {
   });
 });
 
-describe('buildAdviseRecommendations + renderUnifiedDiffForRecommendation', () => {
+describe('buildTrimRecommendations + renderUnifiedDiffForRecommendation', () => {
   it('emits a TRIM diff for the largest section that hand-applies cleanly', async () => {
     const pricing = await loadBuiltinPricing();
     const text = [
@@ -326,7 +326,7 @@ describe('buildAdviseRecommendations + renderUnifiedDiffForRecommendation', () =
       turn({ sessionId, messageId: 'm0', turnIndex: 0, usage: { input: 50, output: 10, reasoning: 0, cacheRead: parsed.tokens + 1000, cacheCreate5m: 0, cacheCreate1h: 0 } }),
     ];
     const attribution = attributeClaudeMd({ files: [parsed], turns, pricing });
-    const recs = buildAdviseRecommendations(attribution, 1);
+    const recs = buildTrimRecommendations(attribution, 1);
     assert.equal(recs.length, 1);
     assert.equal(recs[0]!.section.heading, '## Big');
     const diff = renderUnifiedDiffForRecommendation('/p/CLAUDE.md', text, recs[0]!);
@@ -344,7 +344,7 @@ describe('buildAdviseRecommendations + renderUnifiedDiffForRecommendation', () =
       turn({ sessionId: 's', messageId: 'm', turnIndex: 0, usage: { input: 10, output: 10, reasoning: 0, cacheRead: parsed.tokens + 100, cacheCreate5m: 0, cacheCreate1h: 0 } }),
     ];
     const attribution = attributeClaudeMd({ files: [parsed], turns, pricing });
-    const recs = buildAdviseRecommendations(attribution, 1);
+    const recs = buildTrimRecommendations(attribution, 1);
     const diff = renderUnifiedDiffForRecommendation(
       '/home/u/repo/CLAUDE.md',
       text,

--- a/packages/analyze/src/claude-md.ts
+++ b/packages/analyze/src/claude-md.ts
@@ -338,17 +338,17 @@ function percentile(sorted: number[], p: number): number {
   return sorted[idx]!;
 }
 
-export interface AdviseRecommendation {
+export interface TrimRecommendation {
   filePath: string;
   section: MarkdownSection;
   projectedSavingsPerSession: number;
   projectedSavingsAcrossWindow: number;
 }
 
-export function buildAdviseRecommendations(
+export function buildTrimRecommendations(
   attribution: ClaudeMdAttributionResult,
   topN = 3,
-): AdviseRecommendation[] {
+): TrimRecommendation[] {
   // Pick the most expensive non-preamble sections as TRIM candidates.
   const candidates = attribution.sectionCosts.filter((s) => s.section.level > 0);
   const top = candidates.slice(0, topN);
@@ -363,7 +363,7 @@ export function buildAdviseRecommendations(
 export function renderUnifiedDiffForRecommendation(
   filePath: string,
   fileText: string,
-  rec: AdviseRecommendation,
+  rec: TrimRecommendation,
   baseDir?: string,
 ): string {
   const normalized = fileText.replace(/\r\n/g, '\n');

--- a/packages/analyze/src/cost.ts
+++ b/packages/analyze/src/cost.ts
@@ -88,7 +88,7 @@ function reasoningModeForSource(source: SourceKind): ReasoningMode | undefined {
 
 // Shared lookup: direct match → synthetic reattribution (issue #31, e.g.
 // `hf:deepseek-ai/...`, `accounts/fireworks/models/...`) → generic
-// `provider/model` strip. Used by costForUsage here and by attributeWaste /
+// `provider/model` strip. Used by costForUsage here and by attributeHotspots /
 // attributeClaudeMd so synthetic-routed turns price consistently across views.
 export function lookupModelRate(model: string, pricing: PricingTable): ModelCost | undefined {
   const direct = pricing[model];

--- a/packages/analyze/src/findings.test.ts
+++ b/packages/analyze/src/findings.test.ts
@@ -52,7 +52,7 @@ describe('findings — retry loop adapter', () => {
     assert.equal(f.estimatedSavings.usdPerSession, 0.6);
     assert.equal(f.actions.length, 1);
     assert.equal(f.actions[0]!.type, 'command');
-    assert.match((f.actions[0] as { text: string }).text, /burn diagnose/);
+    assert.match((f.actions[0] as { text: string }).text, /burn hotspots --session/);
   });
 
   it('downgrades severity below thresholds', () => {

--- a/packages/analyze/src/findings.ts
+++ b/packages/analyze/src/findings.ts
@@ -6,7 +6,7 @@
 // downstream consumers that want it. This module wraps each one in a common
 // `WasteFinding` shape so the CLI can render every detector through one
 // table renderer, severity-rank a heterogeneous list, and (eventually) drive
-// a confirmation-gated `burn waste --apply` pipeline against typed
+// a confirmation-gated `burn hotspots --apply` pipeline against typed
 // `WasteAction`s instead of scraping strings.
 
 import type {
@@ -23,7 +23,7 @@ import type {
   SystemPromptTax,
 } from './patterns.js';
 
-// A typed action a finding suggests the user (or `burn waste --apply`) take.
+// A typed action a finding suggests the user (or `burn hotspots --apply`) take.
 // `paste` is text the user copies somewhere (CLAUDE.md, an agent prompt, a
 // chat message); `command` is a shell command; `file-content` is a full file
 // body to write to disk. Keeping the union closed lets `--apply` decide what
@@ -76,11 +76,11 @@ function severityFromUsd(usd: number): WasteSeverity {
   return 'info';
 }
 
-function diagnoseAction(sessionId: string): WasteAction {
+function hotspotsAction(sessionId: string): WasteAction {
   return {
     type: 'command',
     label: 'Inspect this session',
-    text: `burn diagnose ${sessionId}`,
+    text: `burn hotspots --session ${sessionId}`,
   };
 }
 
@@ -104,7 +104,7 @@ export function retryLoopToFinding(loop: RetryLoop): WasteFinding {
       `errored ${loop.tool} calls with the same arguments. Cumulative turn cost ` +
       `${fmtUsd(loop.cost)} — the agent kept retrying without changing inputs.`,
     estimatedSavings: { usdPerSession: loop.cost },
-    actions: [diagnoseAction(loop.sessionId)],
+    actions: [hotspotsAction(loop.sessionId)],
   };
   if (loop.eventSource !== undefined) finding.eventSource = loop.eventSource;
   return finding;
@@ -131,7 +131,7 @@ export function failureRunToFinding(run: FailureRun): WasteFinding {
       `Cumulative turn cost ${fmtUsd(run.cost)} — agent likely stuck without ` +
       `recovering or asking for help.${sigDetail}`,
     estimatedSavings: { usdPerSession: run.cost },
-    actions: [diagnoseAction(run.sessionId)],
+    actions: [hotspotsAction(run.sessionId)],
   };
   if (run.eventSource !== undefined) finding.eventSource = run.eventSource;
   return finding;
@@ -148,7 +148,7 @@ export function cancellationRunToFinding(run: CancellationRun): WasteFinding {
       `Turns ${run.startTurnIndex}-${run.endTurnIndex} ended with cancelled ` +
       `tool/subagent status (${toolList}). Cumulative turn cost ${fmtUsd(run.cost)}.`,
     estimatedSavings: { usdPerSession: run.cost },
-    actions: [diagnoseAction(run.sessionId)],
+    actions: [hotspotsAction(run.sessionId)],
     eventSource: run.eventSource,
   };
 }
@@ -180,7 +180,7 @@ export function compactionLossToFinding(loss: CompactionLoss): WasteFinding {
       `tokens of cache. Pre-compact cacheRead cost ${fmtUsd(loss.cacheLostCost)} — that ` +
       `cache won't be reused on subsequent turns.${lostWorkDetail}`,
     estimatedSavings: savings,
-    actions: [diagnoseAction(loss.sessionId)],
+    actions: [hotspotsAction(loss.sessionId)],
   };
 }
 
@@ -203,7 +203,7 @@ export function editRevertToFinding(cycle: EditRevertCycle): WasteFinding {
       `restored a prior file state ${cycle.spanTurns} turns later. Cumulative anchor-turn ` +
       `cost ${fmtUsd(cycle.cost)} — the intermediate work was erased.${previewDetail}`,
     estimatedSavings: { usdPerSession: cycle.cost },
-    actions: [diagnoseAction(cycle.sessionId)],
+    actions: [hotspotsAction(cycle.sessionId)],
   };
 }
 
@@ -224,7 +224,7 @@ export function editHeavyToFinding(session: EditHeavySession): WasteFinding {
       `turn cost ${fmtUsd(session.cost)} — careless editing without first reading ` +
       `surrounding context.`,
     estimatedSavings: { usdPerSession: session.cost },
-    actions: [diagnoseAction(session.sessionId)],
+    actions: [hotspotsAction(session.sessionId)],
   };
 }
 
@@ -239,7 +239,7 @@ export function skillRecallDupToFinding(dup: SkillRecallDup): WasteFinding {
       `calls (turns ${dup.firstTurnIndex}-${dup.lastTurnIndex}) re-injects the full ` +
       `SKILL.md content into context. Cumulative turn cost ${fmtUsd(dup.cost)}.`,
     estimatedSavings: { usdPerSession: dup.cost },
-    actions: [diagnoseAction(dup.sessionId)],
+    actions: [hotspotsAction(dup.sessionId)],
   };
 }
 
@@ -257,7 +257,7 @@ export function skillPruningProtectionToFinding(
       `cacheRead at turn ${prot.lastCachedTurnIndex}. Invoke + riding-turn cost ` +
       `${fmtUsd(prot.cost)}.`,
     estimatedSavings: { usdPerSession: prot.cost },
-    actions: [diagnoseAction(prot.sessionId)],
+    actions: [hotspotsAction(prot.sessionId)],
   };
 }
 
@@ -279,7 +279,7 @@ export function systemPromptTaxToFinding(tax: SystemPromptTax): WasteFinding {
       tokensPerSession: ridingTokens,
       usdPerSession: tax.totalCost,
     },
-    actions: [diagnoseAction(tax.sessionId)],
+    actions: [hotspotsAction(tax.sessionId)],
   };
 }
 

--- a/packages/analyze/src/ghost-surface.ts
+++ b/packages/analyze/src/ghost-surface.ts
@@ -711,7 +711,7 @@ function severityFromUsd(usd: number): WasteFinding['severity'] {
 // `~/.relayburn/ghost-archive/` keeps the move local to the relayburn data
 // dir so the user can reverse the action without polluting the harness's
 // own home directory. The CLI may override this when a future
-// `burn waste --apply` flag wants to confirm the destination.
+// `burn hotspots --apply` flag wants to confirm the destination.
 function defaultArchiveDir(): string {
   return path.join(os.homedir(), '.relayburn', 'ghost-archive');
 }
@@ -761,7 +761,7 @@ export function ghostSurfaceToFinding(
   // by usdPerSession in `sortFindings`.
   const sessionId = `ghost:${ghost.path}`;
   const dedupNote = ghost.countedByCatalogBloat
-    ? ' Cost is reported as $0 here because the OpenCode catalog-bloat detector already attributes this entry — see `burn waste --patterns opencode-system-prompt`.'
+    ? ' Cost is reported as $0 here because the OpenCode catalog-bloat detector already attributes this entry — see `burn hotspots --patterns opencode-system-prompt`.'
     : '';
   const sessionsClause =
     ghost.sessionCount > 0

--- a/packages/analyze/src/hotspots.test.ts
+++ b/packages/analyze/src/hotspots.test.ts
@@ -13,8 +13,8 @@ import {
   aggregateByBash,
   aggregateByFile,
   aggregateBySubagent,
-  attributeWaste,
-} from './waste.js';
+  attributeHotspots,
+} from './hotspots.js';
 
 function tc(id: string, name: string, target?: string): ToolCall {
   return {
@@ -67,14 +67,14 @@ function userTurn(
   };
 }
 
-describe('attributeWaste', () => {
+describe('attributeHotspots', () => {
   it('attributes the persistence of an 8k Read across 20 ride-along turns within ±10% of hand truth', async () => {
     const pricing = await loadBuiltinPricing();
     const rate = pricing['claude-sonnet-4-6']!;
     const READ_TOKENS = 8000;
     const READ_TEXT = 'x'.repeat(READ_TOKENS * 4); // 4 chars/token estimate
 
-    const sessionId = 's-waste-1';
+    const sessionId = 's-hotspots-1';
     const turns: TurnRecord[] = [];
 
     // Turn 0: assistant emits Read tool_use
@@ -120,7 +120,7 @@ describe('attributeWaste', () => {
       toolResultContent(sessionId, 'tu_read_1', READ_TEXT, '2026-04-20T00:00:00.500Z'),
     ]);
 
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     assert.equal(result.attributions.length, 1);
     const a = result.attributions[0]!;
     assert.equal(a.toolUseId, 'tu_read_1');
@@ -177,7 +177,7 @@ describe('attributeWaste', () => {
       toolResultContent(sessionId, 'tu_b', 'y'.repeat(SMALL_TOKENS * 4), '2026-04-20T00:00:00.101Z'),
     ]);
 
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     const files = aggregateByFile(result.attributions);
     assert.equal(files.length, 2);
     assert.equal(files[0]!.path, '/big.ts');
@@ -210,7 +210,7 @@ describe('attributeWaste', () => {
       toolResultContent(sessionId, 'tu_b_1', 'x'.repeat(4000), '2026-04-20T00:00:00.200Z'),
       toolResultContent(sessionId, 'tu_b_2', 'x'.repeat(4000), '2026-04-20T00:00:00.300Z'),
     ]);
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     const bash = aggregateByBash(result.attributions);
     assert.equal(bash.length, 1);
     assert.equal(bash[0]!.callCount, 3);
@@ -237,7 +237,7 @@ describe('attributeWaste', () => {
     contentBySession.set(sessionId, [
       toolResultContent(sessionId, 'tu_a1', 'z'.repeat(8000), '2026-04-20T00:00:00.100Z'),
     ]);
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     const subagents = aggregateBySubagent(result.attributions);
     assert.equal(subagents.length, 1);
     assert.equal(subagents[0]!.subagentType, 'general-purpose');
@@ -262,7 +262,7 @@ describe('attributeWaste', () => {
         usage: { input: 4000, output: 5, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
       }),
     ];
-    const result = attributeWaste(turns, { pricing });
+    const result = attributeHotspots(turns, { pricing });
     assert.equal(result.attributions.length, 2);
     // Even split: each tool gets half of the next turn's input cost.
     const rate = pricing['claude-sonnet-4-6']!;
@@ -306,7 +306,7 @@ describe('attributeWaste', () => {
       ]),
     ]);
 
-    const result = attributeWaste(turns, { pricing, userTurnsBySession });
+    const result = attributeHotspots(turns, { pricing, userTurnsBySession });
     const byId = new Map(result.attributions.map((a) => [a.toolUseId, a]));
     assert.equal(result.sessionTotals[0]!.attributionMethod, 'sized');
     assert.equal(byId.get('tu_big')!.initialTokens, 3000);
@@ -344,7 +344,7 @@ describe('attributeWaste', () => {
       ]),
     ]);
 
-    const result = attributeWaste(turns, {
+    const result = attributeHotspots(turns, {
       pricing,
       contentBySession,
       userTurnsBySession,
@@ -379,7 +379,7 @@ describe('attributeWaste', () => {
       toolResultContent(sessionId, 'tu_big', 'x'.repeat(6000 * 4), '2026-04-20T00:00:00.100Z'),
       toolResultContent(sessionId, 'tu_med', 'y'.repeat(4000 * 4), '2026-04-20T00:00:00.101Z'),
     ]);
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     const summed = result.attributions.reduce((s, a) => s + a.initialTokens, 0);
     assert.ok(summed <= 5000 + 1e-6, `summed=${summed} > newContent=5000`);
     const big = result.attributions.find((a) => a.toolUseId === 'tu_big')!;
@@ -422,7 +422,7 @@ describe('attributeWaste', () => {
       toolResultContent(sessionId, 'tu_a', 'x'.repeat(4000 * 4), '2026-04-20T00:00:00.100Z'),
       toolResultContent(sessionId, 'tu_b', 'y'.repeat(4000 * 4), '2026-04-20T00:00:00.101Z'),
     ]);
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     const summedPersist = result.attributions.reduce((s, a) => s + a.persistenceTokens, 0);
     assert.ok(summedPersist <= 5000 + 1e-6, `summedPersist=${summedPersist} > cacheRead=5000`);
     for (const a of result.attributions) {
@@ -467,7 +467,7 @@ describe('attributeWaste', () => {
     contentBySession.set(sessionId, [
       toolResultContent(sessionId, 'tu_x', 'z'.repeat(TOK * 4), '2026-04-20T00:00:00.100Z'),
     ]);
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     const a = result.attributions[0]!;
     const expectedInitial = (TOK / 1_000_000) * haiku.input;
     const expectedPersistence = (TOK / 1_000_000) * haiku.cacheRead;
@@ -476,9 +476,9 @@ describe('attributeWaste', () => {
   });
 
   it("session grand total honors source-aware reasoning semantics (Codex doesn't double-bill)", async () => {
-    // Regression test: `attributeWaste` must use the canonical `costForTurn`
+    // Regression test: `attributeHotspots` must use the canonical `costForTurn`
     // so it inherits per-source reasoning-billing semantics (`included_in_output`
-    // for Codex). Otherwise waste's `sessionGrand` overstates Codex spend by
+    // for Codex). Otherwise hotspots's `sessionGrand` overstates Codex spend by
     // `reasoning × output_rate`, contradicting `costForTurn` totals.
     const pricing = await loadBuiltinPricing();
     // Pick a model that exists in the snapshot under both Anthropic and openai
@@ -506,7 +506,7 @@ describe('attributeWaste', () => {
         },
       }),
     ];
-    const result = attributeWaste(turns, { pricing });
+    const result = attributeHotspots(turns, { pricing });
 
     const rate = pricing[codexModel]!;
     const expected =
@@ -539,7 +539,7 @@ describe('attributeWaste', () => {
     contentBySession.set(sessionId, [
       toolResultContent(sessionId, 'tu_z', 'q'.repeat(2000 * 4), '2026-04-20T00:00:00.500Z'),
     ]);
-    const result = attributeWaste(turns, { pricing, contentBySession });
+    const result = attributeHotspots(turns, { pricing, contentBySession });
     assert.ok(Math.abs(result.attributedTotal + result.unattributedTotal - result.grandTotal) < 1e-9);
   });
 });

--- a/packages/analyze/src/hotspots.ts
+++ b/packages/analyze/src/hotspots.ts
@@ -28,7 +28,7 @@ export interface ToolAttribution {
   totalCost: number;
 }
 
-export interface SessionWasteTotals {
+export interface SessionTotals {
   sessionId: string;
   grandCost: number;
   attributedCost: number;
@@ -36,15 +36,15 @@ export interface SessionWasteTotals {
   attributionMethod: AttributionMethod;
 }
 
-export interface WasteResult {
+export interface HotspotsResult {
   attributions: ToolAttribution[];
-  sessionTotals: SessionWasteTotals[];
+  sessionTotals: SessionTotals[];
   grandTotal: number;
   attributedTotal: number;
   unattributedTotal: number;
 }
 
-export interface AttributeWasteOptions {
+export interface HotspotsOptions {
   pricing: PricingTable;
   // sessionId -> ContentRecord[] in source order
   contentBySession?: Map<string, ContentRecord[]>;
@@ -60,10 +60,10 @@ interface PerTurnContent {
   toolResultText: Map<string, string>;
 }
 
-export function attributeWaste(
+export function attributeHotspots(
   turns: TurnRecord[],
-  opts: AttributeWasteOptions,
-): WasteResult {
+  opts: HotspotsOptions,
+): HotspotsResult {
   const { pricing, contentBySession, userTurnsBySession } = opts;
   const bySession = new Map<string, TurnRecord[]>();
   for (const t of turns) {
@@ -76,7 +76,7 @@ export function attributeWaste(
   }
 
   const attributions: ToolAttribution[] = [];
-  const sessionTotals: SessionWasteTotals[] = [];
+  const sessionTotals: SessionTotals[] = [];
   let grandTotal = 0;
   let attributedTotal = 0;
 
@@ -97,7 +97,7 @@ export function attributeWaste(
 
     let sessionGrand = 0;
     for (const t of sessionTurns) {
-      // Use the canonical `costForTurn` so waste-attribution totals stay
+      // Use the canonical `costForTurn` so hotspots attribution totals stay
       // consistent with `cost.ts` for sessions involving reasoning tokens
       // (Codex `included_in_output`, models with a separate reasoning tariff,
       // etc.). Returns null for unknown models — skip those, same as before.

--- a/packages/analyze/src/index.ts
+++ b/packages/analyze/src/index.ts
@@ -7,21 +7,21 @@ export type { CompareCategory, CompareCell, CompareOptions, CompareTable } from 
 export { compareFromArchive } from './compare-archive.js';
 export type { CompareFromArchiveResult } from './compare-archive.js';
 export {
-  attributeWaste,
+  attributeHotspots,
   aggregateByFile,
   aggregateByBash,
   aggregateBySubagent,
-} from './waste.js';
+} from './hotspots.js';
 export type {
   AttributionMethod,
-  AttributeWasteOptions,
+  HotspotsOptions,
   BashAggregation,
   FileAggregation,
-  SessionWasteTotals,
+  SessionTotals,
   SubagentAggregation,
   ToolAttribution,
-  WasteResult,
-} from './waste.js';
+  HotspotsResult,
+} from './hotspots.js';
 export {
   aggregateSubagentTypeStats,
   buildSubagentTree,
@@ -96,14 +96,14 @@ export type {
 } from './quality.js';
 export {
   attributeClaudeMd,
-  buildAdviseRecommendations,
+  buildTrimRecommendations,
   findClaudeMdFiles,
   loadClaudeMdFile,
   parseClaudeMd,
   renderUnifiedDiffForRecommendation,
 } from './claude-md.js';
 export type {
-  AdviseRecommendation,
+  TrimRecommendation,
   AttributeClaudeMdInput,
   ClaudeMdAttributionResult,
   MarkdownSection,
@@ -112,11 +112,11 @@ export type {
   SessionClaudeMdCost,
 } from './claude-md.js';
 export {
-  attributeContext,
+  attributeOverhead,
   describeAppliesTo,
-  findContextFiles,
-  loadContextFile,
-} from './context-md.js';
+  findOverheadFiles,
+  loadOverheadFile,
+} from './overhead.js';
 export { computePlanUsage, cycleBounds, planUsageFromArchive } from './plan-usage.js';
 export type {
   ComputePlanUsageFromArchiveOptions,
@@ -151,13 +151,13 @@ export type {
   UsageCostAggregateRow,
 } from './provider.js';
 export type {
-  AttributeContextInput,
-  ContextAttributionResult,
-  ContextFile,
-  ContextFileAttribution,
-  ContextFileKind,
-  ParsedContextFile,
-} from './context-md.js';
+  AttributeOverheadInput,
+  OverheadAttribution,
+  OverheadFile,
+  OverheadFileAttribution,
+  OverheadFileKind,
+  ParsedOverheadFile,
+} from './overhead.js';
 export {
   claudeGhostAdapter,
   codexGhostAdapter,

--- a/packages/analyze/src/overhead.test.ts
+++ b/packages/analyze/src/overhead.test.ts
@@ -8,11 +8,11 @@ import type { SourceKind, TurnRecord } from '@relayburn/reader';
 
 import { loadClaudeMdFile, parseClaudeMd } from './claude-md.js';
 import {
-  attributeContext,
-  findContextFiles,
-  type ContextFile,
-  type ParsedContextFile,
-} from './context-md.js';
+  attributeOverhead,
+  findOverheadFiles,
+  type OverheadFile,
+  type ParsedOverheadFile,
+} from './overhead.js';
 import { loadBuiltinPricing } from './pricing.js';
 
 function turn(over: Partial<TurnRecord> & {
@@ -31,7 +31,7 @@ function turn(over: Partial<TurnRecord> & {
   };
 }
 
-describe('findContextFiles', () => {
+describe('findOverheadFiles', () => {
   let tmp: string;
   before(async () => {
     tmp = await mkdtemp(path.join(tmpdir(), 'ctx-find-'));
@@ -45,7 +45,7 @@ describe('findContextFiles', () => {
     await mkdir(path.join(tmp, '.claude'), { recursive: true });
     await writeFile(path.join(tmp, '.claude', 'CLAUDE.md'), '# nested');
     await writeFile(path.join(tmp, 'AGENTS.md'), '# agents');
-    const files = await findContextFiles(tmp);
+    const files = await findOverheadFiles(tmp);
     assert.equal(files.length, 3);
     const root = files.find((f) => path.basename(f.path) === 'CLAUDE.md' && path.basename(path.dirname(f.path)) !== '.claude')!;
     const nested = files.find((f) => path.basename(f.path) === 'CLAUDE.md' && path.basename(path.dirname(f.path)) === '.claude')!;
@@ -58,7 +58,7 @@ describe('findContextFiles', () => {
   });
 });
 
-describe('attributeContext', () => {
+describe('attributeOverhead', () => {
   it('routes Claude Code turns to CLAUDE.md and Codex/OpenCode turns to AGENTS.md', async () => {
     const pricing = await loadBuiltinPricing();
     const rate = pricing['claude-sonnet-4-6']!;
@@ -66,7 +66,7 @@ describe('attributeContext', () => {
     const claudeMd = parseClaudeMd('/p/CLAUDE.md', '## Claude\n' + 'c'.repeat(4000));
     const agentsMd = parseClaudeMd('/p/AGENTS.md', '## Agents\n' + 'a'.repeat(4000));
 
-    const files: ParsedContextFile[] = [
+    const files: ParsedOverheadFile[] = [
       {
         file: { kind: 'claude-md', path: '/p/CLAUDE.md', appliesTo: ['claude-code'] },
         parsed: claudeMd,
@@ -104,7 +104,7 @@ describe('attributeContext', () => {
       }),
     ];
 
-    const result = attributeContext({ files, turns, pricing });
+    const result = attributeOverhead({ files, turns, pricing });
     assert.equal(result.perFile.length, 2);
 
     const claudeAttr = result.perFile.find((p) => p.file.kind === 'claude-md')!;
@@ -140,7 +140,7 @@ describe('attributeContext', () => {
     const pricing = await loadBuiltinPricing();
     const small = parseClaudeMd('/p/CLAUDE.md', '## S\n' + 'x'.repeat(2000));
     const big = parseClaudeMd('/p/.claude/CLAUDE.md', '## B\n' + 'y'.repeat(36000));
-    const files: ParsedContextFile[] = [
+    const files: ParsedOverheadFile[] = [
       {
         file: { kind: 'claude-md', path: '/p/CLAUDE.md', appliesTo: ['claude-code'] },
         parsed: small,
@@ -170,7 +170,7 @@ describe('attributeContext', () => {
         usage: { input: 10, output: 10, reasoning: 0, cacheRead: small.tokens + 500, cacheCreate5m: 0, cacheCreate1h: 0 },
       }));
     }
-    const result = attributeContext({ files, turns, pricing });
+    const result = attributeOverhead({ files, turns, pricing });
     const smallAttr = result.perFile.find((p) => p.parsed === small)!;
     const bigAttr = result.perFile.find((p) => p.parsed === big)!;
     assert.equal(smallAttr.attribution.sessionCosts[0]!.ridingTurns, 8); // all 8
@@ -183,7 +183,7 @@ describe('attributeContext', () => {
     const pricing = await loadBuiltinPricing();
     const claudeMd = parseClaudeMd('/p/CLAUDE.md', '## C\n' + 'x'.repeat(4000));
     const agentsMd = parseClaudeMd('/p/AGENTS.md', '## A\n' + 'y'.repeat(4000));
-    const files: ParsedContextFile[] = [
+    const files: ParsedOverheadFile[] = [
       {
         file: { kind: 'claude-md', path: '/p/CLAUDE.md', appliesTo: ['claude-code'] },
         parsed: claudeMd,
@@ -202,7 +202,7 @@ describe('attributeContext', () => {
         usage: { input: 10, output: 10, reasoning: 0, cacheRead: 50_000, cacheCreate5m: 0, cacheCreate1h: 0 },
       }),
     ];
-    const result = attributeContext({ files, turns, pricing });
+    const result = attributeOverhead({ files, turns, pricing });
     const claudeAttr = result.perFile.find((p) => p.file.kind === 'claude-md')!;
     // No claude-code turns ⇒ claude-md file has zero cost, zero sessions.
     assert.equal(claudeAttr.attribution.totalCost, 0);
@@ -210,7 +210,7 @@ describe('attributeContext', () => {
   });
 });
 
-describe('loadContextFile integration', () => {
+describe('loadOverheadFile integration', () => {
   let tmp: string;
   before(async () => {
     tmp = await mkdtemp(path.join(tmpdir(), 'ctx-load-'));
@@ -219,11 +219,11 @@ describe('loadContextFile integration', () => {
     await rm(tmp, { recursive: true, force: true });
   });
 
-  it('parses AGENTS.md via findContextFiles + loadClaudeMdFile', async () => {
+  it('parses AGENTS.md via findOverheadFiles + loadClaudeMdFile', async () => {
     await writeFile(path.join(tmp, 'AGENTS.md'), '## Section\nbody');
-    const files = await findContextFiles(tmp);
+    const files = await findOverheadFiles(tmp);
     assert.equal(files.length, 1);
-    const f = files[0] as ContextFile;
+    const f = files[0] as OverheadFile;
     const parsed = await loadClaudeMdFile(f.path);
     assert.equal(parsed.sections[0]!.heading, '## Section');
   });

--- a/packages/analyze/src/overhead.ts
+++ b/packages/analyze/src/overhead.ts
@@ -11,29 +11,29 @@ import {
 } from './claude-md.js';
 import type { PricingTable } from './pricing.js';
 
-export type ContextFileKind = 'claude-md' | 'agents-md';
+export type OverheadFileKind = 'claude-md' | 'agents-md';
 
-export interface ContextFile {
-  kind: ContextFileKind;
+export interface OverheadFile {
+  kind: OverheadFileKind;
   path: string;
   // Which agent sources read this file into their cached context. A turn's
   // `source` must be in this list for the file to count toward that turn.
   appliesTo: SourceKind[];
 }
 
-export interface ParsedContextFile {
-  file: ContextFile;
+export interface ParsedOverheadFile {
+  file: OverheadFile;
   parsed: ParsedClaudeMd;
 }
 
-export interface ContextFileAttribution {
-  file: ContextFile;
+export interface OverheadFileAttribution {
+  file: OverheadFile;
   parsed: ParsedClaudeMd;
   attribution: ClaudeMdAttributionResult;
 }
 
-export interface ContextAttributionResult {
-  perFile: ContextFileAttribution[];
+export interface OverheadAttribution {
+  perFile: OverheadFileAttribution[];
   grandTotal: number;
   // Count of distinct turns that contributed to at least one file's cost. Not
   // the sum of per-file ridingTurns (a turn could ride along in multiple
@@ -41,8 +41,8 @@ export interface ContextAttributionResult {
   totalRidingTurns: number;
 }
 
-export interface AttributeContextInput {
-  files: ParsedContextFile[];
+export interface AttributeOverheadInput {
+  files: ParsedOverheadFile[];
   turns: TurnRecord[];
   pricing: PricingTable;
 }
@@ -52,7 +52,7 @@ export interface AttributeContextInput {
 // for CLAUDE.md, and a Claude Code session doesn't pay for AGENTS.md, so
 // attribution must filter turns by source.
 interface Candidate {
-  kind: ContextFileKind;
+  kind: OverheadFileKind;
   relativePath: string;
   appliesTo: SourceKind[];
 }
@@ -63,8 +63,8 @@ const CANDIDATES: readonly Candidate[] = [
   { kind: 'agents-md', relativePath: 'AGENTS.md', appliesTo: ['codex', 'opencode'] },
 ];
 
-export async function findContextFiles(projectPath: string): Promise<ContextFile[]> {
-  const out: ContextFile[] = [];
+export async function findOverheadFiles(projectPath: string): Promise<OverheadFile[]> {
+  const out: OverheadFile[] = [];
   for (const c of CANDIDATES) {
     const abs = path.join(projectPath, c.relativePath);
     try {
@@ -79,13 +79,13 @@ export async function findContextFiles(projectPath: string): Promise<ContextFile
   return out;
 }
 
-export async function loadContextFile(file: ContextFile): Promise<ParsedContextFile> {
+export async function loadOverheadFile(file: OverheadFile): Promise<ParsedOverheadFile> {
   const parsed = await loadClaudeMdFile(file.path);
   return { file, parsed };
 }
 
-export function attributeContext(input: AttributeContextInput): ContextAttributionResult {
-  const perFile: ContextFileAttribution[] = [];
+export function attributeOverhead(input: AttributeOverheadInput): OverheadAttribution {
+  const perFile: OverheadFileAttribution[] = [];
   // Per-session max ridingTurns across every file. The eviction check is
   // `cacheRead >= file_tokens`, so a smaller file always rides along for a
   // superset of the turns that a larger file rides along for (same source,

--- a/packages/analyze/src/patterns.ts
+++ b/packages/analyze/src/patterns.ts
@@ -562,7 +562,7 @@ function buildContentIndex(records: ContentRecord[] | undefined): ContentIndex |
 }
 
 // Stringify a tool_result content block to plain text for signature
-// extraction. Mirrors `stringifyToolResult` in waste.ts (kept in-module to
+// extraction. Mirrors `stringifyToolResult` in hotspots.ts (kept in-module to
 // avoid a public export of an internal helper); structured blocks fall back
 // to JSON so an `is_error` payload still has *something* readable.
 function stringifyToolResultContent(content: unknown): string {
@@ -909,7 +909,7 @@ function failureRunSignatures(
   // tool_result we observe for each tool — that's the "what blew up first"
   // signature the user wants to read in a report. Subsequent failures for
   // the same tool may have different signatures; if the user wants those
-  // they can `burn diagnose <session>`.
+  // they can `burn hotspots --session <session>`.
   const out: Array<{ tool: string; firstLine: string }> = [];
   const seen = new Set<string>();
   for (const ref of streak) {

--- a/packages/analyze/src/tool-output-bloat.ts
+++ b/packages/analyze/src/tool-output-bloat.ts
@@ -163,7 +163,7 @@ export function projectClaudeSettingsPath(cwd: string = process.cwd()): string {
 // when the file is missing or malformed — both cases mean "no setting to
 // check", which is indistinguishable from "no waste". We deliberately do NOT
 // throw on parse errors; the user's misconfigured settings.json should not
-// crash `burn waste`.
+// crash `burn hotspots`.
 export async function loadClaudeSettings(
   filePath: string,
 ): Promise<LoadedClaudeSettings | undefined> {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to `@relayburn/cli`.
 
 ### Changed
 
-- `burn waste --patterns tool-output-bloat` now sizes oversized tool output via cl100k token counts from user-turn enrichment instead of bytes/4 estimates. Findings on highly compressible payloads (repetitive logs, base64 dumps) may shift below the 15k default threshold.
+- `burn hotspots` replaces `burn waste` and per-session `burn diagnose`; `burn hotspots --session <id>` keeps the former per-session JSON shape. `burn overhead` and `burn overhead trim` replace `burn context` and `burn context advise`.
+- `burn hotspots --patterns tool-output-bloat` now sizes oversized tool output via cl100k token counts from user-turn enrichment instead of bytes/4 estimates. Findings on highly compressible payloads (repetitive logs, base64 dumps) may shift below the 15k default threshold.
 - `burn summary --subagent-tree` now reads persisted session relationships, including child-session subagents and fork/continuation annotations.
 
 ### Fixed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to `@relayburn/cli`.
 
 ### Changed
 
-- `burn hotspots` replaces `burn waste` and per-session `burn diagnose`; `burn hotspots --session <id>` keeps the former per-session JSON shape. `burn overhead` and `burn overhead trim` replace `burn context` and `burn context advise`.
+- `burn hotspots` replaces `burn waste` and `burn diagnose`; bare `burn hotspots --session` keeps the former aggregate diagnostics, and `burn hotspots --session <id>` keeps the former per-session JSON shape. `burn overhead` and `burn overhead trim` replace `burn context` and `burn context advise`.
 - `burn hotspots --patterns tool-output-bloat` now sizes oversized tool output via cl100k token counts from user-turn enrichment instead of bytes/4 estimates. Findings on highly compressible payloads (repetitive logs, base64 dumps) may shift below the 15k default threshold.
 - `burn summary --subagent-tree` now reads persisted session relationships, including child-session subagents and fork/continuation annotations.
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,8 +3,7 @@ import { parseArgs } from './args.js';
 import { runArchive } from './commands/archive.js';
 import { runCompare } from './commands/compare.js';
 import { runContent, opportunisticPrune } from './commands/content.js';
-import { runContext } from './commands/context.js';
-import { runDiagnose } from './commands/diagnose.js';
+import { runOverhead } from './commands/overhead.js';
 import { runIngest } from './commands/ingest.js';
 import { runLimits } from './commands/limits.js';
 import { runMcpServer } from './commands/mcp-server.js';
@@ -12,7 +11,7 @@ import { runPlans } from './commands/plans.js';
 import { runRebuild } from './commands/rebuild.js';
 import { runWrapper } from './commands/run.js';
 import { runSummary } from './commands/summary.js';
-import { runWaste } from './commands/waste.js';
+import { runHotspots } from './commands/hotspots.js';
 import { runWatch } from './commands/watch.js';
 import { listHarnessNames } from './harnesses/registry.js';
 
@@ -24,12 +23,12 @@ Usage:
   burn summary       [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--provider <p>] [--quality]
                      [--by-provider | --by-tool | --by-subagent-type | --by-relationship[=subagent] | --subagent-tree <session-id>] [--no-archive]
                      (mode flags are mutually exclusive; --by-tool emits tool | calls | attributedCost)
-  burn waste         [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--provider <p>] [--all] [--json]
+  burn hotspots      [--since 7d] [--project <path>] [--workflow <id>] [--provider <p>] [--all] [--json]
+                     [--session <id>]
                      [--patterns[=retries,failures,compaction,reverts]] [--findings]
-  burn diagnose      [<session-id>] [--json] [--explain-drift]
   burn limits        [--watch [5s]] [--json] [--no-api] [--no-forecast]
   burn plans         [add|remove|set-reset-day] …  (run \`burn plans help\` for full usage)
-  burn context       [advise] [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]
+  burn overhead      [trim] [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]
   burn compare       <model_a,model_b[,...]> [--since 7d] [--project <path>] [--session <id>] [--workflow <id>] [--agent <id>] [--min-sample <n>] [--json|--csv]
   burn run <${HARNESS_LIST}>  [--tag k=v ...] [-- <harness args>]
   burn watch         [--interval <ms>] [--once] [--opencode-stream] [--opencode-url <url>]
@@ -46,19 +45,18 @@ Examples:
   burn summary --by-subagent-type --since 7d
   burn summary --by-relationship --since 7d
   burn summary --by-tool --since 7d
-  burn waste --since 7d
-  burn waste --patterns --since 7d
-  burn diagnose <session-id>
-  burn diagnose                       # per-adapter content-capture gap report
+  burn hotspots --since 7d
+  burn hotspots --patterns --since 7d
+  burn hotspots --session <session-id>
   burn limits
   burn limits --watch
   burn limits --no-api
   burn plans
   burn plans add --provider claude --preset max
   burn plans set-reset-day claude-max 15
-  burn context --since 30d
-  burn context --kind claude-md
-  burn context advise --top 3
+  burn overhead --since 30d
+  burn overhead --kind claude-md
+  burn overhead trim --top 3
   burn compare claude-sonnet-4-6,claude-haiku-4-5 --since 30d
   burn run claude   --tag workflow=refactor -- --resume
   burn run codex    --tag workflow=refactor
@@ -91,16 +89,14 @@ async function main(): Promise<number> {
   switch (cmd) {
     case 'summary':
       return runSummary(args);
-    case 'waste':
-      return runWaste(args);
-    case 'diagnose':
-      return runDiagnose(args);
+    case 'hotspots':
+      return runHotspots(args);
     case 'limits':
       return runLimits(args);
     case 'plans':
       return runPlans(args);
-    case 'context':
-      return runContext(args);
+    case 'overhead':
+      return runOverhead(args);
     case 'compare':
       return runCompare(args);
     case 'run':

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,7 +24,7 @@ Usage:
                      [--by-provider | --by-tool | --by-subagent-type | --by-relationship[=subagent] | --subagent-tree <session-id>] [--no-archive]
                      (mode flags are mutually exclusive; --by-tool emits tool | calls | attributedCost)
   burn hotspots      [--since 7d] [--project <path>] [--workflow <id>] [--provider <p>] [--all] [--json]
-                     [--session <id>]
+                     [--session [id]] [--explain-drift]
                      [--patterns[=retries,failures,compaction,reverts]] [--findings]
   burn limits        [--watch [5s]] [--json] [--no-api] [--no-forecast]
   burn plans         [add|remove|set-reset-day] …  (run \`burn plans help\` for full usage)
@@ -47,6 +47,7 @@ Examples:
   burn summary --by-tool --since 7d
   burn hotspots --since 7d
   burn hotspots --patterns --since 7d
+  burn hotspots --session --explain-drift
   burn hotspots --session <session-id>
   burn limits
   burn limits --watch

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -34,7 +34,7 @@ Models:
 Flags:
   --provider    comma-separated list of effective providers to include
                 (e.g. synthetic, anthropic, openai); resolved via the same
-                pricing-layer classifier summary/waste use
+                pricing-layer classifier summary/hotspots use
   --since       relative (e.g. 24h, 7d, 4w) or ISO timestamp; default: all time
   --project     filter by project path or git-canonical projectKey
   --session     filter by sessionId

--- a/packages/cli/src/commands/hotspots-session.test.ts
+++ b/packages/cli/src/commands/hotspots-session.test.ts
@@ -19,7 +19,9 @@ import type {
   TurnRecord,
 } from '@relayburn/reader';
 
+import { runHotspots } from './hotspots.js';
 import { runHotspotsSession } from './hotspots-session.js';
+import type { ParsedArgs } from '../args.js';
 
 // Cross-batch counter so every fakeTurn lands a unique (ts, model, usage,
 // argsHashPrefix) tuple — otherwise the writer's content-fingerprint dedup
@@ -136,7 +138,8 @@ interface CapturedOutput {
 }
 
 async function captureHotspots(
-  args: Parameters<typeof runHotspotsSession>[0],
+  args: ParsedArgs,
+  runner: (args: ParsedArgs) => Promise<number> = runHotspotsSession,
 ): Promise<CapturedOutput> {
   const origStdout = process.stdout.write.bind(process.stdout);
   const origStderr = process.stderr.write.bind(process.stderr);
@@ -152,7 +155,7 @@ async function captureHotspots(
   }) as typeof process.stderr.write;
   let code: number;
   try {
-    code = await runHotspotsSession(args);
+    code = await runner(args);
   } finally {
     process.stdout.write = origStdout;
     process.stderr.write = origStderr;
@@ -188,6 +191,28 @@ describe('burn hotspots --session aggregate (#79)', () => {
     else delete process.env['RELAYBURN_CONTENT_STORE'];
     await rm(tmpHome, { recursive: true, force: true });
     await rm(tmpRelay, { recursive: true, force: true });
+  });
+
+  it('routes bare hotspots --session through the aggregate gap report', async () => {
+    const out = await captureHotspots(
+      {
+        flags: { session: true, json: true },
+        tags: {},
+        positional: [],
+        passthrough: [],
+      },
+      runHotspots,
+    );
+    assert.equal(out.code, 0);
+    assert.equal(out.stderr, '');
+    const parsed = JSON.parse(out.stdout) as {
+      adapters: unknown[];
+      contentMode: string;
+      relationshipDrift: { sessions: number };
+    };
+    assert.deepEqual(parsed.adapters, []);
+    assert.equal(parsed.contentMode, 'full');
+    assert.equal(parsed.relationshipDrift.sessions, 0);
   });
 
   it('reports zero gaps on a ledger where every adapter captures tool_result records', async () => {

--- a/packages/cli/src/commands/hotspots-session.test.ts
+++ b/packages/cli/src/commands/hotspots-session.test.ts
@@ -19,7 +19,7 @@ import type {
   TurnRecord,
 } from '@relayburn/reader';
 
-import { runDiagnose } from './diagnose.js';
+import { runHotspotsSession } from './hotspots-session.js';
 
 // Cross-batch counter so every fakeTurn lands a unique (ts, model, usage,
 // argsHashPrefix) tuple — otherwise the writer's content-fingerprint dedup
@@ -135,8 +135,8 @@ interface CapturedOutput {
   code: number;
 }
 
-async function captureDiagnose(
-  args: Parameters<typeof runDiagnose>[0],
+async function captureHotspots(
+  args: Parameters<typeof runHotspotsSession>[0],
 ): Promise<CapturedOutput> {
   const origStdout = process.stdout.write.bind(process.stdout);
   const origStderr = process.stderr.write.bind(process.stderr);
@@ -152,7 +152,7 @@ async function captureDiagnose(
   }) as typeof process.stderr.write;
   let code: number;
   try {
-    code = await runDiagnose(args);
+    code = await runHotspotsSession(args);
   } finally {
     process.stdout.write = origStdout;
     process.stderr.write = origStderr;
@@ -160,7 +160,7 @@ async function captureDiagnose(
   return { stdout, stderr, code };
 }
 
-describe('burn diagnose aggregate (#79)', () => {
+describe('burn hotspots --session aggregate (#79)', () => {
   let tmpHome: string;
   let tmpRelay: string;
   const originalHome = process.env['HOME'];
@@ -168,8 +168,8 @@ describe('burn diagnose aggregate (#79)', () => {
   const originalStore = process.env['RELAYBURN_CONTENT_STORE'];
 
   beforeEach(async () => {
-    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-diagnose-home-'));
-    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-diagnose-relay-'));
+    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-hotspots-home-'));
+    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-hotspots-relay-'));
     // Point HOME at an empty dir so ingestAll() finds no transcripts to walk —
     // the test fixtures here are pre-seeded directly into the ledger.
     process.env['HOME'] = tmpHome;
@@ -217,7 +217,7 @@ describe('burn diagnose aggregate (#79)', () => {
       }),
     ]);
 
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: { json: true },
       tags: {},
       positional: [],
@@ -292,7 +292,7 @@ describe('burn diagnose aggregate (#79)', () => {
       }),
     ]);
 
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: { json: true },
       tags: {},
       positional: [],
@@ -341,7 +341,7 @@ describe('burn diagnose aggregate (#79)', () => {
         toolCallIds: ['tu-X'],
       }),
     ]);
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: {},
       tags: {},
       positional: [],
@@ -441,7 +441,7 @@ describe('burn diagnose aggregate (#79)', () => {
       },
     ]);
 
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: { json: true, 'explain-drift': true },
       tags: {},
       positional: [],
@@ -469,7 +469,7 @@ describe('burn diagnose aggregate (#79)', () => {
       },
     ]);
 
-    const human = await captureDiagnose({
+    const human = await captureHotspots({
       flags: { 'explain-drift': true },
       tags: {},
       positional: [],
@@ -490,7 +490,7 @@ describe('burn diagnose aggregate (#79)', () => {
         toolCallIds: ['tu-h'],
       }),
     ]);
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: { json: true },
       tags: {},
       positional: [],
@@ -514,7 +514,7 @@ describe('burn diagnose aggregate (#79)', () => {
     assert.equal(claude!.degradedPct, null);
 
     // Human path includes the explanatory note.
-    const human = await captureDiagnose({
+    const human = await captureHotspots({
       flags: {},
       tags: {},
       positional: [],
@@ -524,11 +524,11 @@ describe('burn diagnose aggregate (#79)', () => {
     assert.match(human.stdout, /content store is hash-only/);
   });
 
-  it('preserves the existing per-session diagnose path when a session id is supplied', async () => {
+  it('preserves the existing per-session hotspots session path when a session id is supplied', async () => {
     // Empty ledger → existing behavior is exit 1 with a "no turns found"
     // message on stderr. We're asserting the per-session branch wasn't
     // accidentally rerouted into the aggregate path.
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: {},
       tags: {},
       positional: ['does-not-exist'],
@@ -596,7 +596,7 @@ describe('burn diagnose aggregate (#79)', () => {
       }),
     ]);
 
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: {},
       tags: {},
       positional: ['diag-parent'],
@@ -615,7 +615,7 @@ describe('burn diagnose aggregate (#79)', () => {
     assert.match(out.stdout, /child-read/);
   });
 
-  it('adds graph arrays to diagnose --json', async () => {
+  it('adds graph arrays to hotspots --session --json', async () => {
     await appendTurns([
       fakeTurn({
         sessionId: 'diag-json',
@@ -638,7 +638,7 @@ describe('burn diagnose aggregate (#79)', () => {
       }),
     ]);
 
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: { json: true },
       tags: {},
       positional: ['diag-json'],
@@ -678,7 +678,7 @@ describe('burn diagnose aggregate (#79)', () => {
       }),
     ]);
 
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: {},
       tags: {},
       positional: ['diag-empty-graph'],
@@ -691,7 +691,7 @@ describe('burn diagnose aggregate (#79)', () => {
   });
 
   it('renders an empty-ledger note when there are no adapter sessions at all', async () => {
-    const out = await captureDiagnose({
+    const out = await captureHotspots({
       flags: {},
       tags: {},
       positional: [],

--- a/packages/cli/src/commands/hotspots-session.ts
+++ b/packages/cli/src/commands/hotspots-session.ts
@@ -2,7 +2,7 @@ import {
   aggregateByBash,
   aggregateByFile,
   aggregateBySubagent,
-  attributeWaste,
+  attributeHotspots,
   detectPatterns,
   loadPricing,
   type PatternsResult,
@@ -29,17 +29,19 @@ import { countToolCallGaps, ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
-export async function runDiagnose(args: ParsedArgs): Promise<number> {
-  const sessionId = args.positional[0];
+export async function runHotspotsSession(
+  args: ParsedArgs,
+  sessionId = args.positional[0],
+): Promise<number> {
   if (!sessionId) {
-    return runDiagnoseAggregate(args);
+    return runHotspotsGapReport(args);
   }
 
   await ingestAll();
   const pricing = await loadPricing();
   const turns = await queryAll({ sessionId });
   if (turns.length === 0) {
-    process.stderr.write(`burn diagnose: no turns found for session ${sessionId}\n`);
+    process.stderr.write(`burn hotspots --session: no turns found for session ${sessionId}\n`);
     return 1;
   }
   const compactions = await queryCompactions({ sessionId });
@@ -63,7 +65,7 @@ export async function runDiagnose(args: ParsedArgs): Promise<number> {
   const userTurnsBySession = new Map<string, UserTurnRecord[]>();
   if (userTurns.length > 0) userTurnsBySession.set(sessionId, userTurns);
 
-  const attribution = attributeWaste(turns, {
+  const attribution = attributeHotspots(turns, {
     pricing,
     contentBySession,
     userTurnsBySession,
@@ -565,7 +567,7 @@ interface RelationshipDriftReport {
   details: RelationshipDriftDetail[];
 }
 
-async function runDiagnoseAggregate(args: ParsedArgs): Promise<number> {
+async function runHotspotsGapReport(args: ParsedArgs): Promise<number> {
   await ingestAll();
   const config = await loadConfig();
   const contentMode = config.content.store;

--- a/packages/cli/src/commands/hotspots.test.ts
+++ b/packages/cli/src/commands/hotspots.test.ts
@@ -5,9 +5,9 @@ import { loadBuiltinPricing } from '@relayburn/analyze';
 import type {
   BashAggregation,
   FileAggregation,
-  SessionWasteTotals,
+  SessionTotals,
   SubagentAggregation,
-  WasteResult,
+  HotspotsResult,
 } from '@relayburn/analyze';
 import type { EnrichedTurn } from '@relayburn/ledger';
 import type { Coverage, Fidelity, SourceKind, ToolResultEventRecord } from '@relayburn/reader';
@@ -18,21 +18,21 @@ import {
   describeExcluded,
   fmtCoverageKey,
   formatCoverageNotice,
-  formatWasteReport,
+  formatHotspotsReport,
   isAttributionDegraded,
   renderSourcesClause,
   resolvePatternSelection,
   runPatternsMode,
-  runWasteAttribution,
+  runHotspotsAttribution,
   turnPassesCoverage,
-  type WasteAttributionDeps,
-} from './waste.js';
+  type HotspotsAttributionDeps,
+} from './hotspots.js';
 import type { ParsedArgs } from '../args.js';
 
 function session(
   id: string,
   method: 'sized' | 'even-split',
-): SessionWasteTotals {
+): SessionTotals {
   return {
     sessionId: id,
     grandCost: 1,
@@ -42,7 +42,7 @@ function session(
   };
 }
 
-function makeResult(sessions: SessionWasteTotals[]): WasteResult {
+function makeResult(sessions: SessionTotals[]): HotspotsResult {
   return {
     attributions: [],
     sessionTotals: sessions,
@@ -105,13 +105,13 @@ describe('isAttributionDegraded', () => {
   });
 });
 
-describe('formatWasteReport', () => {
+describe('formatHotspotsReport', () => {
   it('renders no even-split note when all sessions are sized', () => {
     const result = makeResult([
       session('a', 'sized'),
       session('b', 'sized'),
     ]);
-    const out = formatWasteReport({
+    const out = formatHotspotsReport({
       turnsAnalyzed: 100,
       result,
       files: NO_FILES,
@@ -137,7 +137,7 @@ describe('formatWasteReport', () => {
       session('b', 'sized'),
       session('c', 'sized'),
     ]);
-    const out = formatWasteReport({
+    const out = formatHotspotsReport({
       turnsAnalyzed: 100,
       result,
       files: NO_FILES,
@@ -159,7 +159,7 @@ describe('formatWasteReport', () => {
       session('b', 'even-split'),
       session('c', 'sized'),
     ]);
-    const out = formatWasteReport({
+    const out = formatHotspotsReport({
       turnsAnalyzed: 64117,
       result,
       files: NO_FILES,
@@ -192,12 +192,12 @@ describe('formatWasteReport', () => {
   });
 
   it('formats large session counts with thousands separators in the banner', () => {
-    const sessions: SessionWasteTotals[] = [];
+    const sessions: SessionTotals[] = [];
     for (let i = 0; i < 39_587; i++) {
       sessions.push(session(`s${i}`, i < 39_486 ? 'even-split' : 'sized'));
     }
     const result = makeResult(sessions);
-    const out = formatWasteReport({
+    const out = formatHotspotsReport({
       turnsAnalyzed: 64117,
       result,
       files: NO_FILES,
@@ -312,7 +312,7 @@ async function captureStdio<T>(
   }
 }
 
-const EMPTY_DEPS: WasteAttributionDeps = {
+const EMPTY_DEPS: HotspotsAttributionDeps = {
   loadContentForSession: async () => [],
   loadUserTurnsForSession: async () => [],
 };
@@ -470,7 +470,7 @@ describe('resolvePatternSelection', () => {
   });
 });
 
-describe('runWasteAttribution — fidelity refusal (#100)', () => {
+describe('runHotspotsAttribution — fidelity refusal (#100)', () => {
   it('refuses with exit 2, names the missing prerequisite + source kind, when every turn is aggregate-only', async () => {
     const pricing = await loadBuiltinPricing();
     const turns: EnrichedTurn[] = [];
@@ -489,15 +489,15 @@ describe('runWasteAttribution — fidelity refusal (#100)', () => {
       );
     }
     const { result, stdout, stderr } = await captureStdio(() =>
-      runWasteAttribution(args(), turns, pricing, EMPTY_DEPS),
+      runHotspotsAttribution(args(), turns, pricing, EMPTY_DEPS),
     );
     assert.equal(result, 2);
     assert.equal(stdout, '');
-    assert.match(stderr, /burn waste: 142\/142 turns lack tool-call\/tool-result coverage/);
+    assert.match(stderr, /burn hotspots: 142\/142 turns lack tool-call\/tool-result coverage/);
     assert.match(stderr, /codex/);
     assert.match(stderr, /per-session-aggregate/);
     assert.match(stderr, /missing tool-call records, tool-result events/);
-    assert.match(stderr, /No waste analysis was performed/);
+    assert.match(stderr, /No hotspots analysis was performed/);
   });
 
   it('JSON-mode refusal still writes a fidelity block with refused: true and exits 2', async () => {
@@ -515,10 +515,10 @@ describe('runWasteAttribution — fidelity refusal (#100)', () => {
       }),
     ];
     const { result, stdout, stderr } = await captureStdio(() =>
-      runWasteAttribution(args({ json: true }), turns, pricing, EMPTY_DEPS),
+      runHotspotsAttribution(args({ json: true }), turns, pricing, EMPTY_DEPS),
     );
     assert.equal(result, 2);
-    assert.match(stderr, /No waste analysis was performed/);
+    assert.match(stderr, /No hotspots analysis was performed/);
     const payload = JSON.parse(stdout);
     assert.equal(payload.fidelity.refused, true);
     assert.equal(payload.fidelity.analyzed, 0);
@@ -527,20 +527,20 @@ describe('runWasteAttribution — fidelity refusal (#100)', () => {
     assert.equal(payload.fidelity.summary.total, 1);
     assert.equal(payload.fidelity.summary.byClass['aggregate-only'], 1);
     assert.equal(payload.turnsAnalyzed, 0);
-    assert.match(payload.refusalReason, /No waste analysis was performed/);
+    assert.match(payload.refusalReason, /No hotspots analysis was performed/);
   });
 
   it('does not refuse on a fully empty input (no turns at all)', async () => {
     const pricing = await loadBuiltinPricing();
     const { result, stderr } = await captureStdio(() =>
-      runWasteAttribution(args(), [], pricing, EMPTY_DEPS),
+      runHotspotsAttribution(args(), [], pricing, EMPTY_DEPS),
     );
     assert.equal(result, 0, 'empty slice is not a refusal');
     assert.equal(stderr, '');
   });
 });
 
-describe('runWasteAttribution — partial exclusion (#100)', () => {
+describe('runHotspotsAttribution — partial exclusion (#100)', () => {
   it('analyzes only qualifying turns and prints "analyzed N of M" with the exclusion reason', async () => {
     const pricing = await loadBuiltinPricing();
     const goodFidelity = fidelityWith('full', 'per-turn');
@@ -569,7 +569,7 @@ describe('runWasteAttribution — partial exclusion (#100)', () => {
       }),
     ];
     const { result, stdout, stderr } = await captureStdio(() =>
-      runWasteAttribution(args(), turns, pricing, EMPTY_DEPS),
+      runHotspotsAttribution(args(), turns, pricing, EMPTY_DEPS),
     );
     assert.equal(result, 0);
     assert.equal(stderr, '');
@@ -591,7 +591,7 @@ describe('runWasteAttribution — partial exclusion (#100)', () => {
       }),
     ];
     const { result, stdout } = await captureStdio(() =>
-      runWasteAttribution(args(), turns, pricing, EMPTY_DEPS),
+      runHotspotsAttribution(args(), turns, pricing, EMPTY_DEPS),
     );
     assert.equal(result, 0);
     assert.doesNotMatch(stdout, /analyzed \d+ of \d+ turns; \d+ excluded/);
@@ -616,7 +616,7 @@ describe('runWasteAttribution — partial exclusion (#100)', () => {
       }),
     ];
     const { result, stdout } = await captureStdio(() =>
-      runWasteAttribution(args({ json: true }), turns, pricing, EMPTY_DEPS),
+      runHotspotsAttribution(args({ json: true }), turns, pricing, EMPTY_DEPS),
     );
     assert.equal(result, 0);
     const payload = JSON.parse(stdout);
@@ -652,7 +652,7 @@ describe('runPatternsMode — fidelity refusal (#100)', () => {
     );
     assert.equal(result, 2);
     assert.equal(stdout, '');
-    assert.match(stderr, /burn waste --patterns: no selected detectors can run/);
+    assert.match(stderr, /burn hotspots --patterns: no selected detectors can run/);
     assert.match(stderr, /retries: 1\/1 turns lack tool-call records/);
     assert.match(stderr, /failures: 1\/1 turns lack tool-call records/);
     assert.match(stderr, /codex/);

--- a/packages/cli/src/commands/hotspots.ts
+++ b/packages/cli/src/commands/hotspots.ts
@@ -2,7 +2,7 @@ import {
   aggregateByBash,
   aggregateByFile,
   aggregateBySubagent,
-  attributeWaste,
+  attributeHotspots,
   cancellationRunToFinding,
   compactionLossToFinding,
   detectGhostSurface,
@@ -33,7 +33,7 @@ import {
   type SubagentAggregation,
   type ToolOutputBloat,
   type WasteFinding,
-  type WasteResult,
+  type HotspotsResult,
 } from '@relayburn/analyze';
 import {
   queryAll,
@@ -56,6 +56,7 @@ import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 import { filterTurnsByProvider, parseProviderFilter } from '../provider.js';
+import { runHotspotsSession } from './hotspots-session.js';
 
 const DEFAULT_TOP_N = 10;
 const PATTERN_KINDS = ['retries', 'failures', 'cancellations', 'compaction', 'reverts', 'edit-heavy', 'opencode-skill-recall', 'opencode-skill-pruning', 'opencode-system-prompt', 'ghost-surface', 'tool-output-bloat'] as const;
@@ -68,7 +69,7 @@ type PatternKind = (typeof PATTERN_KINDS)[number];
 const EVEN_SPLIT_DEGRADED_THRESHOLD = 0.5;
 
 export function isAttributionDegraded(
-  result: WasteResult,
+  result: HotspotsResult,
   threshold: number = EVEN_SPLIT_DEGRADED_THRESHOLD,
 ): boolean {
   if (result.sessionTotals.length === 0) return false;
@@ -78,7 +79,7 @@ export function isAttributionDegraded(
   return evenSplit / result.sessionTotals.length >= threshold;
 }
 
-// Coverage flags a turn must carry to participate in `attributeWaste` and the
+// Coverage flags a turn must carry to participate in `attributeHotspots` and the
 // matching aggregators. A turn missing either flag has no chronology we can
 // allocate cost against (no per-call records, or no result-side bytes to
 // allocate the next-turn input delta over). Records without `fidelity` (older
@@ -180,11 +181,18 @@ export function renderSourcesClause(breakdown: CoverageGapBreakdown): string {
   return rows.join('; ');
 }
 
-export async function runWaste(args: ParsedArgs): Promise<number> {
+export async function runHotspots(args: ParsedArgs): Promise<number> {
+  if (typeof args.flags['session'] === 'string') {
+    return runHotspotsSession(args, args.flags['session']);
+  }
+  if (args.flags['session'] === true) {
+    process.stderr.write('burn hotspots: --session requires a session id\n');
+    return 2;
+  }
+
   const q: Query = {};
   if (typeof args.flags['since'] === 'string') q.since = parseSinceArg(args.flags['since']);
   if (typeof args.flags['project'] === 'string') q.project = args.flags['project'];
-  if (typeof args.flags['session'] === 'string') q.sessionId = args.flags['session'];
   if (typeof args.flags['workflow'] === 'string') q.enrichment = { workflowId: args.flags['workflow'] };
   const providerFilter = parseProviderFilter(args.flags['provider']);
   if (providerFilter instanceof Error) {
@@ -211,22 +219,22 @@ export async function runWaste(args: ParsedArgs): Promise<number> {
     return runPatternsMode(args, turns, pricing, compactions, selected, { query: q });
   }
 
-  return runWasteAttribution(args, turns, pricing);
+  return runHotspotsAttribution(args, turns, pricing);
 }
 
 // Exposed for tests so they can drive the orchestration with fixture turns
 // and a mocked content/userTurns loader. Production callers go through
-// `runWaste`, which fetches both via the ledger.
-export interface WasteAttributionDeps {
+// `runHotspots`, which fetches both via the ledger.
+export interface HotspotsAttributionDeps {
   loadContentForSession?: (sessionId: string) => Promise<ContentRecord[]>;
   loadUserTurnsForSession?: (sessionId: string) => Promise<UserTurnRecord[]>;
 }
 
-export async function runWasteAttribution(
+export async function runHotspotsAttribution(
   args: ParsedArgs,
   turns: EnrichedTurn[],
   pricing: Awaited<ReturnType<typeof loadPricing>>,
-  deps: WasteAttributionDeps = {},
+  deps: HotspotsAttributionDeps = {},
 ): Promise<number> {
   const total = turns.length;
   const eligible: EnrichedTurn[] = [];
@@ -245,8 +253,8 @@ export async function runWasteAttribution(
     const breakdown = describeExcluded(excluded, ATTRIBUTION_REQUIRED);
     const sourcesClause = renderSourcesClause(breakdown);
     const message =
-      `burn waste: ${total}/${total} turns lack tool-call/tool-result coverage required for waste attribution. ` +
-      `Sources: ${sourcesClause}. No waste analysis was performed.`;
+      `burn hotspots: ${total}/${total} turns lack tool-call/tool-result coverage required for hotspots attribution. ` +
+      `Sources: ${sourcesClause}. No hotspots analysis was performed.`;
     if (args.flags['json'] === true) {
       process.stdout.write(
         JSON.stringify(
@@ -294,7 +302,7 @@ export async function runWasteAttribution(
     if (userTurns.length > 0) userTurnsBySession.set(sessionId, userTurns);
   }
 
-  const result = attributeWaste(eligible, {
+  const result = attributeHotspots(eligible, {
     pricing,
     contentBySession,
     userTurnsBySession,
@@ -339,7 +347,7 @@ export async function runWasteAttribution(
   const showAll = args.flags['all'] === true;
   const limit = showAll ? Number.POSITIVE_INFINITY : DEFAULT_TOP_N;
 
-  const reportInput: FormatWasteReportInput = {
+  const reportInput: FormatHotspotsReportInput = {
     turnsAnalyzed: eligible.length,
     result,
     files,
@@ -349,7 +357,7 @@ export async function runWasteAttribution(
     degraded,
   };
   if (coverageNotice !== undefined) reportInput.coverageNotice = coverageNotice;
-  process.stdout.write(formatWasteReport(reportInput));
+  process.stdout.write(formatHotspotsReport(reportInput));
   return 0;
 }
 
@@ -381,9 +389,9 @@ export function formatCoverageNotice(
   return `analyzed ${formatInt(analyzed)} of ${formatInt(total)} turns; ${formatInt(excluded)} excluded for ${sourceClauses.join(' and ')}`;
 }
 
-interface FormatWasteReportInput {
+interface FormatHotspotsReportInput {
   turnsAnalyzed: number;
-  result: WasteResult;
+  result: HotspotsResult;
   files: FileAggregation[];
   bashes: BashAggregation[];
   subagents: SubagentAggregation[];
@@ -392,7 +400,7 @@ interface FormatWasteReportInput {
   coverageNotice?: string;
 }
 
-export function formatWasteReport(input: FormatWasteReportInput): string {
+export function formatHotspotsReport(input: FormatHotspotsReportInput): string {
   const { turnsAnalyzed, result, files, bashes, subagents, limit, degraded, coverageNotice } = input;
   const evenSplitSessions = result.sessionTotals.filter(
     (s) => s.attributionMethod === 'even-split',
@@ -674,7 +682,7 @@ export async function runPatternsMode(
       );
     }
     const message =
-      `burn waste --patterns: no selected detectors can run on this slice.\n` +
+      `burn hotspots --patterns: no selected detectors can run on this slice.\n` +
       lines.join('\n') +
       `\nNo pattern analysis was performed.`;
 
@@ -1328,7 +1336,7 @@ export function formatFindingsReport(findings: WasteFinding[], analyzed: number)
   out.push(`findings: ${formatInt(findings.length)}`);
   out.push('');
   if (findings.length === 0) {
-    out.push('  (no waste findings)');
+    out.push('  (no hotspot findings)');
     out.push('');
     return out.join('\n');
   }

--- a/packages/cli/src/commands/hotspots.ts
+++ b/packages/cli/src/commands/hotspots.ts
@@ -186,8 +186,7 @@ export async function runHotspots(args: ParsedArgs): Promise<number> {
     return runHotspotsSession(args, args.flags['session']);
   }
   if (args.flags['session'] === true) {
-    process.stderr.write('burn hotspots: --session requires a session id\n');
-    return 2;
+    return runHotspotsSession(args);
   }
 
   const q: Query = {};

--- a/packages/cli/src/commands/overhead.ts
+++ b/packages/cli/src/commands/overhead.ts
@@ -2,18 +2,18 @@ import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import {
-  attributeContext,
-  buildAdviseRecommendations,
+  attributeOverhead,
+  buildTrimRecommendations,
   describeAppliesTo,
-  findContextFiles,
-  loadContextFile,
+  findOverheadFiles,
+  loadOverheadFile,
   loadPricing,
   renderUnifiedDiffForRecommendation,
-  type AdviseRecommendation,
-  type ContextAttributionResult,
-  type ContextFileAttribution,
-  type ContextFileKind,
-  type ParsedContextFile,
+  type TrimRecommendation,
+  type OverheadAttribution,
+  type OverheadFileAttribution,
+  type OverheadFileKind,
+  type ParsedOverheadFile,
   type SectionCost,
 } from '@relayburn/analyze';
 import { queryAll, type Query } from '@relayburn/ledger';
@@ -23,14 +23,14 @@ import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 
-const HELP = `burn context — cost attribution for agent context files (CLAUDE.md, AGENTS.md, …)
+const HELP = `burn overhead — cost attribution for agent overhead files (CLAUDE.md, AGENTS.md, …)
 
 Usage:
-  burn context        [--project <path>] [--since 7d] [--kind <k>] [--json]
-  burn context advise [--project <path>] [--since 7d] [--kind <k>] [--top <n>]
+  burn overhead      [--project <path>] [--since 7d] [--kind <k>] [--json]
+  burn overhead trim [--project <path>] [--since 7d] [--kind <k>] [--top <n>]
 
 What it does:
-  Discovers context files in the project (CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)
+  Discovers overhead files in the project (CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)
   and attributes the cached-prompt cost of each across every session that reads it.
   Different files apply to different harnesses — Claude Code doesn't pay for
   AGENTS.md, Codex/OpenCode don't pay for CLAUDE.md — so turns are filtered by
@@ -40,23 +40,23 @@ Flags:
   --kind <k>   narrow to a single file kind: "claude-md" or "agents-md"
 
 Examples:
-  burn context
-  burn context --since 30d
-  burn context --kind claude-md
-  burn context advise --top 3
+  burn overhead
+  burn overhead --since 30d
+  burn overhead --kind claude-md
+  burn overhead trim --top 3
 `;
 
-const VALID_KINDS: ContextFileKind[] = ['claude-md', 'agents-md'];
+const VALID_KINDS: OverheadFileKind[] = ['claude-md', 'agents-md'];
 
-export async function runContext(args: ParsedArgs): Promise<number> {
+export async function runOverhead(args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
   if (args.flags['help'] === true || sub === 'help' || sub === '--help' || sub === '-h') {
     process.stdout.write(HELP);
     return 0;
   }
-  if (sub === 'advise') return runAdvise(args);
+  if (sub === 'trim') return runTrim(args);
   if (sub !== undefined && sub !== '') {
-    process.stderr.write(`unknown context subcommand: ${sub}\n\n${HELP}`);
+    process.stderr.write(`unknown overhead subcommand: ${sub}\n\n${HELP}`);
     return 1;
   }
   return runReport(args);
@@ -66,8 +66,8 @@ async function gatherAttribution(
   args: ParsedArgs,
   projectPath: string,
 ): Promise<{
-  files: ParsedContextFile[];
-  attribution: ContextAttributionResult;
+  files: ParsedOverheadFile[];
+  attribution: OverheadAttribution;
 } | null> {
   const kindFilter = parseKindFlag(args.flags['kind']);
   if (kindFilter === 'invalid') {
@@ -76,20 +76,20 @@ async function gatherAttribution(
     );
     return null;
   }
-  let found = await findContextFiles(projectPath);
+  let found = await findOverheadFiles(projectPath);
   if (kindFilter) found = found.filter((f) => f.kind === kindFilter);
   if (found.length === 0) {
     if (kindFilter) {
-      process.stderr.write(`no ${kindFilter} context files found at ${projectPath}\n`);
+      process.stderr.write(`no ${kindFilter} overhead files found at ${projectPath}\n`);
     } else {
       process.stderr.write(
-        `no context files found at ${projectPath} (looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)\n`,
+        `no overhead files found at ${projectPath} (looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)\n`,
       );
     }
     return null;
   }
-  const files: ParsedContextFile[] = [];
-  for (const f of found) files.push(await loadContextFile(f));
+  const files: ParsedOverheadFile[] = [];
+  for (const f of found) files.push(await loadOverheadFile(f));
 
   const resolved = resolveProject(projectPath);
   const q: Query = { project: resolved.projectKey ?? projectPath };
@@ -98,7 +98,7 @@ async function gatherAttribution(
   await ingestAll();
   const pricing = await loadPricing();
   const turns = await queryAll(q);
-  const attribution = attributeContext({ files, turns, pricing });
+  const attribution = attributeOverhead({ files, turns, pricing });
   return { files, attribution };
 }
 
@@ -139,7 +139,7 @@ async function runReport(args: ParsedArgs): Promise<number> {
 
   const out: string[] = [];
   out.push('');
-  out.push(`Context files in ${projectPath}:`);
+  out.push(`Overhead files in ${projectPath}:`);
   out.push('');
 
   const sinceLabel = typeof args.flags['since'] === 'string' ? args.flags['since'] : 'all time';
@@ -149,14 +149,14 @@ async function runReport(args: ParsedArgs): Promise<number> {
     out.push('');
   }
 
-  out.push(`Grand total (all context files, ${sinceLabel}): ${formatUsd(data.attribution.grandTotal)}`);
+  out.push(`Grand total (all overhead files, ${sinceLabel}): ${formatUsd(data.attribution.grandTotal)}`);
   out.push('');
   process.stdout.write(out.join('\n'));
   return 0;
 }
 
 function renderFileBlock(
-  fileAttr: ContextFileAttribution,
+  fileAttr: OverheadFileAttribution,
   sinceLabel: string,
   out: string[],
 ): void {
@@ -187,7 +187,7 @@ function renderFileBlock(
   out.push(indent(renderSectionTable(attribution.sectionCosts), '    '));
 }
 
-async function runAdvise(args: ParsedArgs): Promise<number> {
+async function runTrim(args: ParsedArgs): Promise<number> {
   const projectPath = resolveProjectPath(args);
   const data = await gatherAttribution(args, projectPath);
   if (!data) return 1;
@@ -195,14 +195,14 @@ async function runAdvise(args: ParsedArgs): Promise<number> {
   const topPerFile = parseTopN(args.flags['top']);
 
   const out: string[] = [];
-  out.push('# burn context advise — projected savings if trimmed');
-  out.push('# (recommendations only; burn never modifies your context files)');
+  out.push('# burn overhead trim — projected savings if trimmed');
+  out.push('# (recommendations only; burn never modifies your overhead files)');
   out.push('');
 
   const textCache = new Map<string, string>();
   let emitted = 0;
   for (const fileAttr of data.attribution.perFile) {
-    const recs = buildAdviseRecommendations(fileAttr.attribution, topPerFile);
+    const recs = buildTrimRecommendations(fileAttr.attribution, topPerFile);
     if (recs.length === 0) continue;
     out.push(`# === ${path.basename(fileAttr.file.path)} (applies to: ${describeAppliesTo(fileAttr.file.appliesTo)}) ===`);
     out.push('');
@@ -213,14 +213,14 @@ async function runAdvise(args: ParsedArgs): Promise<number> {
     }
     for (const rec of recs) {
       out.push(
-        renderUnifiedDiffForRecommendation(fileAttr.file.path, text, rec as AdviseRecommendation, projectPath),
+        renderUnifiedDiffForRecommendation(fileAttr.file.path, text, rec as TrimRecommendation, projectPath),
       );
       out.push('');
     }
     emitted++;
   }
   if (emitted === 0) {
-    process.stdout.write('# no trim candidates — context files have no headed sections\n');
+    process.stdout.write('# no trim candidates — overhead files have no headed sections\n');
     return 0;
   }
   process.stdout.write(out.join('\n'));
@@ -272,7 +272,7 @@ function parseTopN(v: unknown): number {
   return Math.floor(n);
 }
 
-function parseKindFlag(v: unknown): ContextFileKind | null | 'invalid' {
+function parseKindFlag(v: unknown): OverheadFileKind | null | 'invalid' {
   if (v === undefined || v === true) return null;
   if (typeof v !== 'string') return 'invalid';
   if (v === 'claude-md' || v === 'agents-md') return v;

--- a/packages/cli/src/commands/provider-filter.test.ts
+++ b/packages/cli/src/commands/provider-filter.test.ts
@@ -8,7 +8,7 @@ import { appendTurns, queryAll } from '@relayburn/ledger';
 import type { TurnRecord } from '@relayburn/reader';
 
 import { runSummary } from './summary.js';
-import { runWaste } from './waste.js';
+import { runHotspots } from './hotspots.js';
 import type { ParsedArgs } from '../args.js';
 
 async function captureStdio<T>(
@@ -135,30 +135,30 @@ describe('provider filters', () => {
     assert.doesNotMatch(stdout, /Bash/);
   });
 
-  it('applies --provider synthetic to waste', async () => {
+  it('applies --provider synthetic to hotspots', async () => {
     await appendTurns([
       turn({
-        sessionId: 's-synth-waste',
-        messageId: 'm-synth-waste',
+        sessionId: 's-synth-hotspots',
+        messageId: 'm-synth-hotspots',
         model: 'hf:deepseek-ai/deepseek-r1',
-        toolCalls: [{ id: 'tc-synth-waste', name: 'Bash', target: 'pnpm test', argsHash: 'aaa' }],
+        toolCalls: [{ id: 'tc-synth-hotspots', name: 'Bash', target: 'pnpm test', argsHash: 'aaa' }],
       }),
       turn({
-        sessionId: 's-anthropic-waste',
-        messageId: 'm-anthropic-waste',
+        sessionId: 's-anthropic-hotspots',
+        messageId: 'm-anthropic-hotspots',
         ts: '2026-04-20T00:00:02.000Z',
-        toolCalls: [{ id: 'tc-anthropic-waste', name: 'Read', target: 'anthropic.ts', argsHash: 'bbb' }],
+        toolCalls: [{ id: 'tc-anthropic-hotspots', name: 'Read', target: 'anthropic.ts', argsHash: 'bbb' }],
       }),
     ]);
 
     const { result, stdout } = await captureStdio(() =>
-      runWaste(args({ provider: 'synthetic', json: true })),
+      runHotspots(args({ provider: 'synthetic', json: true })),
     );
     assert.equal(result, 0);
     const parsed = JSON.parse(stdout);
     assert.equal(parsed.turnsAnalyzed, 1);
     assert.equal(parsed.sessions.length, 1);
-    assert.equal(parsed.sessions[0].sessionId, 's-synth-waste');
+    assert.equal(parsed.sessions[0].sessionId, 's-synth-hotspots');
     assert.ok(parsed.grandTotal > 0);
   });
 });

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -145,7 +145,7 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
     // JSON contract: numeric usage fields are always numbers, but the
     // companion `fidelity` block is the only honest answer to "are these
     // zeros real?". Programmatic consumers should consult `summary` (the
-    // slice-wide rollup, same shape compare/waste/limits/plans emit) and
+    // slice-wide rollup, same shape compare/hotspots/limits/plans emit) and
     // `perCell` (per-(model|provider) per-field known/missing counts) before
     // trusting any aggregate.
     const perCell = buildPerCellFidelity(rows, byProvider ? 'provider' : 'model');
@@ -962,7 +962,7 @@ interface PerCellFidelityBlock {
 }
 
 // Per-(model|provider) per-field coverage block for `--json`. Shape mirrors
-// the pattern compare/waste use: a `summary` (slice-wide rollup) plus an
+// the pattern compare/hotspots use: a `summary` (slice-wide rollup) plus an
 // optional `perCell` payload programmatic callers can render without
 // re-walking the ledger. Empty `cells` array (no rows in scope) is a valid
 // payload — callers should treat it the same as "every cell is full".

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 export { runSummary } from './commands/summary.js';
-export { runWaste } from './commands/waste.js';
-export { runContext } from './commands/context.js';
+export { runHotspots } from './commands/hotspots.js';
+export { runOverhead } from './commands/overhead.js';
 export { runIngest } from './commands/ingest.js';
 export { runLimits } from './commands/limits.js';
 export { runPlans } from './commands/plans.js';

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -68,7 +68,7 @@ export interface IngestReport {
 // Per-adapter content-capture gap aggregator. A "gap" is a session that the
 // parser emitted in `contentMode === 'full'` mode with at least one tool call
 // in a committed turn but zero `tool_result` ContentRecords — the load-bearing
-// kind for `burn waste`'s tool-call attribution. See #59 / #33.
+// kind for `burn hotspots`'s tool-call attribution. See #59 / #33.
 //
 // We accumulate per adapter across the ingest loop and emit a single warning
 // at the end. Suppression is per-process: once an adapter has warned, later
@@ -220,7 +220,7 @@ export async function ingestAll(): Promise<IngestReport> {
 // "affected" iff (a) it produced ≥1 turn with ≥1 tool call and (b) no
 // tool_result records were captured for it. Per the issue, we ignore the
 // `text`/`thinking`/`tool_use` content kinds because their absence is not
-// load-bearing for `burn waste` attribution.
+// load-bearing for `burn hotspots` attribution.
 export function countToolCallGaps(
   turns: readonly TurnRecord[],
   content: readonly ContentRecord[],
@@ -255,7 +255,7 @@ function emitGapWarning(
   state.write(
     `[burn] warning: ${adapter} parser produced 0 tool_result records for ${stats.affectedSessions} session${stats.affectedSessions === 1 ? '' : 's'} ` +
       `with ${stats.orphanToolCalls} tool call${stats.orphanToolCalls === 1 ? '' : 's'}. Content capture may not be implemented for this ` +
-      `adapter, so burn waste will use user-turn block sizes when available, then fall back to even-split attribution. See #33.\n`,
+      `adapter, so burn hotspots will use user-turn block sizes when available, then fall back to even-split attribution. See #33.\n`,
   );
 }
 


### PR DESCRIPTION
Closes #152

## Summary
- Replace the CLI waste/diagnose/context surface with hotspots and overhead commands.
- Rename @relayburn/analyze hotspot and overhead APIs without compatibility aliases.
- Update docs, changelogs, and command/action text for the new names.

## Tests
- pnpm run build
- pnpm run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
