### PR TITLE
Bucket Bash hotspots by verb

### DIFF
--- a/packages/analyze/CHANGELOG.md
+++ b/packages/analyze/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/analyze`.
 
 ## [Unreleased]
 
+### Added
+
+- Added `aggregateByBashVerb()` to group Bash hotspot attribution by normalized command verb with persistence and example drill-downs.
+
 ## [1.2.1] - 2026-04-30
 
 ### Changed

--- a/packages/analyze/src/hotspots.test.ts
+++ b/packages/analyze/src/hotspots.test.ts
@@ -7,13 +7,16 @@ import type {
   TurnRecord,
   UserTurnRecord,
 } from '@relayburn/reader';
+import { parseBashCommand } from '@relayburn/reader';
 
 import { loadBuiltinPricing } from './pricing.js';
 import {
   aggregateByBash,
+  aggregateByBashVerb,
   aggregateByFile,
   aggregateBySubagent,
   attributeHotspots,
+  type ToolAttribution,
 } from './hotspots.js';
 
 function tc(id: string, name: string, target?: string): ToolCall {
@@ -64,6 +67,37 @@ function userTurn(
     precedingMessageId: 'msg-0',
     followingMessageId: 'msg-1',
     blocks,
+  };
+}
+
+function bashAttribution(
+  command: string,
+  argsHash: string,
+  totalCost: number,
+  initialTokens: number,
+  persistenceTokens: number,
+  ridingTurns: number,
+): ToolAttribution {
+  return {
+    toolUseId: `tu-${argsHash}`,
+    toolName: 'Bash',
+    target: command,
+    argsHash,
+    sessionId: 's-bash-verb',
+    emitTurnIndex: 0,
+    emitTs: '2026-04-20T00:00:00.000Z',
+    model: 'claude-sonnet-4-6',
+    project: undefined,
+    projectKey: undefined,
+    subagentType: undefined,
+    resultTokens: 0,
+    resultBytesEstimated: true,
+    initialCost: totalCost,
+    initialTokens,
+    persistenceCost: 0,
+    persistenceTokens,
+    ridingTurns,
+    totalCost,
   };
 }
 
@@ -214,6 +248,35 @@ describe('attributeHotspots', () => {
     const bash = aggregateByBash(result.attributions);
     assert.equal(bash.length, 1);
     assert.equal(bash[0]!.callCount, 3);
+  });
+
+  it('aggregates Bash cost by normalized verb with distinct-command and example drill-downs', () => {
+    const attrs: ToolAttribution[] = [
+      bashAttribution('git status', 'git:status', 2, 20, 5, 0),
+      bashAttribution('git status', 'git:status', 2, 20, 5, 0),
+      bashAttribution('git status', 'git:status', 2, 20, 5, 0),
+      bashAttribution('git diff src/a.ts', 'git:diff:a', 5, 100, 10, 1),
+      bashAttribution('git diff src/a.ts', 'git:diff:a', 5, 100, 10, 1),
+      bashAttribution('git diff src/b.ts', 'git:diff:b', 7, 100, 20, 2),
+      bashAttribution('git diff src/b.ts', 'git:diff:b', 7, 100, 20, 2),
+      bashAttribution('git diff src/b.ts', 'git:diff:b', 7, 100, 20, 2),
+      bashAttribution('pnpm run test', 'pnpm:test', 4, 40, 8, 1),
+    ];
+
+    const verbs = aggregateByBashVerb(attrs, parseBashCommand);
+    assert.equal(verbs[0]!.verb, 'git diff');
+    assert.equal(verbs[0]!.callCount, 5);
+    assert.equal(verbs[0]!.distinctCommands, 2);
+    assert.equal(verbs[0]!.totalCost, 31);
+    assert.equal(verbs[0]!.initialTokens, 500);
+    assert.equal(verbs[0]!.persistenceTokens, 80);
+    assert.equal(verbs[0]!.avgPersistenceTurns, 1.6);
+    assert.deepEqual(verbs[0]!.topExamples, ['git diff src/b.ts', 'git diff src/a.ts']);
+
+    assert.equal(verbs[1]!.verb, 'git status');
+    assert.equal(verbs[1]!.callCount, 3);
+    assert.equal(verbs[1]!.distinctCommands, 1);
+    assert.equal(verbs[2]!.verb, 'pnpm test');
   });
 
   it('aggregates subagent calls by subagent_type', async () => {

--- a/packages/analyze/src/hotspots.ts
+++ b/packages/analyze/src/hotspots.ts
@@ -1,4 +1,4 @@
-import type { ContentRecord, TurnRecord, UserTurnRecord } from '@relayburn/reader';
+import type { BashParse, ContentRecord, TurnRecord, UserTurnRecord } from '@relayburn/reader';
 
 import { costForTurn, lookupModelRate } from './cost.js';
 import type { PricingTable } from './pricing.js';
@@ -378,6 +378,17 @@ export interface BashAggregation {
   persistenceTokens: number;
 }
 
+export interface BashVerbAggregation {
+  verb: string;
+  callCount: number;
+  distinctCommands: number;
+  totalCost: number;
+  initialTokens: number;
+  persistenceTokens: number;
+  avgPersistenceTurns: number;
+  topExamples: string[];
+}
+
 export interface SubagentAggregation {
   subagentType: string;
   callCount: number;
@@ -441,6 +452,76 @@ export function aggregateByBash(attributions: ToolAttribution[]): BashAggregatio
     row.persistenceTokens += a.persistenceTokens;
   }
   return [...byHash.values()].sort((a, b) => b.totalCost - a.totalCost);
+}
+
+interface BashVerbAccumulator {
+  verb: string;
+  callCount: number;
+  totalCost: number;
+  initialTokens: number;
+  persistenceTokens: number;
+  ridingTurns: number;
+  hashes: Set<string>;
+  examples: Map<string, { command: string; totalCost: number }>;
+}
+
+export function aggregateByBashVerb(
+  attributions: ToolAttribution[],
+  parse: (cmd: string) => BashParse | null,
+): BashVerbAggregation[] {
+  const byVerb = new Map<string, BashVerbAccumulator>();
+  for (const a of attributions) {
+    if (a.toolName !== 'Bash') continue;
+    const parsed = a.target ? parse(a.target) : null;
+    const verbKey = parsed?.normalized ?? '(unknown)';
+    let row = byVerb.get(verbKey);
+    if (!row) {
+      row = {
+        verb: verbKey,
+        callCount: 0,
+        totalCost: 0,
+        initialTokens: 0,
+        persistenceTokens: 0,
+        ridingTurns: 0,
+        hashes: new Set(),
+        examples: new Map(),
+      };
+      byVerb.set(verbKey, row);
+    }
+    row.callCount++;
+    row.totalCost += a.totalCost;
+    row.initialTokens += a.initialTokens;
+    row.persistenceTokens += a.persistenceTokens;
+    row.ridingTurns += a.ridingTurns;
+    row.hashes.add(a.argsHash);
+
+    const exampleKey = a.argsHash;
+    let example = row.examples.get(exampleKey);
+    if (!example) {
+      example = {
+        command: a.target ?? `(hash ${a.argsHash.slice(0, 8)})`,
+        totalCost: 0,
+      };
+      row.examples.set(exampleKey, example);
+    }
+    example.totalCost += a.totalCost;
+  }
+
+  return [...byVerb.values()]
+    .map((row) => ({
+      verb: row.verb,
+      callCount: row.callCount,
+      distinctCommands: row.hashes.size,
+      totalCost: row.totalCost,
+      initialTokens: row.initialTokens,
+      persistenceTokens: row.persistenceTokens,
+      avgPersistenceTurns: row.callCount > 0 ? row.ridingTurns / row.callCount : 0,
+      topExamples: [...row.examples.values()]
+        .sort((a, b) => b.totalCost - a.totalCost || a.command.localeCompare(b.command))
+        .slice(0, 3)
+        .map((example) => example.command),
+    }))
+    .sort((a, b) => b.totalCost - a.totalCost || a.verb.localeCompare(b.verb));
 }
 
 export function aggregateBySubagent(attributions: ToolAttribution[]): SubagentAggregation[] {

--- a/packages/analyze/src/index.ts
+++ b/packages/analyze/src/index.ts
@@ -10,12 +10,14 @@ export {
   attributeHotspots,
   aggregateByFile,
   aggregateByBash,
+  aggregateByBashVerb,
   aggregateBySubagent,
 } from './hotspots.js';
 export type {
   AttributionMethod,
   HotspotsOptions,
   BashAggregation,
+  BashVerbAggregation,
   FileAggregation,
   SessionTotals,
   SubagentAggregation,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Added
+
+- `burn hotspots` now reports Bash spend by normalized verb before exact-command rows, with JSON `bashVerbs` / `topBashVerbs` fields for drill-downs.
+
 ### Changed
 
 - Style the ingest content-capture gap warning as a `⚠` banner that flows through the active progress spinner (yellow `⚠` via `ora.warn`, multi-line with hang-indent), instead of a `[burn] warning: …` blob that printed mid-spinner.

--- a/packages/cli/src/commands/hotspots-session.test.ts
+++ b/packages/cli/src/commands/hotspots-session.test.ts
@@ -695,6 +695,88 @@ describe('burn hotspots --session aggregate (#79)', () => {
     ]);
   });
 
+  it('adds Bash verb rollups to per-session JSON and human reports', async () => {
+    await appendTurns([
+      fakeTurn({
+        sessionId: 'bash-session',
+        messageId: 'bash-session-1',
+        turnIndex: 0,
+        toolCalls: [
+          { id: 'bash-a', name: 'Bash', target: 'git diff src/a.ts', argsHash: 'git:diff:a' },
+        ],
+      }),
+      fakeTurn({
+        sessionId: 'bash-session',
+        messageId: 'bash-session-2',
+        turnIndex: 1,
+        usage: { input: 1000, output: 5, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
+      }),
+      fakeTurn({
+        sessionId: 'bash-session',
+        messageId: 'bash-session-3',
+        turnIndex: 2,
+        toolCalls: [
+          { id: 'bash-b', name: 'Bash', target: 'git diff src/b.ts', argsHash: 'git:diff:b' },
+        ],
+      }),
+      fakeTurn({
+        sessionId: 'bash-session',
+        messageId: 'bash-session-4',
+        turnIndex: 3,
+        usage: { input: 1000, output: 5, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
+      }),
+    ]);
+    await appendContent([
+      {
+        ...toolResultContent({
+          source: 'claude-code',
+          sessionId: 'bash-session',
+          messageId: 'bash-session-result-a',
+          toolUseId: 'bash-a',
+        }),
+        toolResult: { toolUseId: 'bash-a', content: 'a'.repeat(4000) },
+      },
+      {
+        ...toolResultContent({
+          source: 'claude-code',
+          sessionId: 'bash-session',
+          messageId: 'bash-session-result-b',
+          toolUseId: 'bash-b',
+        }),
+        toolResult: { toolUseId: 'bash-b', content: 'b'.repeat(4000) },
+      },
+    ]);
+
+    const json = await captureHotspots({
+      flags: { json: true },
+      tags: {},
+      positional: ['bash-session'],
+      passthrough: [],
+    });
+    assert.equal(json.code, 0);
+    const parsed = JSON.parse(json.stdout) as {
+      topBashVerbs: Array<{ verb: string; callCount: number; distinctCommands: number }>;
+      topBashes: unknown[];
+    };
+    assert.equal(parsed.topBashVerbs[0]!.verb, 'git diff');
+    assert.equal(parsed.topBashVerbs[0]!.callCount, 2);
+    assert.equal(parsed.topBashVerbs[0]!.distinctCommands, 2);
+    assert.equal(parsed.topBashes.length, 2);
+
+    const human = await captureHotspots({
+      flags: {},
+      tags: {},
+      positional: ['bash-session'],
+      passthrough: [],
+    });
+    assert.equal(human.code, 0);
+    const verbIndex = human.stdout.indexOf('Top Bash verbs by cost');
+    const exactIndex = human.stdout.indexOf('Top exact Bash commands by cost');
+    assert.ok(verbIndex >= 0, 'verb heading present');
+    assert.ok(exactIndex > verbIndex, 'exact-command heading follows verb heading');
+    assert.match(human.stdout, /git diff/);
+  });
+
   it('keeps the human per-session output unchanged when no graph rows exist', async () => {
     await appendTurns([
       fakeTurn({

--- a/packages/cli/src/commands/hotspots-session.ts
+++ b/packages/cli/src/commands/hotspots-session.ts
@@ -1,5 +1,6 @@
 import {
   aggregateByBash,
+  aggregateByBashVerb,
   aggregateByFile,
   aggregateBySubagent,
   attributeHotspots,
@@ -24,6 +25,7 @@ import type {
   TurnRecord,
   UserTurnRecord,
 } from '@relayburn/reader';
+import { parseBashCommand } from '@relayburn/reader';
 
 import { countToolCallGaps, ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, table } from '../format.js';
@@ -121,6 +123,7 @@ export async function runHotspotsSession(
     return result;
   });
   const files = aggregateByFile(attribution.attributions).slice(0, 5);
+  const bashVerbs = aggregateByBashVerb(attribution.attributions, parseBashCommand).slice(0, 5);
   const bashes = aggregateByBash(attribution.attributions).slice(0, 5);
   const subagents = aggregateBySubagent(attribution.attributions).slice(0, 5);
 
@@ -133,6 +136,7 @@ export async function runHotspotsSession(
           totals: attribution.sessionTotals[0] ?? null,
           patterns,
           topFiles: files,
+          topBashVerbs: bashVerbs,
           topBashes: bashes,
           topSubagents: subagents,
           relationships,
@@ -223,7 +227,26 @@ export async function runHotspotsSession(
   }
   out.push('');
 
-  out.push('Top Bash commands by cost');
+  out.push('Top Bash verbs by cost');
+  if (bashVerbs.length === 0) out.push('  (none)');
+  else {
+    out.push(
+      table([
+        ['verb', 'calls', 'commands', 'persist(tok)', 'cost', 'examples'],
+        ...bashVerbs.map((b) => [
+          truncate(b.verb, 32),
+          String(b.callCount),
+          String(b.distinctCommands),
+          formatInt(b.persistenceTokens),
+          formatUsd(b.totalCost),
+          truncate(b.topExamples.map((example) => truncate(example, 28)).join('; '), 60),
+        ]),
+      ]),
+    );
+  }
+  out.push('');
+
+  out.push('Top exact Bash commands by cost');
   if (bashes.length === 0) out.push('  (none)');
   else {
     out.push(

--- a/packages/cli/src/commands/hotspots.test.ts
+++ b/packages/cli/src/commands/hotspots.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { loadBuiltinPricing } from '@relayburn/analyze';
 import type {
   BashAggregation,
+  BashVerbAggregation,
   FileAggregation,
   SessionTotals,
   SubagentAggregation,
@@ -125,7 +126,8 @@ describe('formatHotspotsReport', () => {
     assert.doesNotMatch(out, /\(approximate\)/);
     // Headings render plain.
     assert.match(out, /Top files by cumulative cost\n/);
-    assert.match(out, /Top Bash commands by cost\n/);
+    assert.match(out, /Top Bash verbs by cost\n/);
+    assert.match(out, /Top exact Bash commands by cost\n/);
     assert.match(out, /Top subagent calls by cost\n/);
     // Original combined attributed/unattributed line.
     assert.match(out, /attributed to tool calls: \$25\.00/);
@@ -183,9 +185,10 @@ describe('formatHotspotsReport', () => {
       out,
       /unattributed \$75\.00\s+\(output, system overhead, untracked\)/,
     );
-    // All three table headings are suffixed with "(approximate)".
+    // All attribution table headings are suffixed with "(approximate)".
     assert.match(out, /Top files by cumulative cost \(approximate\)/);
-    assert.match(out, /Top Bash commands by cost \(approximate\)/);
+    assert.match(out, /Top Bash verbs by cost \(approximate\)/);
+    assert.match(out, /Top exact Bash commands by cost \(approximate\)/);
     assert.match(out, /Top subagent calls by cost \(approximate\)/);
     // Old footer note must NOT appear when banner is shown.
     assert.doesNotMatch(out, /^note: \d+\/\d+ sessions used even-split/m);
@@ -210,6 +213,50 @@ describe('formatHotspotsReport', () => {
       out,
       /⚠ attribution is degraded: 39,486 of 39,587 sessions \(99\.7%\)/,
     );
+  });
+
+  it('renders the Bash verb rollup before the exact-command rollup', () => {
+    const result = makeResult([session('a', 'sized')]);
+    const bashVerbs: BashVerbAggregation[] = [
+      {
+        verb: 'git diff',
+        callCount: 5,
+        distinctCommands: 2,
+        totalCost: 31,
+        initialTokens: 500,
+        persistenceTokens: 80,
+        avgPersistenceTurns: 1.6,
+        topExamples: ['git diff src/b.ts', 'git diff src/a.ts'],
+      },
+    ];
+    const bashes: BashAggregation[] = [
+      {
+        argsHash: 'git:diff:b',
+        command: 'git diff src/b.ts',
+        callCount: 3,
+        totalCost: 21,
+        initialTokens: 300,
+        persistenceTokens: 60,
+      },
+    ];
+    const out = formatHotspotsReport({
+      turnsAnalyzed: 100,
+      result,
+      files: NO_FILES,
+      bashVerbs,
+      bashes,
+      subagents: NO_SUBAGENTS,
+      limit: 10,
+      degraded: false,
+    });
+
+    const verbIndex = out.indexOf('Top Bash verbs by cost');
+    const exactIndex = out.indexOf('Top exact Bash commands by cost');
+    assert.ok(verbIndex >= 0, 'verb heading present');
+    assert.ok(exactIndex > verbIndex, 'exact-command heading follows verb heading');
+    assert.match(out, /verb\s+calls\s+commands\s+initial\(tok\)\s+persist\(tok\)/);
+    assert.match(out, /git diff\s+5\s+2\s+500\s+80\s+1\.6\s+\$31\.00/);
+    assert.match(out, /git diff src\/b\.ts; git diff src\/a\.ts/);
   });
 });
 
@@ -627,6 +674,59 @@ describe('runHotspotsAttribution — partial exclusion (#100)', () => {
     assert.equal(payload.fidelity.summary.byClass.full, 1);
     assert.equal(payload.fidelity.summary.byClass.partial, 1);
     assert.equal(payload.turnsAnalyzed, 1);
+  });
+
+  it('JSON mode includes bashVerbs next to exact Bash commands', async () => {
+    const pricing = await loadBuiltinPricing();
+    const turns: EnrichedTurn[] = [
+      makeTurn({
+        sessionId: 'bash-json',
+        messageId: 'm0',
+        turnIndex: 0,
+        source: 'claude-code',
+        fidelity: fidelityWith('full', 'per-turn'),
+        toolCalls: [
+          { id: 'bash-a', name: 'Bash', target: 'git diff src/a.ts', argsHash: 'git:diff:a' },
+        ],
+      }),
+      makeTurn({
+        sessionId: 'bash-json',
+        messageId: 'm1',
+        turnIndex: 1,
+        source: 'claude-code',
+        fidelity: fidelityWith('full', 'per-turn'),
+        usage: { input: 1000, output: 5, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
+      }),
+      makeTurn({
+        sessionId: 'bash-json',
+        messageId: 'm2',
+        turnIndex: 2,
+        source: 'claude-code',
+        fidelity: fidelityWith('full', 'per-turn'),
+        toolCalls: [
+          { id: 'bash-b', name: 'Bash', target: 'git diff src/b.ts', argsHash: 'git:diff:b' },
+        ],
+      }),
+      makeTurn({
+        sessionId: 'bash-json',
+        messageId: 'm3',
+        turnIndex: 3,
+        source: 'claude-code',
+        fidelity: fidelityWith('full', 'per-turn'),
+        usage: { input: 1000, output: 5, reasoning: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0 },
+      }),
+    ];
+
+    const { result, stdout } = await captureStdio(() =>
+      runHotspotsAttribution(args({ json: true }), turns, pricing, EMPTY_DEPS),
+    );
+    assert.equal(result, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.bashVerbs[0].verb, 'git diff');
+    assert.equal(payload.bashVerbs[0].callCount, 2);
+    assert.equal(payload.bashVerbs[0].distinctCommands, 2);
+    assert.deepEqual(payload.bashVerbs[0].topExamples, ['git diff src/a.ts', 'git diff src/b.ts']);
+    assert.equal(payload.bash.length, 2);
   });
 });
 

--- a/packages/cli/src/commands/hotspots.ts
+++ b/packages/cli/src/commands/hotspots.ts
@@ -1,5 +1,6 @@
 import {
   aggregateByBash,
+  aggregateByBashVerb,
   aggregateByFile,
   aggregateBySubagent,
   attributeHotspots,
@@ -24,6 +25,7 @@ import {
   toolOutputBloatToFinding,
   userClaudeSettingsPath,
   type BashAggregation,
+  type BashVerbAggregation,
   type FidelitySummary,
   type FileAggregation,
   type GhostSurfaceFinding,
@@ -51,6 +53,7 @@ import type {
   ToolResultEventRecord,
   UserTurnRecord,
 } from '@relayburn/reader';
+import { parseBashCommand } from '@relayburn/reader';
 
 import { ingestAll } from '../ingest.js';
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
@@ -309,6 +312,7 @@ export async function runHotspotsAttribution(
             attributionDegraded: false,
             sessions: [],
             files: [],
+            bashVerbs: [],
             bash: [],
             subagents: [],
             fidelity: {
@@ -341,6 +345,7 @@ export async function runHotspotsAttribution(
     userTurnsBySession,
   });
   const files = aggregateByFile(result.attributions);
+  const bashVerbs = aggregateByBashVerb(result.attributions, parseBashCommand);
   const bashes = aggregateByBash(result.attributions);
   const subagents = aggregateBySubagent(result.attributions);
   const degraded = isAttributionDegraded(result);
@@ -361,6 +366,7 @@ export async function runHotspotsAttribution(
           attributionDegraded: degraded,
           sessions: result.sessionTotals,
           files,
+          bashVerbs,
           bash: bashes,
           subagents,
           fidelity: {
@@ -384,6 +390,7 @@ export async function runHotspotsAttribution(
     turnsAnalyzed: eligible.length,
     result,
     files,
+    bashVerbs,
     bashes,
     subagents,
     limit,
@@ -426,6 +433,7 @@ interface FormatHotspotsReportInput {
   turnsAnalyzed: number;
   result: HotspotsResult;
   files: FileAggregation[];
+  bashVerbs?: BashVerbAggregation[];
   bashes: BashAggregation[];
   subagents: SubagentAggregation[];
   limit: number;
@@ -434,7 +442,7 @@ interface FormatHotspotsReportInput {
 }
 
 export function formatHotspotsReport(input: FormatHotspotsReportInput): string {
-  const { turnsAnalyzed, result, files, bashes, subagents, limit, degraded, coverageNotice } = input;
+  const { turnsAnalyzed, result, files, bashVerbs = [], bashes, subagents, limit, degraded, coverageNotice } = input;
   const evenSplitSessions = result.sessionTotals.filter(
     (s) => s.attributionMethod === 'even-split',
   );
@@ -500,7 +508,15 @@ export function formatHotspotsReport(input: FormatHotspotsReportInput): string {
   }
   out.push('');
 
-  out.push(`Top Bash commands by cost${approxSuffix}`);
+  out.push(`Top Bash verbs by cost${approxSuffix}`);
+  if (bashVerbs.length === 0) {
+    out.push('  (no Bash tool calls)');
+  } else {
+    out.push(renderBashVerbTable(bashVerbs, limit));
+  }
+  out.push('');
+
+  out.push(`Top exact Bash commands by cost${approxSuffix}`);
   if (bashes.length === 0) {
     out.push('  (no Bash tool calls)');
   } else {
@@ -534,6 +550,26 @@ function renderFileTable(files: FileAggregation[], limit: number, attributed: nu
       formatInt(f.ridingTurns),
       formatUsd(f.totalCost),
       `${pct.toFixed(1)}%`,
+    ]);
+  }
+  return table(rows);
+}
+
+function renderBashVerbTable(bashVerbs: BashVerbAggregation[], limit: number): string {
+  const rows: string[][] = [
+    ['verb', 'calls', 'commands', 'initial(tok)', 'persist(tok)', 'avgRide', 'cost', 'examples'],
+  ];
+  const slice = bashVerbs.slice(0, limit);
+  for (const b of slice) {
+    rows.push([
+      b.verb,
+      formatInt(b.callCount),
+      formatInt(b.distinctCommands),
+      formatInt(b.initialTokens),
+      formatInt(b.persistenceTokens),
+      b.avgPersistenceTurns.toFixed(1),
+      formatUsd(b.totalCost),
+      truncate(b.topExamples.map((example) => truncate(example, 40)).join('; '), 90),
     ]);
   }
   return table(rows);

--- a/packages/reader/CHANGELOG.md
+++ b/packages/reader/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/reader`.
 
 ## [Unreleased]
 
