### PR TITLE
Drop implicit prune from CLI startup; lock publish workflow to lockstep

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,8 @@
-name: Publish Package
+name: Publish Packages
 
 on:
   workflow_dispatch:
     inputs:
-      package:
-        description: 'Which package(s) to publish'
-        required: true
-        default: cli
-        type: choice
-        options:
-          - all
-          - reader
-          - ledger
-          - analyze
-          - mcp
-          - cli
-          - relayburn
       version:
         description: 'Version bump type (ignored if custom_version is set)'
         required: true
@@ -85,35 +72,22 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
-      # Build + test everything regardless of which package is being released —
-      # cli depends on analyze/ledger/reader, analyze depends on ledger/reader,
-      # ledger depends on reader, all via workspace:*. `pnpm pack` rewrites
-      # those specs to concrete versions at pack time, and we want every
-      # package's dist/ to be fresh when that happens.
+      # Packages publish in lockstep. Build + test the whole workspace so every
+      # package's dist/ is fresh before `pnpm pack` rewrites workspace:* deps
+      # to concrete versions at pack time.
       - name: Build workspace
         run: pnpm -r run build
 
       - name: Run tests
         run: pnpm run test
 
-      - name: Resolve target packages (dep order)
+      - name: Resolve target packages
         id: targets
         run: |
-          case "${{ github.event.inputs.package }}" in
-            all)
-              # Dependency order: reader → ledger → analyze → mcp → cli → relayburn.
-              # `relayburn` is a thin wrapper that depends on `@relayburn/cli`,
-              # so cli must publish first.
-              echo "packages=reader ledger analyze mcp cli relayburn" >> "$GITHUB_OUTPUT"
-              ;;
-            reader|ledger|analyze|mcp|cli|relayburn)
-              echo "packages=${{ github.event.inputs.package }}" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "Unknown package: ${{ github.event.inputs.package }}" >&2
-              exit 1
-              ;;
-          esac
+          # Dependency order: reader → ledger → analyze → mcp → cli → relayburn.
+          # `relayburn` is a thin wrapper that depends on `@relayburn/cli`,
+          # so cli must publish first.
+          echo "packages=reader ledger analyze mcp cli relayburn" >> "$GITHUB_OUTPUT"
 
       # Catch the failure mode that bit us on 2026-04-23: a previous publish
       # run shipped @relayburn/*@0.3.0 to npm but failed at the Tag + push

--- a/.github/workflows/verify-publish.yml
+++ b/.github/workflows/verify-publish.yml
@@ -1,9 +1,10 @@
 name: Verify Publish
 
