### PR TITLE
Add `burn --version` flag

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Added
+
+- `burn --version` (and `-v` / `burn version`) prints the installed CLI version.
+
 ## [1.2.2] - 2026-04-30
 
 ### Removed

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -105,6 +105,18 @@ describe('burn CLI state dispatch', () => {
     assert.match(out.stderr, /unknown subcommand/);
   });
 
+  it('burn --version prints the package version', () => {
+    const out = runCli(['--version']);
+    assert.equal(out.status, 0);
+    assert.match(out.stdout, /^\d+\.\d+\.\d+/);
+  });
+
+  it('burn -v prints the package version', () => {
+    const out = runCli(['-v']);
+    assert.equal(out.status, 0);
+    assert.match(out.stdout, /^\d+\.\d+\.\d+/);
+  });
+
   it('does not retain top-level rebuild or content dispatch aliases', () => {
     const rebuild = runCli(['rebuild', 'status']);
     const content = runCli(['content', 'prune']);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
+import { createRequire } from 'node:module';
 import { parseArgs } from './args.js';
 import { listHarnessNames } from './harnesses/registry.js';
 
 const HARNESS_LIST = listHarnessNames().join('|');
+
+function getVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require('../package.json') as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
 
 const HELP = `burn — token usage & cost attribution for agent CLIs
 
@@ -66,6 +77,10 @@ reported as provider "synthetic" without rewriting ledger rows.
 
 async function main(): Promise<number> {
   const [, , cmd, ...rest] = process.argv;
+  if (cmd === '--version' || cmd === '-v' || cmd === 'version') {
+    process.stdout.write(`${getVersion()}\n`);
+    return 0;
+  }
   if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
     process.stdout.write(HELP);
     return 0;


### PR DESCRIPTION
## Summary

- `burn --version`, `burn -v`, and `burn version` now print the installed CLI version (read from `packages/cli/package.json` via `createRequire`).
- Added two CLI tests covering `--version` and `-v`.
- Curated `[Unreleased]` entry in `packages/cli/CHANGELOG.md`.

## Test plan

- [x] `pnpm run build`
- [x] `node --test packages/cli/dist/cli.test.js` (10/10 pass)
- [x] Manual: `burn --version`, `burn -v`, `burn version` all print `1.2.2`
- [x] Manual: `burn --help` and unknown commands still behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)