### PR TITLE
Lift runOverhead into @relayburn/sdk (closes #235)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@relayburn/cli`.
 
 ## [Unreleased]
 
+### Changed
+
+- `burn overhead` and `burn overhead trim` are now thin presenters over `@relayburn/sdk`'s new `overhead()` / `overheadTrim()` functions. Wire shape (TTY + `--json`) is unchanged; the discovery + ingest + attribution pipeline now lives in one place so future MCP tools can call it directly.
+
 ## [1.8.0] - 2026-05-02
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "@relayburn/ledger": "workspace:*",
     "@relayburn/analyze": "workspace:*",
     "@relayburn/ingest": "workspace:*",
+    "@relayburn/sdk": "workspace:*",
     "@relayburn/mcp": "workspace:*",
     "ora": "^9.4.0"
   },

--- a/packages/cli/src/commands/overhead.test.ts
+++ b/packages/cli/src/commands/overhead.test.ts
@@ -2,13 +2,20 @@ import { strict as assert } from 'node:assert';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
-import { loadBuiltinPricing } from '@relayburn/analyze';
+import { __resetIndexCacheForTesting, appendTurns } from '@relayburn/ledger';
 import type { TurnRecord } from '@relayburn/reader';
 
 import { runOverhead, type OverheadDeps } from './overhead.js';
 import type { ParsedArgs } from '../args.js';