-# Manually triggered smoke test against the npm registry — run after a Publish
-# Package workflow completes. Installs the just-published package into a clean
-# environment and exercises it enough to catch "published but broken" failures
-# (bin missing +x, workspace:* deps not rewritten, missing exports, etc.).
+# Manually triggered smoke test against the npm registry — run after a
+# Publish Packages workflow completes. Installs the just-published package into
+# a clean environment and exercises it enough to catch "published but broken"
+# failures (bin missing +x, workspace:* deps not rewritten, missing exports,
+# etc.).
 
 on:
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,8 @@ Breaking changes: append `!` to a Conventional Commits prefix (e.g. `feat!:`) to
 ## Releases
 
 ```bash
-# from GitHub Actions: workflow_dispatch → "Publish Package"
-#   package: all | reader | ledger | analyze | mcp | cli | relayburn
+# from GitHub Actions: workflow_dispatch → "Publish Packages"
+#   always releases all packages in lockstep
 #   version: patch | minor | major | prepatch | … | none (re-publish current)
 #   custom_version: 0.3.1 (overrides version type)
 #   tag: latest | next | beta | alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Changed
+
+- Publish workflow now always targets all lockstep packages and no longer exposes per-package release choices.
+
 ## [1.2.1] - 2026-04-30
 
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed implicit content-sidecar pruning from CLI startup; `burn state` and other commands now respond without first walking source-session directories. Run `burn state prune` to prune on demand.
+
 ## [1.2.1] - 2026-04-30
 
 ### Added

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -76,25 +76,13 @@ describe('burn CLI state dispatch', () => {
     assert.match(out.stdout, /retention=forever/);
   });
 
-  it('burn state prune skips opportunistic pruning even when flags precede the subcommand', async () => {
-    const sessionId = '123e4567-e89b-12d3-a456-426614174000';
-    const contentPath = path.join(tmp, 'content', `${sessionId}.jsonl`);
-    await mkdir(path.dirname(contentPath), { recursive: true });
-    await writeFile(contentPath, '{}\n', 'utf8');
-    const longAgo = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000);
-    await utimes(contentPath, longAgo, longAgo);
-
-    const out = runCli(['state', '--days', 'forever', 'prune'], {
-      RELAYBURN_CONTENT_STORE: 'full',
-      RELAYBURN_CONTENT_TTL_DAYS: '90',
-    });
-
+  it('burn state prune --days forever exits 0 without pruning', () => {
+    const out = runCli(['state', 'prune', '--days', 'forever']);
     assert.equal(out.status, 0);
     assert.match(out.stdout, /retention=forever/);
-    await access(contentPath);
   });
 
-  it('burn state --help does not run opportunistic pruning', async () => {
+  it('no command implicitly prunes content sidecars at startup', async () => {
     const sessionId = '123e4567-e89b-12d3-a456-426614174001';
     const contentPath = path.join(tmp, 'content', `${sessionId}.jsonl`);
     await mkdir(path.dirname(contentPath), { recursive: true });
@@ -102,33 +90,13 @@ describe('burn CLI state dispatch', () => {
     const longAgo = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000);
     await utimes(contentPath, longAgo, longAgo);
 
-    const out = runCli(['state', '--help'], {
-      RELAYBURN_CONTENT_STORE: 'full',
-      RELAYBURN_CONTENT_TTL_DAYS: '90',
-    });
-
-    assert.equal(out.status, 0);
-    assert.match(out.stdout, /burn state/);
-    assert.equal(out.stderr, '');
-    await access(contentPath);
-  });
-
-  it('burn run does not prune before harness dispatch', async () => {
-    const sessionId = '123e4567-e89b-12d3-a456-426614174002';
-    const contentPath = path.join(tmp, 'content', `${sessionId}.jsonl`);
-    await mkdir(path.dirname(contentPath), { recursive: true });
-    await writeFile(contentPath, '{}\n', 'utf8');
-    const longAgo = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000);
-    await utimes(contentPath, longAgo, longAgo);
-
-    const out = runCli(['run', 'nope'], {
-      RELAYBURN_CONTENT_STORE: 'full',
-      RELAYBURN_CONTENT_TTL_DAYS: '90',
-    });
-
-    assert.equal(out.status, 2);
-    assert.match(out.stderr, /unknown harness/);
-    await access(contentPath);
+    for (const argv of [['state', 'status'], ['state', '--help'], ['run', 'nope']]) {
+      runCli(argv, {
+        RELAYBURN_CONTENT_STORE: 'full',
+        RELAYBURN_CONTENT_TTL_DAYS: '90',
+      });
+      await access(contentPath);
+    }
   });
 
   it('burn state rejects unknown subcommands', () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { parseArgs } from './args.js';
 import { listHarnessNames } from './harnesses/registry.js';
-import type { ParsedArgs } from './args.js';
 
 const HARNESS_LIST = listHarnessNames().join('|');
 
@@ -72,12 +71,6 @@ async function main(): Promise<number> {
     return 0;
   }
   const args = parseArgs(rest);
-  // Best-effort retention pruning should not run for help paths or before
-  // latency-sensitive harness startup.
-  if (shouldRunOpportunisticPrune(cmd, args)) {
-    const { opportunisticPrune } = await import('./commands/state.js');
-    await opportunisticPrune();
-  }
   switch (cmd) {
     case 'summary':
       return (await import('./commands/summary.js')).runSummary(args);
@@ -101,18 +94,6 @@ async function main(): Promise<number> {
       process.stderr.write(`unknown command: ${cmd}\n\n${HELP}`);
       return 1;
   }
-}
-
-function shouldRunOpportunisticPrune(cmd: string, args: ParsedArgs): boolean {
-  if (isHelpInvocation(args)) return false;
-  if (cmd === 'run' || cmd === 'mcp-server') return false;
-  if (cmd === 'state' && args.positional[0] === 'prune') return false;
-  return true;
-}
-
-function isHelpInvocation(args: ParsedArgs): boolean {
-  if (args.flags['help'] === true) return true;
-  return args.positional.some((arg) => arg === 'help' || arg === '--help' || arg === '-h');
 }
 
 main().then(

--- a/packages/cli/src/commands/state.ts
+++ b/packages/cli/src/commands/state.ts
@@ -837,41 +837,12 @@ function writeResetSummary(
   process.stdout.write(lines.join('\n') + '\n');
 }
 
-export async function opportunisticPrune(): Promise<void> {
-  try {
-    const { loadConfig, pruneContent, retentionMs } = await import('@relayburn/ledger');
-    const cfg = await loadConfig();
-    if (cfg.content.store === 'off') return;
-    const ms = retentionMs(cfg.content.retentionDays);
-    if (ms === null) return;
-    // Opportunistic prune always applies the recoverable-source check.
-    // Reclaiming recoverable disk requires explicit `burn state prune --force`.
-    // The exception is RELAYBURN_PRUNE_FORCE=1 for unattended automation that
-    // genuinely wants the old behavior.
-    const opts: Parameters<LedgerModule['pruneContent']>[0] = { olderThanMs: ms };
-    if (!isForceEnv()) {
-      const sources = await loadSourceSessionIds();
-      opts.isRecoverable = (sessionId) => sources.has(sessionId);
-    }
-    await pruneContent(opts);
-  } catch (err) {
-    // Best-effort - never fail a CLI operation because of prune, but surface
-    // the reason on stderr so persistent failures are diagnosable.
-    const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[burn] opportunistic content prune failed: ${msg}\n`);
-  }
-}
-
 // --- source index ----------------------------------------------------------
 //
 // Walk the same source roots that `ingest.ts` uses and build an in-memory
