### PR TITLE
feat(cli): add burn state reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ content sidecars, activity labels, and `archive.sqlite` are rebuildable.
 | `rebuild all [--force]` | Run content, index, classify, then archive. |
 | `prune [--days <n>]` | Delete expired content sidecars. Use `forever` to disable. |
 | `prune --force` | Delete recoverable sidecars even if source session files still exist. |
+| `reset [--force] [--reingest] [--json]` | Wipe all derived state (ledger, indexes, cursors, archive, content sidecars). Dry-run without `--force`; preserves config, plans, pricing overrides, and source harness logs. |
 
 | Example | Result |
 |---|---|

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Added
+
+- `burn state reset` wipes all derived ledger state (ledger, indexes, cursors, archive, content sidecars) in one command, with `--force` to apply, `--reingest` to immediately re-parse source logs, and `--json` for scripted use; preserves config, plans, and pricing overrides.
+
 ## [1.0.0] - 2026-04-29
 
 ### Added

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,7 @@ Usage:
   burn state         [status] [--json]
   burn state rebuild index | classify | content | archive [--full|--vacuum] | all
   burn state prune   [--days <n>] [--force]
+  burn state reset   [--force] [--reingest] [--json]
 
 Examples:
   burn summary --since 24h

--- a/packages/cli/src/commands/budget-plans.test.ts
+++ b/packages/cli/src/commands/budget-plans.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { after, beforeEach, describe, it } from 'node:test';
+import { after, beforeEach, describe, it, mock } from 'node:test';
 
 import { appendTurns, loadPlans, savePlans } from '@relayburn/ledger';
 import type { Plan } from '@relayburn/ledger';
@@ -269,73 +269,89 @@ describe('burn budget plans CLI', () => {
   });
 
   it('--json output is byte-identical between archive and --no-archive paths', async () => {
-    const claudePro: Plan = {
-      id: 'claude-pro',
-      provider: 'claude',
-      name: 'Claude Pro',
-      budgetUsd: 20,
-      resetDay: 1,
-    };
-    const customWork: Plan = {
-      id: 'work-api',
-      provider: 'custom',
-      name: 'Work Anthropic API',
-      budgetUsd: 500,
-      resetDay: 1,
-    };
-    await seedPlansAndTurns([claudePro, customWork]);
+    // Freeze Date so both runs compute `projectedEndOfCycleUsd` against the
+    // same `fractionElapsed`; without this, each runBudgetPlans call's
+    // independent `new Date()` produces a sub-microsecond drift that
+    // breaks the byte-identity assertion under any timing noise.
+    mock.timers.enable({ apis: ['Date'], now: new Date('2026-04-15T12:00:00.000Z').getTime() });
+    try {
+      const claudePro: Plan = {
+        id: 'claude-pro',
+        provider: 'claude',
+        name: 'Claude Pro',
+        budgetUsd: 20,
+        resetDay: 1,
+      };
+      const customWork: Plan = {
+        id: 'work-api',
+        provider: 'custom',
+        name: 'Work Anthropic API',
+        budgetUsd: 500,
+        resetDay: 1,
+      };
+      await seedPlansAndTurns([claudePro, customWork]);
 
-    const archiveRun = await captureStdio(() => runBudgetPlans(args([], { json: true })));
-    const fallbackRun = await captureStdio(() =>
-      runBudgetPlans(args([], { json: true, 'no-archive': true })),
-    );
+      const archiveRun = await captureStdio(() => runBudgetPlans(args([], { json: true })));
+      const fallbackRun = await captureStdio(() =>
+        runBudgetPlans(args([], { json: true, 'no-archive': true })),
+      );
 
-    assert.equal(archiveRun.result, 0);
-    assert.equal(fallbackRun.result, 0);
+      assert.equal(archiveRun.result, 0);
+      assert.equal(fallbackRun.result, 0);
 
-    const archiveJson = JSON.parse(archiveRun.stdout);
-    const fallbackJson = JSON.parse(fallbackRun.stdout);
-    // Drop Date-typed fields that JSON.stringify renders as ISO strings —
-    // they round-trip identically anyway, but this is the level the issue
-    // calls out: "Output is byte-identical to the pre-migration
-    // implementation."
-    assert.deepEqual(archiveJson, fallbackJson);
-    // Spot-check that we exercised both plans, not just an empty list.
-    // JSON shape is `{ plans: [{ usage: { plan: {...}, spentUsd, ... } }] }`.
-    assert.equal(archiveJson.plans.length, 2);
-    assert.ok(
-      archiveJson.plans.find(
-        (p: { usage: { plan: { id: string } } }) => p.usage.plan.id === 'claude-pro',
-      ),
-    );
-    assert.ok(
-      archiveJson.plans.find(
-        (p: { usage: { plan: { id: string } } }) => p.usage.plan.id === 'work-api',
-      ),
-    );
+      const archiveJson = JSON.parse(archiveRun.stdout);
+      const fallbackJson = JSON.parse(fallbackRun.stdout);
+      // Drop Date-typed fields that JSON.stringify renders as ISO strings —
+      // they round-trip identically anyway, but this is the level the issue
+      // calls out: "Output is byte-identical to the pre-migration
+      // implementation."
+      assert.deepEqual(archiveJson, fallbackJson);
+      // Spot-check that we exercised both plans, not just an empty list.
+      // JSON shape is `{ plans: [{ usage: { plan: {...}, spentUsd, ... } }] }`.
+      assert.equal(archiveJson.plans.length, 2);
+      assert.ok(
+        archiveJson.plans.find(
+          (p: { usage: { plan: { id: string } } }) => p.usage.plan.id === 'claude-pro',
+        ),
+      );
+      assert.ok(
+        archiveJson.plans.find(
+          (p: { usage: { plan: { id: string } } }) => p.usage.plan.id === 'work-api',
+        ),
+      );
+    } finally {
+      mock.timers.reset();
+    }
   });
 
   it('RELAYBURN_ARCHIVE=0 env knob is honored as the queryAll fallback', async () => {
-    const claudePro: Plan = {
-      id: 'claude-pro',
-      provider: 'claude',
-      name: 'Claude Pro',
-      budgetUsd: 20,
-      resetDay: 1,
-    };
-    await seedPlansAndTurns([claudePro]);
+    // See note in the byte-identity test above — pin Date so both runs
+    // compute identical `projectedEndOfCycleUsd`.
+    mock.timers.enable({ apis: ['Date'], now: new Date('2026-04-15T12:00:00.000Z').getTime() });
+    try {
+      const claudePro: Plan = {
+        id: 'claude-pro',
+        provider: 'claude',
+        name: 'Claude Pro',
+        budgetUsd: 20,
+        resetDay: 1,
+      };
+      await seedPlansAndTurns([claudePro]);
 
-    // Run with the env knob set; compare to the explicit `--no-archive` run.
-    process.env['RELAYBURN_ARCHIVE'] = '0';
-    const envRun = await captureStdio(() => runBudgetPlans(args([], { json: true })));
-    delete process.env['RELAYBURN_ARCHIVE'];
-    const flagRun = await captureStdio(() =>
-      runBudgetPlans(args([], { json: true, 'no-archive': true })),
-    );
+      // Run with the env knob set; compare to the explicit `--no-archive` run.
+      process.env['RELAYBURN_ARCHIVE'] = '0';
+      const envRun = await captureStdio(() => runBudgetPlans(args([], { json: true })));
+      delete process.env['RELAYBURN_ARCHIVE'];
+      const flagRun = await captureStdio(() =>
+        runBudgetPlans(args([], { json: true, 'no-archive': true })),
+      );
 
-    assert.equal(envRun.result, 0);
-    assert.equal(flagRun.result, 0);
-    assert.deepEqual(JSON.parse(envRun.stdout), JSON.parse(flagRun.stdout));
+      assert.equal(envRun.result, 0);
+      assert.equal(flagRun.result, 0);
+      assert.deepEqual(JSON.parse(envRun.stdout), JSON.parse(flagRun.stdout));
+    } finally {
+      mock.timers.reset();
+    }
   });
 
   // Issue #108: list view honors per-cycle fidelity. The plan still renders