+
+// Stop runOverhead from triggering a real `ingestAll()` against the user's
+// session stores during tests — that read can take minutes and pollutes the
+// isolated tmp ledger with unrelated data.
+const NOOP_DEPS: OverheadDeps = {
+  ingestAll: async () => ({ scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 }),
+};
 
 interface CapturedOutput {
   stdout: string;
@@ -17,8 +24,20 @@ interface CapturedOutput {
 }
 
 const tmpPaths: string[] = [];
+let ledgerHome: string;
+const originalHome = process.env['RELAYBURN_HOME'];
+
+beforeEach(async () => {
+  ledgerHome = await mkdtemp(path.join(tmpdir(), 'burn-overhead-ledger-'));
+  process.env['RELAYBURN_HOME'] = ledgerHome;
+  __resetIndexCacheForTesting();
+});
 
 afterEach(async () => {
+  if (originalHome !== undefined) process.env['RELAYBURN_HOME'] = originalHome;
+  else delete process.env['RELAYBURN_HOME'];
+  __resetIndexCacheForTesting();
+  await rm(ledgerHome, { recursive: true, force: true });
   await Promise.all(tmpPaths.splice(0).map((p) => rm(p, { recursive: true, force: true })));
 });
 
@@ -29,10 +48,7 @@ function args(
   return { flags, tags: {}, positional, passthrough: [] };
 }
 
-async function captureOverhead(
-  parsed: ParsedArgs,
-  deps: OverheadDeps,
-): Promise<CapturedOutput> {
+async function captureOverhead(parsed: ParsedArgs): Promise<CapturedOutput> {
   const origStdout = process.stdout.write.bind(process.stdout);
   const origStderr = process.stderr.write.bind(process.stderr);
   let stdout = '';
@@ -46,7 +62,7 @@ async function captureOverhead(
     return true;
   }) as typeof process.stderr.write;
   try {
-    const code = await runOverhead(parsed, deps);
+    const code = await runOverhead(parsed, NOOP_DEPS);
     return { stdout, stderr, code };
   } finally {
     process.stdout.write = origStdout;
@@ -77,15 +93,6 @@ function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
   };
 }
 
-async function makeDeps(turns: TurnRecord[]): Promise<OverheadDeps> {
-  const pricing = await loadBuiltinPricing();
-  return {
-    ingestAll: async () => ({ scannedSessions: 0, ingestedSessions: 0, appendedTurns: 0 }),
-    loadPricing: async () => pricing,
-    queryAll: async () => turns,
-  };
-}
-
 async function makeProject(fileText: string): Promise<string> {
   const projectPath = await mkdtemp(path.join(tmpdir(), 'burn-overhead-json-'));
   tmpPaths.push(projectPath);
@@ -105,11 +112,10 @@ describe('burn overhead trim --json', () => {
         'short section',
       ].join('\n'),
     );
-    const deps = await makeDeps([fakeTurn({ project: projectPath })]);
+    await appendTurns([fakeTurn({ project: projectPath })]);
 
     const out = await captureOverhead(
       args(['trim'], { project: projectPath, since: '30d', top: '1', json: true }),
-      deps,
     );
 
     assert.equal(out.code, 0);
@@ -147,11 +153,10 @@ describe('burn overhead trim --json', () => {
 
   it('emits an empty recommendations array when files have no headed trim candidates', async () => {
     const projectPath = await makeProject('plain instructions\nwithout headings\n');
-    const deps = await makeDeps([fakeTurn({ project: projectPath })]);
+    await appendTurns([fakeTurn({ project: projectPath })]);
 
     const out = await captureOverhead(
       args(['trim'], { project: projectPath, json: true }),
-      deps,
     );
 
     assert.equal(out.code, 0);

--- a/packages/cli/src/commands/overhead.ts
+++ b/packages/cli/src/commands/overhead.ts
@@ -13,7 +13,7 @@ import {
   type OverheadTrimResult,
 } from '@relayburn/sdk';
 
-import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
+import { formatInt, formatUsd, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 import { withProgress } from '../progress.js';
 
@@ -67,10 +67,7 @@ export async function runOverhead(args: ParsedArgs, deps: OverheadDeps = {}): Pr
 
 interface CommonFlags {
   projectPath: string;
-  /** Original user-facing `--since` string, retained for the "Cost over <since>" render label. */
-  sinceLabel: string | undefined;
-  /** ISO timestamp form passed to the SDK / ledger query. */
-  sinceIso: string | undefined;
+  since: string | undefined;
   kind: OverheadFileKind | undefined;
 }
 
@@ -82,8 +79,7 @@ function parseCommonFlags(args: ParsedArgs): CommonFlags | { error: string } {
       : process.cwd();
 
   const sinceFlag = args.flags['since'];
-  const sinceLabel = typeof sinceFlag === 'string' ? sinceFlag : undefined;
-  const sinceIso = sinceLabel !== undefined ? parseSinceArg(sinceLabel) : undefined;
+  const since = typeof sinceFlag === 'string' ? sinceFlag : undefined;
 
   const kindFlag = args.flags['kind'];
   let kind: OverheadFileKind | undefined;
@@ -96,7 +92,7 @@ function parseCommonFlags(args: ParsedArgs): CommonFlags | { error: string } {
     kind = kindFlag as OverheadFileKind;
   }
 
-  return { projectPath, sinceLabel, sinceIso, kind };
+  return { projectPath, since, kind };
 }
 
 async function runReport(args: ParsedArgs, deps: OverheadDeps): Promise<number> {
@@ -118,7 +114,7 @@ async function runReport(args: ParsedArgs, deps: OverheadDeps): Promise<number> 
     const opts: { project: string; since?: string; kind?: OverheadFileKind } = {
       project: parsed.projectPath,
     };
-    if (parsed.sinceIso !== undefined) opts.since = parsed.sinceIso;
+    if (parsed.since !== undefined) opts.since = parsed.since;
     if (parsed.kind !== undefined) opts.kind = parsed.kind;
     const r = await sdkOverhead(opts);
     task.succeed(`attributed overhead cost across ${formatInt(r.files.length)} file${r.files.length === 1 ? '' : 's'}`);
@@ -146,7 +142,7 @@ async function runReport(args: ParsedArgs, deps: OverheadDeps): Promise<number> 
   out.push(`Overhead files in ${result.project}:`);
   out.push('');
 
-  const sinceLabel = parsed.sinceLabel ?? 'all time';
+  const sinceLabel = parsed.since ?? 'all time';
 
   // Pair each per-file attribution row with the parsed-file metadata (lines /
   // tokens) the renderer needs for the header line. SDK keeps them as separate
@@ -220,8 +216,7 @@ async function runTrim(args: ParsedArgs, deps: OverheadDeps): Promise<number> {
 
   const result = await withProgress('building trim recommendations', async (task) => {
     const opts: OverheadTrimOptions = { project: parsed.projectPath, top };
-    if (parsed.sinceIso !== undefined) opts.since = parsed.sinceIso;
-    if (parsed.sinceLabel !== undefined) opts.sinceLabel = parsed.sinceLabel;
+    if (parsed.since !== undefined) opts.since = parsed.since;
     if (parsed.kind !== undefined) opts.kind = parsed.kind;
     const r = await sdkOverheadTrim(opts);
     task.succeed(

--- a/packages/cli/src/commands/overhead.ts
+++ b/packages/cli/src/commands/overhead.ts
@@ -1,25 +1,18 @@
-import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import {
-  attributeOverhead,
-  buildTrimRecommendations,
-  describeAppliesTo,
-  findOverheadFiles,
-  loadOverheadFile,
-  loadPricing,
-  renderUnifiedDiffForRecommendation,
-  type TrimRecommendation,
-  type OverheadAttribution,
-  type OverheadFileAttribution,
-  type OverheadFileKind,
-  type ParsedOverheadFile,
-  type SectionCost,
-} from '@relayburn/analyze';
-import { queryAll, type Query } from '@relayburn/ledger';
-import { resolveProject, type TurnRecord } from '@relayburn/reader';
-
+import { describeAppliesTo } from '@relayburn/analyze';
 import { ingestAll } from '@relayburn/ingest';
+import {
+  overhead as sdkOverhead,
+  overheadTrim as sdkOverheadTrim,
+  type OverheadFileKind,
+  type OverheadFileSummary,
+  type OverheadPerFileEntry,
+  type OverheadSectionCost,
+  type OverheadTrimOptions,
+  type OverheadTrimResult,
+} from '@relayburn/sdk';
+
 import { formatInt, formatUsd, parseSinceArg, table } from '../format.js';
 import type { ParsedArgs } from '../args.js';
 import { withProgress } from '../progress.js';
@@ -50,42 +43,12 @@ Examples:
 
 const VALID_KINDS: OverheadFileKind[] = ['claude-md', 'agents-md'];
 
+// Injection seam for tests so they can substitute a no-op ingest. Without it,
+// a test against an isolated RELAYBURN_HOME still triggers a real `ingestAll()`
+// against the user's actual ~/.claude / ~/.codex / ~/.opencode session stores,
+// which can take minutes and pollutes the tmp ledger with unrelated data.
 export interface OverheadDeps {
   ingestAll?: typeof ingestAll;
-  queryAll?: (q: Query) => Promise<TurnRecord[]>;
-  loadPricing?: typeof loadPricing;
-}
-
-interface TrimJsonRecommendation {
-  file: string;
-  kind: OverheadFileKind;
-  appliesTo: string[];
-  section: {
-    heading: string;
-    startLine: number;
-    endLine: number;
-    tokens: number;
-  };
-  projectedSavings: {
-    perSessionUsd: number;
-    acrossWindowUsd: number;
-    tokens: number;
-    tokenShare: number;
-  };
-  diff: string;
-}
-
-interface TrimJsonPayload {
-  project: string;
-  since: string;
-  recommendations: TrimJsonRecommendation[];
-  summary: {
-    filesAnalyzed: number;
-    filesWithRecommendations: number;
-    totalRecommendations: number;
-    totalProjectedSavingsPerSession: number;
-    totalProjectedSavingsAcrossWindow: number;
-  };
 }
 
 export async function runOverhead(args: ParsedArgs, deps: OverheadDeps = {}): Promise<number> {
@@ -102,135 +65,121 @@ export async function runOverhead(args: ParsedArgs, deps: OverheadDeps = {}): Pr
   return runReport(args, deps);
 }
 
-async function gatherAttribution(
-  args: ParsedArgs,
-  projectPath: string,
-  deps: OverheadDeps,
-): Promise<{
-  files: ParsedOverheadFile[];
-  attribution: OverheadAttribution;
-} | null> {
-  const kindFilter = parseKindFlag(args.flags['kind']);
-  if (kindFilter === 'invalid') {
-    process.stderr.write(
-      `burn: invalid --kind value: ${JSON.stringify(args.flags['kind'])} (expected one of: ${VALID_KINDS.join(', ')})\n`,
-    );
-    return null;
-  }
-  let found = await withProgress('finding overhead files', async (task) => {
-    const files = await findOverheadFiles(projectPath);
-    task.succeed(`found ${formatInt(files.length)} overhead file${files.length === 1 ? '' : 's'}`);
-    return files;
-  });
-  if (kindFilter) found = found.filter((f) => f.kind === kindFilter);
-  if (found.length === 0) {
-    if (kindFilter) {
-      process.stderr.write(`no ${kindFilter} overhead files found at ${projectPath}\n`);
-    } else {
-      process.stderr.write(
-        `no overhead files found at ${projectPath} (looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)\n`,
-      );
+interface CommonFlags {
+  projectPath: string;
+  /** Original user-facing `--since` string, retained for the "Cost over <since>" render label. */
+  sinceLabel: string | undefined;
+  /** ISO timestamp form passed to the SDK / ledger query. */
+  sinceIso: string | undefined;
+  kind: OverheadFileKind | undefined;
+}
+
+function parseCommonFlags(args: ParsedArgs): CommonFlags | { error: string } {
+  const projectFlag = args.flags['project'];
+  const projectPath =
+    typeof projectFlag === 'string' && projectFlag.length > 0
+      ? path.resolve(projectFlag)
+      : process.cwd();
+
+  const sinceFlag = args.flags['since'];
+  const sinceLabel = typeof sinceFlag === 'string' ? sinceFlag : undefined;
+  const sinceIso = sinceLabel !== undefined ? parseSinceArg(sinceLabel) : undefined;
+
+  const kindFlag = args.flags['kind'];
+  let kind: OverheadFileKind | undefined;
+  if (kindFlag !== undefined && kindFlag !== true) {
+    if (typeof kindFlag !== 'string' || !VALID_KINDS.includes(kindFlag as OverheadFileKind)) {
+      return {
+        error: `burn: invalid --kind value: ${JSON.stringify(kindFlag)} (expected one of: ${VALID_KINDS.join(', ')})\n`,
+      };
     }
-    return null;
+    kind = kindFlag as OverheadFileKind;
   }
-  const files: ParsedOverheadFile[] = [];
-  await withProgress('loading overhead files', async (task) => {
-    for (const f of found) files.push(await loadOverheadFile(f));
-    task.succeed(`loaded ${formatInt(files.length)} overhead file${files.length === 1 ? '' : 's'}`);
-  });
 
-  const resolved = resolveProject(projectPath);
-  const q: Query = { project: resolved.projectKey ?? projectPath };
-  if (typeof args.flags['since'] === 'string') q.since = parseSinceArg(args.flags['since']);
-
-  const ingest = deps.ingestAll ?? ingestAll;
-  await withProgress('ingesting latest sessions', (task) =>
-    ingest({ onProgress: (message) => task.update(`ingest: ${message}`) }),
-  );
-  const pricingLoader = deps.loadPricing ?? loadPricing;
-  const pricing = await withProgress('loading pricing snapshot', async (task) => {
-    const loaded = await pricingLoader();
-    task.succeed('loaded pricing snapshot');
-    return loaded;
-  });
-  const turnQuery = deps.queryAll ?? queryAll;
-  const turns = await withProgress('reading ledger turns', async (task) => {
-    const rows = await turnQuery(q);
-    task.succeed(`read ${formatInt(rows.length)} turn${rows.length === 1 ? '' : 's'}`);
-    return rows;
-  });
-  const attribution = await withProgress('attributing overhead cost', async (task) => {
-    const result = attributeOverhead({ files, turns, pricing });
-    task.succeed('attributed overhead cost');
-    return result;
-  });
-  return { files, attribution };
+  return { projectPath, sinceLabel, sinceIso, kind };
 }
 
 async function runReport(args: ParsedArgs, deps: OverheadDeps): Promise<number> {
-  const projectPath = resolveProjectPath(args);
-  const data = await gatherAttribution(args, projectPath, deps);
-  if (!data) return 1;
+  const parsed = parseCommonFlags(args);
+  if ('error' in parsed) {
+    process.stderr.write(parsed.error);
+    return 1;
+  }
+
+  const ingest = deps.ingestAll ?? ingestAll;
+  await withProgress('ingesting latest sessions', (task) =>
+    ingest({
+      onProgress: (message) => task.update(`ingest: ${message}`),
+      onWarn: (body) => task.warn(body),
+    }),
+  );
+
+  const result = await withProgress('attributing overhead cost', async (task) => {
+    const opts: { project: string; since?: string; kind?: OverheadFileKind } = {
+      project: parsed.projectPath,
+    };
+    if (parsed.sinceIso !== undefined) opts.since = parsed.sinceIso;
+    if (parsed.kind !== undefined) opts.kind = parsed.kind;
+    const r = await sdkOverhead(opts);
+    task.succeed(`attributed overhead cost across ${formatInt(r.files.length)} file${r.files.length === 1 ? '' : 's'}`);
+    return r;
+  });
+
+  if (result.files.length === 0) {
+    if (parsed.kind) {
+      process.stderr.write(`no ${parsed.kind} overhead files found at ${parsed.projectPath}\n`);
+    } else {
+      process.stderr.write(
+        `no overhead files found at ${parsed.projectPath} (looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)\n`,
+      );
+    }
+    return 1;
+  }
 
   if (args.flags['json'] === true) {
-    process.stdout.write(
-      JSON.stringify(
-        {
-          project: projectPath,
-          files: data.files.map(({ file, parsed }) => ({
-            kind: file.kind,
-            path: file.path,
-            appliesTo: file.appliesTo,
-            totalLines: parsed.totalLines,
-            bytes: parsed.bytes,
-            tokens: parsed.tokens,
-            sections: parsed.sections,
-            groupingLevel: parsed.groupingLevel,
-          })),
-          perFile: data.attribution.perFile.map((p) => ({
-            path: p.file.path,
-            kind: p.file.kind,
-            appliesTo: p.file.appliesTo,
-            attribution: p.attribution,
-          })),
-          grandTotal: data.attribution.grandTotal,
-        },
-        null,
-        2,
-      ) + '\n',
-    );
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
     return 0;
   }
 
   const out: string[] = [];
   out.push('');
-  out.push(`Overhead files in ${projectPath}:`);
+  out.push(`Overhead files in ${result.project}:`);
   out.push('');
 
-  const sinceLabel = typeof args.flags['since'] === 'string' ? args.flags['since'] : 'all time';
+  const sinceLabel = parsed.sinceLabel ?? 'all time';
 
-  for (const fileAttr of data.attribution.perFile) {
-    renderFileBlock(fileAttr, sinceLabel, out);
+  // Pair each per-file attribution row with the parsed-file metadata (lines /
+  // tokens) the renderer needs for the header line. SDK keeps them as separate
+  // arrays in the result so consumers that only want one half don't pay for
+  // the other; the CLI joins them by path.
+  const filesByPath = new Map(result.files.map((f) => [f.path, f]));
+  for (const fileAttr of result.perFile) {
+    const parsedFile = filesByPath.get(fileAttr.path);
+    if (!parsedFile) continue;
+    renderFileBlock(parsedFile, fileAttr, sinceLabel, out);
     out.push('');
   }
 
-  out.push(`Grand total (all overhead files, ${sinceLabel}): ${formatUsd(data.attribution.grandTotal)}`);
+  out.push(
+    `Grand total (all overhead files, ${sinceLabel}): ${formatUsd(result.grandTotal)}`,
+  );
   out.push('');
   process.stdout.write(out.join('\n'));
   return 0;
 }
 
 function renderFileBlock(
-  fileAttr: OverheadFileAttribution,
+  parsedFile: OverheadFileSummary,
+  fileAttr: OverheadPerFileEntry,
   sinceLabel: string,
   out: string[],
 ): void {
-  const { file, parsed, attribution } = fileAttr;
-  const display = `${path.basename(file.path)} (${path.relative(process.cwd(), file.path) || file.path})`;
+  const { attribution } = fileAttr;
+  const display = `${path.basename(parsedFile.path)} (${path.relative(process.cwd(), parsedFile.path) || parsedFile.path})`;
   out.push(
-    `${display} — ${formatInt(parsed.totalLines)} lines, ~${formatTokens(parsed.tokens)} tokens — applies to: ${describeAppliesTo(file.appliesTo)}`,
+    `${display} — ${formatInt(parsedFile.totalLines)} lines, ~${formatTokens(parsedFile.tokens)} tokens — applies to: ${describeAppliesTo([...parsedFile.appliesTo])}`,
   );
-  if (parsed.tokens === 0) {
+  if (parsedFile.tokens === 0) {
     out.push('  (empty file — no attribution)');
     return;
   }
@@ -253,16 +202,52 @@ function renderFileBlock(
 }
 
 async function runTrim(args: ParsedArgs, deps: OverheadDeps): Promise<number> {
-  const projectPath = resolveProjectPath(args);
-  const data = await gatherAttribution(args, projectPath, deps);
-  if (!data) return 1;
-
-  const topPerFile = parseTopN(args.flags['top']);
+  const parsed = parseCommonFlags(args);
+  if ('error' in parsed) {
+    process.stderr.write(parsed.error);
+    return 1;
+  }
+  const top = parseTopN(args.flags['top']);
   const json = args.flags['json'] === true;
 
+  const ingest = deps.ingestAll ?? ingestAll;
+  await withProgress('ingesting latest sessions', (task) =>
+    ingest({
+      onProgress: (message) => task.update(`ingest: ${message}`),
+      onWarn: (body) => task.warn(body),
+    }),
+  );
+
+  const result = await withProgress('building trim recommendations', async (task) => {
+    const opts: OverheadTrimOptions = { project: parsed.projectPath, top };
+    if (parsed.sinceIso !== undefined) opts.since = parsed.sinceIso;
+    if (parsed.sinceLabel !== undefined) opts.sinceLabel = parsed.sinceLabel;
+    if (parsed.kind !== undefined) opts.kind = parsed.kind;
+    const r = await sdkOverheadTrim(opts);
+    task.succeed(
+      `built ${formatInt(r.recommendations.length)} recommendation${r.recommendations.length === 1 ? '' : 's'}`,
+    );
+    return r;
+  });
+
+  if (result.summary.filesAnalyzed === 0) {
+    if (parsed.kind) {
+      process.stderr.write(`no ${parsed.kind} overhead files found at ${parsed.projectPath}\n`);
+    } else {
+      process.stderr.write(
+        `no overhead files found at ${parsed.projectPath} (looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md)\n`,
+      );
+    }
+    return 1;
+  }
+
   if (json) {
-    const payload = await buildTrimJsonPayload(args, projectPath, data, topPerFile);
-    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  if (result.recommendations.length === 0) {
+    process.stdout.write('# no trim candidates — overhead files have no headed sections\n');
     return 0;
   }
 
@@ -271,99 +256,36 @@ async function runTrim(args: ParsedArgs, deps: OverheadDeps): Promise<number> {
   out.push('# (recommendations only; burn never modifies your overhead files)');
   out.push('');
 
-  const textCache = new Map<string, string>();
-  let emitted = 0;
-  for (const fileAttr of data.attribution.perFile) {
-    const recs = buildTrimRecommendations(fileAttr.attribution, topPerFile);
-    if (recs.length === 0) continue;
-    out.push(`# === ${path.basename(fileAttr.file.path)} (applies to: ${describeAppliesTo(fileAttr.file.appliesTo)}) ===`);
+  const renderTrimRecsByFile = groupRecommendationsByFile(result);
+  for (const [_, recs] of renderTrimRecsByFile) {
+    const first = recs[0]!;
+    out.push(
+      `# === ${path.basename(first.file)} (applies to: ${describeAppliesTo([...first.appliesTo])}) ===`,
+    );
     out.push('');
-    let text = textCache.get(fileAttr.file.path);
-    if (text === undefined) {
-      text = await readFile(fileAttr.file.path, 'utf8');
-      textCache.set(fileAttr.file.path, text);
-    }
     for (const rec of recs) {
-      out.push(
-        renderUnifiedDiffForRecommendation(fileAttr.file.path, text, rec as TrimRecommendation, projectPath),
-      );
+      out.push(rec.diff ?? '');
       out.push('');
     }
-    emitted++;
   }
-  if (emitted === 0) {
-    process.stdout.write('# no trim candidates — overhead files have no headed sections\n');
-    return 0;
-  }
+
   process.stdout.write(out.join('\n'));
   return 0;
 }
 
-async function buildTrimJsonPayload(
-  args: ParsedArgs,
-  projectPath: string,
-  data: {
-    files: ParsedOverheadFile[];
-    attribution: OverheadAttribution;
-  },
-  topPerFile: number,
-): Promise<TrimJsonPayload> {
-  const textCache = new Map<string, string>();
-  const recommendations: TrimJsonRecommendation[] = [];
-  let filesWithRecommendations = 0;
-
-  for (const fileAttr of data.attribution.perFile) {
-    const recs = buildTrimRecommendations(fileAttr.attribution, topPerFile);
-    if (recs.length === 0) continue;
-    filesWithRecommendations++;
-    let text = textCache.get(fileAttr.file.path);
-    if (text === undefined) {
-      text = await readFile(fileAttr.file.path, 'utf8');
-      textCache.set(fileAttr.file.path, text);
-    }
-    for (const rec of recs) {
-      recommendations.push({
-        file: toProjectRelativePath(fileAttr.file.path, projectPath),
-        kind: fileAttr.file.kind,
-        appliesTo: fileAttr.file.appliesTo,
-        section: {
-          heading: rec.section.heading,
-          startLine: rec.section.startLine,
-          endLine: rec.section.endLine,
-          tokens: rec.section.tokens,
-        },
-        projectedSavings: {
-          perSessionUsd: rec.projectedSavingsPerSession,
-          acrossWindowUsd: rec.projectedSavingsAcrossWindow,
-          tokens: rec.section.tokens,
-          tokenShare: rec.tokenShare,
-        },
-        diff: renderUnifiedDiffForRecommendation(fileAttr.file.path, text, rec, projectPath),
-      });
-    }
+function groupRecommendationsByFile(
+  result: OverheadTrimResult,
+): Map<string, OverheadTrimResult['recommendations']> {
+  const out = new Map<string, OverheadTrimResult['recommendations']>();
+  for (const rec of result.recommendations) {
+    const list = out.get(rec.file);
+    if (list) list.push(rec);
+    else out.set(rec.file, [rec]);
   }
-
-  return {
-    project: projectPath,
-    since: typeof args.flags['since'] === 'string' ? args.flags['since'] : 'all time',
-    recommendations,
-    summary: {
-      filesAnalyzed: data.files.length,
-      filesWithRecommendations,
-      totalRecommendations: recommendations.length,
-      totalProjectedSavingsPerSession: recommendations.reduce(
-        (sum, rec) => sum + rec.projectedSavings.perSessionUsd,
-        0,
-      ),
-      totalProjectedSavingsAcrossWindow: recommendations.reduce(
-        (sum, rec) => sum + rec.projectedSavings.acrossWindowUsd,
-        0,
-      ),
-    },
-  };
+  return out;
 }
 
-function renderSectionTable(rows: SectionCost[]): string {
+function renderSectionTable(rows: OverheadSectionCost[]): string {
   const data: string[][] = [['lines', 'heading', 'tokens', 'cost/session', '%file']];
   for (const r of rows) {
     data.push([
@@ -395,28 +317,9 @@ function formatTokens(tokens: number): string {
   return String(tokens);
 }
 
-function resolveProjectPath(args: ParsedArgs): string {
-  const flag = args.flags['project'];
-  if (typeof flag === 'string' && flag.length > 0) return path.resolve(flag);
-  return process.cwd();
-}
-
-function toProjectRelativePath(filePath: string, projectPath: string): string {
-  const rel = path.relative(projectPath, filePath);
-  const display = rel && !rel.startsWith('..') ? rel : filePath;
-  return display.split(path.sep).join('/');
-}
-
 function parseTopN(v: unknown): number {
   if (typeof v !== 'string') return 3;
   const n = Number(v);
   if (!Number.isFinite(n) || n <= 0) return 3;
   return Math.floor(n);
-}
-
-function parseKindFlag(v: unknown): OverheadFileKind | null | 'invalid' {
-  if (v === undefined || v === true) return null;
-  if (typeof v !== 'string') return 'invalid';
-  if (v === 'claude-md' || v === 'agents-md') return v;
-  return 'invalid';
 }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `@relayburn/sdk`.
 - `summary()` and `sessionCost()` read through the SQLite archive by default with transparent fallback to the JSONL ledger walk on archive failure. Pass `onLog` to capture the fallback reason.
 - `overhead({ project, since?, kind? })` returns per-file + per-section overhead cost attribution (the JSON shape `burn overhead --json` now consumes).
 - `overheadTrim({ project, since?, kind?, top?, includeDiff? })` returns trim recommendations with projected savings and (by default) embedded unified diffs (the JSON shape `burn overhead trim --json` now consumes). Pass `includeDiff: false` to skip the per-file disk reads.
+- `summary({ since })` and `overhead({ since })` / `overheadTrim({ since })` now accept either an ISO timestamp or a relative range (`24h`, `7d`, `4w`, `2m`); the SDK normalizes both forms before querying the ledger so direct SDK callers get the same forgiving input shape CLI users have. Previously a raw relative string would silently filter out every turn.
 
 ## [1.7.0] - 2026-05-02
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to `@relayburn/sdk`.
 - `sessionCost({ session })` returns the compact per-session cost shape (`totalUSD`, `totalTokens`, `turnCount`, `models`) the MCP `burn__sessionCost` tool now wraps directly.
 - `summary()` result now includes `turnCount`.
 - `summary()` and `sessionCost()` read through the SQLite archive by default with transparent fallback to the JSONL ledger walk on archive failure. Pass `onLog` to capture the fallback reason.
+- `overhead({ project, since?, kind? })` returns per-file + per-section overhead cost attribution (the JSON shape `burn overhead --json` now consumes).
+- `overheadTrim({ project, since?, kind?, top?, includeDiff? })` returns trim recommendations with projected savings and (by default) embedded unified diffs (the JSON shape `burn overhead trim --json` now consumes). Pass `includeDiff: false` to skip the per-file disk reads.
 
 ## [1.7.0] - 2026-05-02
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -3,7 +3,15 @@
 Embeddable Relayburn SDK for in-process ingestion and analysis. This package is the **source of truth** for the in-process query/compute surface — `@relayburn/mcp` and `@relayburn/cli` consume the SDK rather than duplicating its logic.
 
 ```ts
-import { Ledger, ingest, summary, sessionCost, hotspots } from '@relayburn/sdk';
+import {
+  Ledger,
+  ingest,
+  summary,
+  sessionCost,
+  overhead,
+  overheadTrim,
+  hotspots,
+} from '@relayburn/sdk';
 
 await Ledger.open({ home: '/tmp/relayburn-home' });
 await ingest({ ledgerHome: '/tmp/relayburn-home' });
@@ -15,7 +23,13 @@ const stats = await summary({ session: 'session-id', ledgerHome: '/tmp/relayburn
 // Powers the MCP `burn__sessionCost` tool.
 const cost = await sessionCost({ session: 'session-id' });
 
+// Overhead-file (CLAUDE.md / AGENTS.md / .claude/CLAUDE.md) cost attribution.
+const oh = await overhead({ project: '/path/to/repo', since: '30d' });
+const trim = await overheadTrim({ project: '/path/to/repo', top: 3 });
+
 const findings = await hotspots({ session: 'session-id', patterns: ['retry-loop'] });
 ```
 
-`summary` and `sessionCost` read through the SQLite archive when available, transparently falling back to the JSONL ledger walk if the archive can't be opened. Pass `onLog` to surface fallback messages in your host's log channel.
+`summary`, `sessionCost`, `overhead`, and `overheadTrim` read through the SQLite archive when available, transparently falling back to the JSONL ledger walk if the archive can't be opened. Pass `onLog` to surface fallback messages in your host's log channel.
+
+`overheadTrim` includes a unified-diff string per recommendation by default (matches `burn overhead trim --json`); pass `includeDiff: false` to skip the per-file disk reads when you only need the recommendation rows.

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -7,6 +7,7 @@ export declare function ingest(opts?: IngestOptions): Promise<unknown>
 export interface SummaryOptions {
   session?: string;
   project?: string;
+  /** ISO timestamp (e.g. `2026-04-01T00:00:00Z`) or relative range (`24h`, `7d`, `4w`, `2m`). */
   since?: string;
   ledgerHome?: string;
   /** Optional logger invoked when the SQLite archive read fails and the SDK falls back to a full ledger walk. */
@@ -43,7 +44,7 @@ export type OverheadHarness = 'claude-code' | 'codex' | 'opencode';
 export interface OverheadOptions {
   /** Project path to inspect; defaults to process.cwd(). */
   project?: string;
-  /** Relative range like `7d` or ISO timestamp; passed to ledger query as `since`. */
+  /** ISO timestamp or relative range (`24h`, `7d`, `4w`, `2m`); the SDK normalizes both forms before querying. */
   since?: string;
   /** Narrow to a single overhead file kind. */
   kind?: OverheadFileKind;
@@ -105,10 +106,8 @@ export declare function overhead(opts?: OverheadOptions): Promise<OverheadResult
 export interface OverheadTrimOptions extends OverheadOptions {
   /** Recommendations per file. Default 3. */
   top?: number;
-  /** Skip the unified-diff text (saves a file read per recommended file). Default true. */
+  /** Include the unified-diff text per recommendation (requires a file read per recommended file). Default true; pass false to skip. */
   includeDiff?: boolean;
-  /** Display label echoed back as `since` in the result (e.g. "30d"). Defaults to `since`. */
-  sinceLabel?: string;
 }
 
 export interface OverheadTrimRecommendation {

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -37,6 +37,110 @@ export interface SessionCostResult {
 /** Compact session-scoped cost shape; powers the MCP `burn__sessionCost` tool. */
 export declare function sessionCost(opts?: SessionCostOptions): Promise<SessionCostResult>
 
+export type OverheadFileKind = 'claude-md' | 'agents-md';
+export type OverheadHarness = 'claude-code' | 'codex' | 'opencode';
+
+export interface OverheadOptions {
+  /** Project path to inspect; defaults to process.cwd(). */
+  project?: string;
+  /** Relative range like `7d` or ISO timestamp; passed to ledger query as `since`. */
+  since?: string;
+  /** Narrow to a single overhead file kind. */
+  kind?: OverheadFileKind;
+  ledgerHome?: string;
+  onLog?: (msg: string) => void;
+}
+
+export interface OverheadSection {
+  heading: string;
+  startLine: number;
+  endLine: number;
+  tokens: number;
+}
+
+export interface OverheadSectionCost {
+  filePath: string;
+  section: OverheadSection;
+  tokenShare: number;
+  costPerSession: number;
+  totalCost: number;
+}
+
+export interface OverheadAttributionDetail {
+  sessionCount: number;
+  perSessionAvg: number;
+  perSessionP95: number;
+  totalCost: number;
+  sectionCosts: OverheadSectionCost[];
+}
+
+export interface OverheadFileSummary {
+  kind: OverheadFileKind;
+  path: string;
+  appliesTo: OverheadHarness[];
+  totalLines: number;
+  bytes: number;
+  tokens: number;
+  sections: OverheadSection[];
+  groupingLevel: number;
+}
+
+export interface OverheadPerFileEntry {
+  path: string;
+  kind: OverheadFileKind;
+  appliesTo: OverheadHarness[];
+  attribution: OverheadAttributionDetail;
+}
+
+export interface OverheadResult {
+  project: string;
+  files: OverheadFileSummary[];
+  perFile: OverheadPerFileEntry[];
+  grandTotal: number;
+}
+
+/** Per-file + per-section overhead cost attribution. Powers `burn overhead`. */
+export declare function overhead(opts?: OverheadOptions): Promise<OverheadResult>
+
+export interface OverheadTrimOptions extends OverheadOptions {
+  /** Recommendations per file. Default 3. */
+  top?: number;
+  /** Skip the unified-diff text (saves a file read per recommended file). Default true. */
+  includeDiff?: boolean;
+  /** Display label echoed back as `since` in the result (e.g. "30d"). Defaults to `since`. */
+  sinceLabel?: string;
+}
+
+export interface OverheadTrimRecommendation {
+  file: string;
+  kind: OverheadFileKind;
+  appliesTo: OverheadHarness[];
+  section: { heading: string; startLine: number; endLine: number; tokens: number };
+  projectedSavings: {
+    perSessionUsd: number;
+    acrossWindowUsd: number;
+    tokens: number;
+    tokenShare: number;
+  };
+  diff?: string;
+}
+
+export interface OverheadTrimResult {
+  project: string;
+  since: string;
+  recommendations: OverheadTrimRecommendation[];
+  summary: {
+    filesAnalyzed: number;
+    filesWithRecommendations: number;
+    totalRecommendations: number;
+    totalProjectedSavingsPerSession: number;
+    totalProjectedSavingsAcrossWindow: number;
+  };
+}
+
+/** Trim recommendations for high-cost overhead-file sections. Powers `burn overhead trim`. */
+export declare function overheadTrim(opts?: OverheadTrimOptions): Promise<OverheadTrimResult>
+
 export interface HotspotsOptions {
   session?: string;
   /**

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -7,24 +7,32 @@ import {
   queryToolResultEvents,
 } from '@relayburn/ledger';
 import {
+  attributeOverhead,
   buildGhostSurfaceInputs,
-  loadPricing,
+  buildTrimRecommendations,
   costForTurn,
+  detectGhostSurface,
+  detectPatterns,
+  detectToolCallPatterns,
+  detectToolOutputBloat,
+  findingsFromPatterns,
+  findOverheadFiles,
+  ghostSurfaceToFinding,
+  loadClaudeSettings,
+  loadOverheadFile,
+  loadPricing,
+  projectClaudeSettingsPath,
+  renderUnifiedDiffForRecommendation,
   sumCosts,
   attributeHotspots,
-  detectPatterns,
-  findingsFromPatterns,
-  detectToolOutputBloat,
-  toolOutputBloatToFinding,
-  detectGhostSurface,
-  ghostSurfaceToFinding,
-  detectToolCallPatterns,
   toolCallPatternToFinding,
-  loadClaudeSettings,
+  toolOutputBloatToFinding,
   userClaudeSettingsPath,
-  projectClaudeSettingsPath,
 } from '@relayburn/analyze';
 import { ingestAll } from '@relayburn/ingest';
+import { resolveProject } from '@relayburn/reader';
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
 
 function withHome(home, fn) {
   const prev = process.env.RELAYBURN_HOME;
@@ -246,4 +254,175 @@ function bucketBySession(userTurns) {
     else out.set(ut.sessionId, [ut]);
   }
   return out;
+}
+
+const VALID_OVERHEAD_KINDS = ['claude-md', 'agents-md'];
+
+// Discover and parse overhead files for a project, returning the parsed files
+// alongside the cost attribution (per-file and per-section). Shared by
+// `overhead()` (report mode) and `overheadTrim()` (recommendations mode) so the
+// discovery + ingest + query + attribution pipeline lives in one place.
+async function gatherOverhead(opts = {}) {
+  const projectPath = opts.project ? path.resolve(opts.project) : process.cwd();
+  const kind = opts.kind;
+  if (kind !== undefined && !VALID_OVERHEAD_KINDS.includes(kind)) {
+    throw new Error(
+      `invalid overhead kind: ${JSON.stringify(kind)} (expected one of: ${VALID_OVERHEAD_KINDS.join(', ')})`,
+    );
+  }
+
+  let found = await findOverheadFiles(projectPath);
+  if (kind) found = found.filter((f) => f.kind === kind);
+  if (found.length === 0) {
+    return { projectPath, files: [], attribution: null };
+  }
+
+  const files = [];
+  for (const f of found) files.push(await loadOverheadFile(f));
+
+  const resolved = resolveProject(projectPath);
+  const q = { project: resolved.projectKey ?? projectPath };
+  if (opts.since) q.since = opts.since;
+
+  const turns = await loadTurnsViaArchive(q, opts.onLog);
+  const pricing = await loadPricing();
+  const attribution = attributeOverhead({ files, turns, pricing });
+  return { projectPath, files, attribution };
+}
+
+export async function overhead(opts = {}) {
+  return withHome(opts.ledgerHome, async () => {
+    const data = await gatherOverhead(opts);
+    if (!data.attribution) {
+      return { project: data.projectPath, files: [], perFile: [], grandTotal: 0 };
+    }
+    return {
+      project: data.projectPath,
+      files: data.files.map(({ file, parsed }) => ({
+        kind: file.kind,
+        path: file.path,
+        appliesTo: file.appliesTo,
+        totalLines: parsed.totalLines,
+        bytes: parsed.bytes,
+        tokens: parsed.tokens,
+        sections: parsed.sections,
+        groupingLevel: parsed.groupingLevel,
+      })),
+      perFile: data.attribution.perFile.map((p) => ({
+        path: p.file.path,
+        kind: p.file.kind,
+        appliesTo: p.file.appliesTo,
+        attribution: p.attribution,
+      })),
+      grandTotal: data.attribution.grandTotal,
+    };
+  });
+}
+
+export async function overheadTrim(opts = {}) {
+  return withHome(opts.ledgerHome, async () => {
+    const data = await gatherOverhead(opts);
+    const topPerFile = parseTopN(opts.top);
+    // The `since` label in the result is for human display ("Cost over 30d");
+    // callers can pass `sinceLabel` to keep the user-friendly form (e.g. "30d")
+    // even when `since` is an ISO timestamp. Falls back to the raw `since`
+    // value if no label is provided, then "all time" if nothing was passed.
+    const sinceLabel = opts.sinceLabel ?? opts.since ?? 'all time';
+    if (!data.attribution) {
+      return {
+        project: data.projectPath,
+        since: sinceLabel,
+        recommendations: [],
+        summary: {
+          filesAnalyzed: 0,
+          filesWithRecommendations: 0,
+          totalRecommendations: 0,
+          totalProjectedSavingsPerSession: 0,
+          totalProjectedSavingsAcrossWindow: 0,
+        },
+      };
+    }
+
+    // The diff field is the unified-diff text the trim recommendation would
+    // produce — heavy enough to opt out of but useful enough that the CLI's
+    // --json mode always emits it. Keep that default; allow opts.includeDiff
+    // === false to skip the file reads when a caller (e.g. a future MCP tool)
+    // only wants the recommendation rows.
+    const includeDiff = opts.includeDiff !== false;
+    const textCache = new Map();
+    const recommendations = [];
+    let filesWithRecommendations = 0;
+
+    for (const fileAttr of data.attribution.perFile) {
+      const recs = buildTrimRecommendations(fileAttr.attribution, topPerFile);
+      if (recs.length === 0) continue;
+      filesWithRecommendations++;
+      let text;
+      if (includeDiff) {
+        text = textCache.get(fileAttr.file.path);
+        if (text === undefined) {
+          text = await readFile(fileAttr.file.path, 'utf8');
+          textCache.set(fileAttr.file.path, text);
+        }
+      }
+      for (const rec of recs) {
+        const entry = {
+          file: toProjectRelativePath(fileAttr.file.path, data.projectPath),
+          kind: fileAttr.file.kind,
+          appliesTo: fileAttr.file.appliesTo,
+          section: {
+            heading: rec.section.heading,
+            startLine: rec.section.startLine,
+            endLine: rec.section.endLine,
+            tokens: rec.section.tokens,
+          },
+          projectedSavings: {
+            perSessionUsd: rec.projectedSavingsPerSession,
+            acrossWindowUsd: rec.projectedSavingsAcrossWindow,
+            tokens: rec.section.tokens,
+            tokenShare: rec.tokenShare,
+          },
+        };
+        if (includeDiff) {
+          entry.diff = renderUnifiedDiffForRecommendation(
+            fileAttr.file.path,
+            text,
+            rec,
+            data.projectPath,
+          );
+        }
+        recommendations.push(entry);
+      }
+    }
+
+    return {
+      project: data.projectPath,
+      since: sinceLabel,
+      recommendations,
+      summary: {
+        filesAnalyzed: data.files.length,
+        filesWithRecommendations,
+        totalRecommendations: recommendations.length,
+        totalProjectedSavingsPerSession: recommendations.reduce(
+          (sum, r) => sum + r.projectedSavings.perSessionUsd,
+          0,
+        ),
+        totalProjectedSavingsAcrossWindow: recommendations.reduce(
+          (sum, r) => sum + r.projectedSavings.acrossWindowUsd,
+          0,
+        ),
+      },
+    };
+  });
+}
+
+function parseTopN(v) {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) return 3;
+  return Math.floor(v);
+}
+
+function toProjectRelativePath(filePath, projectPath) {
+  const rel = path.relative(projectPath, filePath);
+  const display = rel && !rel.startsWith('..') ? rel : filePath;
+  return display.split(path.sep).join('/');
 }

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -73,6 +73,37 @@ async function loadSessionTurnsViaArchive(sessionId, onLog) {
   }
 }
 
+// Accept either a CLI-style relative range (`24h`, `7d`, `4w`, `2m`) or an
+// ISO timestamp and return an ISO string the ledger query can compare. The
+// ledger filter does lexical string comparison on `turn.ts`, so passing a raw
+// `7d` would silently filter every turn out (since `'7'` > `'2'` lexically).
+// Lifted from `packages/cli/src/format.ts` so direct SDK callers (and future
+// MCP tools) get the same forgiving input shape the CLI users see, without
+// the silent-drop trap.
+function normalizeSince(since) {
+  if (since === undefined) return undefined;
+  if (typeof since !== 'string' || since.length === 0) return undefined;
+  const m = /^(\d+)([hdwm])$/.exec(since);
+  if (!m) {
+    const d = new Date(since);
+    if (Number.isNaN(d.getTime())) {
+      throw new Error(`invalid since: ${since} (expected ISO timestamp or relative range like 7d)`);
+    }
+    return d.toISOString();
+  }
+  const n = parseInt(m[1], 10);
+  const unit = m[2];
+  const ms =
+    unit === 'h'
+      ? n * 3600_000
+      : unit === 'd'
+        ? n * 86400_000
+        : unit === 'w'
+          ? n * 7 * 86400_000
+          : /* m */ n * 30 * 86400_000;
+  return new Date(Date.now() - ms).toISOString();
+}
+
 export class Ledger {
   static async open(opts = {}) {
     return new Ledger(opts.home);
@@ -89,7 +120,7 @@ export async function ingest(opts = {}) {
 
 export async function summary(opts = {}) {
   return withHome(opts.ledgerHome, async () => {
-    const q = { sessionId: opts.session, project: opts.project, since: opts.since };
+    const q = { sessionId: opts.session, project: opts.project, since: normalizeSince(opts.since) };
     const turns = await loadTurnsViaArchive(q, opts.onLog);
     const pricing = await loadPricing();
     const byTool = new Map();
@@ -282,7 +313,8 @@ async function gatherOverhead(opts = {}) {
 
   const resolved = resolveProject(projectPath);
   const q = { project: resolved.projectKey ?? projectPath };
-  if (opts.since) q.since = opts.since;
+  const normalizedSince = normalizeSince(opts.since);
+  if (normalizedSince) q.since = normalizedSince;
 
   const turns = await loadTurnsViaArchive(q, opts.onLog);
   const pricing = await loadPricing();
@@ -323,11 +355,7 @@ export async function overheadTrim(opts = {}) {
   return withHome(opts.ledgerHome, async () => {
     const data = await gatherOverhead(opts);
     const topPerFile = parseTopN(opts.top);
-    // The `since` label in the result is for human display ("Cost over 30d");
-    // callers can pass `sinceLabel` to keep the user-friendly form (e.g. "30d")
-    // even when `since` is an ISO timestamp. Falls back to the raw `since`
-    // value if no label is provided, then "all time" if nothing was passed.
-    const sinceLabel = opts.sinceLabel ?? opts.since ?? 'all time';
+    const sinceLabel = opts.since ?? 'all time';
     if (!data.attribution) {
       return {
         project: data.projectPath,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@relayburn/analyze": "workspace:*",
     "@relayburn/ingest": "workspace:*",
-    "@relayburn/ledger": "workspace:*"
+    "@relayburn/ledger": "workspace:*",
+    "@relayburn/reader": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@relayburn/reader':
         specifier: workspace:*
         version: link:../reader
+      '@relayburn/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       ora:
         specifier: ^9.4.0
         version: 9.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@relayburn/ledger':
         specifier: workspace:*
         version: link:../ledger
+      '@relayburn/reader':
+        specifier: workspace:*
+        version: link:../reader
 
 packages:
 


### PR DESCRIPTION
Closes #235. Follow-up to #232 (which made `@relayburn/sdk` the canonical in-process query surface). Applies the same pattern — CLI verb → pure SDK function + thin presenter — to `burn overhead` and `burn overhead trim`.

## What changed

**`@relayburn/sdk`** — two new functions, both in-process pure data:

```ts
const result = await overhead({ project, since?, kind?, ledgerHome?, onLog? });
// → { project, files, perFile, grandTotal }

const trim = await overheadTrim({ project, since?, kind?, top?, includeDiff?, sinceLabel?, ... });
// → { project, since, recommendations, summary }
```

Both reuse the `loadTurnsViaArchive` helper from #232 so they get the same archive-with-fallback strategy `summary` / `sessionCost` already have. `overheadTrim` includes a unified-diff string per recommendation by default (matches `burn overhead trim --json`); pass `includeDiff: false` to skip the per-file disk reads when only recommendation rows are needed.

New types declared in `index.d.ts` so consumers don't have to reach into `@relayburn/analyze` for the attribution shape: `OverheadFileSummary`, `OverheadPerFileEntry`, `OverheadSectionCost`, `OverheadAttributionDetail`, plus the `OverheadResult` / `OverheadTrimResult` / option types.

**`@relayburn/cli`** — adds `@relayburn/sdk` as a workspace dep. `runOverhead` / `runTrim` drop ~280 lines of inline gather + attribution + JSON shaping; both now call the SDK and only own flag parsing, `--since` string→ISO conversion, and TTY/diff rendering. CLI keeps a narrow `OverheadDeps { ingestAll? }` injection seam (only ingest, not the whole pipeline) so tests can stub out the real ingest pass — without it, an isolated `RELAYBURN_HOME` test still triggers a real read of the user's `~/.claude` / `~/.codex` / `~/.opencode` stores.

**Wire shape unchanged.** Both `burn overhead --json` and `burn overhead trim --json` emit the same payload they did before; the existing JSON-mode test was rewritten to use a real ledger (`appendTurns` into a tmp `RELAYBURN_HOME`) instead of dep-injection of `queryAll`/`loadPricing`, and asserts the same exact shape.

## Test plan
- [x] `pnpm run build` clean
- [x] `pnpm run test` — 889/889 pass
- [x] Overhead JSON-mode test (the only structured assertion this verb has) passes against the SDK-backed implementation
- [ ] Manual: `burn overhead` and `burn overhead trim --top 3` against a real project produce the same TTY output as before

## Out of scope
- Adding a `burn__overhead` MCP tool. That's a separate PR — should be ~30 lines once this lands (zod schema → `await sdk.overhead(input)` → return).
- The CLI commands listed in #233 (`compare`) and #234 (`hotspots`) — same refactor pattern, separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->