### PR TITLE
Create one GitHub Release per lockstep publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -610,100 +610,160 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # One GitHub Release per package tag. Runs in parallel across packages;
-  # each cell is gated on whether its package was published.
+  # One GitHub Release per publish run. Package tags are still pushed above,
+  # but the public GitHub Release is anchored to the relayburn tag for
+  # lockstep publishes so the releases page has one item per version.
   create-release:
-    name: Release ${{ matrix.package }}
+    name: Create GitHub Release
     needs: publish
     if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.version != 'none' || github.event.inputs.custom_version != '') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        package: [reader, ledger, analyze, mcp, cli, relayburn]
     steps:
-      - name: Check if this package was published
-        id: check
+      - name: Resolve canonical release
+        id: release
         run: |
+          set -euo pipefail
+
           VERSIONS='${{ needs.publish.outputs.versions }}'
+          canonical=""
           for entry in $VERSIONS; do
             pkg="${entry%%:*}"
             ver="${entry##*:}"
-            if [ "$pkg" = "${{ matrix.package }}" ]; then
-              echo "published=true" >> "$GITHUB_OUTPUT"
-              echo "version=$ver" >> "$GITHUB_OUTPUT"
-              if [[ "$ver" == *-* ]]; then
-                echo "prerelease=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "prerelease=false" >> "$GITHUB_OUTPUT"
-              fi
-              exit 0
+            if [ -z "$canonical" ]; then
+              canonical="$entry"
+            fi
+            if [ "$pkg" = "relayburn" ]; then
+              canonical="$entry"
+              break
             fi
           done
