### PR TITLE
storage: introduce ledger storage adapter seam

### DIFF
--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@relayburn/ledger`.
 ### Changed
 
 - Ledger reads, writes, locks, and content sidecars now run through the file-backed storage adapter seam without changing the JSONL filesystem output.
+- Archive helpers (`openArchive`, `buildArchive`, `rebuildArchive`, `vacuumArchive`, `getArchiveStatus`) now throw when `RELAYBURN_STORAGE` is anything other than `file`, instead of silently returning an empty in-memory database — `burn summary` etc. would otherwise report zero turns to users on unsupported backends.
 
 ## [1.1.0] - 2026-04-29
 

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/ledger`.
 
 ## [Unreleased]
 
+### Changed
+
+- Ledger reads, writes, locks, and content sidecars now run through the file-backed storage adapter seam without changing the JSONL filesystem output.
+
 ## [1.0.0] - 2026-04-29
 
 ### Added

--- a/packages/ledger/src/adapters/adapter.ts
+++ b/packages/ledger/src/adapters/adapter.ts
@@ -1,0 +1,42 @@
+import type {
+  CompactionEvent,
+  ContentRecord,
+  SessionRelationshipRecord,
+  ToolResultEventRecord,
+  TurnRecord,
+  UserTurnRecord,
+} from '@relayburn/reader';
+
+import type { PruneOptions, PruneResult, ReadContentSelector } from '../content.js';
+import type { EnrichedTurn, Query } from '../reader.js';
+import type { StampLine } from '../schema.js';
+
+export type StorageAdapterKind = 'file' | 'sqlite' | 'postgres' | 'http';
+
+export type ContentLine = ContentRecord;
+
+export interface StorageAdapter {
+  readonly kind: StorageAdapterKind;
+
+  appendTurns(turns: TurnRecord[]): Promise<void>;
+  appendCompactions(events: CompactionEvent[]): Promise<void>;
+  appendRelationships(records: SessionRelationshipRecord[]): Promise<void>;
+  appendToolResultEvents(records: ToolResultEventRecord[]): Promise<void>;
+  appendUserTurns(records: UserTurnRecord[]): Promise<void>;
+  appendStamp(stamp: StampLine): Promise<void>;
+  appendContent(records: ContentRecord[]): Promise<void>;
+
+  queryTurns(q: Query): AsyncIterable<EnrichedTurn>;
+  queryCompactions(q: Query): AsyncIterable<CompactionEvent>;
+  queryRelationships(q: Query): AsyncIterable<SessionRelationshipRecord>;
+  queryToolResultEvents(q: Query): AsyncIterable<ToolResultEventRecord>;
+  queryUserTurns(q: Query): AsyncIterable<UserTurnRecord>;
+  readContent(selector: ReadContentSelector): AsyncIterable<ContentLine>;
+  listContentSessionIds(): Promise<string[]>;
+  pruneContent(options: PruneOptions): Promise<PruneResult>;
+
+  withLock<T>(name: string, fn: () => Promise<T>): Promise<T>;
+
+  init(): Promise<void>;
+  close(): Promise<void>;
+}

--- a/packages/ledger/src/adapters/factory.ts
+++ b/packages/ledger/src/adapters/factory.ts
@@ -1,0 +1,33 @@
+import type { StorageAdapter, StorageAdapterKind } from './adapter.js';
+import { FileAdapter } from './file-adapter.js';
+
+let adapter: StorageAdapter | undefined;
+
+export function getAdapter(): StorageAdapter {
+  if (adapter) return adapter;
+  const kind = getStorageAdapterKind();
+  switch (kind) {
+    case 'file':
+      adapter = new FileAdapter();
+      return adapter;
+    case 'sqlite':
+    case 'postgres':
+    case 'http':
+      throw new Error(`RELAYBURN_STORAGE=${kind} is not supported in this build`);
+  }
+}
+
+export function getStorageAdapterKind(): StorageAdapterKind {
+  const raw = process.env['RELAYBURN_STORAGE'] ?? 'file';
+  if (raw === 'file' || raw === 'sqlite' || raw === 'postgres' || raw === 'http') {
+    return raw;
+  }
+  throw new Error(
+    `unsupported RELAYBURN_STORAGE=${JSON.stringify(raw)} ` +
+      '(expected file, sqlite, postgres, or http)',
+  );
+}
+
+export function __resetAdapterForTesting(): void {
+  adapter = undefined;
+}

