### PR TITLE
Make @relayburn/sdk the source of truth, have MCP consume it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,11 +84,12 @@ jobs:
       - name: Resolve target packages
         id: targets
         run: |
-          # Dependency order: reader → ledger → analyze → ingest → mcp → cli → sdk → relayburn.
-          # `cli` depends on ingest; `sdk` depends on ingest/ledger/analyze;
-          # `relayburn` is a thin wrapper that depends on `@relayburn/cli`, so
-          # cli must publish before both.
-          echo "packages=reader ledger analyze ingest mcp cli sdk relayburn" >> "$GITHUB_OUTPUT"
+          # Dependency order: reader → ledger → analyze → ingest → sdk → mcp → cli → relayburn.
+          # `sdk` depends on ingest/ledger/analyze; `mcp` depends on sdk
+          # (MCP tools are thin wrappers over SDK functions); `cli` depends
+          # on ingest + mcp; `relayburn` is a thin wrapper that depends on
+          # `@relayburn/cli`, so cli must publish before relayburn.
+          echo "packages=reader ledger analyze ingest sdk mcp cli relayburn" >> "$GITHUB_OUTPUT"
 
       # Catch the failure mode that bit us on 2026-04-23: a previous publish
       # run shipped @relayburn/*@0.3.0 to npm but failed at the Tag + push
@@ -647,7 +648,7 @@ jobs:
           const canonicalPkg = process.env.CANONICAL_PKG;
           const canonicalVersion = process.env.CANONICAL_VERSION;
 