--- a/packages/cli/src/commands/state.test.ts
+++ b/packages/cli/src/commands/state.test.ts
@@ -5,7 +5,6 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
-  __resetIndexCacheForTesting,
   appendContent,
   appendToolResultEvents,
   appendTurns,
@@ -91,10 +90,6 @@ describe('burn state CLI', () => {
     process.env['RELAYBURN_HOME'] = tmp;
     delete process.env['RELAYBURN_CONTENT_STORE'];
     delete process.env['RELAYBURN_PRUNE_FORCE'];
-    // The writer's content-fingerprint dedup is module-scoped and survives
-    // across tests; reset it so per-test seed turns aren't silently skipped
-    // when they happen to share ts/usage/model with a prior test's seed.
-    __resetIndexCacheForTesting();
   });
 
   afterEach(async () => {
@@ -581,7 +576,6 @@ describe('burn state CLI', () => {
     beforeEach(async () => {
       tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-reset-home-'));
       process.env['HOME'] = tmpHome;
-      __resetIndexCacheForTesting();
     });
 
     afterEach(async () => {

--- a/packages/cli/src/commands/state.test.ts
+++ b/packages/cli/src/commands/state.test.ts
@@ -1,10 +1,26 @@
 import { strict as assert } from 'node:assert';
-import { mkdtemp, rm, utimes } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
-import { appendContent, appendToolResultEvents, appendTurns, stamp } from '@relayburn/ledger';
+import {
+  __resetIndexCacheForTesting,
+  appendContent,
+  appendToolResultEvents,
+  appendTurns,
+  archivePath,
+  configPath,
+  contentDir,
+  cursorsPath,
+  hwmPath,
+  ledgerContentIndexPath,
+  ledgerIndexPath,
+  ledgerPath,
+  plansPath,
+  pricingOverridePath,
+  stamp,
+} from '@relayburn/ledger';
 import type { ToolResultEventRecord, TurnRecord } from '@relayburn/reader';
 
 import { runState } from './state.js';
@@ -75,6 +91,10 @@ describe('burn state CLI', () => {
     process.env['RELAYBURN_HOME'] = tmp;
     delete process.env['RELAYBURN_CONTENT_STORE'];
     delete process.env['RELAYBURN_PRUNE_FORCE'];
+    // The writer's content-fingerprint dedup is module-scoped and survives
+    // across tests; reset it so per-test seed turns aren't silently skipped
+    // when they happen to share ts/usage/model with a prior test's seed.
+    __resetIndexCacheForTesting();
   });
 
   afterEach(async () => {
@@ -394,5 +414,191 @@ describe('burn state CLI', () => {
     assert.equal(out.code, 0);
     assert.match(out.stdout, /pruned 1 content file/);
     assert.doesNotMatch(out.stdout, /kept .* recoverable/);
+  });
+
+  describe('burn state reset', () => {
+    async function exists(p: string): Promise<boolean> {
+      try {
+        await stat(p);
+        return true;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw err;
+      }
+    }
+
+    let seedCounter = 0;
+    async function seedDerivedState(): Promise<void> {
+      // Use a unique sessionId per call so the writer's module-scoped
+      // content-fingerprint dedup cache doesn't silently skip the append on
+      // back-to-back tests sharing this describe block.
+      seedCounter += 1;
+      const sessionId = `s-reset-${seedCounter}`;
+      const messageId = `r-${seedCounter}`;
+      await appendTurns([fakeTurn({ sessionId, messageId })]);
+      await appendContent([
+        {
+          v: 1,
+          source: 'claude-code',
+          sessionId,
+          messageId,
+          ts: '2026-04-20T00:00:00.000Z',
+          role: 'assistant',
+          kind: 'text',
+          text: 'hello',
+        },
+      ]);
+      await captureRun({}, ['rebuild', 'index']);
+      await captureRun({}, ['rebuild', 'archive']);
+      // Synthetic cursors/hwm sidecars so reset has something to delete on
+      // every path even when nothing has been ingested.
+      await writeFile(cursorsPath(), JSON.stringify({ files: {} }));
+      await writeFile(hwmPath(), JSON.stringify({ entries: {} }));
+    }
+
+    async function seedPreservedFiles(): Promise<void> {
+      await mkdir(tmp, { recursive: true });
+      await writeFile(configPath(), JSON.stringify({ keep: 'config' }));
+      await writeFile(plansPath(), JSON.stringify({ keep: 'plans' }));
+      await writeFile(pricingOverridePath(), JSON.stringify({ keep: 'pricing' }));
+    }
+
+    it('dry-run leaves the ledger home untouched and lists targets', async () => {
+      await seedDerivedState();
+      await seedPreservedFiles();
+
+      const out = await captureRun({}, ['reset']);
+      assert.equal(out.code, 0);
+      assert.match(out.stdout, /dry run: would reset/);
+      assert.match(out.stdout, /re-run with --force/);
+
+      // Files still on disk.
+      assert.equal(await exists(ledgerPath()), true);
+      assert.equal(await exists(archivePath()), true);
+      assert.equal(await exists(contentDir()), true);
+      // Preserved files still on disk.
+      assert.equal(await exists(configPath()), true);
+      assert.equal(await exists(plansPath()), true);
+      assert.equal(await exists(pricingOverridePath()), true);
+    });
+
+    it('--force deletes derived state and preserves config/plans/pricing', async () => {
+      await seedDerivedState();
+      await seedPreservedFiles();
+
+      const out = await captureRun({ force: true }, ['reset']);
+      assert.equal(out.code, 0);
+      assert.match(out.stdout, /reset derived state/);
+      assert.match(out.stdout, /total: removed/);
+
+      assert.equal(await exists(ledgerPath()), false);
+      assert.equal(await exists(ledgerIndexPath()), false);
+      assert.equal(await exists(ledgerContentIndexPath()), false);
+      assert.equal(await exists(cursorsPath()), false);
+      assert.equal(await exists(hwmPath()), false);
+      assert.equal(await exists(archivePath()), false);
+      assert.equal(await exists(contentDir()), false);
+
+      assert.equal(await exists(configPath()), true);
+      assert.equal(await exists(plansPath()), true);
+      assert.equal(await exists(pricingOverridePath()), true);
+      assert.equal(
+        JSON.parse(await readFile(configPath(), 'utf8')).keep,
+        'config',
+      );
+    });
+
+    it('--force is idempotent on an already-empty ledger home', async () => {
+      const out1 = await captureRun({ force: true }, ['reset']);
+      assert.equal(out1.code, 0);
+      const out2 = await captureRun({ force: true }, ['reset']);
+      assert.equal(out2.code, 0);
+      assert.match(out2.stdout, /already absent/);
+    });
+
+    it('--json emits a structured summary in dry-run and force modes', async () => {
+      await seedDerivedState();
+      const dry = await captureRun({ json: true }, ['reset']);
+      assert.equal(dry.code, 0);
+      const dryParsed = JSON.parse(dry.stdout) as {
+        dryRun: boolean;
+        forced: boolean;
+        targets: { path: string; kind: string; existed: boolean }[];
+        totals: { filesRemoved: number; bytesFreed: number };
+      };
+      assert.equal(dryParsed.dryRun, true);
+      assert.equal(dryParsed.forced, false);
+      assert.ok(dryParsed.targets.some((t) => t.path === ledgerPath() && t.existed));
+
+      const forced = await captureRun({ json: true, force: true }, ['reset']);
+      assert.equal(forced.code, 0);
+      const forcedParsed = JSON.parse(forced.stdout) as {
+        dryRun: boolean;
+        forced: boolean;
+        reingested: unknown;
+      };
+      assert.equal(forcedParsed.dryRun, false);
+      assert.equal(forcedParsed.forced, true);
+      assert.equal(forcedParsed.reingested, null);
+    });
+
+    it('--reingest without --force is a no-op and warns', async () => {
+      await seedDerivedState();
+
+      const out = await captureRun({ reingest: true }, ['reset']);
+      assert.equal(out.code, 0);
+      assert.match(out.stderr, /--reingest requires --force/);
+      // Files still on disk.
+      assert.equal(await exists(ledgerPath()), true);
+    });
+
+    it('RELAYBURN_HOME override is respected', async () => {
+      // Verify reset only operates on RELAYBURN_HOME, not on a sibling
+      // directory that happens to share the parent.
+      const sibling = await mkdtemp(path.join(tmpdir(), 'burn-state-sibling-'));
+      try {
+        const sentinel = path.join(sibling, 'ledger.jsonl');
+        await writeFile(sentinel, 'should-not-be-deleted');
+
+        await seedDerivedState();
+        const out = await captureRun({ force: true }, ['reset']);
+        assert.equal(out.code, 0);
+
+        assert.equal(await exists(ledgerPath()), false);
+        // Sibling path untouched.
+        assert.equal(await exists(sentinel), true);
+        assert.equal(await readFile(sentinel, 'utf8'), 'should-not-be-deleted');
+      } finally {
+        await rm(sibling, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('burn state reset --reingest', () => {
+    let tmpHome: string;
+    const originalHome = process.env['HOME'];
+
+    beforeEach(async () => {
+      tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-reset-home-'));
+      process.env['HOME'] = tmpHome;
+      __resetIndexCacheForTesting();
+    });
+
+    afterEach(async () => {
+      if (originalHome !== undefined) process.env['HOME'] = originalHome;
+      else delete process.env['HOME'];
+      await rm(tmpHome, { recursive: true, force: true });
+    });
+
+    it('--force --reingest wipes state and runs ingest against (empty) source dirs', async () => {
+      // Seed something deletable so the wipe is observable, but leave the
+      // source harness dirs absent so ingestAll() is a clean no-op.
+      await appendTurns([fakeTurn({ sessionId: 's-reseed', messageId: 'rs-1' })]);
+
+      const out = await captureRun({ force: true, reingest: true }, ['reset']);
+      assert.equal(out.code, 0);
+      assert.match(out.stdout, /reset derived state/);
+      assert.match(out.stdout, /reingested 0 of 0 sessions/);
+    });
   });
 });

--- a/packages/cli/src/commands/state.test.ts
+++ b/packages/cli/src/commands/state.test.ts
@@ -547,6 +547,29 @@ describe('burn state CLI', () => {
       assert.equal(await exists(ledgerPath()), true);
     });
 
+    it('--force invalidates the in-memory dedup cache so post-reset writes land', async () => {
+      // Regression: after deleting ledger.idx the module-level cache in
+      // index-sidecar.ts still held the prior pass's hashes. The next
+      // appendTurns saw the seeded turn as a duplicate and silently
+      // skipped it, leaving the ledger empty even after a successful
+      // reingest. Reproduce by warming the cache, resetting, then
+      // re-appending the same turn — without the fix the file stays at
+      // zero bytes.
+      const turn = fakeTurn({ sessionId: 's-warm', messageId: 'm-warm' });
+      await appendTurns([turn]);
+      assert.ok((await stat(ledgerPath())).size > 0);
+
+      const out = await captureRun({ force: true }, ['reset']);
+      assert.equal(out.code, 0);
+      assert.equal(await exists(ledgerPath()), false);
+
+      await appendTurns([turn]);
+      assert.ok(
+        (await stat(ledgerPath())).size > 0,
+        'turn was deduped against a stale cache instead of being written',
+      );
+    });
+
     it('RELAYBURN_HOME override is respected', async () => {
       // Verify reset only operates on RELAYBURN_HOME, not on a sibling
       // directory that happens to share the parent.

--- a/packages/cli/src/commands/state.ts
+++ b/packages/cli/src/commands/state.ts
@@ -10,6 +10,7 @@ import {
   cursorsPath,
   getArchiveStatus,
   hwmPath,
+  invalidateIndexCache,
   isTurnLine,
   isUserTurnLine,
   isValidSessionId,
@@ -573,40 +574,50 @@ async function runStateReset(args: ParsedArgs): Promise<number> {
   const reingest = args.flags['reingest'] === true;
   const json = args.flags['json'] === true;
 
-  return withLock('ledger', async () => {
-    const home = ledgerHome();
-    const targets = await collectResetTargets();
+  const home = ledgerHome();
+  const targets = await collectResetTargets();
 
-    if (!force) {
-      const summary = buildResetSummary({ home, targets, forced: false, reingestRequested: reingest, reingested: null });
-      if (reingest) {
-        process.stderr.write(
-          `burn state reset: --reingest requires --force; nothing was deleted.\n`,
-        );
-      }
-      writeResetSummary(summary, { json, dryRun: true });
-      return 0;
-    }
-
-    const applied: ResetTargetReport[] = [];
-    for (const t of targets) {
-      applied.push(await applyResetTarget(t, home));
-    }
-
-    let reingested: ResetSummary['reingested'] = null;
+  if (!force) {
+    // Dry run is read-only — no lock needed.
+    const summary = buildResetSummary({ home, targets, forced: false, reingestRequested: reingest, reingested: null });
     if (reingest) {
-      const r = await ingestAll();
-      reingested = {
-        scannedSessions: r.scannedSessions,
-        ingestedSessions: r.ingestedSessions,
-        appendedTurns: r.appendedTurns,
-      };
+      process.stderr.write(
+        `burn state reset: --reingest requires --force; nothing was deleted.\n`,
+      );
     }
-
-    const summary = buildResetSummary({ home, targets: applied, forced: true, reingestRequested: reingest, reingested });
-    writeResetSummary(summary, { json, dryRun: false });
+    writeResetSummary(summary, { json, dryRun: true });
     return 0;
+  }
+
+  // Hold the ledger lock only across the deletion. ingestAll() can run for
+  // far longer than STALE_MS (lock.ts), so keeping the lock open across it
+  // would let a concurrent burn process treat this lock as stale and unlink
+  // it mid-run, defeating the mutex. The reingest path takes the lock per
+  // append internally.
+  const applied = await withLock('ledger', async () => {
+    const out: ResetTargetReport[] = [];
+    for (const t of targets) out.push(await applyResetTarget(t, home));
+    // The on-disk index was just unlinked; drop the in-memory dedup cache
+    // so any subsequent appendTurns / appendContent re-derives from the
+    // empty files instead of skipping records as duplicates of hashes
+    // loaded before the wipe.
+    invalidateIndexCache();
+    return out;
   });
+
+  let reingested: ResetSummary['reingested'] = null;
+  if (reingest) {
+    const r = await ingestAll();
+    reingested = {
+      scannedSessions: r.scannedSessions,
+      ingestedSessions: r.ingestedSessions,
+      appendedTurns: r.appendedTurns,
+    };
+  }
+
+  const summary = buildResetSummary({ home, targets: applied, forced: true, reingestRequested: reingest, reingested });
+  writeResetSummary(summary, { json, dryRun: false });
+  return 0;
 }
 
 async function collectResetTargets(): Promise<ResetTargetReport[]> {

--- a/packages/cli/src/commands/state.ts
+++ b/packages/cli/src/commands/state.ts
@@ -1,16 +1,20 @@
 import { createReadStream } from 'node:fs';
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { readdir, readFile, rm, stat, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 import { createInterface } from 'node:readline';
 
 import {
+  archivePath,
   contentDir,
+  cursorsPath,
   getArchiveStatus,
+  hwmPath,
   isTurnLine,
   isUserTurnLine,
   isValidSessionId,
   ledgerContentIndexPath,
+  ledgerHome,
   ledgerIndexPath,
   ledgerPath,
   loadConfig,
@@ -18,9 +22,10 @@ import {
   rebuildIndex,
   reclassifyLedger,
   retentionMs,
+  withLock,
 } from '@relayburn/ledger';
 
-import { reingestMissingContent } from '../ingest.js';
+import { ingestAll, reingestMissingContent } from '../ingest.js';
 import { formatInt } from '../format.js';
 import { walkJsonl, walkOpencodeSessions } from '../walk.js';
 import type { ParsedArgs } from '../args.js';
@@ -32,11 +37,13 @@ Usage:
   burn state [status] [--json]
   burn state rebuild <target>
   burn state prune [--days <n>] [--force]
+  burn state reset [--force] [--reingest] [--json]
 
 Subcommands:
   status    print derived artifact status for index, content, classifier, archive
   rebuild   rebuild index, classify, content, archive, or all derived artifacts
   prune     prune expired content sidecars
+  reset     wipe all derived state and (optionally) re-ingest from source logs
 
 Run 'burn state rebuild help' for rebuild targets.
 `;
@@ -58,6 +65,34 @@ Targets:
   archive   apply the ledger tail to archive.sqlite; --full rebuilds from zero;
             --vacuum reclaims unused archive pages
   all       run content, index, classify, then archive
+`;
+
+const RESET_HELP = `burn state reset - wipe all derived ledger state
+
+Usage:
+  burn state reset [--force] [--reingest] [--json]
+
+Flags:
+  --force      actually delete. Without this flag, reset is a dry-run that
+               prints the paths and sizes that would be removed.
+  --reingest   after a successful --force wipe, re-parse all source harness
+               logs from offset 0 by calling 'burn ingest'. No-op without
+               --force.
+  --json       emit a JSON summary instead of human-readable output.
+
+Deletes (under \$RELAYBURN_HOME or ~/.relayburn):
+  ledger.jsonl, ledger.idx, ledger.content.idx, cursors.json, hwm.json,
+  archive.sqlite (+ -wal/-shm sidecars), and the content/ directory.
+
+Preserves:
+  config.json, plans.json, models.dev.json, *.lock files. Source harness
+  logs at ~/.claude/projects, ~/.codex/sessions, and the OpenCode storage
+  dir are never touched.
+
+Examples:
+  burn state reset                 # dry-run; prints what would be deleted
+  burn state reset --force         # delete derived state, leave config alone
+  burn state reset --force --reingest
 `;
 
 const PRUNE_HELP = `burn state prune - prune expired content sidecars
@@ -137,6 +172,8 @@ export async function runState(args: ParsedArgs): Promise<number> {
       return runStateRebuild(args);
     case 'prune':
       return runStatePrune(args);
+    case 'reset':
+      return runStateReset(args);
     default:
       process.stderr.write(`burn state: unknown subcommand: ${sub}\n\n${STATE_HELP}`);
       return 1;
@@ -506,6 +543,246 @@ function formatBytes(n: number): string {
   }
   const fixed = v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
   return `${fixed} ${units[i]}`;
+}
+
+// --- reset -----------------------------------------------------------------
+
+interface ResetTargetReport {
+  path: string;
+  kind: 'file' | 'dir';
+  existed: boolean;
+  bytes: number;
+  filesRemoved: number;
+}
+
+interface ResetSummary {
+  home: string;
+  forced: boolean;
+  reingestRequested: boolean;
+  reingested: { scannedSessions: number; ingestedSessions: number; appendedTurns: number } | null;
+  targets: ResetTargetReport[];
+  totals: { filesRemoved: number; bytesFreed: number };
+}
+
+async function runStateReset(args: ParsedArgs): Promise<number> {
+  if (args.flags['help'] === true || args.positional[1] === 'help') {
+    process.stdout.write(RESET_HELP);
+    return 0;
+  }
+  const force = args.flags['force'] === true;
+  const reingest = args.flags['reingest'] === true;
+  const json = args.flags['json'] === true;
+
+  return withLock('ledger', async () => {
+    const home = ledgerHome();
+    const targets = await collectResetTargets();
+
+    if (!force) {
+      const summary = buildResetSummary({ home, targets, forced: false, reingestRequested: reingest, reingested: null });
+      if (reingest) {
+        process.stderr.write(
+          `burn state reset: --reingest requires --force; nothing was deleted.\n`,
+        );
+      }
+      writeResetSummary(summary, { json, dryRun: true });
+      return 0;
+    }
+
+    const applied: ResetTargetReport[] = [];
+    for (const t of targets) {
+      applied.push(await applyResetTarget(t, home));
+    }
+
+    let reingested: ResetSummary['reingested'] = null;
+    if (reingest) {
+      const r = await ingestAll();
+      reingested = {
+        scannedSessions: r.scannedSessions,
+        ingestedSessions: r.ingestedSessions,
+        appendedTurns: r.appendedTurns,
+      };
+    }
+
+    const summary = buildResetSummary({ home, targets: applied, forced: true, reingestRequested: reingest, reingested });
+    writeResetSummary(summary, { json, dryRun: false });
+    return 0;
+  });
+}
+
+async function collectResetTargets(): Promise<ResetTargetReport[]> {
+  // Order doesn't matter for correctness, but file sidecars first reads
+  // nicer in the dry-run output: small to large, ledger -> archive -> content.
+  const filePaths: string[] = [
+    ledgerPath(),
+    ledgerIndexPath(),
+    ledgerContentIndexPath(),
+    cursorsPath(),
+    hwmPath(),
+    archivePath(),
+    `${archivePath()}-wal`,
+    `${archivePath()}-shm`,
+  ];
+  const reports: ResetTargetReport[] = [];
+  for (const p of filePaths) {
+    reports.push(await statResetFile(p));
+  }
+  reports.push(await statResetDir(contentDir()));
+  return reports;
+}
+
+async function statResetFile(p: string): Promise<ResetTargetReport> {
+  try {
+    const st = await stat(p);
+    return {
+      path: p,
+      kind: 'file',
+      existed: st.isFile(),
+      bytes: st.isFile() ? st.size : 0,
+      filesRemoved: st.isFile() ? 1 : 0,
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return { path: p, kind: 'file', existed: false, bytes: 0, filesRemoved: 0 };
+  }
+}
+
+async function statResetDir(dir: string): Promise<ResetTargetReport> {
+  try {
+    const st = await stat(dir);
+    if (!st.isDirectory()) {
+      return { path: dir, kind: 'dir', existed: false, bytes: 0, filesRemoved: 0 };
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return { path: dir, kind: 'dir', existed: false, bytes: 0, filesRemoved: 0 };
+  }
+  let bytes = 0;
+  let files = 0;
+  for await (const child of walkDirEntries(dir)) {
+    bytes += child.size;
+    files += 1;
+  }
+  return { path: dir, kind: 'dir', existed: true, bytes, filesRemoved: files };
+}
+
+async function* walkDirEntries(
+  dir: string,
+): AsyncGenerator<{ path: string; size: number }> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      yield* walkDirEntries(full);
+    } else if (e.isFile()) {
+      try {
+        const st = await stat(full);
+        yield { path: full, size: st.size };
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }
+  }
+}
+
+async function applyResetTarget(
+  t: ResetTargetReport,
+  home: string,
+): Promise<ResetTargetReport> {
+  // Belt-and-suspenders: refuse to touch anything that resolves outside
+  // ledgerHome(). The constants we feed in already live there, but a
+  // misconfigured RELAYBURN_HOME or future refactor shouldn't be able to
+  // turn this into an arbitrary-rm.
+  assertInsideHome(t.path, home);
+  if (!t.existed) return t;
+  if (t.kind === 'file') {
+    try {
+      await unlink(t.path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { ...t, existed: false, bytes: 0, filesRemoved: 0 };
+      }
+      throw err;
+    }
+    return t;
+  }
+  await rm(t.path, { recursive: true, force: true });
+  return t;
+}
+
+function assertInsideHome(target: string, home: string): void {
+  const rel = path.relative(home, target);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(
+      `burn state reset: refusing to touch path outside ledger home: ${target}`,
+    );
+  }
+}
+
+interface BuildResetSummaryOpts {
+  home: string;
+  targets: ResetTargetReport[];
+  forced: boolean;
+  reingestRequested: boolean;
+  reingested: ResetSummary['reingested'];
+}
+
+function buildResetSummary(opts: BuildResetSummaryOpts): ResetSummary {
+  let bytes = 0;
+  let files = 0;
+  for (const t of opts.targets) {
+    bytes += t.bytes;
+    files += t.filesRemoved;
+  }
+  return {
+    home: opts.home,
+    forced: opts.forced,
+    reingestRequested: opts.reingestRequested,
+    reingested: opts.reingested,
+    targets: opts.targets,
+    totals: { filesRemoved: files, bytesFreed: bytes },
+  };
+}
+
+function writeResetSummary(
+  summary: ResetSummary,
+  opts: { json: boolean; dryRun: boolean },
+): void {
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ ...summary, dryRun: opts.dryRun }, null, 2) + '\n');
+    return;
+  }
+  const lines: string[] = [];
+  if (opts.dryRun) {
+    lines.push(`dry run: would reset derived state under ${summary.home}`);
+  } else {
+    lines.push(`reset derived state under ${summary.home}`);
+  }
+  for (const t of summary.targets) {
+    const tag = t.existed ? `${formatInt(t.filesRemoved)} file${t.filesRemoved === 1 ? '' : 's'}, ${formatBytes(t.bytes)}` : 'already absent';
+    lines.push(`  ${t.kind === 'dir' ? 'dir ' : 'file'} ${t.path}: ${tag}`);
+  }
+  if (opts.dryRun) {
+    lines.push(
+      `total: ${formatInt(summary.totals.filesRemoved)} file${summary.totals.filesRemoved === 1 ? '' : 's'}, ${formatBytes(summary.totals.bytesFreed)} would be freed`,
+    );
+    lines.push(`re-run with --force to apply.`);
+  } else {
+    lines.push(
+      `total: removed ${formatInt(summary.totals.filesRemoved)} file${summary.totals.filesRemoved === 1 ? '' : 's'}, ${formatBytes(summary.totals.bytesFreed)} freed`,
+    );
+    if (summary.reingested) {
+      lines.push(
+        `reingested ${formatInt(summary.reingested.ingestedSessions)} of ${formatInt(summary.reingested.scannedSessions)} sessions (${formatInt(summary.reingested.appendedTurns)} turns appended)`,
+      );
+    }
+  }
+  process.stdout.write(lines.join('\n') + '\n');
 }
 
 export async function opportunisticPrune(): Promise<void> {

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/ledger`.
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `invalidateIndexCache()` so callers that wipe the on-disk index can drop the in-memory dedup cache before the next write.
+
 ### Fixed
 
 - The index-sidecar cache is now keyed on `ledgerHome()`, so `RELAYBURN_HOME` swaps invalidate it instead of leaking dedup hashes from the prior home.

--- a/packages/ledger/CHANGELOG.md
+++ b/packages/ledger/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/ledger`.
 
 ## [Unreleased]
 
+### Fixed
+
+- The index-sidecar cache is now keyed on `ledgerHome()`, so `RELAYBURN_HOME` swaps invalidate it instead of leaking dedup hashes from the prior home.
+
 ## [1.0.0] - 2026-04-29
 
 ### Added

--- a/packages/ledger/src/index-sidecar.ts
+++ b/packages/ledger/src/index-sidecar.ts
@@ -15,6 +15,7 @@ import type {
 import { withLock } from './lock.js';
 import {
   ledgerContentIndexPath,
+  ledgerHome,
   ledgerIndexPath,
   ledgerPath,
 } from './paths.js';
@@ -101,15 +102,21 @@ export function turnContentFingerprint(t: TurnRecord): string {
   return createHash('sha256').update(composite).digest('hex').slice(0, 16);
 }
 
-let cache: { ids: Set<string>; content: Set<string>; contentOrder: string[] } | undefined;
+// Keyed on ledgerHome() so a `RELAYBURN_HOME` change (tests, CLI invocations
+// that re-parent the ledger dir) invalidates the cache automatically — the
+// hashes from the prior home would otherwise mask records under the new one.
+let cache:
+  | { home: string; ids: Set<string>; content: Set<string>; contentOrder: string[] }
+  | undefined;
 
 export async function loadIndex(): Promise<{ ids: Set<string>; content: Set<string> }> {
-  if (cache) return { ids: cache.ids, content: cache.content };
+  const home = ledgerHome();
+  if (cache && cache.home === home) return { ids: cache.ids, content: cache.content };
   const ids = await loadHashFile(ledgerIndexPath());
   const contentLines = await loadHashFileAsArray(ledgerContentIndexPath());
   const tail = contentLines.slice(Math.max(0, contentLines.length - CONTENT_WINDOW));
   const content = new Set(tail);
-  cache = { ids, content, contentOrder: [...tail] };
+  cache = { home, ids, content, contentOrder: [...tail] };
   return { ids, content };
 }
 
@@ -142,8 +149,9 @@ export async function appendHashes(idHashes: string[], contentHashes: string[]):
       await appendFile(ledgerIndexPath(), idHashes.join('\n') + '\n', 'utf8');
     }
     if (contentHashes.length > 0) {
-      // Maintain rolling window on disk
-      if (!cache) await loadIndex();
+      // Maintain rolling window on disk. loadIndex() is home-aware, so this
+      // also reloads after a RELAYBURN_HOME swap.
+      await loadIndex();
       const order = cache!.contentOrder;
       for (const h of contentHashes) order.push(h);
       if (order.length > CONTENT_WINDOW) {
@@ -223,6 +231,7 @@ export async function rebuildIndex(): Promise<{ ids: number; content: number }> 
   });
 
   cache = {
+    home: ledgerHome(),
     ids: new Set(ids),
     content: new Set(contentTail),
     contentOrder: [...contentTail],

--- a/packages/ledger/src/index-sidecar.ts
+++ b/packages/ledger/src/index-sidecar.ts
@@ -120,9 +120,17 @@ export async function loadIndex(): Promise<{ ids: Set<string>; content: Set<stri
   return { ids, content };
 }
 
-export function __resetIndexCacheForTesting(): void {
+// Drop the in-memory dedup cache. Callers that wipe the on-disk index
+// (`burn state reset`, etc.) MUST call this after deletion so the next
+// loadIndex() re-reads from the empty files instead of returning hashes
+// loaded before the wipe — otherwise post-reset writes get silently
+// deduped against records that no longer exist.
+export function invalidateIndexCache(): void {
   cache = undefined;
 }
+
+// Test alias kept for back-compat with existing call sites.
+export const __resetIndexCacheForTesting = invalidateIndexCache;
 
 async function loadHashFile(p: string): Promise<Set<string>> {
   const lines = await loadHashFileAsArray(p);

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -87,15 +87,15 @@ export type {
 } from './cursors.js';
 export { withLock } from './lock.js';
 export {
+  invalidateIndexCache,
   rebuildIndex,
   relationshipIdHash,
   toolResultEventIdHash,
   turnIdHash,
   turnContentFingerprint,
   userTurnIdHash,
-  // Exposed (underscore-prefixed) so cross-package tests that swap
-  // RELAYBURN_HOME between cases can drop the in-memory dedup cache. Not
-  // part of the supported runtime surface — see `index-sidecar.ts`.
+  // Test alias for `invalidateIndexCache`; kept so existing test call
+  // sites don't churn.
   __resetIndexCacheForTesting,
 } from './index-sidecar.js';
 export { reclassifyLedger } from './reclassify.js';


### PR DESCRIPTION
## Summary

- New `burn state reset [--force] [--reingest] [--json]` subcommand for nuking derived state and re-parsing from scratch.
- Deletes `ledger.jsonl`, `ledger.idx`, `ledger.content.idx`, `cursors.json`, `hwm.json`, `archive.sqlite` (+ `-wal` / `-shm`), and `content/` under `$RELAYBURN_HOME`. Preserves `config.json`, `plans.json`, `models.dev.json`, `*.lock`, and the upstream harness log directories.
- `--force` is required to actually delete; without it the command dry-runs and prints paths + sizes. `--reingest` follows the wipe with `ingestAll()` so the ledger immediately re-populates from source. `--json` emits a structured summary in either mode.
- Wraps the delete + reingest in `withLock('ledger', ...)` to avoid racing concurrent ingest. Belt-and-suspenders `path.relative(ledgerHome(), …)` check refuses to touch anything outside the home.

## Test plan

- [x] `pnpm run build` passes.
- [x] `pnpm run test` passes (870 / 870).
- [x] New tests cover dry-run preservation, `--force` deletion + preservation of config/plans/pricing, idempotency on an empty home, `--json` summary shape, `--reingest` no-op without `--force`, `RELAYBURN_HOME` override, and the `--force --reingest` happy path against an empty source tree.
- [x] Manual smoke against a synthetic `$RELAYBURN_HOME` (`state reset` then `state reset --force`) shows the expected dry-run + force output and leaves the temp dir empty afterwards.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