-// Set<sessionId>. Used to answer "is the upstream agent's session file still
-// on disk?" - if yes, the sidecar is recoverable via `burn state rebuild content`
-// and prune should skip it.
-//
-// Cost: one readdir pass per root; ~100ms even on large ledgers. Run
-// synchronously at prune time; callers cache the result for the duration of
-// a single prune call.
+// Set<sessionId>. Used by `burn state prune` to answer "is the upstream
+// agent's session file still on disk?" - if yes, the sidecar is recoverable
+// via `burn state rebuild content` and prune should skip it.
 
 const CLAUDE_PROJECTS = path.join(homedir(), '.claude', 'projects');
 const CODEX_SESSIONS = path.join(homedir(), '.codex', 'sessions');
@@ -883,7 +854,7 @@ const OPENCODE_SESSION_ROOT = path.join(OPENCODE_STORAGE, 'session');
 const CODEX_UUID_SUFFIX =
   /([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
 
-export async function loadSourceSessionIds(): Promise<Set<string>> {
+async function loadSourceSessionIds(): Promise<Set<string>> {
   const out = new Set<string>();
   await Promise.all([
     collectClaudeSessionIds(out),

--- a/packages/ledger/src/config.ts
+++ b/packages/ledger/src/config.ts
@@ -108,8 +108,7 @@ function normalizeRetention(v: unknown): number | 'forever' | null {
     const s = v.trim().toLowerCase();
     // Empty string means "not set" — important because `RELAYBURN_CONTENT_TTL_DAYS=`
     // (or a CI/CD pipeline producing an empty value) would otherwise parse as
-    // `Number('') === 0` and, combined with opportunisticPrune on every CLI
-    // invocation, silently wipe the entire content sidecar.
+    // `Number('') === 0` and silently configure a zero-day retention.
     if (s === '') return null;
     if (s === 'forever') return 'forever';
     const n = Number(s);

--- a/packages/ledger/src/content.test.ts
+++ b/packages/ledger/src/content.test.ts
@@ -316,10 +316,9 @@ describe('loadConfig', () => {
     assert.equal(cfg.content.retentionDays, 'forever');
   });
 
-  it('treats empty RELAYBURN_CONTENT_TTL_DAYS as unset (does not wipe content)', async () => {
-    // Previously `Number('') === 0` made empty string mean "0 days" which
-    // would trigger opportunisticPrune to delete all content. It should now
-    // be treated as not-set, falling through to the default (90 days).
+  it('treats empty RELAYBURN_CONTENT_TTL_DAYS as unset (does not configure 0-day retention)', async () => {
+    // `Number('') === 0` would make an empty env var mean "0 days" — we
+    // treat it as not-set and fall through to the default (90 days).
     process.env['RELAYBURN_CONTENT_TTL_DAYS'] = '';
     const cfg = await loadConfig();
     assert.equal(cfg.content.retentionDays, 90);


### PR DESCRIPTION
## Summary
- Remove `opportunisticPrune` from CLI dispatch — `burn state` (and every other command) was paying a silent pre-spinner walk over `~/.claude/projects`, `~/.codex/sessions`, and OpenCode storage on every invocation. `burn state prune` is the explicit user-facing path and remains.
- Drop the `package` choice from the Publish Packages workflow_dispatch since packages already release in lockstep, and update AGENTS.md to match.

## Notes
- Two commits, kept separate so the workflow change can be reviewed independently of the CLI behavior change.
- Single-package work goes only in the per-package CHANGELOG (`packages/cli/CHANGELOG.md` for the prune removal); the workflow change lives in the root CHANGELOG since it spans the release pipeline.
- `loadSourceSessionIds` is now module-private — only `burn state prune --force=false` still uses the recoverable-source check.

## Tests
- [x] `pnpm run build`
- [x] `pnpm run test` (893 pass)
- [x] `burn state status` cold-start: ~0.18s → ~0.08s on this machine; spinner now appears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)