-          const packageOrder = ['reader', 'ledger', 'analyze', 'ingest', 'mcp', 'cli', 'sdk', 'relayburn'];
+          const packageOrder = ['reader', 'ledger', 'analyze', 'ingest', 'sdk', 'mcp', 'cli', 'relayburn'];
           const entries = versionsRaw.trim().split(/\s+/).filter(Boolean).map((entry) => {
             const idx = entry.indexOf(':');
             return { pkg: entry.slice(0, idx), ver: entry.slice(idx + 1) };

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,15 @@ pnpm workspace, eight published packages in dependency order:
 @relayburn/ledger   — append-only JSONL ledger + content sidecar at ~/.relayburn/
 @relayburn/analyze  — pricing + per-record cost derivation + comparison aggregator
 @relayburn/ingest   — session-store discovery + parse-and-append orchestration + pending stamps + watch loop
-@relayburn/mcp      — stdio MCP server exposing read-only ledger queries for in-session self-query
+@relayburn/sdk      — embeddable Node API (`ingest`, `summary`, `sessionCost`, `hotspots`); source of truth for the in-process query surface
+@relayburn/mcp      — stdio MCP server exposing read-only ledger queries for in-session self-query (thin wrappers over `@relayburn/sdk`)
 @relayburn/cli      — `burn` binary (summary, hotspots, overhead, compare, `burn run <harness>` wrapper, mcp-server, …)
-@relayburn/sdk      — embeddable Node API (`ingest`, `summary`, `hotspots`) for in-process use
 relayburn           — thin install-wrapper so `npm i -g relayburn` exposes the same `burn` bin as `@relayburn/cli`
 ```
 
-`reader → ledger → analyze → ingest → mcp → cli → sdk → relayburn`. Always build the whole workspace; never touch a single package's `tsconfig.tsbuildinfo` to "skip" a dep.
+`reader → ledger → analyze → ingest → sdk → mcp → cli → relayburn`. Always build the whole workspace; never touch a single package's `tsconfig.tsbuildinfo` to "skip" a dep.
+
+`@relayburn/sdk` owns the canonical query/compute surface — every new read verb should land there first as a pure function. `@relayburn/mcp` and `@relayburn/cli` are presenters: MCP wraps SDK calls in tool definitions, CLI wraps them in flag parsing + table rendering. Don't duplicate query logic across CLI/MCP — extract it into SDK.
 
 ## Common commands
 
@@ -74,7 +76,7 @@ Breaking changes: append `!` to a Conventional Commits prefix (e.g. `feat!:`) to
 
 The workflow:
 1. Builds + tests the whole workspace.
-2. Bumps `package.json` versions in dep order (reader → ledger → analyze → ingest → mcp → cli → sdk → relayburn).
+2. Bumps `package.json` versions in dep order (reader → ledger → analyze → ingest → sdk → mcp → cli → relayburn).
 3. Generates changelog entries from `git log <pkg>-v<last>..HEAD -- packages/<pkg>`.
 4. Publishes via `pnpm pack` + `npm publish` using OIDC trusted-publisher auth (no `NPM_TOKEN`).
 5. Tags `<pkg>-v<version>` and creates a GitHub Release with the changelog body.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Changed
+
+- **Architecture: `@relayburn/sdk` is now the canonical in-process query surface.** Dependency order moves from `… → mcp → cli → sdk → relayburn` to `… → sdk → mcp → cli → relayburn`; `@relayburn/mcp` now depends on `@relayburn/sdk` and rewrites `burn__sessionCost` as a thin wrapper over the SDK's new `sessionCost()` function. New read verbs should land in the SDK first; MCP and CLI become presenters (tool definitions / table rendering) over the same SDK calls so query logic stops drifting between them.
+
 ## [1.8.0] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ Reports read local data from the ledger and derived sidecars.
 | `@relayburn/ledger` | JSONL ledger, stamps, indexes, content sidecars, archive. |
 | `@relayburn/analyze` | Pricing, attribution, comparisons, overhead, and quality. |
 | `@relayburn/ingest` | Session-store discovery, parse-and-append orchestration, pending stamps, watch loop. |
-| `@relayburn/mcp` | Read-only MCP tools for in-session self-query. |
+| `@relayburn/sdk` | Embeddable Node API: `ingest`, `summary`, `sessionCost`, `hotspots`. Source of truth for the in-process query surface. |
+| `@relayburn/mcp` | Read-only MCP tools for in-session self-query. Thin wrappers over `@relayburn/sdk`. |
 | `@relayburn/cli` | The `burn` binary. |
-| `@relayburn/sdk` | Embeddable Node API: `ingest`, `summary`, `hotspots`. |
 | `relayburn` | Thin install wrapper so `npm i -g relayburn` exposes `burn`. |
 
 ## Development

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@relayburn/mcp`.
 
 ## [Unreleased]
 
+### Changed
+
+- `burn__sessionCost` is now a thin wrapper over `@relayburn/sdk`'s new `sessionCost()` function. The wire shape is unchanged (`sessionId`, `totalUSD`, `totalTokens`, `turnCount`, `models`, `note?`); the cost computation, archive-with-fallback strategy, and pricing snapshot all live in the SDK now, eliminating the duplicate query path that previously lived inside the MCP tool.
+- `@relayburn/mcp` now depends on `@relayburn/sdk`. The package's role going forward is "MCP-shaped wrapper over the SDK's query surface" — new tools should call SDK functions rather than re-implementing computation against `@relayburn/analyze` / `@relayburn/ledger`.
+
 ## [1.6.2] - 2026-05-02
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@relayburn/reader": "workspace:*",
     "@relayburn/ledger": "workspace:*",
-    "@relayburn/analyze": "workspace:*"
+    "@relayburn/analyze": "workspace:*",
+    "@relayburn/sdk": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp/src/end-to-end.test.ts
+++ b/packages/mcp/src/end-to-end.test.ts
@@ -2,9 +2,6 @@ import { strict as assert } from 'node:assert';
 import { PassThrough } from 'node:stream';
 import { describe, it } from 'node:test';
 
-import type { PricingTable } from '@relayburn/analyze';
-import type { EnrichedTurn } from '@relayburn/ledger';
-
 import { startStdioServer } from './server.js';
 import { createSessionCostTool } from './tools/session-cost.js';
 
@@ -13,38 +10,6 @@ interface JsonRpcResponse {
   id: number | string | null;
   result?: { content: { type: string; text: string }[]; structuredContent?: unknown };
   error?: { code: number; message: string };
-}
-
-const PRICING: PricingTable = {
-  'claude-sonnet-4-5': {
-    input: 3,
-    output: 15,
-    cacheRead: 0.3,
-    cacheWrite: 3.75,
-    reasoningMode: 'same_as_output',
-  },
-};
-
-function turn(): EnrichedTurn {
-  return {
-    v: 1,
-    source: 'claude-code',
-    sessionId: 'S',
-    messageId: 'm1',
-    turnIndex: 0,
-    ts: '2026-04-24T10:00:00.000Z',
-    model: 'claude-sonnet-4-5',
-    usage: {
-      input: 1_000_000,
-      output: 0,
-      reasoning: 0,
-      cacheRead: 0,
-      cacheCreate5m: 0,
-      cacheCreate1h: 0,
-    },
-    toolCalls: [],
-    enrichment: {},
-  };
 }
 
 function collectResponses(stream: PassThrough): Promise<JsonRpcResponse[]> {
@@ -70,14 +35,19 @@ function send(stream: PassThrough, msg: unknown): void {
 }
 
 describe('end-to-end: spawn server, call burn__sessionCost, verify cost', () => {
-  it('returns the same total a direct cost computation would', async () => {
+  it('returns the same totals the SDK sessionCost would produce', async () => {
     const input = new PassThrough();
     const output = new PassThrough();
     const responses = collectResponses(output);
     const sessionCost = createSessionCostTool({
       defaultSessionId: 'S',
-      queryTurns: async () => [turn()],
-      loadPricing: async () => PRICING,
+      sessionCost: async (opts) => ({
+        sessionId: opts.session ?? null,
+        totalUSD: 3,
+        totalTokens: 1_000_000,
+        turnCount: 1,
+        models: ['claude-sonnet-4-5'],
+      }),
     });
     const server = startStdioServer({
       name: '@relayburn/mcp',
@@ -111,8 +81,6 @@ describe('end-to-end: spawn server, call burn__sessionCost, verify cost', () => 
     assert.ok(callResp.result, 'tool call returned a result');
     const text = callResp.result.content[0]!.text;
     const parsed = JSON.parse(text) as { totalUSD: number; turnCount: number; sessionId: string };
-    // 1M input @ $3/M = $3, matching what `burn summary --session S` would
-    // report for the same turns and pricing.
     assert.equal(parsed.totalUSD, 3);
     assert.equal(parsed.turnCount, 1);
     assert.equal(parsed.sessionId, 'S');

--- a/packages/mcp/src/tools/archive-backed.test.ts
+++ b/packages/mcp/src/tools/archive-backed.test.ts
@@ -41,16 +41,6 @@ function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
   };
 }
 
-const PRICING_LOADER = async () => ({
-  'claude-sonnet-4-5': {
-    input: 3,
-    output: 15,
-    cacheRead: 0.3,
-    cacheWrite: 3.75,
-    reasoningMode: 'same_as_output' as const,
-  },
-});
-
 describe('MCP tool handlers backed by archive (issue #97)', () => {
   let tmpDir: string;
   const originalHome = process.env['RELAYBURN_HOME'];
@@ -98,7 +88,6 @@ describe('MCP tool handlers backed by archive (issue #97)', () => {
 
       const tool = createSessionCostTool({
         defaultSessionId: 's-cost',
-        loadPricing: PRICING_LOADER,
       });
       const result = (await tool.handler({})) as SessionCostResult;
       assert.equal(result.sessionId, 's-cost');
@@ -137,7 +126,6 @@ describe('MCP tool handlers backed by archive (issue #97)', () => {
 
       const tool = createSessionCostTool({
         defaultSessionId: 's-cost',
-        loadPricing: PRICING_LOADER,
       });
       const result = (await tool.handler({})) as SessionCostResult;
       assert.equal(result.turnCount, 2);
@@ -157,7 +145,6 @@ describe('MCP tool handlers backed by archive (issue #97)', () => {
       const logs: string[] = [];
       const tool = createSessionCostTool({
         defaultSessionId: 's-cost',
-        loadPricing: PRICING_LOADER,
         onLog: (m) => logs.push(m),
       });
       const result = (await tool.handler({})) as SessionCostResult;
@@ -166,7 +153,7 @@ describe('MCP tool handlers backed by archive (issue #97)', () => {
       // 1M input @ $3/M = $3.
       assert.equal(result.totalUSD, 3);
       assert.ok(
-        logs.some((m) => /sessionCost: archive query failed/.test(m)),
+        logs.some((m) => /archive query failed/.test(m)),
         `expected an archive-fallback log line, got: ${JSON.stringify(logs)}`,
       );
     });

--- a/packages/mcp/src/tools/session-cost.test.ts
+++ b/packages/mcp/src/tools/session-cost.test.ts
@@ -1,67 +1,42 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import type { PricingTable } from '@relayburn/analyze';
-import type { EnrichedTurn } from '@relayburn/ledger';
-
 import { createSessionCostTool, type SessionCostResult } from './session-cost.js';
 
-const PRICING: PricingTable = {
-  'claude-sonnet-4-5': {
-    input: 3,
-    output: 15,
-    cacheRead: 0.3,
-    cacheWrite: 3.75,
-    reasoningMode: 'same_as_output',
-  },
-};
-
-function turn(overrides: Partial<EnrichedTurn> = {}): EnrichedTurn {
-  return {
-    v: 1,
-    source: 'claude-code',
-    sessionId: 's1',
-    messageId: 'm1',
-    turnIndex: 0,
-    ts: '2026-04-24T10:00:00.000Z',
-    model: 'claude-sonnet-4-5',
-    usage: {
-      input: 1000,
-      output: 500,
-      reasoning: 0,
-      cacheRead: 0,
-      cacheCreate5m: 0,
-      cacheCreate1h: 0,
-    },
-    toolCalls: [],
-    enrichment: {},
-    ...overrides,
-  };
-}
-
 describe('createSessionCostTool', () => {
-  it('returns zero totals when defaultSessionId is missing and no override given', async () => {
+  it('returns the SDK no-session shape with the MCP-specific note when no id is registered', async () => {
     const tool = createSessionCostTool({
       defaultSessionId: undefined,
-      queryTurns: async () => [],
-      loadPricing: async () => PRICING,
+      sessionCost: async () => ({
+        sessionId: null,
+        totalUSD: 0,
+        totalTokens: 0,
+        turnCount: 0,
+        models: [],
+        note: 'no session id provided',
+      }),
     });
     const result = (await tool.handler({})) as SessionCostResult;
     assert.equal(result.sessionId, null);
     assert.equal(result.totalUSD, 0);
     assert.equal(result.turnCount, 0);
-    assert.match(result.note ?? '', /no session id/);
+    assert.match(result.note ?? '', /no session id provided and server was not registered/);
   });
 
   it('uses the override sessionId when provided', async () => {
     let queriedFor: string | undefined;
     const tool = createSessionCostTool({
       defaultSessionId: 'default-id',
-      queryTurns: async (id) => {
-        queriedFor = id;
-        return [turn({ sessionId: id })];
+      sessionCost: async (opts) => {
+        queriedFor = opts.session;
+        return {
+          sessionId: opts.session ?? null,
+          totalUSD: 0,
+          totalTokens: 0,
+          turnCount: 1,
+          models: ['claude-sonnet-4-5'],
+        };
       },
-      loadPricing: async () => PRICING,
     });
     await tool.handler({ sessionId: 'override-id' });
     assert.equal(queriedFor, 'override-id');
@@ -71,63 +46,60 @@ describe('createSessionCostTool', () => {
     let queriedFor: string | undefined;
     const tool = createSessionCostTool({
       defaultSessionId: 'baked-id',
-      queryTurns: async (id) => {
-        queriedFor = id;
-        return [];
+      sessionCost: async (opts) => {
+        queriedFor = opts.session;
+        return {
+          sessionId: opts.session ?? null,
+          totalUSD: 0,
+          totalTokens: 0,
+          turnCount: 0,
+          models: [],
+        };
       },
-      loadPricing: async () => PRICING,
     });
     await tool.handler({});
     assert.equal(queriedFor, 'baked-id');
   });
 
-  it('aggregates usage and cost across turns', async () => {
-    const turns: EnrichedTurn[] = [
-      turn({
-        usage: {
-          input: 1_000_000,
-          output: 0,
-          reasoning: 0,
-          cacheRead: 0,
-          cacheCreate5m: 0,
-          cacheCreate1h: 0,
-        },
-      }),
-      turn({
-        messageId: 'm2',
-        turnIndex: 1,
-        usage: {
-          input: 0,
-          output: 1_000_000,
-          reasoning: 0,
-          cacheRead: 0,
-          cacheCreate5m: 0,
-          cacheCreate1h: 0,
-        },
-      }),
-    ];
+  it('returns the SDK result verbatim when a session id is present', async () => {
     const tool = createSessionCostTool({
       defaultSessionId: 's1',
-      queryTurns: async () => turns,
-      loadPricing: async () => PRICING,
+      sessionCost: async (opts) => ({
+        sessionId: opts.session ?? null,
+        totalUSD: 18,
+        totalTokens: 2_000_000,
+        turnCount: 2,
+        models: ['claude-sonnet-4-5'],
+      }),
     });
     const result = (await tool.handler({})) as SessionCostResult;
+    assert.equal(result.sessionId, 's1');
     assert.equal(result.turnCount, 2);
     assert.equal(result.totalTokens, 2_000_000);
-    // 1M input @ $3/M + 1M output @ $15/M = $18.
     assert.equal(result.totalUSD, 18);
     assert.deepEqual(result.models, ['claude-sonnet-4-5']);
+    assert.equal(result.note, undefined);
   });
 
-  it('records a note when the session has no turns yet', async () => {
+  it('passes the host onLog through to the SDK so archive-fallback messages surface', async () => {
+    let captured: ((msg: string) => void) | undefined;
     const tool = createSessionCostTool({
       defaultSessionId: 's1',
-      queryTurns: async () => [],
-      loadPricing: async () => PRICING,
+      onLog: () => {},
+      sessionCost: async (opts) => {
+        captured = opts.onLog;
+        return {
+          sessionId: opts.session ?? null,
+          totalUSD: 0,
+          totalTokens: 0,
+          turnCount: 0,
+          models: [],
+          note: 'no turns recorded for this session yet',
+        };
+      },
     });
-    const result = (await tool.handler({})) as SessionCostResult;
-    assert.equal(result.turnCount, 0);
-    assert.match(result.note ?? '', /no turns recorded/);
+    await tool.handler({});
+    assert.equal(typeof captured, 'function');
   });
 
   it('declares its tool surface (name, description, schema)', () => {

--- a/packages/mcp/src/tools/session-cost.ts
+++ b/packages/mcp/src/tools/session-cost.ts
@@ -1,7 +1,5 @@
-import { costForTurn, loadPricing, sumCosts } from '@relayburn/analyze';
-import type { PricingTable } from '@relayburn/analyze';
-import { buildArchive, queryAll, queryTurnsFromArchive } from '@relayburn/ledger';
-import type { EnrichedTurn } from '@relayburn/ledger';
+import { sessionCost as sdkSessionCost } from '@relayburn/sdk';
+import type { SessionCostResult as SdkSessionCostResult } from '@relayburn/sdk';
 
 import type { ToolDefinition } from '../types.js';
 
@@ -9,50 +7,24 @@ export interface SessionCostInput {
   sessionId?: string;
 }
 
-export interface SessionCostResult {
-  sessionId: string | null;
-  totalUSD: number;
-  totalTokens: number;
-  turnCount: number;
-  models: string[];
-  note?: string;
-}
+export type SessionCostResult = SdkSessionCostResult;
 
 export interface SessionCostDeps {
   defaultSessionId: string | undefined;
-  queryTurns?: (sessionId: string) => Promise<EnrichedTurn[]>;
-  loadPricing?: () => Promise<PricingTable>;
   /**
-   * Called when the default archive-backed `queryTurns` falls through to the
-   * ledger-walking `queryAll` because the archive open / query threw. Defaults
-   * to no-op so the MCP server stays quiet on the happy path; the CLI server
-   * wires this to stderr so failures are visible in the MCP host's log.
+   * Override for the SDK's `sessionCost(...)` call. Tests inject a fake to
+   * exercise the tool surface without touching the on-disk ledger.
+   */
+  sessionCost?: (opts: { session?: string; onLog?: (msg: string) => void }) => Promise<SdkSessionCostResult>;
+  /**
+   * Forwarded to `@relayburn/sdk` so archive-fallback log lines surface in
+   * whatever channel the host wired up (CLI server uses stderr).
    */
   onLog?: (msg: string) => void;
 }
 
 export function createSessionCostTool(deps: SessionCostDeps): ToolDefinition {
-  const log = deps.onLog ?? (() => {});
-  const queryTurns =
-    deps.queryTurns ??
-    (async (id: string) => {
-      // Hooks append new turns to the JSONL ledger throughout the session,
-      // but the archive is only materialized when something explicitly calls
-      // `buildArchive`. Run an incremental build before each query so the
-      // tool reflects fresh data. The build is
-      // idempotent + cursor-driven, so it's a no-op when nothing has changed
-      // since the last call.
-      try {
-        await buildArchive();
-        return await queryTurnsFromArchive({ sessionId: id });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        log(`sessionCost: archive query failed, falling back to ledger walk: ${msg}`);
-        return queryAll({ sessionId: id });
-      }
-    });
-  const pricingLoader = deps.loadPricing ?? loadPricing;
-
+  const callSessionCost = deps.sessionCost ?? sdkSessionCost;
   return {
     name: 'burn__sessionCost',
     description:
@@ -74,56 +46,18 @@ export function createSessionCostTool(deps: SessionCostDeps): ToolDefinition {
     handler: async (raw) => {
       const input = raw as SessionCostInput;
       const sessionId = input.sessionId ?? deps.defaultSessionId;
-      if (!sessionId) {
-        return {
-          sessionId: null,
-          totalUSD: 0,
-          totalTokens: 0,
-          turnCount: 0,
-          models: [],
-          note: 'no session id provided and server was not registered with one',
-        } satisfies SessionCostResult;
+      const opts: { session?: string; onLog?: (msg: string) => void } = {};
+      if (sessionId !== undefined) opts.session = sessionId;
+      if (deps.onLog !== undefined) opts.onLog = deps.onLog;
+      const result = await callSessionCost(opts);
+      // The SDK's "no session id" note is generic ("no session id provided");
+      // keep the more descriptive variant the MCP tool used to surface so the
+      // hint that the *server* should have been registered with one stays
+      // visible to MCP clients.
+      if (result.sessionId === null && sessionId === undefined) {
+        return { ...result, note: 'no session id provided and server was not registered with one' };
       }
-      const turns = await queryTurns(sessionId);
-      if (turns.length === 0) {
-        return {
-          sessionId,
-          totalUSD: 0,
-          totalTokens: 0,
-          turnCount: 0,
-          models: [],
-          note: 'no turns recorded for this session yet',
-        } satisfies SessionCostResult;
-      }
-      const pricing = await pricingLoader();
-      const models = new Set<string>();
-      let totalTokens = 0;
-      const costs = [];
-      for (const t of turns) {
-        models.add(t.model);
-        const u = t.usage;
-        totalTokens +=
-          (u.input ?? 0) +
-          (u.output ?? 0) +
-          (u.reasoning ?? 0) +
-          (u.cacheRead ?? 0) +
-          (u.cacheCreate5m ?? 0) +
-          (u.cacheCreate1h ?? 0);
-        const c = costForTurn(t, pricing);
-        if (c) costs.push(c);
-      }
-      const total = sumCosts(costs);
-      return {
-        sessionId,
-        totalUSD: round6(total.total),
-        totalTokens,
-        turnCount: turns.length,
-        models: [...models].sort(),
-      } satisfies SessionCostResult;
+      return result;
     },
   };
-}
-
-function round6(n: number): number {
-  return Math.round(n * 1_000_000) / 1_000_000;
 }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@relayburn/sdk`.
 
 ## [Unreleased]
 
+### Added
+
+- `sessionCost({ session })` returns the compact per-session cost shape (`totalUSD`, `totalTokens`, `turnCount`, `models`) the MCP `burn__sessionCost` tool now wraps directly.
+- `summary()` result now includes `turnCount`.
+- `summary()` and `sessionCost()` read through the SQLite archive by default with transparent fallback to the JSONL ledger walk on archive failure. Pass `onLog` to capture the fallback reason.
+
 ## [1.7.0] - 2026-05-02
 
 ### Added

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,12 +1,21 @@
 # @relayburn/sdk
 
-Embeddable Relayburn SDK for in-process ingestion and analysis.
+Embeddable Relayburn SDK for in-process ingestion and analysis. This package is the **source of truth** for the in-process query/compute surface — `@relayburn/mcp` and `@relayburn/cli` consume the SDK rather than duplicating its logic.
 
 ```ts
-import { Ledger, ingest, summary, hotspots } from '@relayburn/sdk';
+import { Ledger, ingest, summary, sessionCost, hotspots } from '@relayburn/sdk';
 
 await Ledger.open({ home: '/tmp/relayburn-home' });
 await ingest({ ledgerHome: '/tmp/relayburn-home' });
+
+// Slice-wide rollup: turnCount + per-model + per-tool aggregates.
 const stats = await summary({ session: 'session-id', ledgerHome: '/tmp/relayburn-home' });
+
+// Compact session-scoped cost shape (totalUSD/totalTokens/turnCount/models).
+// Powers the MCP `burn__sessionCost` tool.
+const cost = await sessionCost({ session: 'session-id' });
+
 const findings = await hotspots({ session: 'session-id', patterns: ['retry-loop'] });
 ```
+
+`summary` and `sessionCost` read through the SQLite archive when available, transparently falling back to the JSONL ledger walk if the archive can't be opened. Pass `onLog` to surface fallback messages in your host's log channel.

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -4,8 +4,38 @@ export declare class Ledger { static open(opts?: LedgerOpenOptions): Promise<Led
 export interface IngestOptions { sessionId?: string; harness?: 'claude-code'|'codex'|'opencode'; ledgerHome?: string }
 export declare function ingest(opts?: IngestOptions): Promise<unknown>
 
-export interface SummaryOptions { session?: string; project?: string; since?: string; ledgerHome?: string }
-export declare function summary(opts?: SummaryOptions): Promise<{ totalTokens: number; totalCost: number; byTool: Array<{tool:string;tokens:number;cost:number;count:number}>; byModel: Array<{model:string;tokens:number;cost:number}> }>
+export interface SummaryOptions {
+  session?: string;
+  project?: string;
+  since?: string;
+  ledgerHome?: string;
+  /** Optional logger invoked when the SQLite archive read fails and the SDK falls back to a full ledger walk. */
+  onLog?: (msg: string) => void;
+}
+export declare function summary(opts?: SummaryOptions): Promise<{
+  totalTokens: number;
+  totalCost: number;
+  turnCount: number;
+  byTool: Array<{ tool: string; tokens: number; cost: number; count: number }>;
+  byModel: Array<{ model: string; tokens: number; cost: number }>;
+}>
+
+export interface SessionCostOptions {
+  /** Session id to total. Omit for `{ note: 'no session id provided' }`. */
+  session?: string;
+  ledgerHome?: string;
+  onLog?: (msg: string) => void;
+}
+export interface SessionCostResult {
+  sessionId: string | null;
+  totalUSD: number;
+  totalTokens: number;
+  turnCount: number;
+  models: string[];
+  note?: string;
+}
+/** Compact session-scoped cost shape; powers the MCP `burn__sessionCost` tool. */
+export declare function sessionCost(opts?: SessionCostOptions): Promise<SessionCostResult>
 
 export interface HotspotsOptions {
   session?: string;

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -1,8 +1,16 @@
-import { queryAll, queryUserTurns, queryToolResultEvents } from '@relayburn/ledger';
+import {
+  buildArchive,
+  queryAll,
+  queryAllFromArchive,
+  queryTurnsFromArchive,
+  queryUserTurns,
+  queryToolResultEvents,
+} from '@relayburn/ledger';
 import {
   buildGhostSurfaceInputs,
   loadPricing,
   costForTurn,
+  sumCosts,
   attributeHotspots,
   detectPatterns,
   findingsFromPatterns,
@@ -29,6 +37,34 @@ function withHome(home, fn) {
   });
 }
 
+// Bring the SQLite archive current and query against it, falling back to a
+// full ledger walk if the archive can't be built or read. Mirrors the strategy
+// the CLI's loadTurns() uses so SDK consumers (and the MCP server, which now
+// calls through here) get the same hot-path performance without re-implementing
+// the fallback logic in every caller. `onLog` lets callers surface the
+// fallback reason; defaults to a no-op so library use stays quiet.
+async function loadTurnsViaArchive(q, onLog) {
+  try {
+    await buildArchive();
+    return await queryAllFromArchive(q);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    onLog?.(`archive query failed, falling back to ledger walk: ${msg}`);
+    return queryAll(q);
+  }
+}
+
+async function loadSessionTurnsViaArchive(sessionId, onLog) {
+  try {
+    await buildArchive();
+    return await queryTurnsFromArchive({ sessionId });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    onLog?.(`archive query failed, falling back to ledger walk: ${msg}`);
+    return queryAll({ sessionId });
+  }
+}
+
 export class Ledger {
   static async open(opts = {}) {
     return new Ledger(opts.home);
@@ -46,7 +82,7 @@ export async function ingest(opts = {}) {
 export async function summary(opts = {}) {
   return withHome(opts.ledgerHome, async () => {
     const q = { sessionId: opts.session, project: opts.project, since: opts.since };
-    const turns = await queryAll(q);
+    const turns = await loadTurnsViaArchive(q, opts.onLog);
     const pricing = await loadPricing();
     const byTool = new Map();
     const byModel = new Map();
@@ -79,7 +115,71 @@ export async function summary(opts = {}) {
       }
     }
 
-    return { totalTokens, totalCost, byTool: [...byTool.values()], byModel: [...byModel.values()] };
+    return {
+      totalTokens,
+      totalCost,
+      turnCount: turns.length,
+      byTool: [...byTool.values()],
+      byModel: [...byModel.values()],
+    };
+  });
+}
+
+// Compact session-scoped cost summary. Same numbers as `summary({ session })`
+// but shaped for callers that just want the headline: totalUSD, totalTokens,
+// turnCount, distinct models. The MCP `burn__sessionCost` tool wraps this
+// directly so the cost shape lives in one place. `note` is set when the
+// session is empty or when no session id was provided so MCP clients can
+// surface a human-readable reason without re-deriving it.
+export async function sessionCost(opts = {}) {
+  return withHome(opts.ledgerHome, async () => {
+    const sessionId = opts.session;
+    if (!sessionId) {
+      return {
+        sessionId: null,
+        totalUSD: 0,
+        totalTokens: 0,
+        turnCount: 0,
+        models: [],
+        note: 'no session id provided',
+      };
+    }
+    const turns = await loadSessionTurnsViaArchive(sessionId, opts.onLog);
+    if (turns.length === 0) {
+      return {
+        sessionId,
+        totalUSD: 0,
+        totalTokens: 0,
+        turnCount: 0,
+        models: [],
+        note: 'no turns recorded for this session yet',
+      };
+    }
+    const pricing = await loadPricing();
+    const models = new Set();
+    let totalTokens = 0;
+    const costs = [];
+    for (const t of turns) {
+      models.add(t.model);
+      const u = t.usage;
+      totalTokens +=
+        (u.input ?? 0) +
+        (u.output ?? 0) +
+        (u.reasoning ?? 0) +
+        (u.cacheRead ?? 0) +
+        (u.cacheCreate5m ?? 0) +
+        (u.cacheCreate1h ?? 0);
+      const c = costForTurn(t, pricing);
+      if (c) costs.push(c);
+    }
+    const total = sumCosts(costs);
+    return {
+      sessionId,
+      totalUSD: Math.round(total.total * 1_000_000) / 1_000_000,
+      totalTokens,
+      turnCount: turns.length,
+      models: [...models].sort(),
+    };
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@relayburn/reader':
         specifier: workspace:*
         version: link:../reader
+      '@relayburn/sdk':
+        specifier: workspace:*
+        version: link:../sdk
 
   packages/reader:
     dependencies:


### PR DESCRIPTION
## Summary

Counter-proposal to #210. Restructures the dep graph so `@relayburn/sdk` is the canonical in-process query/compute surface, then makes `@relayburn/mcp` consume it. New read verbs land in SDK first as pure functions; MCP and CLI become presenters (tool definitions / table rendering) over the same calls — drift between the two becomes a compile error instead of a silent skew.

This PR is the structural fix. Lifting all the existing CLI verbs (`compare`, `overhead`, `hotspots`, etc.) into SDK functions is the obvious follow-up but intentionally not included here — each one is a real refactor and deserves its own PR.

### Why not the original #210 plan (MCP shells out to `burn <verb> --json`)?

The duplication that #210 wants to eliminate is real, but the root cause is that *verb-level query logic lives inside CLI commands*. Subprocessing `burn` solves it by adding spawn overhead, a `burn`-on-PATH assumption, and a JSON parse round-trip on every MCP call. Routing through SDK fixes the same drift in-process, with no extra failure mode, and SDK gets the missing verbs as a free side effect for embedders.

## What changed

**`@relayburn/sdk`**
- New `sessionCost(opts)` returning `{ sessionId, totalUSD, totalTokens, turnCount, models, note? }` — the compact per-session shape the MCP tool now wraps.
- `summary()` result gains `turnCount`.
- Both `summary()` and `sessionCost()` now go through the SQLite archive by default with transparent fallback to a JSONL ledger walk on archive failure (the strategy that previously lived inline in `packages/mcp/src/tools/session-cost.ts`).
- Optional `onLog` hook to surface archive-fallback messages.

**`@relayburn/mcp`**
- Adds `@relayburn/sdk` as a workspace dep.
- `burn__sessionCost` is now ~60 lines wrapping `sdk.sessionCost(...)` instead of ~130 lines duplicating the cost arithmetic. Wire shape unchanged.
- Test injection seam moves from `{ queryTurns, loadPricing }` to `{ sessionCost }` — tests stub the SDK function instead of low-level ledger/pricing pieces.

**Dep graph**
- `AGENTS.md` / `CLAUDE.md` / `README.md`: order is now `reader → ledger → analyze → ingest → sdk → mcp → cli → relayburn` with new guidance that SDK is the source of truth and MCP/CLI are presenters.
- `.github/workflows/publish.yml`: publish order matches.

## Test plan
- [x] `pnpm run build` clean
- [x] `pnpm run test` — 889/889 pass
- [x] `archive-backed.test.ts` still exercises the buildArchive + corruption-fallback path (through SDK now)
- [x] `end-to-end.test.ts` still exercises the JSON-RPC pipe end-to-end
- [ ] Manual: `burn mcp-server` boots and `burn__sessionCost` returns expected shape against a real ledger (recommend smoke-testing before merge)

## Follow-ups (not in this PR)
- Lift `runCompare` core into SDK `compare(opts)` + add `burn__compare` MCP tool
- Lift `runHotspots` rendering split into SDK `hotspots(opts)` (already partially there) + add `burn__hotspots` MCP tool
- Same for `overhead`, `state status`
- Each is its own PR — touches a 600-1400 line CLI command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->