### PR TITLE
Fix CLI startup pruning overhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,13 @@ export const cursorAdapter: HarnessAdapter = {
 };
 ```
 
-Then add it to the registry array in `harnesses/registry.ts`. The CLI help block reads `listHarnessNames()` so it updates automatically.
+Then add it to the lazy registry object in `harnesses/registry.ts`:
+
+```ts
+cursor: async () => (await import('./cursor.js')).cursorAdapter,
+```
+
+The CLI help block reads `listHarnessNames()` so it updates automatically.
 
 The codex / opencode adapters share the pending-stamp + watch-loop shape; both are constructed via `createPendingStampAdapter` in `harnesses/pending-stamp.ts`. New harnesses with the same shape can reuse it.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Fixed
+
+- `burn state --help`, `burn run`, and `burn mcp-server` now skip opportunistic content pruning so help output and latency-sensitive startup are not delayed by retention scans.
+
 ## [1.1.0] - 2026-04-29
 
 ### Added
@@ -27,7 +31,6 @@ All notable changes to `@relayburn/cli`.
 
 ### Fixed
 
-- `burn state --help`, `burn run`, and `burn mcp-server` now skip opportunistic content pruning so help output and latency-sensitive startup are not delayed by retention scans.
 - `burn state rebuild archive vacuum` now preserves archive space reclamation after the top-level archive command removal.
 - `burn state` status now streams ledger counts instead of materializing all turns.
 - `burn ingest --watch --opencode-stream` now preserves stream cursor progress when polling fallback saves file-ingest cursors concurrently.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to `@relayburn/cli`.
 
 ### Fixed
 
+- `burn state --help`, `burn run`, and `burn mcp-server` now skip opportunistic content pruning so help output and latency-sensitive startup are not delayed by retention scans.
 - `burn state rebuild archive vacuum` now preserves archive space reclamation after the top-level archive command removal.
 - `burn state` status now streams ledger counts instead of materializing all turns.
 - `burn ingest --watch --opencode-stream` now preserves stream cursor progress when polling fallback saves file-ingest cursors concurrently.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -94,6 +94,43 @@ describe('burn CLI state dispatch', () => {
     await access(contentPath);
   });
 
+  it('burn state --help does not run opportunistic pruning', async () => {
+    const sessionId = '123e4567-e89b-12d3-a456-426614174001';
+    const contentPath = path.join(tmp, 'content', `${sessionId}.jsonl`);
+    await mkdir(path.dirname(contentPath), { recursive: true });
+    await writeFile(contentPath, '{}\n', 'utf8');
+    const longAgo = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000);
+    await utimes(contentPath, longAgo, longAgo);
+
+    const out = runCli(['state', '--help'], {
+      RELAYBURN_CONTENT_STORE: 'full',
+      RELAYBURN_CONTENT_TTL_DAYS: '90',
+    });
+
+    assert.equal(out.status, 0);
+    assert.match(out.stdout, /burn state/);
+    assert.equal(out.stderr, '');
+    await access(contentPath);
+  });
+
+  it('burn run does not prune before harness dispatch', async () => {
+    const sessionId = '123e4567-e89b-12d3-a456-426614174002';
+    const contentPath = path.join(tmp, 'content', `${sessionId}.jsonl`);
+    await mkdir(path.dirname(contentPath), { recursive: true });
+    await writeFile(contentPath, '{}\n', 'utf8');
+    const longAgo = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000);
+    await utimes(contentPath, longAgo, longAgo);
+
+    const out = runCli(['run', 'nope'], {
+      RELAYBURN_CONTENT_STORE: 'full',
+      RELAYBURN_CONTENT_TTL_DAYS: '90',
+    });
+
+    assert.equal(out.status, 2);
+    assert.match(out.stderr, /unknown harness/);
+    await access(contentPath);
+  });
+
   it('burn state rejects unknown subcommands', () => {
     const out = runCli(['state', 'nope']);
     assert.notEqual(out.status, 0);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,15 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from './args.js';
-import { runBudget } from './commands/budget.js';
-import { runCompare } from './commands/compare.js';
-import { runOverhead } from './commands/overhead.js';
-import { runIngest } from './commands/ingest.js';
-import { runMcpServer } from './commands/mcp-server.js';
-import { runWrapper } from './commands/run.js';
-import { runState, opportunisticPrune } from './commands/state.js';
-import { runSummary } from './commands/summary.js';
-import { runHotspots } from './commands/hotspots.js';
 import { listHarnessNames } from './harnesses/registry.js';
+import type { ParsedArgs } from './args.js';
 
 const HARNESS_LIST = listHarnessNames().join('|');
 
@@ -79,34 +71,47 @@ async function main(): Promise<number> {
     return 0;
   }
   const args = parseArgs(rest);
-  // Opportunistic content-sidecar retention prune on every invocation.
-  // Best-effort; never fails the CLI.
-  if (!(cmd === 'state' && args.positional[0] === 'prune')) {
+  // Best-effort retention pruning should not run for help paths or before
+  // latency-sensitive harness startup.
+  if (shouldRunOpportunisticPrune(cmd, args)) {
+    const { opportunisticPrune } = await import('./commands/state.js');
     await opportunisticPrune();
   }
   switch (cmd) {
     case 'summary':
-      return runSummary(args);
+      return (await import('./commands/summary.js')).runSummary(args);
     case 'hotspots':
-      return runHotspots(args);
+      return (await import('./commands/hotspots.js')).runHotspots(args);
     case 'budget':
-      return runBudget(args);
+      return (await import('./commands/budget.js')).runBudget(args);
     case 'overhead':
-      return runOverhead(args);
+      return (await import('./commands/overhead.js')).runOverhead(args);
     case 'compare':
-      return runCompare(args);
+      return (await import('./commands/compare.js')).runCompare(args);
     case 'run':
-      return runWrapper(args);
+      return (await import('./commands/run.js')).runWrapper(args);
     case 'ingest':
-      return runIngest(args);
+      return (await import('./commands/ingest.js')).runIngest(args);
     case 'mcp-server':
-      return runMcpServer(args);
+      return (await import('./commands/mcp-server.js')).runMcpServer(args);
     case 'state':
-      return runState(args);
+      return (await import('./commands/state.js')).runState(args);
     default:
       process.stderr.write(`unknown command: ${cmd}\n\n${HELP}`);
       return 1;
   }
+}
+
+function shouldRunOpportunisticPrune(cmd: string, args: ParsedArgs): boolean {
+  if (isHelpInvocation(args)) return false;
+  if (cmd === 'run' || cmd === 'mcp-server') return false;
+  if (cmd === 'state' && args.positional[0] === 'prune') return false;
+  return true;
+}
+
+function isHelpInvocation(args: ParsedArgs): boolean {
+  if (args.flags['help'] === true) return true;
+  return args.positional.some((arg) => arg === 'help' || arg === '--help' || arg === '-h');
 }
 
 main().then(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -44,7 +44,7 @@ export async function runWrapper(
     process.stdout.write(RUN_HELP);
     return (harnessName || args.flags['help'] === true) ? 0 : 2;
   }
-  const adapter = lookupHarness(harnessName);
+  const adapter = await lookupHarness(harnessName);
   if (!adapter) {
     process.stderr.write(
       `burn: unknown harness "${harnessName}". Known: ${listHarnessNames().join(', ')}\n`,
@@ -115,4 +115,3 @@ export async function runWithAdapter(
   );
   return code;
 }
-

--- a/packages/cli/src/commands/state.ts
+++ b/packages/cli/src/commands/state.ts
@@ -4,33 +4,12 @@ import { homedir } from 'node:os';
 import * as path from 'node:path';
 import { createInterface } from 'node:readline';
 
-import {
-  archivePath,
-  contentDir,
-  cursorsPath,
-  getArchiveStatus,
-  hwmPath,
-  invalidateIndexCache,
-  isTurnLine,
-  isUserTurnLine,
-  isValidSessionId,
-  ledgerContentIndexPath,
-  ledgerHome,
-  ledgerIndexPath,
-  ledgerPath,
-  loadConfig,
-  pruneContent,
-  rebuildIndex,
-  reclassifyLedger,
-  retentionMs,
-  withLock,
-} from '@relayburn/ledger';
-
-import { ingestAll, reingestMissingContent } from '../ingest.js';
 import { formatInt } from '../format.js';
-import { walkJsonl, walkOpencodeSessions } from '../walk.js';
 import type { ParsedArgs } from '../args.js';
-import { formatArchiveStatusLines, runArchiveBuild, runArchiveVacuum } from './archive.js';
+
+type LedgerModule = typeof import('@relayburn/ledger');
+type ArchiveStatus = Awaited<ReturnType<LedgerModule['getArchiveStatus']>>;
+type FormatArchiveStatusLines = (status: ArchiveStatus) => string[];
 
 const STATE_HELP = `burn state - inspect and maintain derived ledger state
 