-          echo "published=false" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$canonical" ]; then
+            echo "::error title=Missing release target::publish job did not report any package versions"
+            exit 1
+          fi
+
+          pkg="${canonical%%:*}"
+          ver="${canonical##*:}"
+          echo "canonical_pkg=$pkg" >> "$GITHUB_OUTPUT"
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$pkg-v$ver" >> "$GITHUB_OUTPUT"
+          if [[ "$ver" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout
-        if: steps.check.outputs.published == 'true'
         uses: actions/checkout@v6
         with:
-          # Need the tag that the publish job just pushed.
-          ref: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
+          # Need the canonical tag that the publish job just pushed.
+          ref: ${{ steps.release.outputs.tag_name }}
 
-      - name: Resolve npm name
-        if: steps.check.outputs.published == 'true'
-        id: name
-        run: |
-          NPM_NAME=$(node -p "require('./packages/${{ matrix.package }}/package.json').name")
-          echo "npm_name=$NPM_NAME" >> "$GITHUB_OUTPUT"
-
-      # Prefer the per-package CHANGELOG section that was generated and
-      # committed during publish. Falls back to auto-generated notes for
-      # prereleases and first publishes (where no CHANGELOG entry exists).
-      - name: Extract changelog notes
-        if: steps.check.outputs.published == 'true'
+      - name: Build combined release notes
         id: notes
         run: |
-          pkg="${{ matrix.package }}"
-          ver="${{ steps.check.outputs.version }}"
-          file="packages/$pkg/CHANGELOG.md"
-          out=/tmp/release-notes.md
-          : > "$out"
-          if [ -f "$file" ]; then
-            awk -v prefix="## [$ver]" '
-              index($0, prefix) == 1 { flag=1; print; next }
-              /^## \[/ && flag { exit }
-              flag { print }
-            ' "$file" > "$out"
-          fi
-          if [ -s "$out" ]; then
-            echo "has_notes=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_notes=false" >> "$GITHUB_OUTPUT"
-          fi
+          cat > /tmp/build-release-notes.mjs << 'GENEOF'
+          import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-      - name: Create GitHub Release (stable, with changelog)
-        if: steps.check.outputs.published == 'true' && steps.check.outputs.prerelease != 'true' && steps.notes.outputs.has_notes == 'true'
+          const versionsRaw = process.env.VERSIONS || '';
+          const canonicalPkg = process.env.CANONICAL_PKG;
+          const canonicalVersion = process.env.CANONICAL_VERSION;
+
+          const packageOrder = ['reader', 'ledger', 'analyze', 'mcp', 'cli', 'relayburn'];
+          const entries = versionsRaw.trim().split(/\s+/).filter(Boolean).map((entry) => {
+            const idx = entry.indexOf(':');
+            return { pkg: entry.slice(0, idx), ver: entry.slice(idx + 1) };
+          }).sort((a, b) => packageOrder.indexOf(a.pkg) - packageOrder.indexOf(b.pkg));
+
+          if (entries.length === 0) {
+            throw new Error('publish job did not report any package versions');
+          }
+
+          const packageInfo = entries.map(({ pkg, ver }) => {
+            const pkgJson = JSON.parse(readFileSync(`packages/${pkg}/package.json`, 'utf8'));
+            return {
+              pkg,
+              ver,
+              npmName: pkgJson.name,
+              tag: `${pkg}-v${ver}`,
+            };
+          });
+
+          const canonical =
+            packageInfo.find((entry) => entry.pkg === canonicalPkg && entry.ver === canonicalVersion) ||
+            packageInfo[0];
+
+          function escapeRegExp(value) {
+            return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          }
+
+          function extractChangelogBody(path, version) {
+            if (!existsSync(path)) return '';
+            const raw = readFileSync(path, 'utf8');
+            const headerRe = new RegExp(`^## \\[${escapeRegExp(version)}\\][^\\n]*\\n`, 'm');
+            const header = raw.match(headerRe);
+            if (!header || header.index === undefined) return '';
+
+            const start = header.index + header[0].length;
+            const tail = raw.slice(start);
+            const next = tail.match(/^## \[/m);
+            const end = next && next.index !== undefined ? start + next.index : raw.length;
+            return raw.slice(start, end).trim();
+          }
+
+          function nestChangelogHeadings(notes) {
+            return notes.replace(/^(#{3,5}) /gm, '#$1 ');
+          }
+
+          const lines = ['## Packages', ''];
+          for (const entry of packageInfo) {
+            lines.push(`- \`${entry.npmName}@${entry.ver}\` (tag: \`${entry.tag}\`)`);
+          }
+
+          const rootNotes = extractChangelogBody('CHANGELOG.md', canonical.ver);
+          const packageNotes = packageInfo
+            .map((entry) => ({
+              ...entry,
+              notes: extractChangelogBody(`packages/${entry.pkg}/CHANGELOG.md`, entry.ver),
+            }))
+            .filter((entry) => entry.notes.length > 0);
+
+          if (rootNotes.length > 0) {
+            lines.push('', '## Release Notes', '', rootNotes);
+          }
+
+          if (packageNotes.length > 0) {
+            lines.push('', '## Package Changelogs', '');
+            for (const entry of packageNotes) {
+              lines.push(`### ${entry.npmName}`, '', nestChangelogHeadings(entry.notes), '');
+            }
+          }
+
+          if (rootNotes.length === 0 && packageNotes.length === 0) {
+            lines.push('', '## Release Notes', '', '_No changelog entry was generated for this release._');
+          }
+
+          writeFileSync('/tmp/release-notes.md', `${lines.join('\n').trimEnd()}\n`);
+
+          const releaseName =
+            canonical.pkg === 'relayburn'
+              ? `relayburn@${canonical.ver}`
+              : `${canonical.npmName}@${canonical.ver}`;
+          appendFileSync(process.env.GITHUB_OUTPUT, `release_name=${releaseName}\n`);
+          GENEOF
+
+          VERSIONS='${{ needs.publish.outputs.versions }}' \
+          CANONICAL_PKG='${{ steps.release.outputs.canonical_pkg }}' \
+          CANONICAL_VERSION='${{ steps.release.outputs.version }}' \
+          node /tmp/build-release-notes.mjs
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
-          name: "${{ steps.name.outputs.npm_name }}@${{ steps.check.outputs.version }}"
+          tag_name: ${{ steps.release.outputs.tag_name }}
+          name: ${{ steps.notes.outputs.release_name }}
           body_path: /tmp/release-notes.md
-
-      - name: Create GitHub Release (stable, auto notes)
-        if: steps.check.outputs.published == 'true' && steps.check.outputs.prerelease != 'true' && steps.notes.outputs.has_notes != 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
-          name: "${{ steps.name.outputs.npm_name }}@${{ steps.check.outputs.version }}"
-          generate_release_notes: true
-
-      - name: Create GitHub Release (prerelease)
-        if: steps.check.outputs.published == 'true' && steps.check.outputs.prerelease == 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ matrix.package }}-v${{ steps.check.outputs.version }}
-          name: "${{ steps.name.outputs.npm_name }}@${{ steps.check.outputs.version }} (prerelease)"
-          prerelease: true
-          generate_release_notes: true
+          prerelease: ${{ steps.release.outputs.prerelease }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Changed
+
+- Publish workflow now creates one GitHub Release per lockstep publish, anchored to `relayburn`, with all package versions listed in the release body.
+
 ## [1.0.0] - 2026-04-29
 
 ### Added


### PR DESCRIPTION
## Summary
- Collapse publish.yml release creation from a per-package matrix to one canonical GitHub Release per publish run.
- Anchor lockstep releases to the relayburn tag while keeping all package tags.
- Build a combined release body listing all package versions plus root and package changelog sections.

## Verification
- Parsed .github/workflows/publish.yml as YAML.
- Checked the extracted release-note builder with node --check.
- Executed the extracted builder against the current 1.0.0 package set and inspected the generated body.
- Ran git diff --check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
