### PR TITLE
Add CLI progress reporting

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Added
+
+- `burn` now reports interactive progress for ingest scans, harness startup/finalization, derived-state rebuilds, archive work, and analysis reads so long-running tasks no longer appear stalled.
+
 ### Fixed
 
 - `burn state --help`, `burn run`, and `burn mcp-server` now skip opportunistic content pruning so help output and latency-sensitive startup are not delayed by retention scans.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,8 @@
     "@relayburn/reader": "workspace:*",
     "@relayburn/ledger": "workspace:*",
     "@relayburn/analyze": "workspace:*",
-    "@relayburn/mcp": "workspace:*"
+    "@relayburn/mcp": "workspace:*",
+    "ora": "^9.4.0"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/src/commands/archive.ts
+++ b/packages/cli/src/commands/archive.ts
@@ -9,17 +9,30 @@ import {
 
 import { formatInt } from '../format.js';
 import type { ParsedArgs } from '../args.js';
+import { withProgress } from '../progress.js';
 
 export async function runArchiveBuild(
   args: ParsedArgs,
   opts: { full?: boolean } = {},
 ): Promise<number> {
-  const result = opts.full ? await rebuildArchive() : await buildArchive();
+  const mode = opts.full ? 'rebuilding archive from ledger' : 'building archive tail';
+  const result = await withProgress(mode, async (task) => {
+    const r = opts.full ? await rebuildArchive() : await buildArchive();
+    task.succeed(
+      `${opts.full ? 'rebuilt' : 'built'} archive: ` +
+        `${formatInt(r.turnsApplied)} turn${r.turnsApplied === 1 ? '' : 's'} applied`,
+    );
+    return r;
+  });
   return printArchiveBuildResult(result, args, opts.full ? 'rebuild' : 'build');
 }
 
 export async function runArchiveStatus(args: ParsedArgs): Promise<number> {
-  const status = await getArchiveStatus();
+  const status = await withProgress('checking archive status', async (task) => {
+    const s = await getArchiveStatus();
+    task.succeed('checked archive status');
+    return s;
+  });
   if (args.flags['json'] === true) {
     process.stdout.write(JSON.stringify(status, null, 2) + '\n');
     return 0;
@@ -29,7 +42,11 @@ export async function runArchiveStatus(args: ParsedArgs): Promise<number> {
 }
 
 export async function runArchiveVacuum(args: ParsedArgs): Promise<number> {
-  const result = await vacuumArchive();
+  const result = await withProgress('vacuuming archive', async (task) => {
+    const r = await vacuumArchive();
+    task.succeed('vacuumed archive');
+    return r;
+  });
   if (args.flags['json'] === true) {
     process.stdout.write(JSON.stringify(result, null, 2) + '\n');
     return 0;

--- a/packages/cli/src/commands/budget-plans.test.ts
+++ b/packages/cli/src/commands/budget-plans.test.ts
@@ -10,7 +10,7 @@ import { EMPTY_COVERAGE, makeFidelity } from '@relayburn/reader';
 import type { Fidelity, TurnRecord } from '@relayburn/reader';
 
 import type { ParsedArgs } from '../args.js';
-import { runBudgetPlans } from './budget-plans.js';
+import { loadPlanStatuses, runBudgetPlans } from './budget-plans.js';
 
 function args(positional: string[] = [], flags: Record<string, string | true> = {}): ParsedArgs {
   return { positional, flags, tags: {}, passthrough: [] };
@@ -46,6 +46,7 @@ describe('burn budget plans CLI', () => {
   const originalRelay = process.env['RELAYBURN_HOME'];
   const originalHome = process.env['HOME'];
   const originalArchive = process.env['RELAYBURN_ARCHIVE'];
+  const originalProgress = process.env['RELAYBURN_PROGRESS'];
 
   beforeEach(async () => {
     tmp = await mkdtemp(path.join(tmpdir(), 'burn-plans-cli-'));
@@ -57,6 +58,7 @@ describe('burn budget plans CLI', () => {
     // test ledger and contaminate parity numbers.
     process.env['HOME'] = tmpHome;
     delete process.env['RELAYBURN_ARCHIVE'];
+    delete process.env['RELAYBURN_PROGRESS'];
   });
 
   after(async () => {
@@ -66,6 +68,8 @@ describe('burn budget plans CLI', () => {
     else delete process.env['HOME'];
     if (originalArchive !== undefined) process.env['RELAYBURN_ARCHIVE'] = originalArchive;
     else delete process.env['RELAYBURN_ARCHIVE'];
+    if (originalProgress !== undefined) process.env['RELAYBURN_PROGRESS'] = originalProgress;
+    else delete process.env['RELAYBURN_PROGRESS'];
     await rm(tmp, { recursive: true, force: true });
     await rm(tmpHome, { recursive: true, force: true });
   });
@@ -96,6 +100,26 @@ describe('burn budget plans CLI', () => {
     assert.equal(result, 0);
     const plans = await loadPlans();
     assert.equal(plans[0]!.resetDay, 15);
+  });
+
+  it('can silence nested plan-status progress output', async () => {
+    await savePlans([
+      {
+        id: 'claude-pro',
+        provider: 'claude',
+        name: 'Claude Pro',
+        budgetUsd: 20,
+        resetDay: 1,
+      },
+    ]);
+    process.env['RELAYBURN_PROGRESS'] = '1';
+
+    const { result, stderr } = await captureStdio(() =>
+      loadPlanStatuses(undefined, { quiet: true }),
+    );
+
+    assert.equal(result.length, 1);
+    assert.equal(stderr, '');
   });
 
   it('rejects --reset-day outside 1-31', async () => {

--- a/packages/cli/src/commands/budget-plans.ts
+++ b/packages/cli/src/commands/budget-plans.ts
@@ -18,7 +18,8 @@ import type { PlanUsage } from '@relayburn/analyze';
 
 import type { ParsedArgs } from '../args.js';
 import { ingestAll } from '../ingest.js';
-import { formatUsd, table } from '../format.js';
+import { formatInt, formatUsd, table } from '../format.js';
+import { withProgress } from '../progress.js';
 
 const BUDGET_PLANS_HELP = `burn budget plans — monthly quota tracking against your plan budget
 
@@ -303,6 +304,10 @@ export interface PlanStatus {
   usage: PlanUsage;
 }
 
+export interface LoadPlanStatusesOptions {
+  quiet?: boolean;
+}
+
 interface StatusForPlansOptions {
   /**
    * When true, aggregate spend with one SQL query per plan against the
@@ -313,11 +318,18 @@ interface StatusForPlansOptions {
    * stays on the legacy path until it's migrated separately. See #91.
    */
   useArchive?: boolean;
+  quiet?: boolean;
 }
 
-export async function loadPlanStatuses(args?: ParsedArgs): Promise<PlanStatus[]> {
+export async function loadPlanStatuses(
+  args?: ParsedArgs,
+  opts: LoadPlanStatusesOptions = {},
+): Promise<PlanStatus[]> {
   const plans = await loadPlans();
-  return statusForPlans(plans, { useArchive: args ? shouldUseArchive(args) : false });
+  return statusForPlans(plans, {
+    useArchive: args ? shouldUseArchive(args) : false,
+    ...progressOptions(opts),
+  });
 }
 
 // Shared by `burn budget plans` (list view) and `burn budget` (composite view)
@@ -327,15 +339,30 @@ async function statusForPlans(
   opts: StatusForPlansOptions = {},
 ): Promise<PlanStatus[]> {
   if (plans.length === 0) return [];
-  await ingestAll();
-  const pricing = await loadPricing();
+  const progress = progressOptions(opts);
+  await withProgress(
+    'ingesting latest sessions',
+    (task) => ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    progress,
+  );
+  const pricing = await withProgress('loading pricing snapshot', async (task) => {
+    const loaded = await loadPricing();
+    task.succeed('loaded pricing snapshot');
+    return loaded;
+  }, progress);
   const useArchive = opts.useArchive ?? false;
 
   if (useArchive) {
     // Materialize the ledger tail into the archive once before any plan
     // queries so `SELECT SUM(...) FROM turns` sees every turn the legacy
     // `queryAll()` path would have. Cheap when up to date (idempotent).
-    await buildArchive();
+    await withProgress('updating archive', async (task) => {
+      const result = await buildArchive();
+      task.succeed(
+        `updated archive: ${formatInt(result.turnsApplied)} turn` +
+          `${result.turnsApplied === 1 ? '' : 's'} applied`,
+      );
+    }, progress);
     const db = await openArchive();
     try {
       const now = new Date();
@@ -357,8 +384,16 @@ async function statusForPlans(
     })
     .reduce((a, b) => Math.min(a, b), Date.now());
   const since = new Date(oldestStart).toISOString();
-  const turns = await queryAll({ since });
+  const turns = await withProgress('reading ledger turns', async (task) => {
+    const rows = await queryAll({ since });
+    task.succeed(`read ${formatInt(rows.length)} turn${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  }, progress);
   return plans.map((plan) => ({ usage: computePlanUsage(plan, turns, { pricing }) }));
+}
+
+function progressOptions(opts: { quiet?: boolean }): { quiet?: boolean } {
+  return opts.quiet === undefined ? {} : { quiet: opts.quiet };
 }
 
 /**

--- a/packages/cli/src/commands/budget.ts
+++ b/packages/cli/src/commands/budget.ts
@@ -187,7 +187,7 @@ export async function runBudget(args: ParsedArgs, deps: BudgetDeps = {}): Promis
     let planStatuses: PlanStatus[] = [];
     try {
       planStatuses = await withProgress('loading budget plans', async (task) => {
-        const statuses = await loadPlanStatuses({ quiet: watchFlag !== undefined });
+        const statuses = await loadPlanStatuses({ quiet: true });
         task.succeed(
           `loaded ${statuses.length} budget plan${statuses.length === 1 ? '' : 's'}`,
         );

--- a/packages/cli/src/commands/budget.ts
+++ b/packages/cli/src/commands/budget.ts
@@ -11,7 +11,13 @@ import type { TurnRecord } from '@relayburn/reader';
 import type { ParsedArgs } from '../args.js';
 import { formatUsd } from '../format.js';
 import { ingestAll } from '../ingest.js';
-import { loadPlanStatuses as defaultLoadPlanStatuses, runBudgetPlans, type PlanStatus } from './budget-plans.js';
+import { withProgress } from '../progress.js';
+import {
+  loadPlanStatuses as defaultLoadPlanStatuses,
+  runBudgetPlans,
+  type LoadPlanStatusesOptions,
+  type PlanStatus,
+} from './budget-plans.js';
 
 const USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage';
 const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20';
@@ -91,7 +97,7 @@ export interface BudgetDeps {
   fetchUsage?: (token: string) => Promise<UsageResponse>;
   now?: () => Date;
   loadForecast?: (windowStartMs: number, nowMs: number) => Promise<ForecastResult | null>;
-  loadPlanStatuses?: () => Promise<PlanStatus[]>;
+  loadPlanStatuses?: (opts?: LoadPlanStatusesOptions) => Promise<PlanStatus[]>;
 }
 
 export async function runBudget(args: ParsedArgs, deps: BudgetDeps = {}): Promise<number> {
@@ -117,14 +123,19 @@ export async function runBudget(args: ParsedArgs, deps: BudgetDeps = {}): Promis
   const fetchUsage = deps.fetchUsage ?? fetchUsageFromApi;
   const now = deps.now ?? (() => new Date());
   const loadForecast = deps.loadForecast ?? loadForecastFromLedger;
-  const loadPlanStatuses = deps.loadPlanStatuses ?? (() => defaultLoadPlanStatuses());
+  const loadPlanStatuses = deps.loadPlanStatuses ?? ((opts?: LoadPlanStatusesOptions) =>
+    defaultLoadPlanStatuses(undefined, opts));
 
   // Resolve the OAuth token once per invocation, not per render. The macOS
   // Keychain path spawns `security`, which is expensive enough that calling
   // it on every --watch tick (every 5s by default) would dominate the loop.
   let token: string | null = null;
   if (!noApi) {
-    token = await loadToken();
+    token = await withProgress('loading Claude OAuth token', async (task) => {
+      const loaded = await loadToken();
+      task.succeed(loaded ? 'loaded Claude OAuth token' : 'Claude OAuth token not found');
+      return loaded;
+    }, { quiet: watchFlag !== undefined });
     if (!token) {
       process.stderr.write(
         'burn budget: no Claude OAuth token found. Run `claude /login` to authenticate, ' +
@@ -141,7 +152,11 @@ export async function runBudget(args: ParsedArgs, deps: BudgetDeps = {}): Promis
     let usageError: string | null = null;
     if (token !== null) {
       try {
-        usage = await fetchOnce(token);
+        usage = await withProgress('fetching Claude usage', async (task) => {
+          const fetched = await fetchOnce(token);
+          task.succeed('fetched Claude usage');
+          return fetched;
+        }, { quiet: watchFlag !== undefined });
       } catch (err) {
         usageError = err instanceof Error ? err.message : String(err);
       }
@@ -151,7 +166,11 @@ export async function runBudget(args: ParsedArgs, deps: BudgetDeps = {}): Promis
     let forecast: { window: ForecastWindow; data: ForecastInput; fidelity: ForecastFidelity } | null = null;
     if (!noForecast) {
       const windowStartMs = forecastWindowStartMs(usage?.five_hour, nowDate);
-      const result = await loadForecast(windowStartMs, nowDate.getTime());
+      const result = await withProgress('forecasting from local ledger', async (task) => {
+        const forecastResult = await loadForecast(windowStartMs, nowDate.getTime());
+        task.succeed(forecastResult ? 'forecasted from local ledger' : 'no local forecast data');
+        return forecastResult;
+      }, { quiet: watchFlag !== undefined });
       if (result) {
         forecast = { window: { startMs: windowStartMs }, data: result.input, fidelity: result.fidelity };
       }
@@ -167,7 +186,13 @@ export async function runBudget(args: ParsedArgs, deps: BudgetDeps = {}): Promis
     // once on stderr and degrade to an empty plan list.
     let planStatuses: PlanStatus[] = [];
     try {
-      planStatuses = await loadPlanStatuses();
+      planStatuses = await withProgress('loading budget plans', async (task) => {
+        const statuses = await loadPlanStatuses({ quiet: watchFlag !== undefined });
+        task.succeed(
+          `loaded ${statuses.length} budget plan${statuses.length === 1 ? '' : 's'}`,
+        );
+        return statuses;
+      }, { quiet: watchFlag !== undefined });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[burn] warning: could not load plans (${msg})\n`);

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -16,6 +16,7 @@ import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 import { filterTurnsByProvider, parseProviderFilter } from '../provider.js';
+import { withProgress } from '../progress.js';
 
 const COMPARE_HELP = `burn compare — per-(model, activity) comparison table
 
@@ -191,8 +192,21 @@ export async function runCompare(
   const query = deps.queryAll ?? queryAll;
   const loadPricingFn = deps.loadPricing ?? loadPricing;
 
-  await ingest();
-  const pricing = await loadPricingFn();
+  if (deps.ingestAll) {
+    await withProgress('ingesting latest sessions', async (task) => {
+      await ingest();
+      task.succeed('ingested latest sessions');
+    });
+  } else {
+    await withProgress('ingesting latest sessions', (task) =>
+      ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    );
+  }
+  const pricing = await withProgress('loading pricing snapshot', async (task) => {
+    const loaded = await loadPricingFn();
+    task.succeed('loaded pricing snapshot');
+    return loaded;
+  });
 
   const opts: Parameters<typeof buildCompareTable>[1] = { pricing, minSample, models };
 
@@ -225,13 +239,30 @@ export async function runCompare(
     // Materialize the ledger tail before reading. ingestAll() above only
     // writes to the JSONL ledger; the archive is a derived read model that
     // needs an explicit catch-up build to reflect the just-appended turns.
-    await buildArchive();
-    const result = await compareFromArchive(q, opts);
+    await withProgress('updating archive', async (task) => {
+      const archiveResult = await buildArchive();
+      task.succeed(
+        `updated archive: ${formatInt(archiveResult.turnsApplied)} turn` +
+          `${archiveResult.turnsApplied === 1 ? '' : 's'} applied`,
+      );
+    });
+    const result = await withProgress('building compare table from archive', async (task) => {
+      const archiveCompare = await compareFromArchive(q, opts);
+      task.succeed(
+        `built compare table from ${formatInt(archiveCompare.analyzedTurns)} turn` +
+          `${archiveCompare.analyzedTurns === 1 ? '' : 's'}`,
+      );
+      return archiveCompare;
+    });
     table = result.table;
     // For fidelity-permissive mode the JSON summary reflects everything in
     // the queried slice; we still emit a zero-excluded breakdown so the
     // schema is stable.
-    const turnsForSummary = await query(q);
+    const turnsForSummary = await withProgress('reading turns for fidelity summary', async (task) => {
+      const turns = await query(q);
+      task.succeed(`read ${formatInt(turns.length)} turn${turns.length === 1 ? '' : 's'}`);
+      return turns;
+    });
     summary = summarizeFidelity(turnsForSummary);
     filteredTurns = turnsForSummary;
     void result.analyzedTurns;
@@ -239,7 +270,12 @@ export async function runCompare(
     // `--provider` narrows the queried slice up front so coverage / fidelity
     // counts reflect the provider-scoped input, not the cross-provider total
     // (which would over-count "excluded" turns relative to what's rendered).
-    const turns = filterTurnsByProvider(await query(q), providerFilter);
+    const queriedTurns = await withProgress('reading ledger turns', async (task) => {
+      const turns = await query(q);
+      task.succeed(`read ${formatInt(turns.length)} turn${turns.length === 1 ? '' : 's'}`);
+      return turns;
+    });
+    const turns = filterTurnsByProvider(queriedTurns, providerFilter);
     // Summarize fidelity over the *unfiltered* slice (modulo provider) so
     // coverage notes and the JSON `summary` reflect the input the user
     // actually queried, not what survived the fidelity gate. The summary
@@ -253,7 +289,14 @@ export async function runCompare(
     filteredTurns = minFidelity === 'partial'
       ? turns
       : turns.filter((t) => hasMinimumFidelity(t.fidelity, minFidelity));
-    table = buildCompareTable(filteredTurns, opts);
+    table = await withProgress('building compare table', async (task) => {
+      const built = buildCompareTable(filteredTurns, opts);
+      task.succeed(
+        `built compare table from ${formatInt(filteredTurns.length)} turn` +
+          `${filteredTurns.length === 1 ? '' : 's'}`,
+      );
+      return built;
+    });
   }
   const excluded = computeExcluded(summary, minFidelity);
 

--- a/packages/cli/src/commands/hotspots-session.ts
+++ b/packages/cli/src/commands/hotspots-session.ts
@@ -28,6 +28,7 @@ import type {
 import { countToolCallGaps, ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
+import { withProgress } from '../progress.js';
 
 export async function runHotspotsSession(
   args: ParsedArgs,
@@ -37,19 +38,42 @@ export async function runHotspotsSession(
     return runHotspotsGapReport(args);
   }
 
-  await ingestAll();
-  const pricing = await loadPricing();
-  const turns = await queryAll({ sessionId });
+  await withProgress('ingesting latest sessions', (task) =>
+    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+  );
+  const pricing = await withProgress('loading pricing snapshot', async (task) => {
+    const loaded = await loadPricing();
+    task.succeed('loaded pricing snapshot');
+    return loaded;
+  });
+  const turns = await withProgress('reading session turns', async (task) => {
+    const rows = await queryAll({ sessionId });
+    task.succeed(`read ${formatInt(rows.length)} session turn${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
   if (turns.length === 0) {
     process.stderr.write(`burn hotspots --session: no turns found for session ${sessionId}\n`);
     return 1;
   }
-  const compactions = await queryCompactions({ sessionId });
-  const relationships = await queryRelationships({ sessionId });
+  const compactions = await withProgress('reading session compactions', async (task) => {
+    const rows = await queryCompactions({ sessionId });
+    task.succeed(`read ${formatInt(rows.length)} compaction event${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
+  const relationships = await withProgress('reading session relationships', async (task) => {
+    const rows = await queryRelationships({ sessionId });
+    task.succeed(`read ${formatInt(rows.length)} relationship${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
   const graphSessionIds = collectGraphSessionIds(sessionId, relationships);
-  const eventBatches = await Promise.all(
-    [...graphSessionIds].map((sid) => queryToolResultEvents({ sessionId: sid })),
-  );
+  const eventBatches = await withProgress('reading tool-result events', async (task) => {
+    const batches = await Promise.all(
+      [...graphSessionIds].map((sid) => queryToolResultEvents({ sessionId: sid })),
+    );
+    const total = batches.reduce((sum, batch) => sum + batch.length, 0);
+    task.succeed(`read ${formatInt(total)} tool-result event${total === 1 ? '' : 's'}`);
+    return batches;
+  });
   const toolResultEvents = sortToolResultEvents(
     eventBatches.reduce<ToolResultEventRecord[]>((out, batch) => {
       out.push(...batch);
@@ -58,24 +82,40 @@ export async function runHotspotsSession(
   );
   const toolResultStatusBySession = summarizeToolResultStatuses(toolResultEvents);
 
-  const contentRecords: ContentRecord[] = await readContent({ sessionId });
+  const contentRecords: ContentRecord[] = await withProgress('reading session content', async (task) => {
+    const records = await readContent({ sessionId });
+    task.succeed(`read ${formatInt(records.length)} content record${records.length === 1 ? '' : 's'}`);
+    return records;
+  });
   const contentBySession = new Map<string, ContentRecord[]>();
   if (contentRecords.length > 0) contentBySession.set(sessionId, contentRecords);
-  const userTurns: UserTurnRecord[] = await queryUserTurns({ sessionId });
+  const userTurns: UserTurnRecord[] = await withProgress('reading user turns', async (task) => {
+    const rows = await queryUserTurns({ sessionId });
+    task.succeed(`read ${formatInt(rows.length)} user turn${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
   const userTurnsBySession = new Map<string, UserTurnRecord[]>();
   if (userTurns.length > 0) userTurnsBySession.set(sessionId, userTurns);
 
-  const attribution = attributeHotspots(turns, {
-    pricing,
-    contentBySession,
-    userTurnsBySession,
+  const attribution = await withProgress('attributing hotspots', async (task) => {
+    const result = attributeHotspots(turns, {
+      pricing,
+      contentBySession,
+      userTurnsBySession,
+    });
+    task.succeed('attributed hotspots');
+    return result;
   });
-  const patterns = detectPatterns(turns, {
-    pricing,
-    compactions,
-    userTurnsBySession,
-    contentBySession,
-    toolResultEvents,
+  const patterns = await withProgress('detecting session patterns', async (task) => {
+    const result = detectPatterns(turns, {
+      pricing,
+      compactions,
+      userTurnsBySession,
+      contentBySession,
+      toolResultEvents,
+    });
+    task.succeed('detected session patterns');
+    return result;
   });
   const files = aggregateByFile(attribution.attributions).slice(0, 5);
   const bashes = aggregateByBash(attribution.attributions).slice(0, 5);
@@ -568,11 +608,25 @@ interface RelationshipDriftReport {
 }
 
 async function runHotspotsGapReport(args: ParsedArgs): Promise<number> {
-  await ingestAll();
-  const config = await loadConfig();
+  await withProgress('ingesting latest sessions', (task) =>
+    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+  );
+  const config = await withProgress('loading burn configuration', async (task) => {
+    const loaded = await loadConfig();
+    task.succeed('loaded burn configuration');
+    return loaded;
+  });
   const contentMode = config.content.store;
-  const turns = await queryAll();
-  const relationships = await queryRelationships();
+  const turns = await withProgress('reading ledger turns', async (task) => {
+    const rows = await queryAll();
+    task.succeed(`read ${formatInt(rows.length)} turn${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
+  const relationships = await withProgress('reading session relationships', async (task) => {
+    const rows = await queryRelationships();
+    task.succeed(`read ${formatInt(rows.length)} relationship${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
 
   const sessionsByAdapter = new Map<Adapter, Map<string, TurnRecord[]>>();
   const adapterBySession = new Map<string, Adapter>();

--- a/packages/cli/src/commands/hotspots.ts
+++ b/packages/cli/src/commands/hotspots.ts
@@ -56,6 +56,7 @@ import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 import { filterTurnsByProvider, parseProviderFilter } from '../provider.js';
+import { withProgress } from '../progress.js';
 import { runHotspotsSession } from './hotspots-session.js';
 
 const DEFAULT_TOP_N = 10;
@@ -199,9 +200,20 @@ export async function runHotspots(args: ParsedArgs): Promise<number> {
     return 2;
   }
 
-  await ingestAll();
-  const pricing = await loadPricing();
-  const turns = filterTurnsByProvider(await queryAll(q), providerFilter);
+  await withProgress('ingesting latest sessions', (task) =>
+    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+  );
+  const pricing = await withProgress('loading pricing snapshot', async (task) => {
+    const loaded = await loadPricing();
+    task.succeed('loaded pricing snapshot');
+    return loaded;
+  });
+  const queriedTurns = await withProgress('reading ledger turns', async (task) => {
+    const rows = await queryAll(q);
+    task.succeed(`read ${formatInt(rows.length)} turn${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
+  const turns = filterTurnsByProvider(queriedTurns, providerFilter);
 
   // `--findings` is the unified-render flag for `--patterns`; passing it
   // standalone (without `--patterns`) is taken as `--patterns --findings`.
@@ -213,7 +225,15 @@ export async function runHotspots(args: ParsedArgs): Promise<number> {
     const selected = resolvePatternSelection(patternsFlag);
     const sessionIds = new Set(turns.map((t) => t.sessionId));
     const compactions = selected.has('compaction')
-      ? (await queryCompactions(q)).filter((c) => sessionIds.has(c.sessionId))
+      ? (
+          await withProgress('reading compaction events', async (task) => {
+            const rows = await queryCompactions(q);
+            task.succeed(
+              `read ${formatInt(rows.length)} compaction event${rows.length === 1 ? '' : 's'}`,
+            );
+            return rows;
+          })
+        ).filter((c) => sessionIds.has(c.sessionId))
       : [];
     return runPatternsMode(args, turns, pricing, compactions, selected, { query: q });
   }
@@ -742,7 +762,11 @@ export async function runPatternsMode(
   const needUserTurns =
     selected.has('opencode-system-prompt') || selected.has('tool-output-bloat');
   const userTurnsBySession = needUserTurns
-    ? await loadUserTurnsBySession(perDetector)
+    ? await withProgress('reading user turns for pattern detectors', async (task) => {
+        const rows = await loadUserTurnsBySession(perDetector);
+        task.succeed(`read user turns for ${formatInt(rows.size)} session${rows.size === 1 ? '' : 's'}`);
+        return rows;
+      })
     : undefined;
 
   // Load content sidecars for the four detectors that surface content-derived
@@ -753,13 +777,24 @@ export async function runPatternsMode(
   const enrichableDetectors: PatternKind[] = ['retries', 'failures', 'compaction', 'reverts'];
   const needContent = enrichableDetectors.some((d) => selected.has(d));
   const contentBySession = needContent
-    ? await loadContentBySession(perDetector, enrichableDetectors)
+    ? await withProgress('reading content for pattern detectors', async (task) => {
+        const rows = await loadContentBySession(perDetector, enrichableDetectors);
+        task.succeed(`read content for ${formatInt(rows.size)} session${rows.size === 1 ? '' : 's'}`);
+        return rows;
+      })
     : undefined;
 
   const needToolResultEvents =
     selected.has('retries') || selected.has('failures') || selected.has('cancellations');
   const toolResultEvents = needToolResultEvents
-    ? (deps.toolResultEvents ?? await loadToolResultEventsForTurns(turns, deps.query))
+    ? (
+        deps.toolResultEvents ??
+        await withProgress('reading tool-result events for patterns', async (task) => {
+          const rows = await loadToolResultEventsForTurns(turns, deps.query);
+          task.succeed(`read ${formatInt(rows.length)} tool-result event${rows.length === 1 ? '' : 's'}`);
+          return rows;
+        })
+      )
     : undefined;
 
   if (selected.has('retries')) {
@@ -829,11 +864,18 @@ export async function runPatternsMode(
     // file in `detectStaticConfigBloat`'s last-wins merge. Missing or
     // malformed files yield `undefined` from the loader and are dropped from
     // the input list — see `loadClaudeSettings`.
-    const settings: LoadedClaudeSettings[] = [];
-    const userLoaded = await loadClaudeSettings(userClaudeSettingsPath());
-    if (userLoaded) settings.push(userLoaded);
-    const projectLoaded = await loadClaudeSettings(projectClaudeSettingsPath());
-    if (projectLoaded) settings.push(projectLoaded);
+    const settings = await withProgress('loading Claude settings', async (task) => {
+      const loadedSettings: LoadedClaudeSettings[] = [];
+      const userLoaded = await loadClaudeSettings(userClaudeSettingsPath());
+      if (userLoaded) loadedSettings.push(userLoaded);
+      const projectLoaded = await loadClaudeSettings(projectClaudeSettingsPath());
+      if (projectLoaded) loadedSettings.push(projectLoaded);
+      task.succeed(
+        `loaded ${formatInt(loadedSettings.length)} Claude settings file` +
+          `${loadedSettings.length === 1 ? '' : 's'}`,
+      );
+      return loadedSettings;
+    });
 
     // Signal B inputs: stream `tool_result_events` from the ledger. We pass
     // the full TurnRecord set so the detector can join tool_use_ids back to
@@ -844,16 +886,24 @@ export async function runPatternsMode(
     // reused across detectors — flatten its values here since the detector
     // keys lookups by `(source|sessionId|toolUseId)` and doesn't need the
     // per-session structure preserved.
-    const toolResultEvents = await loadToolResultEventsForTurns(turns, deps.query);
+    const toolResultEvents = await withProgress('reading tool-result events for output bloat', async (task) => {
+      const rows = await loadToolResultEventsForTurns(turns, deps.query);
+      task.succeed(`read ${formatInt(rows.length)} tool-result event${rows.length === 1 ? '' : 's'}`);
+      return rows;
+    });
     const allUserTurns: UserTurnRecord[] = userTurnsBySession
       ? [...userTurnsBySession.values()].flat()
       : [];
-    toolOutputBloats = detectToolOutputBloat({
-      settings,
-      toolResultEvents,
-      userTurns: allUserTurns,
-      turns,
-      pricing,
+    toolOutputBloats = await withProgress('detecting tool output bloat', async (task) => {
+      const rows = detectToolOutputBloat({
+        settings,
+        toolResultEvents,
+        userTurns: allUserTurns,
+        turns,
+        pricing,
+      });
+      task.succeed(`detected ${formatInt(rows.length)} tool-output bloat finding${rows.length === 1 ? '' : 's'}`);
+      return rows;
     });
   }
 
@@ -865,8 +915,16 @@ export async function runPatternsMode(
   let ghostFindings: GhostSurfaceFinding[] = [];
   if (selected.has('ghost-surface')) {
     const allTurns = perDetector.get('ghost-surface') ?? turns;
-    const ghostInputs = await buildGhostSurfaceInputs(allTurns, pricing);
-    ghostFindings = await detectGhostSurface(ghostInputs);
+    const ghostInputs = await withProgress('building ghost-surface inputs', async (task) => {
+      const inputs = await buildGhostSurfaceInputs(allTurns, pricing);
+      task.succeed('built ghost-surface inputs');
+      return inputs;
+    });
+    ghostFindings = await withProgress('detecting ghost surfaces', async (task) => {
+      const findings = await detectGhostSurface(ghostInputs);
+      task.succeed(`detected ${formatInt(findings.length)} ghost-surface finding${findings.length === 1 ? '' : 's'}`);
+      return findings;
+    });
   }
 
   // Build session summaries on the union — anything attributed by *any*

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -33,6 +33,7 @@ import {
   startWatchLoop,
   type WatchController,
 } from '../watch-loop.js';
+import { withProgress } from '../progress.js';
 
 export {
   runIngestTick,
@@ -118,7 +119,9 @@ async function runIngestHook(hook: string, quiet: boolean): Promise<number> {
 }
 
 async function runIngestOnce(): Promise<number> {
-  const report = await runIngestTick();
+  const report = await withProgress('ingesting session stores', (task) =>
+    runIngestTick({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+  );
   process.stdout.write(renderIngestReport(report));
   return 0;
 }

--- a/packages/cli/src/commands/mcp-server.ts
+++ b/packages/cli/src/commands/mcp-server.ts
@@ -7,6 +7,7 @@ import {
 
 import { ingestAll } from '../ingest.js';
 import type { ParsedArgs } from '../args.js';
+import { withProgress } from '../progress.js';
 
 const MCP_HELP = `burn mcp-server — stdio MCP server exposing read-only ledger queries
 
@@ -34,7 +35,9 @@ export async function runMcpServer(args: ParsedArgs): Promise<number> {
   // doesn't return zeros for a session that's already had activity. Cheap on
   // a steady-state ledger thanks to the cursor index.
   try {
-    await ingestAll();
+    await withProgress('mcp server initial ingest', (task) =>
+      ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    );
   } catch (err) {
     // Don't fail server startup on a partial ingest — let the tools handle
     // missing data gracefully. Log to stderr (which Claude Code surfaces in
@@ -48,7 +51,13 @@ export async function runMcpServer(args: ParsedArgs): Promise<number> {
   // Idempotent and incremental — a no-op when nothing has changed since the
   // last build (issue #97).
   try {
-    await buildArchive();
+    await withProgress('mcp server archive warmup', async (task) => {
+      const result = await buildArchive();
+      task.succeed(
+        `mcp archive warmup: ${result.turnsApplied} turn` +
+          `${result.turnsApplied === 1 ? '' : 's'} applied`,
+      );
+    });
   } catch (err) {
     // Tools fall back to `queryAll` if the archive is unavailable; log the
     // build failure so an operator can spot a persistent breakage but don't

--- a/packages/cli/src/commands/overhead.ts
+++ b/packages/cli/src/commands/overhead.ts
@@ -22,6 +22,7 @@ import { resolveProject } from '@relayburn/reader';
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
+import { withProgress } from '../progress.js';
 
 const HELP = `burn overhead — cost attribution for agent overhead files (CLAUDE.md, AGENTS.md, …)
 
@@ -76,7 +77,11 @@ async function gatherAttribution(
     );
     return null;
   }
-  let found = await findOverheadFiles(projectPath);
+  let found = await withProgress('finding overhead files', async (task) => {
+    const files = await findOverheadFiles(projectPath);
+    task.succeed(`found ${formatInt(files.length)} overhead file${files.length === 1 ? '' : 's'}`);
+    return files;
+  });
   if (kindFilter) found = found.filter((f) => f.kind === kindFilter);
   if (found.length === 0) {
     if (kindFilter) {
@@ -89,16 +94,33 @@ async function gatherAttribution(
     return null;
   }
   const files: ParsedOverheadFile[] = [];
-  for (const f of found) files.push(await loadOverheadFile(f));
+  await withProgress('loading overhead files', async (task) => {
+    for (const f of found) files.push(await loadOverheadFile(f));
+    task.succeed(`loaded ${formatInt(files.length)} overhead file${files.length === 1 ? '' : 's'}`);
+  });
 
   const resolved = resolveProject(projectPath);
   const q: Query = { project: resolved.projectKey ?? projectPath };
   if (typeof args.flags['since'] === 'string') q.since = parseSinceArg(args.flags['since']);
 
-  await ingestAll();
-  const pricing = await loadPricing();
-  const turns = await queryAll(q);
-  const attribution = attributeOverhead({ files, turns, pricing });
+  await withProgress('ingesting latest sessions', (task) =>
+    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+  );
+  const pricing = await withProgress('loading pricing snapshot', async (task) => {
+    const loaded = await loadPricing();
+    task.succeed('loaded pricing snapshot');
+    return loaded;
+  });
+  const turns = await withProgress('reading ledger turns', async (task) => {
+    const rows = await queryAll(q);
+    task.succeed(`read ${formatInt(rows.length)} turn${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
+  const attribution = await withProgress('attributing overhead cost', async (task) => {
+    const result = attributeOverhead({ files, turns, pricing });
+    task.succeed('attributed overhead cost');
+    return result;
+  });
   return { files, attribution };
 }
 

--- a/packages/cli/src/commands/run.test.ts
+++ b/packages/cli/src/commands/run.test.ts
@@ -100,7 +100,11 @@ describe('runWithAdapter', () => {
     };
 
     const stderrChunks: string[] = [];
+    const originalProgress = process.env['RELAYBURN_PROGRESS'];
+    const originalIsTTY = process.stderr.isTTY;
     const origWrite = process.stderr.write.bind(process.stderr);
+    process.env['RELAYBURN_PROGRESS'] = '1';
+    process.stderr.isTTY = false;
     process.stderr.write = ((chunk: string | Uint8Array): boolean => {
       stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
       return true;
@@ -117,6 +121,9 @@ describe('runWithAdapter', () => {
       });
     } finally {
       process.stderr.write = origWrite;
+      process.stderr.isTTY = originalIsTTY;
+      if (originalProgress !== undefined) process.env['RELAYBURN_PROGRESS'] = originalProgress;
+      else delete process.env['RELAYBURN_PROGRESS'];
     }
 
     assert.equal(code, 0);
@@ -128,6 +135,10 @@ describe('runWithAdapter', () => {
     const reportLine = stderrChunks.find((s) => s.includes('fake-watching ingest:'));
     assert.ok(reportLine, `expected report line in: ${stderrChunks.join('|')}`);
     assert.match(reportLine!, /fake-watching ingest: 3 sessions \(\+8 turns\)/);
+    assert.ok(
+      stderrChunks.some((s) => s.includes('finalized fake-watching ingest')),
+      `expected final ingest success line in: ${stderrChunks.join('|')}`,
+    );
   });
 
   it('returns 127 when the child fails to spawn', async () => {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -124,14 +124,12 @@ export async function runWithAdapter(
     }
     finalTask.update(`running final ${adapter.name} ingest pass`);
     finalReport = await adapter.afterExit(ctx, plan);
-    finalReport = await adapter.afterExit(ctx, plan);
     finalTask.succeed(`finalized ${adapter.name} ingest`);
   } catch (err) {
     finalTask.fail(`final ${adapter.name} ingest failed`);
     throw err;
   } finally {
     finalTask.stop();
-  }
   }
   totalIngestedSessions += finalReport.ingestedSessions;
   totalAppendedTurns += finalReport.appendedTurns;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -8,6 +8,7 @@ import {
   readSpawnEnvTags,
   spawnTagEnvOverrides,
 } from '../spawn-tags.js';
+import { ProgressReporter, withProgress } from '../progress.js';
 
 import { listHarnessNames, lookupHarness } from '../harnesses/registry.js';
 import type { HarnessAdapter, HarnessRunContext } from '../harnesses/types.js';
@@ -60,6 +61,7 @@ export async function runWithAdapter(
   opts: RunWrapperOptions = {},
 ): Promise<number> {
   const spawn = opts.spawn ?? nodeSpawn;
+  const progress = new ProgressReporter();
   const envTags = readSpawnEnvTags();
   const tags = mergeSpawnTags(envTags, args.tags);
   tags['harness'] = adapter.name;
@@ -74,8 +76,15 @@ export async function runWithAdapter(
     spawnStartTs,
   };
 
-  const plan = await adapter.plan(ctx);
-  await adapter.beforeSpawn(ctx, plan);
+  const plan = await withProgress(`preparing ${adapter.name} harness`, async (task) => {
+    const planned = await adapter.plan(ctx);
+    task.succeed(`prepared ${adapter.name}: ${planned.binary}`);
+    return planned;
+  });
+  await withProgress(`tagging ${adapter.name} session`, async (task) => {
+    await adapter.beforeSpawn(ctx, plan);
+    task.succeed(`tagged ${adapter.name} session`);
+  });
 
   let totalIngestedSessions = 0;
   let totalAppendedTurns = 0;
@@ -85,6 +94,8 @@ export async function runWithAdapter(
   };
 
   const watcher = adapter.startWatcher?.(ctx, onReport) ?? null;
+  if (watcher) progress.info(`${adapter.name}: ingest watcher ready`);
+  progress.info(`${adapter.name}: starting ${plan.binary}`);
 
   const child = spawn(plan.binary, plan.args, {
     stdio: 'inherit',
@@ -104,8 +115,22 @@ export async function runWithAdapter(
     });
   });
 
-  if (watcher) await watcher.stop();
-  const finalReport = await adapter.afterExit(ctx, plan);
+  let finalReport: IngestReport;
+  const finalTask = progress.start(`finalizing ${adapter.name} ingest`);
+  try {
+    if (watcher) {
+      finalTask.update(`stopping ${adapter.name} ingest watcher`);
+      await watcher.stop();
+    }
+    finalTask.update(`running final ${adapter.name} ingest pass`);
+    finalReport = await adapter.afterExit(ctx, plan);
+    finalTask.succeed(`finalized ${adapter.name} ingest`);
+  } catch (err) {
+    finalTask.fail(`final ${adapter.name} ingest failed`);
+    throw err;
+  } finally {
+    finalTask.stop();
+  }
   totalIngestedSessions += finalReport.ingestedSessions;
   totalAppendedTurns += finalReport.appendedTurns;
   process.stderr.write(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -124,12 +124,14 @@ export async function runWithAdapter(
     }
     finalTask.update(`running final ${adapter.name} ingest pass`);
     finalReport = await adapter.afterExit(ctx, plan);
+    finalReport = await adapter.afterExit(ctx, plan);
     finalTask.succeed(`finalized ${adapter.name} ingest`);
   } catch (err) {
     finalTask.fail(`final ${adapter.name} ingest failed`);
     throw err;
   } finally {
     finalTask.stop();
+  }
   }
   totalIngestedSessions += finalReport.ingestedSessions;
   totalAppendedTurns += finalReport.appendedTurns;

--- a/packages/cli/src/commands/state.ts
+++ b/packages/cli/src/commands/state.ts
@@ -6,6 +6,7 @@ import { createInterface } from 'node:readline';
 
 import { formatInt } from '../format.js';
 import type { ParsedArgs } from '../args.js';
+import { withProgress } from '../progress.js';
 
 type LedgerModule = typeof import('@relayburn/ledger');
 type ArchiveStatus = Awaited<ReturnType<LedgerModule['getArchiveStatus']>>;
@@ -241,7 +242,11 @@ async function runContentRebuild(): Promise<number> {
 
 async function rebuildClassify(lines: string[], force: boolean): Promise<void> {
   const { reclassifyLedger } = await import('@relayburn/ledger');
-  const report = await reclassifyLedger({ force });
+  const report = await withProgress('reclassifying ledger turns', async (task) => {
+    const r = await reclassifyLedger({ force });
+    task.succeed(`reclassified ${formatInt(r.processed)} turn${r.processed === 1 ? '' : 's'}`);
+    return r;
+  });
   const unchanged = report.processed - report.changed;
   lines.push(
     `reclassified ${formatInt(report.processed)} of ${formatInt(report.scanned)} turns` +
@@ -261,7 +266,16 @@ async function rebuildClassify(lines: string[], force: boolean): Promise<void> {
 
 async function rebuildContent(lines: string[]): Promise<void> {
   const { reingestMissingContent } = await import('../ingest.js');
-  const r = await reingestMissingContent();
+  const r = await withProgress('rebuilding content sidecars', async (task) => {
+    const report = await reingestMissingContent({
+      onProgress: (message) => task.update(`content rebuild: ${message}`),
+    });
+    task.succeed(
+      `rebuilt content sidecars for ${formatInt(report.reingestedSessions)} session` +
+        `${report.reingestedSessions === 1 ? '' : 's'}`,
+    );
+    return report;
+  });
   lines.push(
     `reingested derived content for ${formatInt(r.reingestedSessions)} sessions` +
       ` (${formatInt(r.scannedFiles)} files scanned,` +
@@ -274,14 +288,25 @@ async function rebuildContent(lines: string[]): Promise<void> {
 
 async function rebuildIndexTarget(lines: string[]): Promise<void> {
   const { rebuildIndex } = await import('@relayburn/ledger');
-  const { ids, content } = await rebuildIndex();
+  const { ids, content } = await withProgress('rebuilding ledger indexes', async (task) => {
+    const result = await rebuildIndex();
+    task.succeed(
+      `rebuilt ledger indexes: ${formatInt(result.ids)} id hashes, ` +
+        `${formatInt(result.content)} content fingerprints`,
+    );
+    return result;
+  });
   lines.push(
     `rebuilt ledger index: ${formatInt(ids)} id hashes, ${formatInt(content)} content fingerprints`,
   );
 }
 
 async function runStatus(args: ParsedArgs): Promise<number> {
-  const status = await collectStateStatus();
+  const status = await withProgress('checking derived state', async (task) => {
+    const s = await collectStateStatus();
+    task.succeed('checked derived state');
+    return s;
+  });
   if (args.flags['json'] === true) {
     process.stdout.write(JSON.stringify(status, null, 2) + '\n');
     return 0;
@@ -496,10 +521,18 @@ async function runStatePrune(args: ParsedArgs): Promise<number> {
   const force = args.flags['force'] === true || isForceEnv();
   const opts: Parameters<LedgerModule['pruneContent']>[0] = { olderThanMs: ms };
   if (!force) {
-    const sources = await loadSourceSessionIds();
+    const sources = await withProgress('scanning source session files', async (task) => {
+      const result = await loadSourceSessionIds();
+      task.succeed(`scanned ${formatInt(result.size)} source session id${result.size === 1 ? '' : 's'}`);
+      return result;
+    });
     opts.isRecoverable = (sessionId) => sources.has(sessionId);
   }
-  const result = await pruneContent(opts);
+  const result = await withProgress('pruning content sidecars', async (task) => {
+    const r = await pruneContent(opts);
+    task.succeed(`pruned ${formatInt(r.filesDeleted)} content file${r.filesDeleted === 1 ? '' : 's'}`);
+    return r;
+  });
   process.stdout.write(
     `pruned ${formatInt(result.filesDeleted)} content file${result.filesDeleted === 1 ? '' : 's'} (${formatBytes(result.bytesFreed)})\n`,
   );

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -38,6 +38,7 @@ import type {
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
+import { withProgress } from '../progress.js';
 import {
   filterTurnsByProvider,
   parseProviderFilter,
@@ -104,10 +105,24 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
     return 2;
   }
 
-  const ingestReport = await ingestAll();
-  const pricing = await loadPricing();
+  const ingestReport = await withProgress('ingesting latest sessions', (task) =>
+    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+  );
+  const pricing = await withProgress('loading pricing snapshot', async (task) => {
+    const loaded = await loadPricing();
+    task.succeed('loaded pricing snapshot');
+    return loaded;
+  });
   const agentSessionIds =
-    agentFilter !== undefined ? await resolveAgentSessionTree(agentFilter) : undefined;
+    agentFilter !== undefined
+      ? await withProgress('resolving agent session tree', async (task) => {
+          const ids = await resolveAgentSessionTree(agentFilter);
+          task.succeed(
+            `resolved ${formatInt(ids.size)} linked session${ids.size === 1 ? '' : 's'}`,
+          );
+          return ids;
+        })
+      : undefined;
   if (subagentTreeFlag !== undefined) {
     return renderSubagentTreeMode(
       args,
@@ -245,8 +260,16 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   }
 
   if (args.flags['quality'] === true) {
-    const contentBySession = await loadContentForQuality(turns);
-    const quality = computeQuality(turns, { contentBySession });
+    const contentBySession = await withProgress('reading content for quality summary', async (task) => {
+      const content = await loadContentForQuality(turns);
+      task.succeed(`read content for ${formatInt(content.size)} session${content.size === 1 ? '' : 's'}`);
+      return content;
+    });
+    const quality = await withProgress('computing quality summary', async (task) => {
+      const result = computeQuality(turns, { contentBySession });
+      task.succeed('computed quality summary');
+      return result;
+    });
     lines.push(renderQuality(quality));
     lines.push('');
   }
@@ -405,16 +428,28 @@ async function renderSubagentTreeMode(
     process.stderr.write('burn: --subagent-tree requires a session id (positional or --session)\n');
     return 2;
   }
-  const relationships = await collectSubagentTreeRelationships(sessionId, q);
+  const relationships = await withProgress('reading subagent relationships', async (task) => {
+    const rows = await collectSubagentTreeRelationships(sessionId, q);
+    task.succeed(`read ${formatInt(rows.length)} relationship${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
   const turns = filterTurnsByProvider(
     filterTurnsByAgent(
-      await loadSubagentTreeTurns(sessionId, relationships, q, args),
+      await withProgress('reading subagent tree turns', async (task) => {
+        const rows = await loadSubagentTreeTurns(sessionId, relationships, q, args);
+        task.succeed(`read ${formatInt(rows.length)} turn${rows.length === 1 ? '' : 's'}`);
+        return rows;
+      }),
       agentFilter,
       agentSessionIds,
     ),
     providerFilter,
   );
-  const trees = buildSubagentTree(turns, { pricing, relationships });
+  const trees = await withProgress('building subagent tree', async (task) => {
+    const built = buildSubagentTree(turns, { pricing, relationships });
+    task.succeed(`built ${formatInt(built.size)} subagent tree${built.size === 1 ? '' : 's'}`);
+    return built;
+  });
   const root = trees.get(sessionId) ?? findTreeNode(trees, sessionId);
   if (!root) {
     process.stdout.write(`no turns found for session ${sessionId}\n`);
@@ -494,12 +529,20 @@ async function renderByToolMode(
   turns: EnrichedTurn[],
   pricing: Parameters<typeof costForTurn>[1],
 ): Promise<number> {
-  const userTurnsBySession = await loadUserTurnsForByTool(turns);
-  const { byTool, unattributed } = attributeCostToTools(
-    turns,
-    pricing,
-    userTurnsBySession,
-  );
+  const userTurnsBySession = await withProgress('reading user turns for tool attribution', async (task) => {
+    const rows = await loadUserTurnsForByTool(turns);
+    task.succeed(`read user turns for ${formatInt(rows.size)} session${rows.size === 1 ? '' : 's'}`);
+    return rows;
+  });
+  const { byTool, unattributed } = await withProgress('attributing tool cost', async (task) => {
+    const result = attributeCostToTools(
+      turns,
+      pricing,
+      userTurnsBySession,
+    );
+    task.succeed(`attributed cost to ${formatInt(result.byTool.size)} tool${result.byTool.size === 1 ? '' : 's'}`);
+    return result;
+  });
   const fidelity = summarizeFidelity(turns);
   const sorted = [...byTool.entries()].sort((a, b) => b[1].cost - a[1].cost);
 
@@ -759,7 +802,11 @@ async function renderRelationshipMode(
   q: Query,
   flag: string | true,
 ): Promise<number> {
-  const relationships = await queryRelationships(relationshipQueryForTurnSlice(q));
+  const relationships = await withProgress('reading session relationships', async (task) => {
+    const rows = await queryRelationships(relationshipQueryForTurnSlice(q));
+    task.succeed(`read ${formatInt(rows.length)} relationship${rows.length === 1 ? '' : 's'}`);
+    return rows;
+  });
   const matches = matchRelationshipsToTurns(relationships, turns, pricing);
   const stats = aggregateRelationshipStats(matches);
 
@@ -1057,18 +1104,36 @@ async function loadTurns(q: Query, args: ParsedArgs): Promise<EnrichedTurn[]> {
   const noArchiveFlag = args.flags['no-archive'] === true;
   const envDisabled = process.env['RELAYBURN_ARCHIVE'] === '0';
   if (noArchiveFlag || envDisabled) {
-    return queryAll(q);
+    return withProgress('reading ledger turns', async (task) => {
+      const turns = await queryAll(q);
+      task.succeed(`read ${formatInt(turns.length)} ledger turn${turns.length === 1 ? '' : 's'}`);
+      return turns;
+    });
   }
   try {
-    await buildArchive();
-    return await queryAllFromArchive(q);
+    await withProgress('updating archive', async (task) => {
+      const result = await buildArchive();
+      task.succeed(
+        `updated archive: ${formatInt(result.turnsApplied)} turn` +
+          `${result.turnsApplied === 1 ? '' : 's'} applied`,
+      );
+    });
+    return await withProgress('querying archive', async (task) => {
+      const turns = await queryAllFromArchive(q);
+      task.succeed(`read ${formatInt(turns.length)} archive turn${turns.length === 1 ? '' : 's'}`);
+      return turns;
+    });
   } catch (err) {
     // Don't let an archive-side failure (corrupt sqlite, schema mismatch we
     // didn't recover from cleanly, etc.) take down `burn summary`. Surface
     // the reason on stderr and fall back to the streaming reader.
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`burn: archive read failed (${msg}); falling back to ledger walk\n`);
-    return queryAll(q);
+    return withProgress('reading ledger turns', async (task) => {
+      const turns = await queryAll(q);
+      task.succeed(`read ${formatInt(turns.length)} ledger turn${turns.length === 1 ? '' : 's'}`);
+      return turns;
+    });
   }
 }
 

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -65,6 +65,10 @@ export interface IngestReport {
   appendedTurns: number;
 }
 
+export interface IngestOptions {
+  onProgress?: (message: string) => void;
+}
+
 // Per-adapter content-capture gap aggregator. A "gap" is a session that the
 // parser emitted in `contentMode === 'full'` mode with at least one tool call
 // in a committed turn but zero `tool_result` ContentRecords — the load-bearing
@@ -113,41 +117,56 @@ export function setIngestGapWriter(write: (msg: string) => void): (msg: string) 
   return prev;
 }
 
-export async function ingestClaudeProjects(): Promise<IngestReport> {
+export async function ingestClaudeProjects(opts: IngestOptions = {}): Promise<IngestReport> {
+  opts.onProgress?.('cleaning pending spawn stamps');
   await cleanupStalePendingStamps();
+  opts.onProgress?.('loading ingest cursors');
   const cursors = await loadCursors();
   const before = cloneCursors(cursors);
   const report = emptyReport();
+  opts.onProgress?.('loading content settings');
   const contentMode = await resolveContentMode();
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
+  opts.onProgress?.('scanning Claude Code sessions');
   await ingestClaudeInto(cursors, report, contentMode, gap);
   emitGapWarning('claude', contentMode, gap, moduleGapState);
+  opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
 }
 
-export async function ingestCodexSessions(): Promise<IngestReport> {
+export async function ingestCodexSessions(opts: IngestOptions = {}): Promise<IngestReport> {
+  opts.onProgress?.('cleaning pending spawn stamps');
   await cleanupStalePendingStamps();
+  opts.onProgress?.('loading ingest cursors');
   const cursors = await loadCursors();
   const before = cloneCursors(cursors);
   const report = emptyReport();
+  opts.onProgress?.('loading content settings');
   const contentMode = await resolveContentMode();
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
+  opts.onProgress?.('scanning Codex sessions');
   await ingestCodexInto(cursors, report, contentMode, gap);
   emitGapWarning('codex', contentMode, gap, moduleGapState);
+  opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
 }
 
-export async function ingestOpencodeSessions(): Promise<IngestReport> {
+export async function ingestOpencodeSessions(opts: IngestOptions = {}): Promise<IngestReport> {
+  opts.onProgress?.('cleaning pending spawn stamps');
   await cleanupStalePendingStamps();
+  opts.onProgress?.('loading ingest cursors');
   const cursors = await loadCursors();
   const before = cloneCursors(cursors);
   const report = emptyReport();
+  opts.onProgress?.('loading content settings');
   const contentMode = await resolveContentMode();
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
+  opts.onProgress?.('scanning OpenCode sessions');
   await ingestOpencodeInto(cursors, report, contentMode, gap);
   emitGapWarning('opencode', contentMode, gap, moduleGapState);
+  opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
 }
@@ -196,21 +215,28 @@ export async function ingestClaudeSession(cwd: string, sessionId: string): Promi
   return { scannedSessions: 1, ingestedSessions: 1, appendedTurns: turns.length };
 }
 
-export async function ingestAll(): Promise<IngestReport> {
+export async function ingestAll(opts: IngestOptions = {}): Promise<IngestReport> {
+  opts.onProgress?.('cleaning pending spawn stamps');
   await cleanupStalePendingStamps();
+  opts.onProgress?.('loading ingest cursors');
   const cursors = await loadCursors();
   const before = cloneCursors(cursors);
   const report = emptyReport();
+  opts.onProgress?.('loading content settings');
   const contentMode = await resolveContentMode();
   const claudeGap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   const codexGap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   const opencodeGap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
+  opts.onProgress?.('scanning Claude Code sessions');
   await ingestClaudeInto(cursors, report, contentMode, claudeGap);
+  opts.onProgress?.('scanning Codex sessions');
   await ingestCodexInto(cursors, report, contentMode, codexGap);
+  opts.onProgress?.('scanning OpenCode sessions');
   await ingestOpencodeInto(cursors, report, contentMode, opencodeGap);
   emitGapWarning('claude', contentMode, claudeGap, moduleGapState);
   emitGapWarning('codex', contentMode, codexGap, moduleGapState);
   emitGapWarning('opencode', contentMode, opencodeGap, moduleGapState);
+  opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
 }
@@ -613,8 +639,12 @@ export interface ReingestContentReport {
 // user-turn rows. Used by `burn state rebuild content` to fix up historical
 // sessions ingested before those derived records were written (or where the
 // sidecar was pruned). Does NOT touch cursors, ledger turns, or compactions.
-export async function reingestMissingContent(): Promise<ReingestContentReport> {
+export async function reingestMissingContent(
+  opts: IngestOptions = {},
+): Promise<ReingestContentReport> {
+  opts.onProgress?.('loading existing content records');
   const existingContent = await listContentSessionIds();
+  opts.onProgress?.('loading existing user-turn records');
   const existingUserTurns = new Set(
     (await queryUserTurns()).map((userTurn) => userTurn.sessionId),
   );
@@ -626,8 +656,11 @@ export async function reingestMissingContent(): Promise<ReingestContentReport> {
     appendedUserTurns: 0,
     failed: 0,
   };
+  opts.onProgress?.('re-parsing Claude Code sessions for content');
   await reingestClaudeContent(existingContent, existingUserTurns, report);
+  opts.onProgress?.('re-parsing Codex sessions for content');
   await reingestCodexContent(existingContent, existingUserTurns, report);
+  opts.onProgress?.('re-parsing OpenCode sessions for content');
   await reingestOpencodeContent(existingContent, existingUserTurns, report);
   return report;
 }

--- a/packages/cli/src/progress.ts
+++ b/packages/cli/src/progress.ts
@@ -1,0 +1,174 @@
+import type { WriteStream } from 'node:tty';
+
+import ora, { type Ora } from 'ora';
+
+type ProgressMode = 'spinner' | 'log' | 'silent';
+
+export interface ProgressOptions {
+  quiet?: boolean;
+  stream?: NodeJS.WritableStream & Partial<Pick<WriteStream, 'isTTY'>>;
+}
+
+export interface ProgressTask {
+  update(text: string): void;
+  info(text: string): void;
+  succeed(text?: string): void;
+  fail(text?: string): void;
+  stop(): void;
+}
+
+export class ProgressReporter {
+  readonly mode: ProgressMode;
+  readonly stream: NodeJS.WritableStream;
+
+  constructor(opts: ProgressOptions = {}) {
+    this.stream = opts.stream ?? process.stderr;
+    this.mode = resolveProgressMode(opts, this.stream);
+  }
+
+  get enabled(): boolean {
+    return this.mode !== 'silent';
+  }
+
+  start(text: string): ProgressTask {
+    if (this.mode === 'spinner') return new OraProgressTask(text, this.stream);
+    if (this.mode === 'log') return new LogProgressTask(text, this.stream);
+    return silentTask;
+  }
+
+  info(text: string): void {
+    if (this.mode === 'silent') return;
+    this.stream.write(`[burn] ${text}\n`);
+  }
+}
+
+export async function withProgress<T>(
+  text: string,
+  fn: (task: ProgressTask) => Promise<T>,
+  opts: ProgressOptions = {},
+): Promise<T> {
+  const task = new ProgressReporter(opts).start(text);
+  try {
+    return await fn(task);
+  } catch (err) {
+    task.fail(`${text} failed`);
+    throw err;
+  } finally {
+    task.stop();
+  }
+}
+
+function resolveProgressMode(
+  opts: ProgressOptions,
+  stream: NodeJS.WritableStream & Partial<Pick<WriteStream, 'isTTY'>>,
+): ProgressMode {
+  if (opts.quiet === true) return 'silent';
+  const forced = parseBooleanEnv(process.env['RELAYBURN_PROGRESS']);
+  if (forced === false) return 'silent';
+  if (forced === true) return stream.isTTY === true ? 'spinner' : 'log';
+  if (process.env['CI'] === 'true') return 'silent';
+  return stream.isTTY === true ? 'spinner' : 'silent';
+}
+
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  switch (value.trim().toLowerCase()) {
+    case '1':
+    case 'true':
+    case 'yes':
+    case 'on':
+      return true;
+    case '0':
+    case 'false':
+    case 'no':
+    case 'off':
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+class OraProgressTask implements ProgressTask {
+  private spinner: Ora;
+  private done = false;
+
+  constructor(text: string, stream: NodeJS.WritableStream) {
+    this.spinner = ora({
+      text,
+      stream,
+      discardStdin: false,
+    }).start();
+  }
+
+  update(text: string): void {
+    if (!this.done) this.spinner.text = text;
+  }
+
+  info(text: string): void {
+    if (this.done) return;
+    this.spinner.info(text);
+    this.done = true;
+  }
+
+  succeed(text?: string): void {
+    if (this.done) return;
+    this.spinner.succeed(text);
+    this.done = true;
+  }
+
+  fail(text?: string): void {
+    if (this.done) return;
+    this.spinner.fail(text);
+    this.done = true;
+  }
+
+  stop(): void {
+    if (this.done) return;
+    this.spinner.stop();
+    this.done = true;
+  }
+}
+
+class LogProgressTask implements ProgressTask {
+  private current: string;
+  private done = false;
+
+  constructor(text: string, private readonly stream: NodeJS.WritableStream) {
+    this.current = text;
+    this.stream.write(`[burn] ${text}\n`);
+  }
+
+  update(text: string): void {
+    this.current = text;
+  }
+
+  info(text: string): void {
+    if (this.done) return;
+    this.stream.write(`[burn] ${text}\n`);
+    this.done = true;
+  }
+
+  succeed(text?: string): void {
+    if (this.done) return;
+    this.stream.write(`[burn] ${text ?? this.current}\n`);
+    this.done = true;
+  }
+
+  fail(text?: string): void {
+    if (this.done) return;
+    this.stream.write(`[burn] ${text ?? `${this.current} failed`}\n`);
+    this.done = true;
+  }
+
+  stop(): void {
+    this.done = true;
+  }
+}
+
+const silentTask: ProgressTask = {
+  update() {},
+  info() {},
+  succeed() {},
+  fail() {},
+  stop() {},
+};

--- a/packages/cli/src/watch-loop.ts
+++ b/packages/cli/src/watch-loop.ts
@@ -1,4 +1,4 @@
-import { ingestAll, type IngestReport } from './ingest.js';
+import { ingestAll, type IngestOptions, type IngestReport } from './ingest.js';
 
 export interface WatchController {
   tick(): Promise<void>;
@@ -13,8 +13,8 @@ export interface StartWatchLoopOptions {
   onError?: (err: unknown) => void;
 }
 
-export async function runIngestTick(): Promise<IngestReport> {
-  return ingestAll();
+export async function runIngestTick(opts: IngestOptions = {}): Promise<IngestReport> {
+  return ingestAll(opts);
 }
 
 export function startWatchLoop(opts: StartWatchLoopOptions = {}): WatchController {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@relayburn/reader':
         specifier: workspace:*
         version: link:../reader
+      ora:
+        specifier: ^9.4.0
+        version: 9.4.0
 
   packages/ledger:
     dependencies:
@@ -77,6 +80,70 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  ora@9.4.0:
+    resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
+    engines: {node: '>=20'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -84,6 +151,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -93,6 +164,64 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  ansi-regex@6.2.2: {}
+
+  chalk@5.6.2: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@3.4.0: {}
+
+  get-east-asian-width@1.5.0: {}
+
+  is-interactive@2.0.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
+  mimic-function@5.0.1: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  ora@9.4.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.1
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  signal-exit@4.1.0: {}
+
+  stdin-discarder@0.3.2: {}
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  yoctocolors@2.1.2: {}


### PR DESCRIPTION
## Summary
- add an Ora-backed progress reporter for interactive CLI tasks
- report progress across ingest scans, harness startup/final ingest, state/archive work, and analysis reads
- keep stdout JSON/CSV clean by writing progress to stderr, with RELAYBURN_PROGRESS to force or disable output

## Verification
- pnpm run build
- pnpm run test
- RELAYBURN_PROGRESS=1 RELAYBURN_HOME=/tmp/burn-progress-pr-check HOME=/tmp/burn-progress-pr-home node packages/cli/dist/cli.js ingest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
