### PR TITLE
Add JSON output for overhead trim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Added
+
+- `burn overhead trim --json` now emits structured trim recommendations for programmatic review while preserving the existing unified diff text output.
+
 ## [1.1.0] - 2026-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ attributes cached prompt cost to files and headed sections.
 | `--since <range>` | Limit attribution to a time window. |
 | `--kind <k>` | Limit to `claude-md` or `agents-md`. |
 | `--top <n>` | In `trim` mode, recommendations per file. |
-| `--json` | Emit machine-readable attribution for report mode. |
+| `--json` | Emit machine-readable attribution for report mode or structured trim recommendations in `trim` mode. |
 
 | Example | Result |
 |---|---|
@@ -155,6 +155,7 @@ attributes cached prompt cost to files and headed sections.
 | `burn overhead --since 30d` | Overhead cost from the last 30 days. |
 | `burn overhead --kind claude-md` | Claude instruction files only. |
 | `burn overhead trim --top 3` | Top three trim recommendations per file. |
+| `burn overhead trim --json` | Structured trim recommendations with projected savings and unified diffs. |
 
 Harnesses pay for different files: Claude Code pays for `CLAUDE.md`; Codex and
 OpenCode pay for `AGENTS.md`.

--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/analyze`.
 
 ## [Unreleased]
 
+### Changed
+
+- `buildTrimRecommendations()` now includes each recommended section's token share so callers can rank recommendations without recomputing attribution.
+
 ## [1.0.0] - 2026-04-29
 
 ### Changed

--- a/packages/analyze/src/claude-md.test.ts
+++ b/packages/analyze/src/claude-md.test.ts
@@ -329,6 +329,7 @@ describe('buildTrimRecommendations + renderUnifiedDiffForRecommendation', () => 
     const recs = buildTrimRecommendations(attribution, 1);
     assert.equal(recs.length, 1);
     assert.equal(recs[0]!.section.heading, '## Big');
+    assert.ok(recs[0]!.tokenShare > 0);
     const diff = renderUnifiedDiffForRecommendation('/p/CLAUDE.md', text, recs[0]!);
     assert.ok(diff.includes('# TRIM: ## Big'));
     assert.ok(diff.includes('--- a/'));

--- a/packages/analyze/src/claude-md.ts
+++ b/packages/analyze/src/claude-md.ts
@@ -343,6 +343,7 @@ export interface TrimRecommendation {
   section: MarkdownSection;
   projectedSavingsPerSession: number;
   projectedSavingsAcrossWindow: number;
+  tokenShare: number;
 }
 
 export function buildTrimRecommendations(
@@ -357,6 +358,7 @@ export function buildTrimRecommendations(
     section: s.section,
     projectedSavingsPerSession: s.costPerSession,
     projectedSavingsAcrossWindow: s.totalCost,
+    tokenShare: s.tokenShare,
   }));
 }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Added
+
+- `burn overhead trim --json` now emits structured trim recommendations with section metadata, projected savings, and the unified diff for each recommendation.
+
 ## [1.2.0] - 2026-04-30
 
 ### Added

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -45,6 +45,7 @@ Examples:
   burn overhead --since 30d
   burn overhead --kind claude-md
   burn overhead trim --top 3
+  burn overhead trim --json
   burn compare claude-sonnet-4-6,claude-haiku-4-5 --since 30d
   burn run claude   --tag workflow=refactor -- --resume
   burn run codex    --tag workflow=refactor

--- a/packages/cli/src/commands/overhead.test.ts
+++ b/packages/cli/src/commands/overhead.test.ts
@@ -1,0 +1,171 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import { loadBuiltinPricing } from '@relayburn/analyze';
+import type { TurnRecord } from '@relayburn/reader';
+
+import { runOverhead, type OverheadDeps } from './overhead.js';
+import type { ParsedArgs } from '../args.js';
+
+interface CapturedOutput {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+const tmpPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tmpPaths.splice(0).map((p) => rm(p, { recursive: true, force: true })));
+});
+
+function args(
+  positional: string[] = [],
+  flags: Record<string, string | true> = {},
+): ParsedArgs {
+  return { flags, tags: {}, positional, passthrough: [] };
+}
+
+async function captureOverhead(
+  parsed: ParsedArgs,
+  deps: OverheadDeps,
+): Promise<CapturedOutput> {
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origStderr = process.stderr.write.bind(process.stderr);
+  let stdout = '';
+  let stderr = '';
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdout += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderr += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const code = await runOverhead(parsed, deps);
+    return { stdout, stderr, code };
+  } finally {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+  }
+}
+
+function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    sessionId: 's-overhead-json',
+    messageId: 'm-overhead-json-1',
+    turnIndex: 0,
+    ts: '2026-04-29T00:00:00.000Z',
+    model: 'claude-sonnet-4-6',
+    usage: {
+      input: 100,
+      output: 50,
+      reasoning: 0,
+      cacheRead: 100_000,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    },
+    toolCalls: [],
+    project: '/tmp/project',
+    ...overrides,
+  };
+}
+
+async function makeDeps(turns: TurnRecord[]): Promise<OverheadDeps> {
+  const pricing = await loadBuiltinPricing();
+  return {
+    ingestAll: async () => ({ scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 }),
+    loadPricing: async () => pricing,
+    queryAll: async () => turns,
+  };
+}
+
+async function makeProject(fileText: string): Promise<string> {
+  const projectPath = await mkdtemp(path.join(tmpdir(), 'burn-overhead-json-'));
+  tmpPaths.push(projectPath);
+  await writeFile(path.join(projectPath, 'CLAUDE.md'), fileText, 'utf8');
+  return projectPath;
+}
+
+describe('burn overhead trim --json', () => {
+  it('emits structured trim recommendations with embedded unified diffs', async () => {
+    const projectPath = await makeProject(
+      [
+        '# Project',
+        '',
+        '## Big',
+        'x'.repeat(8000),
+        '## Small',
+        'short section',
+      ].join('\n'),
+    );
+    const deps = await makeDeps([fakeTurn({ project: projectPath })]);
+
+    const out = await captureOverhead(
+      args(['trim'], { project: projectPath, since: '30d', top: '1', json: true }),
+      deps,
+    );
+
+    assert.equal(out.code, 0);
+    assert.equal(out.stderr, '');
+    const payload = JSON.parse(out.stdout);
+    assert.equal(payload.project, projectPath);
+    assert.equal(payload.since, '30d');
+    assert.deepEqual(payload.summary, {
+      filesAnalyzed: 1,
+      filesWithRecommendations: 1,
+      totalRecommendations: 1,
+      totalProjectedSavingsPerSession: payload.recommendations[0].projectedSavings.perSessionUsd,
+      totalProjectedSavingsAcrossWindow: payload.recommendations[0].projectedSavings.acrossWindowUsd,
+    });
+
+    const rec = payload.recommendations[0];
+    assert.equal(rec.file, 'CLAUDE.md');
+    assert.equal(rec.kind, 'claude-md');
+    assert.deepEqual(rec.appliesTo, ['claude-code']);
+    assert.deepEqual(rec.section, {
+      heading: '## Big',
+      startLine: 3,
+      endLine: 4,
+      tokens: rec.projectedSavings.tokens,
+    });
+    assert.equal(typeof rec.projectedSavings.perSessionUsd, 'number');
+    assert.ok(rec.projectedSavings.perSessionUsd > 0);
+    assert.equal(typeof rec.projectedSavings.acrossWindowUsd, 'number');
+    assert.ok(rec.projectedSavings.acrossWindowUsd > 0);
+    assert.equal(typeof rec.projectedSavings.tokenShare, 'number');
+    assert.ok(rec.projectedSavings.tokenShare > 0);
+    assert.match(rec.diff, /^# TRIM: ## Big\n/);
+    assert.match(rec.diff, /\n--- a\/CLAUDE\.md\n\+\+\+ b\/CLAUDE\.md\n@@ -3,2 \+3,0 @@\n/);
+  });
+
+  it('emits an empty recommendations array when files have no headed trim candidates', async () => {
+    const projectPath = await makeProject('plain instructions\nwithout headings\n');
+    const deps = await makeDeps([fakeTurn({ project: projectPath })]);
+
+    const out = await captureOverhead(
+      args(['trim'], { project: projectPath, json: true }),
+      deps,
+    );
+
+    assert.equal(out.code, 0);
+    assert.equal(out.stderr, '');
+    const payload = JSON.parse(out.stdout);
+    assert.equal(payload.project, projectPath);
+    assert.equal(payload.since, 'all time');
+    assert.deepEqual(payload.recommendations, []);
+    assert.deepEqual(payload.summary, {
+      filesAnalyzed: 1,
+      filesWithRecommendations: 0,
+      totalRecommendations: 0,
+      totalProjectedSavingsPerSession: 0,
+      totalProjectedSavingsAcrossWindow: 0,
+    });
+  });
+});

--- a/packages/cli/src/commands/overhead.ts
+++ b/packages/cli/src/commands/overhead.ts
@@ -17,7 +17,7 @@ import {
   type SectionCost,
 } from '@relayburn/analyze';
 import { queryAll, type Query } from '@relayburn/ledger';
-import { resolveProject } from '@relayburn/reader';
+import { resolveProject, type TurnRecord } from '@relayburn/reader';
 
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
@@ -28,7 +28,7 @@ const HELP = `burn overhead — cost attribution for agent overhead files (CLAUD
 
 Usage:
   burn overhead      [--project <path>] [--since 7d] [--kind <k>] [--json]
-  burn overhead trim [--project <path>] [--since 7d] [--kind <k>] [--top <n>]
+  burn overhead trim [--project <path>] [--since 7d] [--kind <k>] [--top <n>] [--json]
 
 What it does:
   Discovers overhead files in the project (CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)
@@ -45,27 +45,67 @@ Examples:
   burn overhead --since 30d
   burn overhead --kind claude-md
   burn overhead trim --top 3
+  burn overhead trim --json | jq '.recommendations[] | select(.projectedSavings.perSessionUsd > 0.01)'
 `;
 
 const VALID_KINDS: OverheadFileKind[] = ['claude-md', 'agents-md'];
 
-export async function runOverhead(args: ParsedArgs): Promise<number> {
+export interface OverheadDeps {
+  ingestAll?: typeof ingestAll;
+  queryAll?: (q: Query) => Promise<TurnRecord[]>;
+  loadPricing?: typeof loadPricing;
+}
+
+interface TrimJsonRecommendation {
+  file: string;
+  kind: OverheadFileKind;
+  appliesTo: string[];
+  section: {
+    heading: string;
+    startLine: number;
+    endLine: number;
+    tokens: number;
+  };
+  projectedSavings: {
+    perSessionUsd: number;
+    acrossWindowUsd: number;
+    tokens: number;
+    tokenShare: number;
+  };
+  diff: string;
+}
+
+interface TrimJsonPayload {
+  project: string;
+  since: string;
+  recommendations: TrimJsonRecommendation[];
+  summary: {
+    filesAnalyzed: number;
+    filesWithRecommendations: number;
+    totalRecommendations: number;
+    totalProjectedSavingsPerSession: number;
+    totalProjectedSavingsAcrossWindow: number;
+  };
+}
+
+export async function runOverhead(args: ParsedArgs, deps: OverheadDeps = {}): Promise<number> {
   const sub = args.positional[0];
   if (args.flags['help'] === true || sub === 'help' || sub === '--help' || sub === '-h') {
     process.stdout.write(HELP);
     return 0;
   }
-  if (sub === 'trim') return runTrim(args);
+  if (sub === 'trim') return runTrim(args, deps);
   if (sub !== undefined && sub !== '') {
     process.stderr.write(`unknown overhead subcommand: ${sub}\n\n${HELP}`);
     return 1;
   }
-  return runReport(args);
+  return runReport(args, deps);
 }
 
 async function gatherAttribution(
   args: ParsedArgs,
   projectPath: string,
+  deps: OverheadDeps,
 ): Promise<{
   files: ParsedOverheadFile[];
   attribution: OverheadAttribution;
@@ -103,16 +143,19 @@ async function gatherAttribution(
   const q: Query = { project: resolved.projectKey ?? projectPath };
   if (typeof args.flags['since'] === 'string') q.since = parseSinceArg(args.flags['since']);
 
+  const ingest = deps.ingestAll ?? ingestAll;
   await withProgress('ingesting latest sessions', (task) =>
-    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    ingest({ onProgress: (message) => task.update(`ingest: ${message}`) }),
   );
+  const pricingLoader = deps.loadPricing ?? loadPricing;
   const pricing = await withProgress('loading pricing snapshot', async (task) => {
-    const loaded = await loadPricing();
+    const loaded = await pricingLoader();
     task.succeed('loaded pricing snapshot');
     return loaded;
   });
+  const turnQuery = deps.queryAll ?? queryAll;
   const turns = await withProgress('reading ledger turns', async (task) => {
-    const rows = await queryAll(q);
+    const rows = await turnQuery(q);
     task.succeed(`read ${formatInt(rows.length)} turn${rows.length === 1 ? '' : 's'}`);
     return rows;
   });
@@ -124,9 +167,9 @@ async function gatherAttribution(
   return { files, attribution };
 }
 
-async function runReport(args: ParsedArgs): Promise<number> {
+async function runReport(args: ParsedArgs, deps: OverheadDeps): Promise<number> {
   const projectPath = resolveProjectPath(args);
-  const data = await gatherAttribution(args, projectPath);
+  const data = await gatherAttribution(args, projectPath, deps);
   if (!data) return 1;
 
   if (args.flags['json'] === true) {
@@ -209,12 +252,19 @@ function renderFileBlock(
   out.push(indent(renderSectionTable(attribution.sectionCosts), '    '));
 }
 
-async function runTrim(args: ParsedArgs): Promise<number> {
+async function runTrim(args: ParsedArgs, deps: OverheadDeps): Promise<number> {
   const projectPath = resolveProjectPath(args);
-  const data = await gatherAttribution(args, projectPath);
+  const data = await gatherAttribution(args, projectPath, deps);
   if (!data) return 1;
 
   const topPerFile = parseTopN(args.flags['top']);
+  const json = args.flags['json'] === true;
+
+  if (json) {
+    const payload = await buildTrimJsonPayload(args, projectPath, data, topPerFile);
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
 
   const out: string[] = [];
   out.push('# burn overhead trim — projected savings if trimmed');
@@ -247,6 +297,70 @@ async function runTrim(args: ParsedArgs): Promise<number> {
   }
   process.stdout.write(out.join('\n'));
   return 0;
+}
+
+async function buildTrimJsonPayload(
+  args: ParsedArgs,
+  projectPath: string,
+  data: {
+    files: ParsedOverheadFile[];
+    attribution: OverheadAttribution;
+  },
+  topPerFile: number,
+): Promise<TrimJsonPayload> {
+  const textCache = new Map<string, string>();
+  const recommendations: TrimJsonRecommendation[] = [];
+  let filesWithRecommendations = 0;
+
+  for (const fileAttr of data.attribution.perFile) {
+    const recs = buildTrimRecommendations(fileAttr.attribution, topPerFile);
+    if (recs.length === 0) continue;
+    filesWithRecommendations++;
+    let text = textCache.get(fileAttr.file.path);
+    if (text === undefined) {
+      text = await readFile(fileAttr.file.path, 'utf8');
+      textCache.set(fileAttr.file.path, text);
+    }
+    for (const rec of recs) {
+      recommendations.push({
+        file: toProjectRelativePath(fileAttr.file.path, projectPath),
+        kind: fileAttr.file.kind,
+        appliesTo: fileAttr.file.appliesTo,
+        section: {
+          heading: rec.section.heading,
+          startLine: rec.section.startLine,
+          endLine: rec.section.endLine,
+          tokens: rec.section.tokens,
+        },
+        projectedSavings: {
+          perSessionUsd: rec.projectedSavingsPerSession,
+          acrossWindowUsd: rec.projectedSavingsAcrossWindow,
+          tokens: rec.section.tokens,
+          tokenShare: rec.tokenShare,
+        },
+        diff: renderUnifiedDiffForRecommendation(fileAttr.file.path, text, rec, projectPath),
+      });
+    }
+  }
+
+  return {
+    project: projectPath,
+    since: typeof args.flags['since'] === 'string' ? args.flags['since'] : 'all time',
+    recommendations,
+    summary: {
+      filesAnalyzed: data.files.length,
+      filesWithRecommendations,
+      totalRecommendations: recommendations.length,
+      totalProjectedSavingsPerSession: recommendations.reduce(
+        (sum, rec) => sum + rec.projectedSavings.perSessionUsd,
+        0,
+      ),
+      totalProjectedSavingsAcrossWindow: recommendations.reduce(
+        (sum, rec) => sum + rec.projectedSavings.acrossWindowUsd,
+        0,
+      ),
+    },
+  };
 }
 
 function renderSectionTable(rows: SectionCost[]): string {
@@ -285,6 +399,12 @@ function resolveProjectPath(args: ParsedArgs): string {
   const flag = args.flags['project'];
   if (typeof flag === 'string' && flag.length > 0) return path.resolve(flag);
   return process.cwd();
+}
+
+function toProjectRelativePath(filePath: string, projectPath: string): string {
+  const rel = path.relative(projectPath, filePath);
+  const display = rel && !rel.startsWith('..') ? rel : filePath;
+  return display.split(path.sep).join('/');
 }
 
 function parseTopN(v: unknown): number {


### PR DESCRIPTION
Summary:
- Add burn overhead trim --json with structured recommendations, projected savings, token share, and embedded unified diffs.
- Keep existing text output unchanged and document the JSON mode.
- Add coverage for populated and empty recommendation payloads.

Tests:
- pnpm run build
- pnpm run test
- node --test --test-reporter=spec packages/analyze/dist/claude-md.test.js packages/cli/dist/commands/overhead.test.js

Closes #204
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
