### PR TITLE
Style ingest gap warning as a spinner-friendly ⚠ banner

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Changed
+
+- Style the ingest content-capture gap warning as a `⚠` banner that flows through the active progress spinner (yellow `⚠` via `ora.warn`, multi-line with hang-indent), instead of a `[burn] warning: …` blob that printed mid-spinner.
+
 ## [1.3.1] - 2026-04-30
 
 ### Fixed

--- a/packages/cli/src/commands/budget-plans.ts
+++ b/packages/cli/src/commands/budget-plans.ts
@@ -342,7 +342,11 @@ async function statusForPlans(
   const progress = progressOptions(opts);
   await withProgress(
     'ingesting latest sessions',
-    (task) => ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    (task) =>
+      ingestAll({
+        onProgress: (message) => task.update(`ingest: ${message}`),
+        onWarn: (body) => task.warn(body),
+      }),
     progress,
   );
   const pricing = await withProgress('loading pricing snapshot', async (task) => {

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -199,7 +199,10 @@ export async function runCompare(
     });
   } else {
     await withProgress('ingesting latest sessions', (task) =>
-      ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+      ingestAll({
+        onProgress: (message) => task.update(`ingest: ${message}`),
+        onWarn: (body) => task.warn(body),
+      }),
     );
   }
   const pricing = await withProgress('loading pricing snapshot', async (task) => {

--- a/packages/cli/src/commands/hotspots-session.ts
+++ b/packages/cli/src/commands/hotspots-session.ts
@@ -39,7 +39,10 @@ export async function runHotspotsSession(
   }
 
   await withProgress('ingesting latest sessions', (task) =>
-    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    ingestAll({
+      onProgress: (message) => task.update(`ingest: ${message}`),
+      onWarn: (body) => task.warn(body),
+    }),
   );
   const pricing = await withProgress('loading pricing snapshot', async (task) => {
     const loaded = await loadPricing();
@@ -609,7 +612,10 @@ interface RelationshipDriftReport {
 
 async function runHotspotsGapReport(args: ParsedArgs): Promise<number> {
   await withProgress('ingesting latest sessions', (task) =>
-    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    ingestAll({
+      onProgress: (message) => task.update(`ingest: ${message}`),
+      onWarn: (body) => task.warn(body),
+    }),
   );
   const config = await withProgress('loading burn configuration', async (task) => {
     const loaded = await loadConfig();

--- a/packages/cli/src/commands/hotspots.ts
+++ b/packages/cli/src/commands/hotspots.ts
@@ -201,7 +201,10 @@ export async function runHotspots(args: ParsedArgs): Promise<number> {
   }
 
   await withProgress('ingesting latest sessions', (task) =>
-    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    ingestAll({
+      onProgress: (message) => task.update(`ingest: ${message}`),
+      onWarn: (body) => task.warn(body),
+    }),
   );
   const pricing = await withProgress('loading pricing snapshot', async (task) => {
     const loaded = await loadPricing();

--- a/packages/cli/src/commands/mcp-server.ts
+++ b/packages/cli/src/commands/mcp-server.ts
@@ -36,7 +36,10 @@ export async function runMcpServer(args: ParsedArgs): Promise<number> {
   // a steady-state ledger thanks to the cursor index.
   try {
     await withProgress('mcp server initial ingest', (task) =>
-      ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+      ingestAll({
+        onProgress: (message) => task.update(`ingest: ${message}`),
+        onWarn: (body) => task.warn(body),
+      }),
     );
   } catch (err) {
     // Don't fail server startup on a partial ingest — let the tools handle

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -106,7 +106,10 @@ export async function runSummary(args: ParsedArgs): Promise<number> {
   }
 
   const ingestReport = await withProgress('ingesting latest sessions', (task) =>
-    ingestAll({ onProgress: (message) => task.update(`ingest: ${message}`) }),
+    ingestAll({
+      onProgress: (message) => task.update(`ingest: ${message}`),
+      onWarn: (body) => task.warn(body),
+    }),
   );
   const pricing = await withProgress('loading pricing snapshot', async (task) => {
     const loaded = await loadPricing();

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -67,6 +67,11 @@ export interface IngestReport {
 
 export interface IngestOptions {
   onProgress?: (message: string) => void;
+  // Receives the body of a gap warning (no leading symbol, no trailing
+  // newline). Pass `task.warn` here to route the warning through an active
+  // ora spinner so it lands as a yellow ⚠ banner that pauses and resumes
+  // the spinner instead of tearing it.
+  onWarn?: (body: string) => void;
 }
 
 // Per-adapter content-capture gap aggregator. A "gap" is a session that the
@@ -90,17 +95,20 @@ interface GapTrackerState {
   // notice — if a second pass turns up *additional* affected sessions we
   // still warn, but a steady state stays silent.
   warnedAffectedSessions: Map<AdapterName, number>;
-  // Override the writer used for warnings. Tests inject a buffer-backed sink
-  // so they can assert on the formatted message without scribbling on
-  // stderr.
-  write: (msg: string) => void;
+  // Default sink for gap warnings when the caller has not provided an
+  // `onWarn` (e.g. plain stderr contexts like `burn run` or watch loops).
+  // Receives the warning body and is responsible for whatever framing the
+  // sink wants — the default prepends the ⚠ glyph and a trailing newline.
+  // Tests inject a buffer-backed sink so they can assert on the body
+  // without scribbling on stderr.
+  write: (body: string) => void;
 }
 
 type AdapterName = 'claude' | 'codex' | 'opencode';
 
 const moduleGapState: GapTrackerState = {
   warnedAffectedSessions: new Map(),
-  write: (msg) => process.stderr.write(msg),
+  write: (body) => process.stderr.write(`⚠ ${body}\n`),
 };
 
 // Test-only: clear per-process suppression state. Safe to call from prod
@@ -129,7 +137,7 @@ export async function ingestClaudeProjects(opts: IngestOptions = {}): Promise<In
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   opts.onProgress?.('scanning Claude Code sessions');
   await ingestClaudeInto(cursors, report, contentMode, gap);
-  emitGapWarning('claude', contentMode, gap, moduleGapState);
+  emitGapWarning('claude', contentMode, gap, moduleGapState, opts.onWarn);
   opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
@@ -147,7 +155,7 @@ export async function ingestCodexSessions(opts: IngestOptions = {}): Promise<Ing
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   opts.onProgress?.('scanning Codex sessions');
   await ingestCodexInto(cursors, report, contentMode, gap);
-  emitGapWarning('codex', contentMode, gap, moduleGapState);
+  emitGapWarning('codex', contentMode, gap, moduleGapState, opts.onWarn);
   opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
@@ -165,7 +173,7 @@ export async function ingestOpencodeSessions(opts: IngestOptions = {}): Promise<
   const gap: GapStats = { affectedSessions: 0, orphanToolCalls: 0 };
   opts.onProgress?.('scanning OpenCode sessions');
   await ingestOpencodeInto(cursors, report, contentMode, gap);
-  emitGapWarning('opencode', contentMode, gap, moduleGapState);
+  emitGapWarning('opencode', contentMode, gap, moduleGapState, opts.onWarn);
   opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
@@ -233,9 +241,9 @@ export async function ingestAll(opts: IngestOptions = {}): Promise<IngestReport>
   await ingestCodexInto(cursors, report, contentMode, codexGap);
   opts.onProgress?.('scanning OpenCode sessions');
   await ingestOpencodeInto(cursors, report, contentMode, opencodeGap);
-  emitGapWarning('claude', contentMode, claudeGap, moduleGapState);
-  emitGapWarning('codex', contentMode, codexGap, moduleGapState);
-  emitGapWarning('opencode', contentMode, opencodeGap, moduleGapState);
+  emitGapWarning('claude', contentMode, claudeGap, moduleGapState, opts.onWarn);
+  emitGapWarning('codex', contentMode, codexGap, moduleGapState, opts.onWarn);
+  emitGapWarning('opencode', contentMode, opencodeGap, moduleGapState, opts.onWarn);
   opts.onProgress?.('saving ingest cursors');
   await saveCursorChanges(before, cursors);
   return report;
@@ -269,6 +277,7 @@ function emitGapWarning(
   contentMode: ContentStoreMode,
   stats: GapStats,
   state: GapTrackerState,
+  onWarn: ((body: string) => void) | undefined,
 ): void {
   if (contentMode !== 'full') return;
   if (stats.affectedSessions === 0) return;
@@ -278,11 +287,14 @@ function emitGapWarning(
   const priorEmitted = state.warnedAffectedSessions.get(adapter);
   if (priorEmitted !== undefined && stats.affectedSessions <= priorEmitted) return;
   state.warnedAffectedSessions.set(adapter, stats.affectedSessions);
-  state.write(
-    `[burn] warning: ${adapter} parser produced 0 tool_result records for ${stats.affectedSessions} session${stats.affectedSessions === 1 ? '' : 's'} ` +
-      `with ${stats.orphanToolCalls} tool call${stats.orphanToolCalls === 1 ? '' : 's'}. Content capture may not be implemented for this ` +
-      `adapter, so burn hotspots will use user-turn block sizes when available, then fall back to even-split attribution.\n`,
-  );
+  const sessions = `${stats.affectedSessions} session${stats.affectedSessions === 1 ? '' : 's'}`;
+  const calls = `${stats.orphanToolCalls} tool call${stats.orphanToolCalls === 1 ? '' : 's'}`;
+  const body =
+    `${adapter} parser produced 0 tool_result records for ${sessions} (${calls}).\n` +
+    `  Content capture may not be implemented for this adapter; burn hotspots will use\n` +
+    `  user-turn block sizes when available, then fall back to even-split attribution.`;
+  if (onWarn) onWarn(body);
+  else state.write(body);
 }
 
 async function resolveContentMode(): Promise<ContentStoreMode> {

--- a/packages/cli/src/progress.ts
+++ b/packages/cli/src/progress.ts
@@ -12,6 +12,11 @@ export interface ProgressOptions {
 export interface ProgressTask {
   update(text: string): void;
   info(text: string): void;
+  // Print a multi-line warning above the spinner without ending the task.
+  // The body should be the text after the symbol; the implementation prepends
+  // the warning glyph and resumes the spinner so subsequent progress ticks
+  // continue cleanly.
+  warn(text: string): void;
   succeed(text?: string): void;
   fail(text?: string): void;
   stop(): void;
@@ -110,6 +115,17 @@ class OraProgressTask implements ProgressTask {
     this.done = true;
   }
 
+  warn(text: string): void {
+    if (this.done) return;
+    // ora's `warn` is implemented via `stopAndPersist`, which stops the
+    // spinner. Capture the active frame text first so we can restart the
+    // spinner after the persisted warn line lands above it.
+    const wasSpinning = this.spinner.isSpinning;
+    const prevText = this.spinner.text;
+    this.spinner.warn(text);
+    if (wasSpinning) this.spinner.start(prevText);
+  }
+
   succeed(text?: string): void {
     if (this.done) return;
     this.spinner.succeed(text);
@@ -148,6 +164,11 @@ class LogProgressTask implements ProgressTask {
     this.done = true;
   }
 
+  warn(text: string): void {
+    if (this.done) return;
+    this.stream.write(`⚠ ${text}\n`);
+  }
+
   succeed(text?: string): void {
     if (this.done) return;
     this.stream.write(`[burn] ${text ?? this.current}\n`);
@@ -168,6 +189,7 @@ class LogProgressTask implements ProgressTask {
 const silentTask: ProgressTask = {
   update() {},
   info() {},
+  warn() {},
   succeed() {},
   fail() {},
   stop() {},


### PR DESCRIPTION
## Summary

- The content-capture gap warning printed as `[burn] warning: <one long line>` directly to stderr — out of step with the spinner output (`✔ ingested …`) and ugly when it tore through an active ora frame mid-ingest.
- Reformatted the warning into a multi-line `⚠ <headline>` banner with two-space hang-indented continuation lines, matching the existing `⚠ attribution is degraded` banner in `burn hotspots`.
- Plumbed an `onWarn` callback through `IngestOptions` and added `task.warn` to `ProgressTask`. Call sites that wrap `ingestAll` in `withProgress` (`hotspots`, `hotspots --session`, `summary`, `compare`, `mcp-server`, `budget plans`) now route the warning through the spinner via ora's `stopAndPersist`-based `warn` (yellow `⚠` via `log-symbols`); the spinner is then restarted with the prior frame text so subsequent ticks keep flowing instead of tearing.
- Watch loops, `burn run`, and the existing test sink all keep their stderr path: the default writer simply prepends `⚠ ` to the warning body.

## Before / after

Before:
```
[burn] warning: claude parser produced 0 tool_result records for 10 sessions with 453 tool calls. Content capture may not be implemented for this adapter, so burn hotspots will use user-turn block sizes when available, then fall back to even-split attribution.
```

After (log mode):
```
[burn] ingesting latest sessions
⚠ claude parser produced 0 tool_result records for 10 sessions (453 tool calls).
  Content capture may not be implemented for this adapter; burn hotspots will use
  user-turn block sizes when available, then fall back to even-split attribution.
[burn] ✔ ingested latest sessions
```

In a real TTY, the same banner is printed in yellow above a continuing spinner.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm run test` (899 / 899 passing on `main`-rebased branch)
- [x] Verified log-mode output matches the new banner format via a small smoke script.
- [ ] Eyeball the spinner branch in a real terminal (`burn hotspots` against a ledger that has a parser-gap session) to confirm the spinner pauses, prints the yellow ⚠ banner, and resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)