+### Added
+
+- Added `parseBashCommand()` for normalized Bash verb extraction from shell command strings.
+
 ## [1.2.1] - 2026-04-30
 
 ### Changed

--- a/packages/reader/src/classifier.test.ts
+++ b/packages/reader/src/classifier.test.ts
@@ -95,6 +95,7 @@ describe('parseBashCommand', () => {
     const cases: Array<[string, string]> = [
       ['pytest', 'pytest'],
       ['python -m pytest -q', 'pytest'],
+      ['python -I -X dev -m pytest -q', 'pytest'],
       ['vitest run', 'vitest'],
       ['bun test', 'bun test'],
       ['npm test', 'npm test'],
@@ -128,6 +129,20 @@ describe('parseBashCommand', () => {
       ['kubectl apply -f k8s/', 'kubectl apply'],
       ['terraform plan', 'terraform plan'],
       ['make build', 'make build'],
+    ];
+
+    for (const [cmd, expected] of cases) {
+      assert.equal(normalized(cmd), expected, cmd);
+    }
+  });
+
+  it('only treats Python -m as a module flag before script execution starts', () => {
+    const cases: Array<[string, string]> = [
+      ['python tool.py -m pytest', 'python'],
+      ['python ./scripts/tool.py -m pytest', 'python'],
+      ['python -c "print(1)" -m pytest', 'python'],
+      ['python -- tool.py -m pytest', 'python'],
+      ['python -m pytest tool.py', 'pytest'],
     ];
 
     for (const [cmd, expected] of cases) {

--- a/packages/reader/src/classifier.test.ts
+++ b/packages/reader/src/classifier.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { classifyActivity, countRetries, normalizeToolName } from './classifier.js';
+import { classifyActivity, countRetries, normalizeToolName, parseBashCommand } from './classifier.js';
 import type { ToolCall } from './types.js';
 
 const tc = (name: string, target?: string, id = name): ToolCall => {
@@ -81,6 +81,94 @@ describe('classifyActivity — tool-pattern classification', () => {
   it('classifies read-only tool turns as exploration', () => {
     const r = classifyActivity({ toolCalls: [tc('Read', '/a.ts'), tc('Grep', 'foo')] });
     assert.equal(r.activity, 'exploration');
+  });
+});
+
+describe('parseBashCommand', () => {
+  const normalized = (cmd: string): string => {
+    const parsed = parseBashCommand(cmd);
+    assert.ok(parsed, `expected parse for ${cmd}`);
+    return parsed.normalized;
+  };
+
+  it('normalizes representative classifier Bash pattern examples', () => {
+    const cases: Array<[string, string]> = [
+      ['pytest', 'pytest'],
+      ['python -m pytest -q', 'pytest'],
+      ['vitest run', 'vitest'],
+      ['bun test', 'bun test'],
+      ['npm test', 'npm test'],
+      ['pnpm run test', 'pnpm test'],
+      ['go test ./...', 'go test'],
+      ['cargo test', 'cargo test'],
+      ['node --test', 'node --test'],
+      ['make test', 'make test'],
+      ['git status', 'git status'],
+      ['git -C repo diff --stat', 'git diff'],
+      ['git show HEAD~1', 'git show'],
+      ['gh pr diff 123', 'gh pr diff'],
+      ['gh pr view 123', 'gh pr view'],
+      ['gh run view 99', 'gh run view'],
+      ['git push origin main', 'git push'],
+      ['git commit -m "x"', 'git commit'],
+      ['npm install', 'npm install'],
+      ['pip3 uninstall foo', 'pip3 uninstall'],
+      ['python -m pip install black', 'pip install'],
+      ['uv pip install ruff', 'uv pip install'],
+      ['go mod tidy', 'go mod tidy'],
+      ['brew update', 'brew update'],
+      ['apt-get install jq', 'apt-get install'],
+      ['prettier --check .', 'prettier'],
+      ['eslint . --fix', 'eslint'],
+      ['cargo fmt --check', 'cargo fmt'],
+      ['tsc --noEmit', 'tsc'],
+      ['./node_modules/.bin/eslint .', 'eslint'],
+      ['docker compose build api', 'docker compose build'],
+      ['docker build .', 'docker build'],
+      ['kubectl apply -f k8s/', 'kubectl apply'],
+      ['terraform plan', 'terraform plan'],
+      ['make build', 'make build'],
+    ];
+
+    for (const [cmd, expected] of cases) {
+      assert.equal(normalized(cmd), expected, cmd);
+    }
+  });
+
+  it('handles env, cd, subshell, shell-c, and first-segment wrappers', () => {
+    const cases: Array<[string, string]> = [
+      ['CI=1 NODE_ENV=test pytest -q', 'pytest'],
+      ['cd /tmp && git status', 'git status'],
+      ['cd /tmp; git status', 'git status'],
+      ['(git status)', 'git status'],
+      ['bash -c "git status"', 'git status'],
+      ['bash -lc "git status"', 'git status'],
+      ['bash --norc -c "git status"', 'git status'],
+      ['sh -c "pnpm run test"', 'pnpm test'],
+      ['git status | cat', 'git status'],
+      ['git status && git diff', 'git status'],
+      ['git status; git diff', 'git status'],
+    ];
+
+    for (const [cmd, expected] of cases) {
+      assert.equal(normalized(cmd), expected, cmd);
+    }
+  });
+
+  it('returns shell buckets for compound shell forms and null for empty input', () => {
+    assert.equal(parseBashCommand('   '), null);
+    assert.deepEqual(parseBashCommand('for f in *; do echo "$f"; done'), {
+      binary: '(shell)',
+      normalized: '(shell)',
+    });
+    assert.deepEqual(parseBashCommand('if true; then git status; fi'), {
+      binary: '(shell)',
+      normalized: '(shell)',
+    });
+    assert.deepEqual(parseBashCommand('cat <<EOF\nhello\nEOF'), {
+      binary: '(shell)',
+      normalized: '(shell)',
+    });
   });
 });
 

--- a/packages/reader/src/classifier.ts
+++ b/packages/reader/src/classifier.ts
@@ -20,6 +20,12 @@ export interface ClassificationResult {
   hasEdits: boolean;
 }
 
+export interface BashParse {
+  binary: string;
+  subcommand?: string;
+  normalized: string;
+}
+
 const EDIT_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
 const DELEGATION_TOOLS = new Set(['Agent', 'Task']);
 const READ_ONLY_TOOLS = new Set([
@@ -62,6 +68,379 @@ const TOOL_ALIASES: Record<string, string> = {
 
 export function normalizeToolName(name: string): string {
   return TOOL_ALIASES[name] ?? name;
+}
+
+const MULTIWORD_BINARIES = new Set([
+  'git',
+  'gh',
+  'npm',
+  'pnpm',
+  'yarn',
+  'bun',
+  'pip',
+  'pip3',
+  'uv',
+  'poetry',
+  'cargo',
+  'make',
+  'docker',
+  'kubectl',
+  'helm',
+  'terraform',
+  'brew',
+  'apt',
+  'apt-get',
+  'gem',
+  'bundle',
+  'go',
+]);
+
+const PACKAGE_RUNNERS = new Set(['npm', 'pnpm', 'yarn', 'bun']);
+const SHELL_BINARIES = new Set(['bash', 'sh', 'zsh']);
+const PYTHON_BINARIES = new Set(['python', 'python3']);
+const TWO_PART_SUBCOMMANDS: Record<string, Set<string>> = {
+  docker: new Set(['compose']),
+  gh: new Set(['pr', 'run', 'issue', 'repo', 'workflow', 'release']),
+  go: new Set(['mod']),
+  uv: new Set(['pip']),
+};
+const OPTION_TAKES_VALUE = new Set([
+  '-C',
+  '-c',
+  '-F',
+  '--config',
+  '--filter',
+  '--git-dir',
+  '--namespace',
+  '--prefix',
+  '--repo',
+  '--repository',
+  '--work-tree',
+]);
+
+export function parseBashCommand(command: string): BashParse | null {
+  return parseBashCommandInner(command, 0);
+}
+
+function parseBashCommandInner(command: string, depth: number): BashParse | null {
+  if (depth > 5) return shellParse();
+  let cmd = command.trim();
+  if (!cmd) return null;
+  if (hasHeredoc(cmd) || startsWithCompoundShellSyntax(cmd)) return shellParse();
+  if (!hasBalancedShellDelimiters(cmd)) return shellParse();
+
+  const unwrapped = unwrapSubshell(cmd);
+  if (unwrapped !== null) return parseBashCommandInner(unwrapped, depth + 1);
+
+  const withoutCd = stripLeadingCdPrefix(cmd);
+  if (withoutCd !== null) return parseBashCommandInner(withoutCd, depth + 1);
+
+  const first = firstTopLevelSegment(cmd);
+  if (first === null) return shellParse();
+  cmd = first.trim();
+  if (!cmd) return null;
+  if (hasHeredoc(cmd) || startsWithCompoundShellSyntax(cmd)) return shellParse();
+
+  const segmentUnwrapped = unwrapSubshell(cmd);
+  if (segmentUnwrapped !== null) {
+    return parseBashCommandInner(segmentUnwrapped, depth + 1);
+  }
+
+  const tokens = shellWords(cmd);
+  if (tokens === null) return shellParse();
+  let i = skipEnvAssignments(tokens, 0);
+  if (i >= tokens.length) return null;
+
+  const rawBinary = tokens[i]!;
+  const binary = normalizeBinary(rawBinary);
+
+  if (SHELL_BINARIES.has(binary)) {
+    const shellCommand = shellCommandArg(tokens, i + 1);
+    if (shellCommand !== null) return parseBashCommandInner(shellCommand, depth + 1);
+    return verb(binary);
+  }
+
+  if (binary === 'env') {
+    const envCommand = envCommandArgs(tokens, i + 1);
+    if (envCommand.length === 0) return null;
+    return parseBashCommandInner(envCommand.join(' '), depth + 1);
+  }
+
+  if (PYTHON_BINARIES.has(binary)) {
+    const parsed = parsePythonModule(tokens, i + 1);
+    if (parsed) return parsed;
+  }
+
+  if (binary === 'node' && tokens.slice(i + 1).includes('--test')) {
+    return verb(binary, '--test');
+  }
+
+  const subIndex = skipLeadingOptions(tokens, i + 1);
+  if (subIndex >= tokens.length || !MULTIWORD_BINARIES.has(binary)) {
+    return verb(binary);
+  }
+
+  let subcommand = tokens[subIndex]!;
+  if (PACKAGE_RUNNERS.has(binary) && subcommand === 'run' && subIndex + 1 < tokens.length) {
+    subcommand = tokens[subIndex + 1]!;
+  } else {
+    const nested = TWO_PART_SUBCOMMANDS[binary];
+    if (nested?.has(subcommand) && subIndex + 1 < tokens.length) {
+      subcommand = `${subcommand} ${tokens[subIndex + 1]!}`;
+    }
+  }
+
+  return verb(binary, subcommand);
+}
+
+function verb(binary: string, subcommand?: string): BashParse {
+  if (!subcommand) return { binary, normalized: binary };
+  return { binary, subcommand, normalized: `${binary} ${subcommand}` };
+}
+
+function shellParse(): BashParse {
+  return { binary: '(shell)', normalized: '(shell)' };
+}
+
+function hasHeredoc(cmd: string): boolean {
+  return /<<-?\s*\S+/.test(cmd);
+}
+
+function startsWithCompoundShellSyntax(cmd: string): boolean {
+  return /^(?:for|while|until|if|case|select|function)\b/.test(cmd) || /^\{\s/.test(cmd);
+}
+
+function hasBalancedShellDelimiters(cmd: string): boolean {
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let depth = 0;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth < 0) return false;
+    }
+  }
+  return quote === null && depth === 0;
+}
+
+function unwrapSubshell(cmd: string): string | null {
+  if (!cmd.startsWith('(') || !cmd.endsWith(')')) return null;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let depth = 0;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0 && i !== cmd.length - 1) return null;
+      if (depth < 0) return null;
+    }
+  }
+  if (quote || depth !== 0) return null;
+  return cmd.slice(1, -1).trim();
+}
+
+function stripLeadingCdPrefix(cmd: string): string | null {
+  const op = firstTopLevelOperator(cmd, ['&&', ';']);
+  if (!op) return null;
+  const before = cmd.slice(0, op.index).trim();
+  const words = shellWords(before);
+  if (words === null) return null;
+  const commandIndex = skipEnvAssignments(words, 0);
+  if (words[commandIndex] !== 'cd') return null;
+  return cmd.slice(op.index + op.operator.length).trim();
+}
+
+function firstTopLevelSegment(cmd: string): string | null {
+  const op = firstTopLevelOperator(cmd, ['&&', '||', ';', '|', '\n']);
+  if (!op) return cmd;
+  return cmd.slice(0, op.index);
+}
+
+function firstTopLevelOperator(
+  cmd: string,
+  operators: readonly string[],
+): { index: number; operator: string } | null {
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let depth = 0;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === '(') {
+      depth++;
+      continue;
+    }
+    if (ch === ')') {
+      depth--;
+      if (depth < 0) return null;
+      continue;
+    }
+    if (depth !== 0) continue;
+    for (const operator of operators) {
+      if (cmd.startsWith(operator, i)) return { index: i, operator };
+    }
+  }
+  if (quote || depth !== 0) return null;
+  return null;
+}
+
+function shellWords(segment: string): string[] | null {
+  const words: string[] = [];
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let current = '';
+  for (let i = 0; i < segment.length; i++) {
+    const ch = segment[i]!;
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        words.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (escaped) current += '\\';
+  if (quote) return null;
+  if (current) words.push(current);
+  return words;
+}
+
+function skipEnvAssignments(tokens: string[], start: number): number {
+  let i = start;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i]!)) i++;
+  return i;
+}
+
+function skipLeadingOptions(tokens: string[], start: number): number {
+  let i = start;
+  while (i < tokens.length) {
+    const token = tokens[i]!;
+    if (token === '--') return i + 1;
+    if (!token.startsWith('-')) return i;
+    const optionName = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
+    i++;
+    if (!token.includes('=') && OPTION_TAKES_VALUE.has(optionName) && i < tokens.length) i++;
+  }
+  return i;
+}
+
+function shellCommandArg(tokens: string[], start: number): string | null {
+  for (let i = start; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (token === '-c' || (token.startsWith('-') && !token.startsWith('--') && token.includes('c'))) {
+      return tokens[i + 1] ?? null;
+    }
+  }
+  return null;
+}
+
+function envCommandArgs(tokens: string[], start: number): string[] {
+  let i = start;
+  while (i < tokens.length) {
+    const token = tokens[i]!;
+    if (token === '--') {
+      i++;
+      break;
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+      i++;
+      continue;
+    }
+    if (token.startsWith('-')) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  return tokens.slice(i);
+}
+
+function parsePythonModule(tokens: string[], start: number): BashParse | null {
+  const moduleFlag = tokens.indexOf('-m', start);
+  if (moduleFlag === -1 || moduleFlag + 1 >= tokens.length) return null;
+  const module = normalizeBinary(tokens[moduleFlag + 1]!);
+  if (module === 'pytest') return verb('pytest');
+  if (module === 'pip' || module === 'pip3') {
+    const subIndex = skipLeadingOptions(tokens, moduleFlag + 2);
+    if (subIndex < tokens.length) return verb(module, tokens[subIndex]!);
+    return verb(module);
+  }
+  return verb(module);
+}
+
+function normalizeBinary(raw: string): string {
+  const parts = raw.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? raw;
 }
 
 // Bash command heuristics. Match on the first non-env token after stripping

--- a/packages/reader/src/classifier.ts
+++ b/packages/reader/src/classifier.ts
@@ -117,6 +117,13 @@ const OPTION_TAKES_VALUE = new Set([
   '--repository',
   '--work-tree',
 ]);
+const PYTHON_OPTION_TAKES_VALUE = new Set([
+  '-c',
+  '-m',
+  '-W',
+  '-X',
+  '--check-hash-based-pycs',
+]);
 
 export function parseBashCommand(command: string): BashParse | null {
   return parseBashCommandInner(command, 0);
@@ -426,8 +433,8 @@ function envCommandArgs(tokens: string[], start: number): string[] {
 }
 
 function parsePythonModule(tokens: string[], start: number): BashParse | null {
-  const moduleFlag = tokens.indexOf('-m', start);
-  if (moduleFlag === -1 || moduleFlag + 1 >= tokens.length) return null;
+  const moduleFlag = findPythonModuleFlag(tokens, start);
+  if (moduleFlag === null || moduleFlag + 1 >= tokens.length) return null;
   const module = normalizeBinary(tokens[moduleFlag + 1]!);
   if (module === 'pytest') return verb('pytest');
   if (module === 'pip' || module === 'pip3') {
@@ -436,6 +443,20 @@ function parsePythonModule(tokens: string[], start: number): BashParse | null {
     return verb(module);
   }
   return verb(module);
+}
+
+function findPythonModuleFlag(tokens: string[], start: number): number | null {
+  for (let i = start; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (token === '--') return null;
+    if (token === '-m') return i;
+    if (token === '-c') return null;
+    if (!token.startsWith('-') || token === '-') return null;
+
+    const optionName = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
+    if (!token.includes('=') && PYTHON_OPTION_TAKES_VALUE.has(optionName)) i++;
+  }
+  return null;
 }
 
 function normalizeBinary(raw: string): string {

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -26,8 +26,8 @@ export type {
   UsageGranularity,
 } from './types.js';
 export { classifyFidelity, makeFidelity, EMPTY_COVERAGE } from './fidelity.js';
-export { classifyActivity, countRetries, normalizeToolName } from './classifier.js';
-export type { ClassificationInput, ClassificationResult } from './classifier.js';
+export { classifyActivity, countRetries, normalizeToolName, parseBashCommand } from './classifier.js';
+export type { BashParse, ClassificationInput, ClassificationResult } from './classifier.js';
 export type { UserTurnTokenizer } from './userTurn.js';
 export {
   parseClaudeSession,


### PR DESCRIPTION
## Summary
- add `parseBashCommand()` to normalize Bash commands across env/cd/shell wrappers and first shell segments
- add `aggregateByBashVerb()` with distinct command counts, persistence tokens, average ride turns, and top examples
- render Bash verb rollups before exact-command rows in `burn hotspots` and per-session reports, including JSON fields

## Tests
- `pnpm run build`
- `pnpm run test`
- `node --test --test-reporter=spec packages/reader/dist/classifier.test.js`

Closes #216