@@ -138,7 +117,7 @@ interface StateStatus {
     classified: number;
     missing: number;
   };
-  archive: Awaited<ReturnType<typeof getArchiveStatus>>;
+  archive: ArchiveStatus;
 }
 
 interface ContentSidecarStatus {
@@ -219,6 +198,7 @@ async function runArchiveTarget(args: ParsedArgs): Promise<number> {
     process.stderr.write(`burn state rebuild archive: --full and --vacuum cannot be combined\n`);
     return 1;
   }
+  const { runArchiveBuild, runArchiveVacuum } = await import('./archive.js');
   if (vacuum) return runArchiveVacuum(args);
   return runArchiveBuild(args, { full: args.flags['full'] === true });
 }
@@ -228,6 +208,7 @@ async function runAll(args: ParsedArgs): Promise<number> {
   await rebuildContent(lines);
   await rebuildIndexTarget(lines);
   await rebuildClassify(lines, args.flags['force'] === true);
+  const { runArchiveBuild } = await import('./archive.js');
   const flags = { ...args.flags };
   delete flags['json'];
   const archiveArgs = { ...args, flags };
@@ -259,6 +240,7 @@ async function runContentRebuild(): Promise<number> {
 }
 
 async function rebuildClassify(lines: string[], force: boolean): Promise<void> {
+  const { reclassifyLedger } = await import('@relayburn/ledger');
   const report = await reclassifyLedger({ force });
   const unchanged = report.processed - report.changed;
   lines.push(
@@ -278,6 +260,7 @@ async function rebuildClassify(lines: string[], force: boolean): Promise<void> {
 }
 
 async function rebuildContent(lines: string[]): Promise<void> {
+  const { reingestMissingContent } = await import('../ingest.js');
   const r = await reingestMissingContent();
   lines.push(
     `reingested derived content for ${formatInt(r.reingestedSessions)} sessions` +
@@ -290,6 +273,7 @@ async function rebuildContent(lines: string[]): Promise<void> {
 }
 
 async function rebuildIndexTarget(lines: string[]): Promise<void> {
+  const { rebuildIndex } = await import('@relayburn/ledger');
   const { ids, content } = await rebuildIndex();
   lines.push(
     `rebuilt ledger index: ${formatInt(ids)} id hashes, ${formatInt(content)} content fingerprints`,
@@ -302,11 +286,17 @@ async function runStatus(args: ParsedArgs): Promise<number> {
     process.stdout.write(JSON.stringify(status, null, 2) + '\n');
     return 0;
   }
-  process.stdout.write(formatStateStatusLines(status).join('\n') + '\n');
+  const { formatArchiveStatusLines } = await import('./archive.js');
+  process.stdout.write(formatStateStatusLines(status, formatArchiveStatusLines).join('\n') + '\n');
   return 0;
 }
 
 async function collectStateStatus(): Promise<StateStatus> {
+  const {
+    getArchiveStatus,
+    ledgerContentIndexPath,
+    ledgerIndexPath,
+  } = await import('@relayburn/ledger');
   const [ids, content, contentSidecar, ledgerCounts, archive] = await Promise.all([
     indexFileStatus(ledgerIndexPath()),
     indexFileStatus(ledgerContentIndexPath()),
@@ -342,6 +332,7 @@ async function indexFileStatus(filePath: string): Promise<IndexFileStatus> {
 }
 
 async function contentSidecarStatus(): Promise<ContentSidecarStatus> {
+  const { contentDir, isValidSessionId } = await import('@relayburn/ledger');
   const dir = contentDir();
   let entries: string[];
   try {
@@ -385,6 +376,7 @@ async function contentSidecarStatus(): Promise<ContentSidecarStatus> {
 }
 
 async function ledgerDerivedCounts(): Promise<LedgerDerivedCounts> {
+  const { isTurnLine, isUserTurnLine, ledgerPath } = await import('@relayburn/ledger');
   const filePath = ledgerPath();
   const exists = await stat(filePath)
     .then((s) => s.isFile())
@@ -419,7 +411,10 @@ async function ledgerDerivedCounts(): Promise<LedgerDerivedCounts> {
   return counts;
 }
 
-function formatStateStatusLines(status: StateStatus): string[] {
+function formatStateStatusLines(
+  status: StateStatus,
+  formatArchiveStatusLines: FormatArchiveStatusLines,
+): string[] {
   const lines: string[] = [];
   lines.push('derived state:');
   lines.push('index:');
@@ -478,6 +473,7 @@ async function captureStdout(fn: () => Promise<number>): Promise<{ code: number;
 }
 
 async function runStatePrune(args: ParsedArgs): Promise<number> {
+  const { loadConfig, pruneContent, retentionMs } = await import('@relayburn/ledger');
   const cfg = await loadConfig();
   let retention: number | 'forever';
   if (typeof args.flags['days'] === 'string') {
@@ -498,7 +494,7 @@ async function runStatePrune(args: ParsedArgs): Promise<number> {
     return 0;
   }
   const force = args.flags['force'] === true || isForceEnv();
-  const opts: Parameters<typeof pruneContent>[0] = { olderThanMs: ms };
+  const opts: Parameters<LedgerModule['pruneContent']>[0] = { olderThanMs: ms };
   if (!force) {
     const sources = await loadSourceSessionIds();
     opts.isRecoverable = (sessionId) => sources.has(sessionId);
@@ -570,6 +566,7 @@ async function runStateReset(args: ParsedArgs): Promise<number> {
     process.stdout.write(RESET_HELP);
     return 0;
   }
+  const { invalidateIndexCache, ledgerHome, withLock } = await import('@relayburn/ledger');
   const force = args.flags['force'] === true;
   const reingest = args.flags['reingest'] === true;
   const json = args.flags['json'] === true;
@@ -607,6 +604,7 @@ async function runStateReset(args: ParsedArgs): Promise<number> {
 
   let reingested: ResetSummary['reingested'] = null;
   if (reingest) {
+    const { ingestAll } = await import('../ingest.js');
     const r = await ingestAll();
     reingested = {
       scannedSessions: r.scannedSessions,
@@ -621,17 +619,27 @@ async function runStateReset(args: ParsedArgs): Promise<number> {
 }
 
 async function collectResetTargets(): Promise<ResetTargetReport[]> {
+  const {
+    archivePath,
+    contentDir,
+    cursorsPath,
+    hwmPath,
+    ledgerContentIndexPath,
+    ledgerIndexPath,
+    ledgerPath,
+  } = await import('@relayburn/ledger');
   // Order doesn't matter for correctness, but file sidecars first reads
   // nicer in the dry-run output: small to large, ledger -> archive -> content.
+  const archive = archivePath();
   const filePaths: string[] = [
     ledgerPath(),
     ledgerIndexPath(),
     ledgerContentIndexPath(),
     cursorsPath(),
     hwmPath(),
-    archivePath(),
-    `${archivePath()}-wal`,
-    `${archivePath()}-shm`,
+    archive,
+    `${archive}-wal`,
+    `${archive}-shm`,
   ];
   const reports: ResetTargetReport[] = [];
   for (const p of filePaths) {
@@ -798,6 +806,7 @@ function writeResetSummary(
 
 export async function opportunisticPrune(): Promise<void> {
   try {
+    const { loadConfig, pruneContent, retentionMs } = await import('@relayburn/ledger');
     const cfg = await loadConfig();
     if (cfg.content.store === 'off') return;
     const ms = retentionMs(cfg.content.retentionDays);
@@ -806,7 +815,7 @@ export async function opportunisticPrune(): Promise<void> {
     // Reclaiming recoverable disk requires explicit `burn state prune --force`.
     // The exception is RELAYBURN_PRUNE_FORCE=1 for unattended automation that
     // genuinely wants the old behavior.
-    const opts: Parameters<typeof pruneContent>[0] = { olderThanMs: ms };
+    const opts: Parameters<LedgerModule['pruneContent']>[0] = { olderThanMs: ms };
     if (!isForceEnv()) {
       const sources = await loadSourceSessionIds();
       opts.isRecoverable = (sessionId) => sources.has(sessionId);
@@ -879,6 +888,7 @@ async function collectClaudeSessionIds(out: Set<string>): Promise<void> {
 async function collectCodexSessionIds(out: Set<string>): Promise<void> {
   let files: string[];
   try {
+    const { walkJsonl } = await import('../walk.js');
     files = await walkJsonl(CODEX_SESSIONS);
   } catch {
     return;
@@ -893,6 +903,7 @@ async function collectCodexSessionIds(out: Set<string>): Promise<void> {
 async function collectOpencodeSessionIds(out: Set<string>): Promise<void> {
   let files: string[];
   try {
+    const { walkOpencodeSessions } = await import('../walk.js');
     files = await walkOpencodeSessions(OPENCODE_SESSION_ROOT);
   } catch {
     return;

--- a/packages/cli/src/harnesses/registry.test.ts
+++ b/packages/cli/src/harnesses/registry.test.ts
@@ -27,5 +27,8 @@ describe('harness registry', () => {
     assert.equal(await lookupHarness('cursor'), undefined);
     assert.equal(await lookupHarness(''), undefined);
     assert.equal(await lookupHarness('claude '), undefined);
+    assert.equal(await lookupHarness('constructor'), undefined);
+    assert.equal(await lookupHarness('toString'), undefined);
+    assert.equal(await lookupHarness('__proto__'), undefined);
   });
 });

--- a/packages/cli/src/harnesses/registry.test.ts
+++ b/packages/cli/src/harnesses/registry.test.ts
@@ -9,23 +9,23 @@ describe('harness registry', () => {
     assert.deepEqual([...names].sort(), ['claude', 'codex', 'opencode']);
   });
 
-  it('looks up adapters by name', () => {
-    const claude = lookupHarness('claude');
+  it('looks up adapters by name', async () => {
+    const claude = await lookupHarness('claude');
     assert.ok(claude);
     assert.equal(claude!.name, 'claude');
 
-    const codex = lookupHarness('codex');
+    const codex = await lookupHarness('codex');
     assert.ok(codex);
     assert.equal(codex!.name, 'codex');
 
-    const opencode = lookupHarness('opencode');
+    const opencode = await lookupHarness('opencode');
     assert.ok(opencode);
     assert.equal(opencode!.name, 'opencode');
   });
 
-  it('returns undefined for unknown harnesses', () => {
-    assert.equal(lookupHarness('cursor'), undefined);
-    assert.equal(lookupHarness(''), undefined);
-    assert.equal(lookupHarness('claude '), undefined);
+  it('returns undefined for unknown harnesses', async () => {
+    assert.equal(await lookupHarness('cursor'), undefined);
+    assert.equal(await lookupHarness(''), undefined);
+    assert.equal(await lookupHarness('claude '), undefined);
   });
 });

--- a/packages/cli/src/harnesses/registry.ts
+++ b/packages/cli/src/harnesses/registry.ts
@@ -11,7 +11,7 @@ const ADAPTERS: Record<string, AdapterLoader> = {
 };
 
 export async function lookupHarness(name: string): Promise<HarnessAdapter | undefined> {
-  const load = ADAPTERS[name];
+  const load = Object.hasOwn(ADAPTERS, name) ? ADAPTERS[name] : undefined;
   return load ? load() : undefined;
 }
 

--- a/packages/cli/src/harnesses/registry.ts
+++ b/packages/cli/src/harnesses/registry.ts
@@ -1,20 +1,20 @@
-import { claudeAdapter } from './claude.js';
-import { codexAdapter } from './codex.js';
-import { opencodeAdapter } from './opencode.js';
 import type { HarnessAdapter } from './types.js';
 
-// Static registry of known harnesses. Adding a fourth harness is a one-line
-// import + one-line array entry — no driver changes, no help-block edits.
-const ADAPTERS: ReadonlyArray<HarnessAdapter> = [
-  claudeAdapter,
-  codexAdapter,
-  opencodeAdapter,
-];
+type AdapterLoader = () => Promise<HarnessAdapter>;
 
-export function lookupHarness(name: string): HarnessAdapter | undefined {
-  return ADAPTERS.find((a) => a.name === name);
+// Static registry of known harnesses. Adapter modules are loaded lazily so
+// top-level help and unrelated commands do not pay ingest/ledger startup cost.
+const ADAPTERS: Record<string, AdapterLoader> = {
+  claude: async () => (await import('./claude.js')).claudeAdapter,
+  codex: async () => (await import('./codex.js')).codexAdapter,
+  opencode: async () => (await import('./opencode.js')).opencodeAdapter,
+};
+
+export async function lookupHarness(name: string): Promise<HarnessAdapter | undefined> {
+  const load = ADAPTERS[name];
+  return load ? load() : undefined;
 }
 
 export function listHarnessNames(): string[] {
-  return ADAPTERS.map((a) => a.name);
+  return Object.keys(ADAPTERS);
 }


### PR DESCRIPTION
## Summary
- skip opportunistic content pruning for help, run, and mcp-server startup paths
- lazy-load CLI command modules and harness adapters so simple commands do not import ingest/ledger-heavy paths
- add regression coverage for state help and run dispatch avoiding prune side effects

## Tests
- pnpm run build
- pnpm run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