--- a/packages/ledger/src/adapters/file-adapter.ts
+++ b/packages/ledger/src/adapters/file-adapter.ts
@@ -1,0 +1,592 @@
+import { createReadStream } from 'node:fs';
+import {
+  appendFile,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  unlink,
+} from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import * as path from 'node:path';
+
+import type {
+  CompactionEvent,
+  ContentRecord,
+  SessionRelationshipRecord,
+  SourceKind,
+  ToolResultEventRecord,
+  TurnRecord,
+  UserTurnRecord,
+} from '@relayburn/reader';
+
+import {
+  appendHashes,
+  compactionIdHash,
+  loadIndex,
+  relationshipIdHash,
+  toolResultEventIdHash,
+  turnContentFingerprint,
+  turnIdHash,
+  userTurnIdHash,
+} from '../index-sidecar.js';
+import { contentDir, contentFilePath, isValidSessionId, ledgerPath } from '../paths.js';
+import {
+  isCompactionLine,
+  isSessionRelationshipLine,
+  isStampLine,
+  isToolResultEventLine,
+  isTurnLine,
+  isUserTurnLine,
+  stampMatches,
+  type CompactionLine,
+  type Enrichment,
+  type LedgerLine,
+  type SessionRelationshipLine,
+  type StampLine,
+  type ToolResultEventLine,
+  type TurnLine,
+  type UserTurnLine,
+} from '../schema.js';
+import type { PruneOptions, PruneResult, ReadContentSelector } from '../content.js';
+import type { EnrichedTurn, Query } from '../reader.js';
+import type { StorageAdapter } from './adapter.js';
+import { FileLockManager } from './file-lock.js';
+
+export class FileAdapter implements StorageAdapter {
+  readonly kind = 'file' as const;
+
+  private readonly locks = new FileLockManager();
+
+  async init(): Promise<void> {}
+
+  async close(): Promise<void> {}
+
+  async withLock<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    return this.locks.withLock(name, fn);
+  }
+
+  async appendTurns(turns: TurnRecord[]): Promise<void> {
+    if (turns.length === 0) return;
+    const idx = await loadIndex();
+    // Snapshot content set before this batch: content-fingerprint dedup only
+    // compares against historically-committed turns, never within the same batch.
+    const historicalContent = new Set(idx.content);
+    const fresh: TurnRecord[] = [];
+    const newIds: string[] = [];
+    const newContent: string[] = [];
+    for (const t of turns) {
+      const id = turnIdHash(t);
+      if (idx.ids.has(id)) continue;
+      const cf = turnContentFingerprint(t);
+      if (historicalContent.has(cf)) continue;
+      fresh.push(t);
+      newIds.push(id);
+      newContent.push(cf);
+      idx.ids.add(id); // primary dedup DOES apply within batch: same messageId = same turn
+    }
+    if (fresh.length === 0) return;
+    for (const cf of newContent) idx.content.add(cf);
+    const lines: TurnLine[] = fresh.map((record) => ({ v: 1, kind: 'turn', record }));
+    await this.appendLines(lines);
+    await appendHashes(newIds, newContent);
+  }
+
+  async appendCompactions(events: CompactionEvent[]): Promise<void> {
+    if (events.length === 0) return;
+    // Dedup piggybacks on the ledger-id index. Compaction ids share the same
+    // namespace as turn ids: they hash different inputs so collisions are not
+    // a practical concern, and we get crash-safe persistence for free.
+    const idx = await loadIndex();
+    const fresh: CompactionEvent[] = [];
+    const newIds: string[] = [];
+    for (const e of events) {
+      const id = compactionIdHash(e);
+      if (idx.ids.has(id)) continue;
+      fresh.push(e);
+      newIds.push(id);
+      idx.ids.add(id);
+    }
+    if (fresh.length === 0) return;
+    const lines: CompactionLine[] = fresh.map((record) => ({
+      v: 1,
+      kind: 'compaction',
+      record,
+    }));
+    await this.appendLines(lines);
+    await appendHashes(newIds, []);
+  }
+
+  async appendRelationships(records: SessionRelationshipRecord[]): Promise<void> {
+    if (records.length === 0) return;
+    const idx = await loadIndex();
+    const fresh: SessionRelationshipRecord[] = [];
+    const newIds: string[] = [];
+    for (const r of records) {
+      const id = relationshipIdHash(r);
+      if (idx.ids.has(id)) continue;
+      fresh.push(r);
+      newIds.push(id);
+      idx.ids.add(id);
+    }
+    if (fresh.length === 0) return;
+    const lines: SessionRelationshipLine[] = fresh.map((record) => ({
+      v: 1,
+      kind: 'relationship',
+      record,
+    }));
+    await this.appendLines(lines);
+    await appendHashes(newIds, []);
+  }
+
+  async appendUserTurns(records: UserTurnRecord[]): Promise<void> {
+    if (records.length === 0) return;
+    // Dedup piggybacks on the ledger-id index. User-turn ids share the same
+    // namespace as turn / compaction / relationship / tool-result-event ids:
+    // they hash different inputs (source|sessionId|userUuid) so collisions are
+    // not a practical concern, and we get crash-safe persistence for free.
+    const idx = await loadIndex();
+    const fresh: UserTurnRecord[] = [];
+    const newIds: string[] = [];
+    for (const r of records) {
+      const id = userTurnIdHash(r);
+      if (idx.ids.has(id)) continue;
+      fresh.push(r);
+      newIds.push(id);
+      idx.ids.add(id);
+    }
+    if (fresh.length === 0) return;
+    const lines: UserTurnLine[] = fresh.map((record) => ({
+      v: 1,
+      kind: 'user_turn',
+      record,
+    }));
+    await this.appendLines(lines);
+    await appendHashes(newIds, []);
+  }
+
+  async appendToolResultEvents(records: ToolResultEventRecord[]): Promise<void> {
+    if (records.length === 0) return;
+    const idx = await loadIndex();
+    const fresh: ToolResultEventRecord[] = [];
+    const newIds: string[] = [];
+    for (const r of records) {
+      const id = toolResultEventIdHash(r);
+      if (idx.ids.has(id)) continue;
+      fresh.push(r);
+      newIds.push(id);
+      idx.ids.add(id);
+    }
+    if (fresh.length === 0) return;
+    const lines: ToolResultEventLine[] = fresh.map((record) => ({
+      v: 1,
+      kind: 'tool_result_event',
+      record,
+    }));
+    await this.appendLines(lines);
+    await appendHashes(newIds, []);
+  }
+
+  async appendStamp(line: StampLine): Promise<void> {
+    const relationship = spawnEnvRelationshipFromStamp(line);
+    if (!relationship) {
+      await this.appendLines([line]);
+      return;
+    }
+
+    const idx = await loadIndex();
+    const id = relationshipIdHash(relationship);
+    if (idx.ids.has(id)) {
+      await this.appendLines([line]);
+      return;
+    }
+    idx.ids.add(id);
+    await this.appendLines([
+      line,
+      {
+        v: 1,
+        kind: 'relationship',
+        record: relationship,
+      },
+    ]);
+    await appendHashes([id], []);
+  }
+
+  async appendContent(records: ContentRecord[]): Promise<void> {
+    if (records.length === 0) return;
+    const grouped = new Map<string, ContentRecord[]>();
+    for (const r of records) {
+      const key = r.sessionId;
+      if (!key) continue;
+      if (!isValidSessionId(key)) {
+        process.stderr.write(
+          `[burn] skipping content record with unsafe sessionId: ${JSON.stringify(key)}\n`,
+        );
+        continue;
+      }
+      let bucket = grouped.get(key);
+      if (!bucket) {
+        bucket = [];
+        grouped.set(key, bucket);
+      }
+      bucket.push(r);
+    }
+    if (grouped.size === 0) return;
+    await mkdir(contentDir(), { recursive: true });
+    for (const [sessionId, items] of grouped) {
+      await this.appendSessionContent(sessionId, items);
+    }
+  }
+
+  async *queryTurns(q: Query = {}): AsyncIterable<EnrichedTurn> {
+    const filePath = ledgerPath();
+    if (!(await fileExists(filePath))) return;
+    const stamps = await collectStamps(filePath);
+    for await (const parsed of streamLines(filePath)) {
+      if (!isTurnLine(parsed)) continue;
+      const enrichment = foldStamps(parsed.record, stamps);
+      if (!turnPasses(parsed.record, q, enrichment)) continue;
+      yield { ...parsed.record, enrichment };
+    }
+  }
+
+  async *queryCompactions(q: Query = {}): AsyncIterable<CompactionEvent> {
+    const filePath = ledgerPath();
+    if (!(await fileExists(filePath))) return;
+    for await (const parsed of streamLines(filePath)) {
+      if (!isCompactionLine(parsed)) continue;
+      if (!compactionPasses(parsed.record, q)) continue;
+      yield parsed.record;
+    }
+  }
+
+  async *queryRelationships(
+    q: Query = {},
+  ): AsyncIterable<SessionRelationshipRecord> {
+    const filePath = ledgerPath();
+    if (!(await fileExists(filePath))) return;
+    for await (const parsed of streamLines(filePath)) {
+      if (!isSessionRelationshipLine(parsed)) continue;
+      if (!relationshipPasses(parsed.record, q)) continue;
+      yield parsed.record;
+    }
+  }
+
+  async *queryToolResultEvents(
+    q: Query = {},
+  ): AsyncIterable<ToolResultEventRecord> {
+    const filePath = ledgerPath();
+    if (!(await fileExists(filePath))) return;
+    for await (const parsed of streamLines(filePath)) {
+      if (!isToolResultEventLine(parsed)) continue;
+      if (!toolResultEventPasses(parsed.record, q)) continue;
+      yield parsed.record;
+    }
+  }
+
+  async *queryUserTurns(q: Query = {}): AsyncIterable<UserTurnRecord> {
+    const filePath = ledgerPath();
+    if (!(await fileExists(filePath))) return;
+    for await (const parsed of streamLines(filePath)) {
+      if (!isUserTurnLine(parsed)) continue;
+      if (!userTurnPasses(parsed.record, q)) continue;
+      yield parsed.record;
+    }
+  }
+
+  async *readContent(selector: ReadContentSelector): AsyncIterable<ContentRecord> {
+    const file = contentFilePath(selector.sessionId);
+    let raw: string;
+    try {
+      raw = await readFile(file, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (!parsed || typeof parsed !== 'object') continue;
+      const rec = parsed as ContentRecord;
+      if (selector.messageId !== undefined && rec.messageId !== selector.messageId)
+        continue;
+      yield rec;
+    }
+  }
+
+  async listContentSessionIds(): Promise<string[]> {
+    const dir = contentDir();
+    const out: string[] = [];
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return out;
+      throw err;
+    }
+    for (const name of entries) {
+      if (!name.endsWith('.jsonl')) continue;
+      const sessionId = name.slice(0, -'.jsonl'.length);
+      if (!isValidSessionId(sessionId)) continue;
+      // An empty sidecar signals "attempted but nothing written" and should be
+      // re-parsed rather than treated as already-populated.
+      try {
+        const st = await stat(path.join(dir, name));
+        if (st.size > 0) out.push(sessionId);
+      } catch {
+        // raced with deletion; ignore
+      }
+    }
+    return out;
+  }
+
+  async pruneContent(options: PruneOptions): Promise<PruneResult> {
+    const dir = contentDir();
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { filesDeleted: 0, bytesFreed: 0, skippedRecoverable: 0 };
+      }
+      throw err;
+    }
+    const cutoff = Date.now() - options.olderThanMs;
+    const isRecoverable = options.isRecoverable;
+    let filesDeleted = 0;
+    let bytesFreed = 0;
+    let skippedRecoverable = 0;
+    for (const name of entries) {
+      if (!name.endsWith('.jsonl')) continue;
+      const sessionId = name.slice(0, -'.jsonl'.length);
+      if (!isValidSessionId(sessionId)) continue;
+      const full = path.join(dir, name);
+      // Acquire the same per-session lock used by appendSessionContent so a
+      // prune cannot race with an in-flight write for this session. We re-stat
+      // inside the lock to ensure we're deciding on the post-write mtime.
+      type Outcome =
+        | { kind: 'deleted'; size: number }
+        | { kind: 'skippedRecoverable' }
+        | null;
+      const outcome: Outcome = await this.withLock(`content.${sessionId}`, async () => {
+        let st: Awaited<ReturnType<typeof stat>>;
+        try {
+          st = await stat(full);
+        } catch {
+          return null;
+        }
+        if (!st.isFile()) return null;
+        // Inclusive cutoff: files whose mtime equals now - olderThanMs are
+        // eligible. This also makes `pruneContent({olderThanMs: 0})` clear the
+        // directory reliably.
+        if (st.mtimeMs > cutoff) return null;
+        // Source-aware protection: if the upstream agent's session file still
+        // exists, the sidecar is recoverable via `burn state rebuild content`, so
+        // deleting it on retention alone is silently lossy. Callers opt in by
+        // supplying `isRecoverable`; the ledger package itself never reaches
+        // out to adapter-specific paths.
+        if (isRecoverable) {
+          try {
+            if (await isRecoverable(sessionId)) {
+              return { kind: 'skippedRecoverable' };
+            }
+          } catch {
+            // If the predicate throws, fall through to the existing behavior:
+            // we'd rather prune than fail-open and accumulate forever on a
+            // broken source index.
+          }
+        }
+        try {
+          await unlink(full);
+          return { kind: 'deleted', size: st.size };
+        } catch {
+          // raced with another deleter or was already gone
+          return null;
+        }
+      });
+      if (outcome?.kind === 'deleted') {
+        filesDeleted++;
+        bytesFreed += outcome.size;
+      } else if (outcome?.kind === 'skippedRecoverable') {
+        skippedRecoverable++;
+      }
+    }
+    return { filesDeleted, bytesFreed, skippedRecoverable };
+  }
+
+  private async appendLines(lines: LedgerLine[]): Promise<void> {
+    if (lines.length === 0) return;
+    const filePath = ledgerPath();
+    await ensureDir(filePath);
+    const payload = lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
+    // Hold the same 'ledger' lock that reclassifyLedger acquires for its
+    // read-modify-write pass. Without this, an appendFile that lands between
+    // reclassify's readFile and rename would write to the soon-orphaned old
+    // inode, and its turns would be silently dropped when the rename swaps in
+    // the rewritten file. The race is hard to force in tests on a fast SSD
+    // (libuv tends to drain queued appendFiles before reclassify starts
+    // reading) but is real under heavier contention.
+    await this.withLock('ledger', async () => {
+      await appendFile(filePath, payload, { encoding: 'utf8' });
+    });
+  }
+
+  private async appendSessionContent(
+    sessionId: string,
+    records: ContentRecord[],
+  ): Promise<void> {
+    const file = contentFilePath(sessionId);
+    await this.withLock(`content.${sessionId}`, async () => {
+      const lines = records.map((r) => JSON.stringify(r));
+      let existing = new Set<string>();
+      try {
+        const raw = await readFile(file, 'utf8');
+        existing = new Set(raw.split('\n').filter((line) => line.length > 0));
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+      const fresh = lines.filter((line) => {
+        if (existing.has(line)) return false;
+        existing.add(line);
+        return true;
+      });
+      if (fresh.length === 0) return;
+      const payload = fresh.join('\n') + '\n';
+      await appendFile(file, payload, { encoding: 'utf8' });
+    });
+  }
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    const s = await stat(p);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function* streamLines(filePath: string): AsyncIterable<unknown> {
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  });
+  try {
+    for await (const line of rl) {
+      const t = line.trim();
+      if (!t) continue;
+      try {
+        yield JSON.parse(t);
+      } catch {
+        // skip malformed
+      }
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+async function collectStamps(filePath: string): Promise<StampLine[]> {
+  const stamps: StampLine[] = [];
+  for await (const parsed of streamLines(filePath)) {
+    if (isStampLine(parsed)) stamps.push(parsed);
+  }
+  stamps.sort((a, b) => a.ts.localeCompare(b.ts));
+  return stamps;
+}
+
+function turnPasses(turn: TurnRecord, q: Query, enrichment: Enrichment): boolean {
+  if (q.since && turn.ts < q.since) return false;
+  if (q.until && turn.ts > q.until) return false;
+  if (q.project && turn.project !== q.project && turn.projectKey !== q.project) return false;
+  if (q.sessionId && turn.sessionId !== q.sessionId) return false;
+  if (q.source && turn.source !== q.source) return false;
+  if (q.enrichment) {
+    for (const [k, v] of Object.entries(q.enrichment)) {
+      if (v === undefined) continue;
+      if (enrichment[k] !== v) return false;
+    }
+  }
+  return true;
+}
+
+function foldStamps(turn: TurnRecord, stamps: StampLine[]): Enrichment {
+  const out: Enrichment = {};
+  for (const s of stamps) {
+    if (!stampMatches(s, turn)) continue;
+    for (const [k, v] of Object.entries(s.enrichment)) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function compactionPasses(e: CompactionEvent, q: Query): boolean {
+  if (q.since && e.ts < q.since) return false;
+  if (q.until && e.ts > q.until) return false;
+  if (q.sessionId && e.sessionId !== q.sessionId) return false;
+  if (q.source && e.source !== q.source) return false;
+  // project and enrichment don't filter compaction events (they live at the
+  // session level; callers that need project-scoping should pre-filter by
+  // sessionId from a turn query).
+  return true;
+}
+
+function relationshipPasses(r: SessionRelationshipRecord, q: Query): boolean {
+  if (q.since && r.ts && r.ts < q.since) return false;
+  if (q.until && r.ts && r.ts > q.until) return false;
+  if (q.sessionId && r.sessionId !== q.sessionId && r.relatedSessionId !== q.sessionId)
+    return false;
+  if (q.source && r.source !== q.source) return false;
+  return true;
+}
+
+function toolResultEventPasses(r: ToolResultEventRecord, q: Query): boolean {
+  if (q.since && r.ts && r.ts < q.since) return false;
+  if (q.until && r.ts && r.ts > q.until) return false;
+  if (q.sessionId && r.sessionId !== q.sessionId) return false;
+  if (q.source && r.source !== q.source) return false;
+  return true;
+}
+
+function userTurnPasses(r: UserTurnRecord, q: Query): boolean {
+  if (q.since && r.ts < q.since) return false;
+  if (q.until && r.ts > q.until) return false;
+  if (q.sessionId && r.sessionId !== q.sessionId) return false;
+  if (q.source && r.source !== q.source) return false;
+  // project and enrichment don't filter user turns (they live at the session
+  // level; callers that need project-scoping should pre-filter by sessionId
+  // from a turn query).
+  return true;
+}
+
+function spawnEnvRelationshipFromStamp(
+  line: StampLine,
+): SessionRelationshipRecord | null {
+  const sessionId = line.selector.sessionId;
+  if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
+  const parentAgentId = line.enrichment['parentAgentId'];
+  if (typeof parentAgentId !== 'string' || parentAgentId.length === 0) return null;
+
+  const relationship: SessionRelationshipRecord = {
+    v: 1,
+    source: 'spawn-env',
+    sessionId,
+    relatedSessionId: parentAgentId,
+    relationshipType: 'subagent',
+    ts: line.ts,
+  };
+  const agentId = line.enrichment['agentId'];
+  if (typeof agentId === 'string' && agentId.length > 0) relationship.agentId = agentId;
+  return relationship;
+}

--- a/packages/ledger/src/adapters/file-lock.ts
+++ b/packages/ledger/src/adapters/file-lock.ts
@@ -1,0 +1,142 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { open, stat, unlink, mkdir } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { lockPath } from '../paths.js';
+
+// Two-phase acquire:
+//
+//   Phase 1 (fast): cheap retries that cover normal in-process contention
+//   between concurrent writers. ~1s total.
+//
+//   Phase 2 (slow): longer waits that outlast STALE_MS so a single invocation
+//   can self-heal an orphan lock left by a crashed process. ~10s total.
+//
+// The previous tuning (RETRY_DELAY_MS=20, MAX_RETRIES=50, STALE_MS=30_000)
+// gave a 1s retry budget against a 30s stale threshold, leaving a 29s window
+// where any acquirer would hard-fail with "could not acquire lock after 50
+// attempts" even though the lock was already orphaned. See #62.
+export const FAST_RETRY_DELAY_MS = 20;
+export const FAST_RETRIES = 50; // 1s: normal concurrent-writer contention
+export const SLOW_RETRY_DELAY_MS = 250;
+export const SLOW_RETRIES = 40; // 10s: covers an orphan twice over
+export const STALE_MS = 5_000;
+
+const TOTAL_RETRY_BUDGET_MS =
+  FAST_RETRY_DELAY_MS * FAST_RETRIES + SLOW_RETRY_DELAY_MS * SLOW_RETRIES;
+
+// Invariant the issue calls out: the retry budget MUST outlast the stale
+// threshold (plus at least one retry cycle) so a single invocation can wait
+// out an orphan and unlink it. Asserting at module-load time means future
+// tuning of either constant can't silently reintroduce the gap.
+if (TOTAL_RETRY_BUDGET_MS <= STALE_MS + SLOW_RETRY_DELAY_MS) {
+  throw new Error(
+    `lock retry budget (${TOTAL_RETRY_BUDGET_MS}ms) must exceed STALE_MS ` +
+      `(${STALE_MS}ms) + one slow retry (${SLOW_RETRY_DELAY_MS}ms)`,
+  );
+}
+
+export interface AcquireOptions {
+  fastRetries: number;
+  fastRetryDelayMs: number;
+  slowRetries: number;
+  slowRetryDelayMs: number;
+  staleMs: number;
+}
+
+const DEFAULT_OPTIONS: AcquireOptions = {
+  fastRetries: FAST_RETRIES,
+  fastRetryDelayMs: FAST_RETRY_DELAY_MS,
+  slowRetries: SLOW_RETRIES,
+  slowRetryDelayMs: SLOW_RETRY_DELAY_MS,
+  staleMs: STALE_MS,
+};
+
+export class FileLockManager {
+  private readonly heldLocks = new AsyncLocalStorage<Set<string>>();
+
+  async withLock<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const lp = lockPath(name);
+    const held = this.heldLocks.getStore();
+    if (held?.has(lp)) return fn();
+
+    await mkdir(path.dirname(lp), { recursive: true });
+    await acquire(lp, DEFAULT_OPTIONS);
+    const nextHeld = new Set(held ?? []);
+    nextHeld.add(lp);
+    try {
+      return await this.heldLocks.run(nextHeld, fn);
+    } finally {
+      try {
+        await unlink(lp);
+      } catch {
+        // ignore; next acquirer will see it as stale
+      }
+    }
+  }
+}
+
+// Exported for tests that need to drive the timeout path with a tiny budget
+// without holding a real lock for ~11 seconds.
+export async function __acquireFileLockForTesting(
+  lp: string,
+  options: AcquireOptions,
+): Promise<void> {
+  await mkdir(path.dirname(lp), { recursive: true });
+  await acquire(lp, options);
+}
+
+async function acquire(lp: string, options: AcquireOptions): Promise<void> {
+  // Track which failure mode we kept hitting so the timeout error can name
+  // the side it timed out on instead of the ambiguous "after N attempts".
+  let lastReason: 'live' | 'stale-unlink-failed' = 'live';
+
+  const totalRetries = options.fastRetries + options.slowRetries;
+  const budgetMs =
+    options.fastRetries * options.fastRetryDelayMs +
+    options.slowRetries * options.slowRetryDelayMs;
+  for (let attempt = 0; attempt < totalRetries; attempt++) {
+    try {
+      const handle = await open(lp, 'wx');
+      await handle.close();
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      const st = await stat(lp).catch(() => null);
+      if (st && Date.now() - st.mtimeMs > options.staleMs) {
+        try {
+          await unlink(lp);
+          // unlink succeeded: loop and retry the open immediately. Don't
+          // count this as a stale-unlink-failed attempt.
+          continue;
+        } catch (unlinkErr) {
+          const code = (unlinkErr as NodeJS.ErrnoException).code;
+          if (code === 'ENOENT') {
+            // Another acquirer already cleaned it up; race the open again.
+            continue;
+          }
+          // Real failure (EPERM, EBUSY, etc.). Record it and back off so the
+          // final error message can distinguish this from "live holder".
+          lastReason = 'stale-unlink-failed';
+        }
+      } else {
+        lastReason = 'live';
+      }
+      const delayMs =
+        attempt < options.fastRetries ? options.fastRetryDelayMs : options.slowRetryDelayMs;
+      await delay(delayMs);
+    }
+  }
+  const detail =
+    lastReason === 'stale-unlink-failed'
+      ? 'lock appears stale but unlink kept failing'
+      : 'held by live process';
+  throw new Error(
+    `could not acquire lock after ${totalRetries} attempts ` +
+      `(~${budgetMs}ms) - ${detail}: ${lp}`,
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/ledger/src/archive.test.ts
+++ b/packages/ledger/src/archive.test.ts
@@ -1326,4 +1326,22 @@ describe('archive', () => {
     const status = await getArchiveStatus();
     assert.equal(status.rowCounts.turns, 1);
   });
+
+  it('archive helpers throw when RELAYBURN_STORAGE is not file', async () => {
+    const originalStorage = process.env['RELAYBURN_STORAGE'];
+    process.env['RELAYBURN_STORAGE'] = 'sqlite';
+    try {
+      await assert.rejects(buildArchive(), /RELAYBURN_STORAGE=file/);
+      await assert.rejects(rebuildArchive(), /RELAYBURN_STORAGE=file/);
+      await assert.rejects(vacuumArchive(), /RELAYBURN_STORAGE=file/);
+      await assert.rejects(getArchiveStatus(), /RELAYBURN_STORAGE=file/);
+      await assert.rejects(openArchive(), /RELAYBURN_STORAGE=file/);
+    } finally {
+      if (originalStorage === undefined) {
+        delete process.env['RELAYBURN_STORAGE'];
+      } else {
+        process.env['RELAYBURN_STORAGE'] = originalStorage;
+      }
+    }
+  });
 });

--- a/packages/ledger/src/archive.ts
+++ b/packages/ledger/src/archive.ts
@@ -37,6 +37,7 @@ installSqliteWarningFilter();
 
 import type { TurnRecord } from '@relayburn/reader';
 
+import { getStorageAdapterKind } from './adapters/factory.js';
 import { withLock } from './lock.js';
 import { archivePath, ledgerPath } from './paths.js';
 import {
@@ -311,6 +312,18 @@ export interface BuildResult {
  * we delete and recreate, since the archive is by design rebuildable.
  */
 export async function openArchive(): Promise<DatabaseSync> {
+  if (!archiveEnabled()) {
+    const db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    db.exec(SCHEMA_SQL);
+    applyAdditiveMigrations(db);
+    db.prepare(
+      `INSERT INTO archive_state (id, ledger_offset_bytes, ledger_mtime_ms, archive_version)
+       VALUES (1, 0, 0, ?)`,
+    ).run(ARCHIVE_VERSION);
+    return db;
+  }
+
   const dbPath = archivePath();
   await mkdir(path.dirname(dbPath), { recursive: true });
 
@@ -400,6 +413,49 @@ async function fileExists(p: string): Promise<boolean> {
   }
 }
 
+function archiveEnabled(): boolean {
+  return getStorageAdapterKind() === 'file';
+}
+
+function emptyBuildResult(): BuildResult {
+  return {
+    scannedBytes: 0,
+    turnsApplied: 0,
+    sessionsTouched: 0,
+    stampsApplied: 0,
+    compactionsApplied: 0,
+    toolResultEventsApplied: 0,
+    rebuiltFromZero: false,
+  };
+}
+
+function emptyArchiveStatus(
+  archiveFilePath: string,
+  ledgerSizeBytes: number,
+  ledgerMtimeMsCurrent: number,
+): ArchiveStatus {
+  return {
+    archivePath: archiveFilePath,
+    exists: false,
+    archiveVersion: ARCHIVE_VERSION,
+    ledgerOffsetBytes: 0,
+    ledgerMtimeMs: 0,
+    ledgerSizeBytes,
+    ledgerMtimeMsCurrent,
+    upToDate: false,
+    lastBuiltAt: null,
+    lastRebuildAt: null,
+    rowCounts: {
+      sessions: 0,
+      turns: 0,
+      toolCalls: 0,
+      toolResultEvents: 0,
+      compactions: 0,
+    },
+    fidelityHistogram: {},
+  };
+}
+
 /**
  * Drop the archive entirely and rebuild from the ledger.
  *
@@ -409,6 +465,7 @@ async function fileExists(p: string): Promise<boolean> {
  * threw).
  */
 export async function rebuildArchive(): Promise<BuildResult> {
+  if (!archiveEnabled()) return emptyBuildResult();
   return withLock('archive', async () => {
     const dbPath = archivePath();
     await unlink(dbPath).catch(() => undefined);
@@ -431,6 +488,7 @@ export async function rebuildArchive(): Promise<BuildResult> {
  * path.
  */
 export async function buildArchive(): Promise<BuildResult> {
+  if (!archiveEnabled()) return emptyBuildResult();
   return withLock('archive', () => buildArchiveLocked());
 }
 
@@ -454,6 +512,15 @@ export async function buildArchive(): Promise<BuildResult> {
  * against an artificially small pre-vacuum number.
  */
 export async function vacuumArchive(): Promise<VacuumResult> {
+  if (!archiveEnabled()) {
+    return {
+      archivePath: archivePath(),
+      existed: false,
+      beforeBytes: 0,
+      afterBytes: 0,
+      reclaimedBytes: 0,
+    };
+  }
   return withLock('archive', async () => {
     const dbPath = archivePath();
     if (!(await fileExists(dbPath))) {
@@ -1244,6 +1311,9 @@ async function* readJsonlFrom(filePath: string, startOffset: number): AsyncItera
  * consistent read view.
  */
 export async function getArchiveStatus(): Promise<ArchiveStatus> {
+  if (!archiveEnabled()) {
+    return emptyArchiveStatus(archivePath(), 0, 0);
+  }
   const dbPath = archivePath();
   const exists = await fileExists(dbPath);
   const ledger = ledgerPath();

--- a/packages/ledger/src/archive.ts
+++ b/packages/ledger/src/archive.ts
@@ -312,17 +312,7 @@ export interface BuildResult {
  * we delete and recreate, since the archive is by design rebuildable.
  */
 export async function openArchive(): Promise<DatabaseSync> {
-  if (!archiveEnabled()) {
-    const db = new DatabaseSync(':memory:');
-    db.exec('PRAGMA foreign_keys = ON');
-    db.exec(SCHEMA_SQL);
-    applyAdditiveMigrations(db);
-    db.prepare(
-      `INSERT INTO archive_state (id, ledger_offset_bytes, ledger_mtime_ms, archive_version)
-       VALUES (1, 0, 0, ?)`,
-    ).run(ARCHIVE_VERSION);
-    return db;
-  }
+  assertFileStorage();
 
   const dbPath = archivePath();
   await mkdir(path.dirname(dbPath), { recursive: true });
@@ -413,47 +403,13 @@ async function fileExists(p: string): Promise<boolean> {
   }
 }
 
-function archiveEnabled(): boolean {
-  return getStorageAdapterKind() === 'file';
-}
-
-function emptyBuildResult(): BuildResult {
-  return {
-    scannedBytes: 0,
-    turnsApplied: 0,
-    sessionsTouched: 0,
-    stampsApplied: 0,
-    compactionsApplied: 0,
-    toolResultEventsApplied: 0,
-    rebuiltFromZero: false,
-  };
-}
-
-function emptyArchiveStatus(
-  archiveFilePath: string,
-  ledgerSizeBytes: number,
-  ledgerMtimeMsCurrent: number,
-): ArchiveStatus {
-  return {
-    archivePath: archiveFilePath,
-    exists: false,
-    archiveVersion: ARCHIVE_VERSION,
-    ledgerOffsetBytes: 0,
-    ledgerMtimeMs: 0,
-    ledgerSizeBytes,
-    ledgerMtimeMsCurrent,
-    upToDate: false,
-    lastBuiltAt: null,
-    lastRebuildAt: null,
-    rowCounts: {
-      sessions: 0,
-      turns: 0,
-      toolCalls: 0,
-      toolResultEvents: 0,
-      compactions: 0,
-    },
-    fidelityHistogram: {},
-  };
+function assertFileStorage(): void {
+  const kind = getStorageAdapterKind();
+  if (kind !== 'file') {
+    throw new Error(
+      `archive operations require RELAYBURN_STORAGE=file (got ${kind})`,
+    );
+  }
 }
 
 /**
@@ -465,7 +421,7 @@ function emptyArchiveStatus(
  * threw).
  */
 export async function rebuildArchive(): Promise<BuildResult> {
-  if (!archiveEnabled()) return emptyBuildResult();
+  assertFileStorage();
   return withLock('archive', async () => {
     const dbPath = archivePath();
     await unlink(dbPath).catch(() => undefined);
@@ -488,7 +444,7 @@ export async function rebuildArchive(): Promise<BuildResult> {
  * path.
  */
 export async function buildArchive(): Promise<BuildResult> {
-  if (!archiveEnabled()) return emptyBuildResult();
+  assertFileStorage();
   return withLock('archive', () => buildArchiveLocked());
 }
 
@@ -512,15 +468,7 @@ export async function buildArchive(): Promise<BuildResult> {
  * against an artificially small pre-vacuum number.
  */
 export async function vacuumArchive(): Promise<VacuumResult> {
-  if (!archiveEnabled()) {
-    return {
-      archivePath: archivePath(),
-      existed: false,
-      beforeBytes: 0,
-      afterBytes: 0,
-      reclaimedBytes: 0,
-    };
-  }
+  assertFileStorage();
   return withLock('archive', async () => {
     const dbPath = archivePath();
     if (!(await fileExists(dbPath))) {
@@ -1311,9 +1259,7 @@ async function* readJsonlFrom(filePath: string, startOffset: number): AsyncItera
  * consistent read view.
  */
 export async function getArchiveStatus(): Promise<ArchiveStatus> {
-  if (!archiveEnabled()) {
-    return emptyArchiveStatus(archivePath(), 0, 0);
-  }
+  assertFileStorage();
   const dbPath = archivePath();
   const exists = await fileExists(dbPath);
   const ledger = ledgerPath();

--- a/packages/ledger/src/content.ts
+++ b/packages/ledger/src/content.ts
@@ -1,22 +1,13 @@
-import {
-  appendFile,
-  mkdir,
-  readFile,
-  readdir,
-  stat,
-  unlink,
-  utimes,
-} from 'node:fs/promises';
-import * as path from 'node:path';
+import { utimes } from 'node:fs/promises';
 
 import type { ContentRecord } from '@relayburn/reader';
 
-import { withLock } from './lock.js';
-import { contentDir, contentFilePath, isValidSessionId } from './paths.js';
+import { getAdapter } from './adapters/factory.js';
+import { contentFilePath } from './paths.js';
 
 export interface PruneOptions {
   olderThanMs: number;
-  // When provided, prune skips sessions for which the callback returns true —
+  // When provided, prune skips sessions for which the callback returns true -
   // the source session file still exists upstream and `burn state rebuild content`
   // can rederive the sidecar at any time, so deleting it would be silently
   // lossy. The ledger package stays decoupled from adapter-specific paths;
@@ -40,183 +31,23 @@ export interface ReadContentSelector {
 }
 
 export async function appendContent(records: ContentRecord[]): Promise<void> {
-  if (records.length === 0) return;
-  const grouped = new Map<string, ContentRecord[]>();
-  for (const r of records) {
-    const key = r.sessionId;
-    if (!key) continue;
-    if (!isValidSessionId(key)) {
-      process.stderr.write(
-        `[burn] skipping content record with unsafe sessionId: ${JSON.stringify(key)}\n`,
-      );
-      continue;
-    }
-    let bucket = grouped.get(key);
-    if (!bucket) {
-      bucket = [];
-      grouped.set(key, bucket);
-    }
-    bucket.push(r);
-  }
-  if (grouped.size === 0) return;
-  await mkdir(contentDir(), { recursive: true });
-  for (const [sessionId, items] of grouped) {
-    await appendSessionContent(sessionId, items);
-  }
-}
-
-async function appendSessionContent(
-  sessionId: string,
-  records: ContentRecord[],
-): Promise<void> {
-  const file = contentFilePath(sessionId);
-  await withLock(`content.${sessionId}`, async () => {
-    const lines = records.map((r) => JSON.stringify(r));
-    let existing = new Set<string>();
-    try {
-      const raw = await readFile(file, 'utf8');
-      existing = new Set(raw.split('\n').filter((line) => line.length > 0));
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-    }
-    const fresh = lines.filter((line) => {
-      if (existing.has(line)) return false;
-      existing.add(line);
-      return true;
-    });
-    if (fresh.length === 0) return;
-    const payload = fresh.join('\n') + '\n';
-    await appendFile(file, payload, { encoding: 'utf8' });
-  });
+  return getAdapter().appendContent(records);
 }
 
 export async function readContent(
   selector: ReadContentSelector,
 ): Promise<ContentRecord[]> {
-  const file = contentFilePath(selector.sessionId);
-  let raw: string;
-  try {
-    raw = await readFile(file, 'utf8');
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
-    throw err;
-  }
   const out: ContentRecord[] = [];
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      continue;
-    }
-    if (!parsed || typeof parsed !== 'object') continue;
-    const rec = parsed as ContentRecord;
-    if (selector.messageId !== undefined && rec.messageId !== selector.messageId) continue;
-    out.push(rec);
-  }
+  for await (const record of getAdapter().readContent(selector)) out.push(record);
   return out;
 }
 
 export async function pruneContent(options: PruneOptions): Promise<PruneResult> {
-  const dir = contentDir();
-  let entries: string[];
-  try {
-    entries = await readdir(dir);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { filesDeleted: 0, bytesFreed: 0, skippedRecoverable: 0 };
-    }
-    throw err;
-  }
-  const cutoff = Date.now() - options.olderThanMs;
-  const isRecoverable = options.isRecoverable;
-  let filesDeleted = 0;
-  let bytesFreed = 0;
-  let skippedRecoverable = 0;
-  for (const name of entries) {
-    if (!name.endsWith('.jsonl')) continue;
-    const sessionId = name.slice(0, -'.jsonl'.length);
-    if (!isValidSessionId(sessionId)) continue;
-    const full = path.join(dir, name);
-    // Acquire the same per-session lock used by appendSessionContent so a
-    // prune cannot race with an in-flight write for this session. We re-stat
-    // inside the lock to ensure we're deciding on the post-write mtime.
-    type Outcome =
-      | { kind: 'deleted'; size: number }
-      | { kind: 'skippedRecoverable' }
-      | null;
-    const outcome: Outcome = await withLock(`content.${sessionId}`, async () => {
-      let st: Awaited<ReturnType<typeof stat>>;
-      try {
-        st = await stat(full);
-      } catch {
-        return null;
-      }
-      if (!st.isFile()) return null;
-      // Inclusive cutoff: files whose mtime equals now - olderThanMs are
-      // eligible. This also makes `pruneContent({olderThanMs: 0})` clear the
-      // directory reliably.
-      if (st.mtimeMs > cutoff) return null;
-      // Source-aware protection: if the upstream agent's session file still
-      // exists, the sidecar is recoverable via `burn state rebuild content`, so
-      // deleting it on retention alone is silently lossy. Callers opt in by
-      // supplying `isRecoverable`; the ledger package itself never reaches
-      // out to adapter-specific paths.
-      if (isRecoverable) {
-        try {
-          if (await isRecoverable(sessionId)) {
-            return { kind: 'skippedRecoverable' };
-          }
-        } catch {
-          // If the predicate throws, fall through to the existing behavior —
-          // we'd rather prune than fail-open and accumulate forever on a
-          // broken source index.
-        }
-      }
-      try {
-        await unlink(full);
-        return { kind: 'deleted', size: st.size };
-      } catch {
-        // raced with another deleter or was already gone
-        return null;
-      }
-    });
-    if (outcome?.kind === 'deleted') {
-      filesDeleted++;
-      bytesFreed += outcome.size;
-    } else if (outcome?.kind === 'skippedRecoverable') {
-      skippedRecoverable++;
-    }
-  }
-  return { filesDeleted, bytesFreed, skippedRecoverable };
+  return getAdapter().pruneContent(options);
 }
 
 export async function listContentSessionIds(): Promise<Set<string>> {
-  const dir = contentDir();
-  const out = new Set<string>();
-  let entries: string[];
-  try {
-    entries = await readdir(dir);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return out;
-    throw err;
-  }
-  for (const name of entries) {
-    if (!name.endsWith('.jsonl')) continue;
-    const sessionId = name.slice(0, -'.jsonl'.length);
-    if (!isValidSessionId(sessionId)) continue;
-    // An empty sidecar signals "attempted but nothing written" and should be
-    // re-parsed rather than treated as already-populated.
-    try {
-      const st = await stat(path.join(dir, name));
-      if (st.size > 0) out.add(sessionId);
-    } catch {
-      // raced with deletion; ignore
-    }
-  }
-  return out;
+  return new Set(await getAdapter().listContentSessionIds());
 }
 
 // Test helper: set the mtime/atime on a session's content file.

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -86,6 +86,12 @@ export type {
   OpencodeStreamCursor,
 } from './cursors.js';
 export { withLock } from './lock.js';
+export { getAdapter } from './adapters/factory.js';
+export type {
+  ContentLine,
+  StorageAdapter,
+  StorageAdapterKind,
+} from './adapters/adapter.js';
 export {
   rebuildIndex,
   relationshipIdHash,

--- a/packages/ledger/src/lock.ts
+++ b/packages/ledger/src/lock.ts
@@ -1,78 +1,18 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-import { open, stat, unlink, mkdir } from 'node:fs/promises';
-import * as path from 'node:path';
+import { getAdapter } from './adapters/factory.js';
+import { __acquireFileLockForTesting } from './adapters/file-lock.js';
+import type { AcquireOptions } from './adapters/file-lock.js';
 
-import { lockPath } from './paths.js';
-
-// Two-phase acquire:
-//
-//   Phase 1 (fast): cheap retries that cover normal in-process contention
-//   between concurrent writers. ~1s total.
-//
-//   Phase 2 (slow): longer waits that outlast STALE_MS so a single invocation
-//   can self-heal an orphan lock left by a crashed process. ~10s total —
-//   spans the stale-detection window twice.
-//
-// The previous tuning (RETRY_DELAY_MS=20, MAX_RETRIES=50, STALE_MS=30_000)
-// gave a 1s retry budget against a 30s stale threshold, leaving a 29s window
-// where any acquirer would hard-fail with "could not acquire lock after 50
-// attempts" even though the lock was already orphaned. See #62.
-export const FAST_RETRY_DELAY_MS = 20;
-export const FAST_RETRIES = 50; // 1s — normal concurrent-writer contention
-export const SLOW_RETRY_DELAY_MS = 250;
-export const SLOW_RETRIES = 40; // 10s — covers an orphan twice over
-export const STALE_MS = 5_000;
-
-const TOTAL_RETRY_BUDGET_MS =
-  FAST_RETRY_DELAY_MS * FAST_RETRIES + SLOW_RETRY_DELAY_MS * SLOW_RETRIES;
-
-// Invariant the issue calls out: the retry budget MUST outlast the stale
-// threshold (plus at least one retry cycle) so a single invocation can wait
-// out an orphan and unlink it. Asserting at module-load time means future
-// tuning of either constant can't silently reintroduce the gap.
-if (TOTAL_RETRY_BUDGET_MS <= STALE_MS + SLOW_RETRY_DELAY_MS) {
-  throw new Error(
-    `lock retry budget (${TOTAL_RETRY_BUDGET_MS}ms) must exceed STALE_MS ` +
-      `(${STALE_MS}ms) + one slow retry (${SLOW_RETRY_DELAY_MS}ms)`,
-  );
-}
-
-export interface AcquireOptions {
-  fastRetries: number;
-  fastRetryDelayMs: number;
-  slowRetries: number;
-  slowRetryDelayMs: number;
-  staleMs: number;
-}
-
-const DEFAULT_OPTIONS: AcquireOptions = {
-  fastRetries: FAST_RETRIES,
-  fastRetryDelayMs: FAST_RETRY_DELAY_MS,
-  slowRetries: SLOW_RETRIES,
-  slowRetryDelayMs: SLOW_RETRY_DELAY_MS,
-  staleMs: STALE_MS,
-};
-
-const heldLocks = new AsyncLocalStorage<Set<string>>();
+export {
+  FAST_RETRIES,
+  FAST_RETRY_DELAY_MS,
+  SLOW_RETRIES,
+  SLOW_RETRY_DELAY_MS,
+  STALE_MS,
+} from './adapters/file-lock.js';
+export type { AcquireOptions } from './adapters/file-lock.js';
 
 export async function withLock<T>(name: string, fn: () => Promise<T>): Promise<T> {
-  const lp = lockPath(name);
-  const held = heldLocks.getStore();
-  if (held?.has(lp)) return fn();
-
-  await mkdir(path.dirname(lp), { recursive: true });
-  await acquire(lp, DEFAULT_OPTIONS);
-  const nextHeld = new Set(held ?? []);
-  nextHeld.add(lp);
-  try {
-    return await heldLocks.run(nextHeld, fn);
-  } finally {
-    try {
-      await unlink(lp);
-    } catch {
-      // ignore; next acquirer will see it as stale
-    }
-  }
+  return getAdapter().withLock(name, fn);
 }
 
 // Exported for tests that need to drive the timeout path with a tiny budget
@@ -81,61 +21,5 @@ export async function __acquireForTesting(
   lp: string,
   options: AcquireOptions,
 ): Promise<void> {
-  await mkdir(path.dirname(lp), { recursive: true });
-  await acquire(lp, options);
-}
-
-async function acquire(lp: string, options: AcquireOptions): Promise<void> {
-  // Track which failure mode we kept hitting so the timeout error can name
-  // the side it timed out on instead of the ambiguous "after N attempts".
-  let lastReason: 'live' | 'stale-unlink-failed' = 'live';
-
-  const totalRetries = options.fastRetries + options.slowRetries;
-  const budgetMs =
-    options.fastRetries * options.fastRetryDelayMs +
-    options.slowRetries * options.slowRetryDelayMs;
-  for (let attempt = 0; attempt < totalRetries; attempt++) {
-    try {
-      const handle = await open(lp, 'wx');
-      await handle.close();
-      return;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-      const st = await stat(lp).catch(() => null);
-      if (st && Date.now() - st.mtimeMs > options.staleMs) {
-        try {
-          await unlink(lp);
-          // unlink succeeded — loop and retry the open immediately. Don't
-          // count this as a stale-unlink-failed attempt.
-          continue;
-        } catch (unlinkErr) {
-          const code = (unlinkErr as NodeJS.ErrnoException).code;
-          if (code === 'ENOENT') {
-            // Another acquirer already cleaned it up; race the open again.
-            continue;
-          }
-          // Real failure (EPERM, EBUSY, …). Record it and back off so the
-          // final error message can distinguish this from "live holder".
-          lastReason = 'stale-unlink-failed';
-        }
-      } else {
-        lastReason = 'live';
-      }
-      const delayMs =
-        attempt < options.fastRetries ? options.fastRetryDelayMs : options.slowRetryDelayMs;
-      await delay(delayMs);
-    }
-  }
-  const detail =
-    lastReason === 'stale-unlink-failed'
-      ? 'lock appears stale but unlink kept failing'
-      : 'held by live process';
-  throw new Error(
-    `could not acquire lock after ${totalRetries} attempts ` +
-      `(~${budgetMs}ms) — ${detail}: ${lp}`,
-  );
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+  return __acquireFileLockForTesting(lp, options);
 }

--- a/packages/ledger/src/reader.ts
+++ b/packages/ledger/src/reader.ts
@@ -1,7 +1,3 @@
-import { createReadStream } from 'node:fs';
-import { stat } from 'node:fs/promises';
-import { createInterface } from 'node:readline';
-
 import type {
   CompactionEvent,
   SessionRelationshipRecord,
@@ -11,18 +7,8 @@ import type {
   UserTurnRecord,
 } from '@relayburn/reader';
 
-import { ledgerPath } from './paths.js';
-import {
-  isCompactionLine,
-  isSessionRelationshipLine,
-  isStampLine,
-  isToolResultEventLine,
-  isTurnLine,
-  isUserTurnLine,
-  stampMatches,
-  type Enrichment,
-  type StampLine,
-} from './schema.js';
+import { getAdapter } from './adapters/factory.js';
+import type { Enrichment } from './schema.js';
 
 export interface Query {
   since?: string;
@@ -37,175 +23,36 @@ export interface EnrichedTurn extends TurnRecord {
   enrichment: Enrichment;
 }
 
-async function fileExists(p: string): Promise<boolean> {
-  try {
-    const s = await stat(p);
-    return s.isFile();
-  } catch {
-    return false;
-  }
-}
-
-async function* streamLines(filePath: string): AsyncIterable<unknown> {
-  const rl = createInterface({
-    input: createReadStream(filePath, { encoding: 'utf8' }),
-    crlfDelay: Infinity,
-  });
-  try {
-    for await (const line of rl) {
-      const t = line.trim();
-      if (!t) continue;
-      try {
-        yield JSON.parse(t);
-      } catch {
-        // skip malformed
-      }
-    }
-  } finally {
-    rl.close();
-  }
-}
-
-async function collectStamps(filePath: string): Promise<StampLine[]> {
-  const stamps: StampLine[] = [];
-  for await (const parsed of streamLines(filePath)) {
-    if (isStampLine(parsed)) stamps.push(parsed);
-  }
-  stamps.sort((a, b) => a.ts.localeCompare(b.ts));
-  return stamps;
-}
-
-function turnPasses(turn: TurnRecord, q: Query, enrichment: Enrichment): boolean {
-  if (q.since && turn.ts < q.since) return false;
-  if (q.until && turn.ts > q.until) return false;
-  if (q.project && turn.project !== q.project && turn.projectKey !== q.project) return false;
-  if (q.sessionId && turn.sessionId !== q.sessionId) return false;
-  if (q.source && turn.source !== q.source) return false;
-  if (q.enrichment) {
-    for (const [k, v] of Object.entries(q.enrichment)) {
-      if (v === undefined) continue;
-      if (enrichment[k] !== v) return false;
-    }
-  }
-  return true;
-}
-
-function foldStamps(turn: TurnRecord, stamps: StampLine[]): Enrichment {
-  const out: Enrichment = {};
-  for (const s of stamps) {
-    if (!stampMatches(s, turn)) continue;
-    for (const [k, v] of Object.entries(s.enrichment)) {
-      out[k] = v;
-    }
-  }
-  return out;
-}
-
 export async function* query(q: Query = {}): AsyncIterable<EnrichedTurn> {
-  const filePath = ledgerPath();
-  if (!(await fileExists(filePath))) return;
-  const stamps = await collectStamps(filePath);
-  for await (const parsed of streamLines(filePath)) {
-    if (!isTurnLine(parsed)) continue;
-    const enrichment = foldStamps(parsed.record, stamps);
-    if (!turnPasses(parsed.record, q, enrichment)) continue;
-    yield { ...parsed.record, enrichment };
-  }
+  yield* getAdapter().queryTurns(q);
 }
 
 export async function queryAll(q: Query = {}): Promise<EnrichedTurn[]> {
-  const out: EnrichedTurn[] = [];
-  for await (const t of query(q)) out.push(t);
-  return out;
-}
-
-function compactionPasses(e: CompactionEvent, q: Query): boolean {
-  if (q.since && e.ts < q.since) return false;
-  if (q.until && e.ts > q.until) return false;
-  if (q.sessionId && e.sessionId !== q.sessionId) return false;
-  if (q.source && e.source !== q.source) return false;
-  // project and enrichment don't filter compaction events (they live at the
-  // session level; callers that need project-scoping should pre-filter by
-  // sessionId from a turn query).
-  return true;
+  return collect(getAdapter().queryTurns(q));
 }
 
 export async function queryCompactions(q: Query = {}): Promise<CompactionEvent[]> {
-  const filePath = ledgerPath();
-  if (!(await fileExists(filePath))) return [];
-  const out: CompactionEvent[] = [];
-  for await (const parsed of streamLines(filePath)) {
-    if (!isCompactionLine(parsed)) continue;
-    if (!compactionPasses(parsed.record, q)) continue;
-    out.push(parsed.record);
-  }
-  return out;
-}
-
-function relationshipPasses(r: SessionRelationshipRecord, q: Query): boolean {
-  if (q.since && r.ts && r.ts < q.since) return false;
-  if (q.until && r.ts && r.ts > q.until) return false;
-  if (q.sessionId && r.sessionId !== q.sessionId && r.relatedSessionId !== q.sessionId)
-    return false;
-  if (q.source && r.source !== q.source) return false;
-  return true;
-}
-
-function toolResultEventPasses(r: ToolResultEventRecord, q: Query): boolean {
-  if (q.since && r.ts && r.ts < q.since) return false;
-  if (q.until && r.ts && r.ts > q.until) return false;
-  if (q.sessionId && r.sessionId !== q.sessionId) return false;
-  if (q.source && r.source !== q.source) return false;
-  return true;
+  return collect(getAdapter().queryCompactions(q));
 }
 
 export async function queryRelationships(
   q: Query = {},
 ): Promise<SessionRelationshipRecord[]> {
-  const filePath = ledgerPath();
-  if (!(await fileExists(filePath))) return [];
-  const out: SessionRelationshipRecord[] = [];
-  for await (const parsed of streamLines(filePath)) {
-    if (!isSessionRelationshipLine(parsed)) continue;
-    if (!relationshipPasses(parsed.record, q)) continue;
-    out.push(parsed.record);
-  }
-  return out;
+  return collect(getAdapter().queryRelationships(q));
 }
 
 export async function queryToolResultEvents(
   q: Query = {},
 ): Promise<ToolResultEventRecord[]> {
-  const filePath = ledgerPath();
-  if (!(await fileExists(filePath))) return [];
-  const out: ToolResultEventRecord[] = [];
-  for await (const parsed of streamLines(filePath)) {
-    if (!isToolResultEventLine(parsed)) continue;
-    if (!toolResultEventPasses(parsed.record, q)) continue;
-    out.push(parsed.record);
-  }
-  return out;
-}
-
-function userTurnPasses(r: UserTurnRecord, q: Query): boolean {
-  if (q.since && r.ts < q.since) return false;
-  if (q.until && r.ts > q.until) return false;
-  if (q.sessionId && r.sessionId !== q.sessionId) return false;
-  if (q.source && r.source !== q.source) return false;
-  // project and enrichment don't filter user turns (they live at the session
-  // level; callers that need project-scoping should pre-filter by sessionId
-  // from a turn query).
-  return true;
+  return collect(getAdapter().queryToolResultEvents(q));
 }
 
 export async function queryUserTurns(q: Query = {}): Promise<UserTurnRecord[]> {
-  const filePath = ledgerPath();
-  if (!(await fileExists(filePath))) return [];
-  const out: UserTurnRecord[] = [];
-  for await (const parsed of streamLines(filePath)) {
-    if (!isUserTurnLine(parsed)) continue;
-    if (!userTurnPasses(parsed.record, q)) continue;
-    out.push(parsed.record);
-  }
+  return collect(getAdapter().queryUserTurns(q));
+}
+
+async function collect<T>(items: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of items) out.push(item);
   return out;
 }

--- a/packages/ledger/src/writer.ts
+++ b/packages/ledger/src/writer.ts
@@ -1,6 +1,3 @@
-import { appendFile, mkdir } from 'node:fs/promises';
-import * as path from 'node:path';
-
 import type {
   CompactionEvent,
   SessionRelationshipRecord,
@@ -9,174 +6,31 @@ import type {
   UserTurnRecord,
 } from '@relayburn/reader';
 
-import {
-  appendHashes,
-  compactionIdHash,
-  loadIndex,
-  relationshipIdHash,
-  toolResultEventIdHash,
-  turnContentFingerprint,
-  turnIdHash,
-  userTurnIdHash,
-} from './index-sidecar.js';
-import { withLock } from './lock.js';
-import { ledgerPath } from './paths.js';
-import type {
-  CompactionLine,
-  Enrichment,
-  LedgerLine,
-  SessionRelationshipLine,
-  StampLine,
-  StampSelector,
-  ToolResultEventLine,
-  TurnLine,
-  UserTurnLine,
-} from './schema.js';
-
-async function ensureDir(filePath: string): Promise<void> {
-  await mkdir(path.dirname(filePath), { recursive: true });
-}
-
-async function appendLines(lines: LedgerLine[]): Promise<void> {
-  if (lines.length === 0) return;
-  const filePath = ledgerPath();
-  await ensureDir(filePath);
-  const payload = lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
-  // Hold the same 'ledger' lock that reclassifyLedger acquires for its
-  // read-modify-write pass. Without this, an appendFile that lands between
-  // reclassify's readFile and rename would write to the soon-orphaned old
-  // inode, and its turns would be silently dropped when the rename swaps in
-  // the rewritten file. The race is hard to force in tests on a fast SSD
-  // (libuv tends to drain queued appendFiles before reclassify starts
-  // reading) but is real under heavier contention.
-  await withLock('ledger', async () => {
-    await appendFile(filePath, payload, { encoding: 'utf8' });
-  });
-}
+import { getAdapter } from './adapters/factory.js';
+import type { Enrichment, StampLine, StampSelector } from './schema.js';
 
 export async function appendTurns(turns: TurnRecord[]): Promise<void> {
-  if (turns.length === 0) return;
-  const idx = await loadIndex();
-  // Snapshot content set before this batch — content-fingerprint dedup only
-  // compares against historically-committed turns, never within the same batch.
-  const historicalContent = new Set(idx.content);
-  const fresh: TurnRecord[] = [];
-  const newIds: string[] = [];
-  const newContent: string[] = [];
-  for (const t of turns) {
-    const id = turnIdHash(t);
-    if (idx.ids.has(id)) continue;
-    const cf = turnContentFingerprint(t);
-    if (historicalContent.has(cf)) continue;
-    fresh.push(t);
-    newIds.push(id);
-    newContent.push(cf);
-    idx.ids.add(id); // primary dedup DOES apply within batch — same messageId = same turn
-  }
-  if (fresh.length === 0) return;
-  for (const cf of newContent) idx.content.add(cf);
-  const lines: TurnLine[] = fresh.map((record) => ({ v: 1, kind: 'turn', record }));
-  await appendLines(lines);
-  await appendHashes(newIds, newContent);
+  return getAdapter().appendTurns(turns);
 }
 
 export async function appendCompactions(events: CompactionEvent[]): Promise<void> {
-  if (events.length === 0) return;
-  // Dedup piggybacks on the ledger-id index. Compaction ids share the same
-  // namespace as turn ids — they hash different inputs so collisions are not
-  // a practical concern, and we get crash-safe persistence for free.
-  const idx = await loadIndex();
-  const fresh: CompactionEvent[] = [];
-  const newIds: string[] = [];
-  for (const e of events) {
-    const id = compactionIdHash(e);
-    if (idx.ids.has(id)) continue;
-    fresh.push(e);
-    newIds.push(id);
-    idx.ids.add(id);
-  }
-  if (fresh.length === 0) return;
-  const lines: CompactionLine[] = fresh.map((record) => ({
-    v: 1,
-    kind: 'compaction',
-    record,
-  }));
-  await appendLines(lines);
-  await appendHashes(newIds, []);
+  return getAdapter().appendCompactions(events);
 }
 
 export async function appendRelationships(
   records: SessionRelationshipRecord[],
 ): Promise<void> {
-  if (records.length === 0) return;
-  const idx = await loadIndex();
-  const fresh: SessionRelationshipRecord[] = [];
-  const newIds: string[] = [];
-  for (const r of records) {
-    const id = relationshipIdHash(r);
-    if (idx.ids.has(id)) continue;
-    fresh.push(r);
-    newIds.push(id);
-    idx.ids.add(id);
-  }
-  if (fresh.length === 0) return;
-  const lines: SessionRelationshipLine[] = fresh.map((record) => ({
-    v: 1,
-    kind: 'relationship',
-    record,
-  }));
-  await appendLines(lines);
-  await appendHashes(newIds, []);
+  return getAdapter().appendRelationships(records);
 }
 
 export async function appendUserTurns(records: UserTurnRecord[]): Promise<void> {
-  if (records.length === 0) return;
-  // Dedup piggybacks on the ledger-id index. User-turn ids share the same
-  // namespace as turn / compaction / relationship / tool-result-event ids —
-  // they hash different inputs (source|sessionId|userUuid) so collisions are
-  // not a practical concern, and we get crash-safe persistence for free.
-  const idx = await loadIndex();
-  const fresh: UserTurnRecord[] = [];
-  const newIds: string[] = [];
-  for (const r of records) {
-    const id = userTurnIdHash(r);
-    if (idx.ids.has(id)) continue;
-    fresh.push(r);
-    newIds.push(id);
-    idx.ids.add(id);
-  }
-  if (fresh.length === 0) return;
-  const lines: UserTurnLine[] = fresh.map((record) => ({
-    v: 1,
-    kind: 'user_turn',
-    record,
-  }));
-  await appendLines(lines);
-  await appendHashes(newIds, []);
+  return getAdapter().appendUserTurns(records);
 }
 
 export async function appendToolResultEvents(
   records: ToolResultEventRecord[],
 ): Promise<void> {
-  if (records.length === 0) return;
-  const idx = await loadIndex();
-  const fresh: ToolResultEventRecord[] = [];
-  const newIds: string[] = [];
-  for (const r of records) {
-    const id = toolResultEventIdHash(r);
-    if (idx.ids.has(id)) continue;
-    fresh.push(r);
-    newIds.push(id);
-    idx.ids.add(id);
-  }
-  if (fresh.length === 0) return;
-  const lines: ToolResultEventLine[] = fresh.map((record) => ({
-    v: 1,
-    kind: 'tool_result_event',
-    record,
-  }));
-  await appendLines(lines);
-  await appendHashes(newIds, []);
+  return getAdapter().appendToolResultEvents(records);
 }
 
 export async function stamp(
@@ -197,47 +51,5 @@ export async function stamp(
     selector,
     enrichment,
   };
-  const relationship = spawnEnvRelationshipFromStamp(line);
-  if (!relationship) {
-    await appendLines([line]);
-    return;
-  }
-
-  const idx = await loadIndex();
-  const id = relationshipIdHash(relationship);
-  if (idx.ids.has(id)) {
-    await appendLines([line]);
-    return;
-  }
-  idx.ids.add(id);
-  await appendLines([
-    line,
-    {
-      v: 1,
-      kind: 'relationship',
-      record: relationship,
-    },
-  ]);
-  await appendHashes([id], []);
-}
-
-function spawnEnvRelationshipFromStamp(
-  line: StampLine,
-): SessionRelationshipRecord | null {
-  const sessionId = line.selector.sessionId;
-  if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
-  const parentAgentId = line.enrichment['parentAgentId'];
-  if (typeof parentAgentId !== 'string' || parentAgentId.length === 0) return null;
-
-  const relationship: SessionRelationshipRecord = {
-    v: 1,
-    source: 'spawn-env',
-    sessionId,
-    relatedSessionId: parentAgentId,
-    relationshipType: 'subagent',
-    ts: line.ts,
-  };
-  const agentId = line.enrichment['agentId'];
-  if (typeof agentId === 'string' && agentId.length > 0) relationship.agentId = agentId;
-  return relationship;
+  return getAdapter().appendStamp(line);
 }


### PR DESCRIPTION
Closes #140

Summary:
- Add the @relayburn/ledger StorageAdapter contract, file adapter implementation, and process-singleton factory.
- Delegate existing writer, reader, content, and lock public APIs through the file adapter without changing their caller-facing behavior.
- Keep archive APIs file-backed for current storage and no-op derived-cache maintenance when RELAYBURN_STORAGE is non-file.

Testing:
- pnpm run build
- pnpm run test
- RELAYBURN_STORAGE=sqlite node --input-type=module -e smoke test for archive no-op calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
