### PR TITLE
Lift runCompare into @relayburn/sdk as compare()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 ### Changed
 
 - **Architecture: `@relayburn/sdk` is now the canonical in-process query surface.** Dependency order moves from `… → mcp → cli → sdk → relayburn` to `… → sdk → mcp → cli → relayburn`; `@relayburn/mcp` now depends on `@relayburn/sdk` and rewrites `burn__sessionCost` as a thin wrapper over the SDK's new `sessionCost()` function. New read verbs should land in the SDK first; MCP and CLI become presenters (tool definitions / table rendering) over the same SDK calls so query logic stops drifting between them.
+- `burn compare` joins `summary` / `sessionCost` / `overhead` / `overheadTrim` as a thin presenter over `@relayburn/sdk`'s new `compare()` function. The archive-vs-ledger branching and fidelity-gate logic move into the SDK so a future `burn__compare` MCP tool (and embedders) can wrap the same call without re-implementing them.
 
 ## [1.8.0] - 2026-05-02
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `@relayburn/cli`.
 
 ### Changed
 
+- `burn compare` is now a thin presenter over `@relayburn/sdk`'s new `compare()` function. Flag parsing, ingest, and TTY/JSON/CSV rendering stay in the CLI; the archive-vs-ledger branching, fidelity gate, and result shaping live in the SDK. Wire shape (TTY + `--json` + `--csv`) is unchanged.
 - `burn overhead` and `burn overhead trim` are now thin presenters over `@relayburn/sdk`'s new `overhead()` / `overheadTrim()` functions. Wire shape (TTY + `--json`) is unchanged; the discovery + ingest + attribution pipeline now lives in one place so future MCP tools can call it directly.
 
 ## [1.8.0] - 2026-05-02

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -690,6 +690,40 @@ describe('@relayburn/sdk compare() — ledger integration', () => {
     assert.equal(sonnet.turns, 2);
   });
 
+  it('RELAYBURN_ARCHIVE=0 forces the ledger walk (no archive build)', async () => {
+    // Regression for #238 review: the SDK previously called
+    // `loadTurnsViaArchive` unconditionally, which builds + reads the
+    // archive even when `RELAYBURN_ARCHIVE=0` (the env var the CLI sets
+    // when `--no-archive` is passed). After the fix, the archive must
+    // stay un-built when the env disables it.
+    const { archivePath } = await import('@relayburn/ledger');
+    const { stat } = await import('node:fs/promises');
+    await appendTurns([
+      fakeLedgerTurn({ messageId: 'na-1' }),
+      fakeLedgerTurn({
+        messageId: 'na-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        model: 'claude-haiku-4-5',
+      }),
+    ]);
+    await assert.rejects(stat(archivePath()), /ENOENT/);
+
+    process.env['RELAYBURN_ARCHIVE'] = '0';
+    try {
+      const result = await sdkCompare({
+        models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+        minFidelity: 'partial',
+      });
+      assert.equal(result.analyzedTurns, 2);
+    } finally {
+      delete process.env['RELAYBURN_ARCHIVE'];
+    }
+    // Same fallback behavior as `burn summary --no-archive`: archive stays
+    // un-materialized.
+    await assert.rejects(stat(archivePath()), /ENOENT/);
+  });
+
   it('archive path (partial fidelity, no provider) returns the same shape as the ledger walk', async () => {
     await appendTurns([
       fakeLedgerTurn({ messageId: 'p-1' }),

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -1,13 +1,18 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { loadBuiltinPricing } from '@relayburn/analyze';
-import type { EnrichedTurn } from '@relayburn/ledger';
+import { __resetIndexCacheForTesting, appendTurns, type EnrichedTurn } from '@relayburn/ledger';
 import {
   EMPTY_COVERAGE,
   makeFidelity,
 } from '@relayburn/reader';
-import type { ActivityCategory, Fidelity } from '@relayburn/reader';
+import type { ActivityCategory, Fidelity, TurnRecord } from '@relayburn/reader';
+
+import { compare as sdkCompare } from '@relayburn/sdk';
 
 import { runCompare, type CompareDeps } from './compare.js';
 import type { ParsedArgs } from '../args.js';
@@ -570,5 +575,145 @@ describe('burn compare — required positional models (#159)', () => {
     assert.equal(result, 0);
     const parsed = JSON.parse(stdout);
     assert.deepEqual(parsed.models, ['claude-sonnet-4-6', 'claude-haiku-4-5']);
+  });
+});
+
+// SDK integration tests for `compare()`. These exercise the production path
+// (no `deps.queryAll`) by writing fixtures to an isolated tmp ledger and
+// calling `sdkCompare` directly. The CLI's runCompare wraps this with flag
+// parsing + rendering; this suite covers the SDK contract those presenters
+// rely on.
+describe('@relayburn/sdk compare() — ledger integration', () => {
+  let tmpHome: string;
+  let tmpRelay: string;
+  const originalHome = process.env['HOME'];
+  const originalRelay = process.env['RELAYBURN_HOME'];
+  const originalArchive = process.env['RELAYBURN_ARCHIVE'];
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), 'burn-compare-home-'));
+    tmpRelay = await mkdtemp(path.join(tmpdir(), 'burn-compare-relay-'));
+    process.env['HOME'] = tmpHome;
+    process.env['RELAYBURN_HOME'] = tmpRelay;
+    delete process.env['RELAYBURN_ARCHIVE'];
+    __resetIndexCacheForTesting();
+  });
+
+  afterEach(async () => {
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+    else delete process.env['HOME'];
+    if (originalRelay !== undefined) process.env['RELAYBURN_HOME'] = originalRelay;
+    else delete process.env['RELAYBURN_HOME'];
+    if (originalArchive !== undefined) process.env['RELAYBURN_ARCHIVE'] = originalArchive;
+    else delete process.env['RELAYBURN_ARCHIVE'];
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(tmpRelay, { recursive: true, force: true });
+  });
+
+  function fakeLedgerTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
+    return {
+      v: 1,
+      source: 'claude-code',
+      sessionId: 's-cmp',
+      messageId: `m-${Math.random().toString(36).slice(2, 10)}`,
+      turnIndex: 0,
+      ts: '2026-04-20T00:00:00.000Z',
+      model: 'claude-sonnet-4-6',
+      activity: 'coding',
+      hasEdits: true,
+      retries: 0,
+      usage: {
+        input: 1000,
+        output: 500,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheCreate5m: 0,
+        cacheCreate1h: 0,
+      },
+      toolCalls: [],
+      fidelity: makeFidelity('per-turn', {
+        ...EMPTY_COVERAGE,
+        hasInputTokens: true,
+        hasOutputTokens: true,
+        hasCacheReadTokens: true,
+        hasToolCalls: true,
+        hasToolResultEvents: true,
+        hasSessionRelationships: true,
+      }),
+      ...overrides,
+    };
+  }
+
+  it('rejects fewer than 2 models', async () => {
+    await assert.rejects(
+      () => sdkCompare({ models: ['claude-sonnet-4-6'] }),
+      /needs at least 2 models/,
+    );
+  });
+
+  it('rejects an invalid minFidelity value', async () => {
+    await assert.rejects(
+      () =>
+        sdkCompare({
+          models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+          minFidelity: 'bogus' as never,
+        }),
+      /invalid minFidelity/,
+    );
+  });
+
+  it('returns the JSON-shaped CompareResult against an isolated ledger', async () => {
+    await appendTurns([
+      fakeLedgerTurn({ messageId: 'm-1' }),
+      fakeLedgerTurn({ messageId: 'm-2', turnIndex: 1, ts: '2026-04-20T00:01:00.000Z' }),
+      fakeLedgerTurn({
+        messageId: 'm-3',
+        turnIndex: 2,
+        ts: '2026-04-20T00:02:00.000Z',
+        model: 'claude-haiku-4-5',
+      }),
+    ]);
+
+    const result = await sdkCompare({
+      models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+    });
+    assert.equal(result.analyzedTurns, 3);
+    assert.deepEqual([...result.models].sort(), ['claude-haiku-4-5', 'claude-sonnet-4-6']);
+    assert.equal(result.fidelity.minimum, 'usage-only');
+    assert.equal(result.fidelity.excluded.total, 0);
+    // cells is a flat array, not the nested CompareTable shape.
+    assert.ok(Array.isArray(result.cells));
+    const sonnet = result.cells.find(
+      (c) => c.model === 'claude-sonnet-4-6' && c.category === 'coding',
+    );
+    assert.ok(sonnet);
+    assert.equal(sonnet.turns, 2);
+  });
+
+  it('archive path (partial fidelity, no provider) returns the same shape as the ledger walk', async () => {
+    await appendTurns([
+      fakeLedgerTurn({ messageId: 'p-1' }),
+      fakeLedgerTurn({
+        messageId: 'p-2',
+        turnIndex: 1,
+        ts: '2026-04-20T00:01:00.000Z',
+        model: 'claude-haiku-4-5',
+      }),
+    ]);
+
+    const archive = await sdkCompare({
+      models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+      minFidelity: 'partial',
+    });
+    process.env['RELAYBURN_ARCHIVE'] = '0';
+    const ledger = await sdkCompare({
+      models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+      minFidelity: 'partial',
+    });
+    delete process.env['RELAYBURN_ARCHIVE'];
+
+    assert.equal(archive.analyzedTurns, ledger.analyzedTurns);
+    assert.deepEqual(archive.totals, ledger.totals);
+    assert.equal(archive.cells.length, ledger.cells.length);
   });
 });

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -1,16 +1,19 @@
 import {
   buildCompareTable,
-  compareFromArchive,
   DEFAULT_MIN_SAMPLE,
   hasMinimumFidelity,
   loadPricing,
   summarizeFidelity,
-  type CompareCell,
-  type CompareTable,
   type FidelitySummary,
 } from '@relayburn/analyze';
-import { buildArchive, queryAll, type EnrichedTurn, type Query } from '@relayburn/ledger';
+import { type EnrichedTurn, type Query } from '@relayburn/ledger';
 import type { FidelityClass } from '@relayburn/reader';
+import {
+  compare as sdkCompare,
+  type CompareCellResult,
+  type CompareExcludedBreakdown,
+  type CompareResult,
+} from '@relayburn/sdk';
 
 import { ingestAll } from '@relayburn/ingest';
 import { formatInt, formatUsd, parseSinceArg } from '../format.js';
@@ -117,8 +120,6 @@ export async function runCompare(
     return 2;
   }
 
-  // Required positional: a comma-separated list of >=2 models. Same
-  // trim/dedupe rules the old --models flag used.
   const seen = new Set<string>();
   const models: string[] = [];
   if (typeof first === 'string') {
@@ -135,12 +136,12 @@ export async function runCompare(
     return 2;
   }
 
-  const q: Query = {};
-  if (typeof args.flags['since'] === 'string') q.since = parseSinceArg(args.flags['since']);
-  if (typeof args.flags['project'] === 'string') q.project = args.flags['project'];
-  if (typeof args.flags['session'] === 'string') q.sessionId = args.flags['session'];
-  if (typeof args.flags['workflow'] === 'string') q.enrichment = { workflowId: args.flags['workflow'] };
-  if (typeof args.flags['agent'] === 'string') q.enrichment = { ...(q.enrichment ?? {}), agentId: args.flags['agent'] };
+  const since = typeof args.flags['since'] === 'string' ? parseSinceArg(args.flags['since']) : undefined;
+  const project = typeof args.flags['project'] === 'string' ? args.flags['project'] : undefined;
+  const session = typeof args.flags['session'] === 'string' ? args.flags['session'] : undefined;
+  const workflow = typeof args.flags['workflow'] === 'string' ? args.flags['workflow'] : undefined;
+  const agent = typeof args.flags['agent'] === 'string' ? args.flags['agent'] : undefined;
+
   const providerFilter = parseProviderFilter(args.flags['provider']);
   if (providerFilter instanceof Error) {
     process.stderr.write(providerFilter.message);
@@ -154,9 +155,8 @@ export async function runCompare(
     return 2;
   }
 
-  // Resolve --fidelity / --include-partial. --include-partial is just sugar
-  // for --fidelity partial; passing both is fine as long as they agree, and
-  // we error otherwise so the user doesn't get a surprising effective level.
+  // Resolve --fidelity / --include-partial. --include-partial is sugar for
+  // --fidelity partial; passing both is fine if they agree, error otherwise.
   const includePartial = args.flags['include-partial'] === true;
   const fidelityFlag = args.flags['fidelity'];
   let minFidelity: FidelityClass = 'usage-only';
@@ -188,15 +188,52 @@ export async function runCompare(
     return 2;
   }
 
-  const ingest = deps.ingestAll ?? ingestAll;
-  const query = deps.queryAll ?? queryAll;
-  const loadPricingFn = deps.loadPricing ?? loadPricing;
-
-  if (deps.ingestAll) {
+  // Test path (deps.queryAll injected). Bypass `sdk.compare` so tests stay
+  // hermetic against the user's real `~/.relayburn/archive.sqlite`. Mirrors
+  // the production pipeline against in-memory turns: provider filter, fidelity
+  // gate, buildCompareTable, then the same `CompareResult` shape `sdkCompare`
+  // returns.
+  let result: CompareResult;
+  if (deps.queryAll) {
+    const ingest = deps.ingestAll ?? ingestAll;
     await withProgress('ingesting latest sessions', async (task) => {
       await ingest();
       task.succeed('ingested latest sessions');
     });
+    const loadPricingFn = deps.loadPricing ?? loadPricing;
+    const pricing = await withProgress('loading pricing snapshot', async (task) => {
+      const loaded = await loadPricingFn();
+      task.succeed('loaded pricing snapshot');
+      return loaded;
+    });
+    const q: Query = {};
+    if (since !== undefined) q.since = since;
+    if (project !== undefined) q.project = project;
+    if (session !== undefined) q.sessionId = session;
+    if (workflow !== undefined || agent !== undefined) {
+      q.enrichment = {};
+      if (workflow !== undefined) q.enrichment.workflowId = workflow;
+      if (agent !== undefined) q.enrichment.agentId = agent;
+    }
+    const queriedTurns = await withProgress('reading ledger turns', async (task) => {
+      const turns = await deps.queryAll!(q);
+      task.succeed(`read ${formatInt(turns.length)} turn${turns.length === 1 ? '' : 's'}`);
+      return turns;
+    });
+    const turns = filterTurnsByProvider(queriedTurns, providerFilter);
+    const summary = summarizeFidelity(turns);
+    const filteredTurns = minFidelity === 'partial'
+      ? turns
+      : turns.filter((t) => hasMinimumFidelity(t.fidelity, minFidelity));
+    const table = await withProgress('building compare table', async (task) => {
+      const built = buildCompareTable(filteredTurns, { pricing, minSample, models });
+      task.succeed(
+        `built compare table from ${formatInt(filteredTurns.length)} turn` +
+          `${filteredTurns.length === 1 ? '' : 's'}`,
+      );
+      return built;
+    });
+    result = shapeCompareResult(table, filteredTurns.length, minFidelity, summary);
   } else {
     await withProgress('ingesting latest sessions', (task) =>
       ingestAll({
@@ -204,161 +241,111 @@ export async function runCompare(
         onWarn: (body) => task.warn(body),
       }),
     );
+    // Honor --no-archive / RELAYBURN_ARCHIVE=0 by forcing the SDK off the
+    // archive path. The SDK falls back to the ledger walk transparently when
+    // the archive read fails, so the easiest way to express "ledger only" is
+    // to set a non-default fidelity / provider — but those would change the
+    // semantic gate. Instead, mirror the env contract here: the SDK reads
+    // RELAYBURN_ARCHIVE itself via the underlying analyze layer where
+    // applicable, and the CLI flag forwards by setting the env for the call.
+    const restoreArchiveEnv = applyArchiveOverride(args);
+    try {
+      result = await withProgress('querying compare slice', async (task) => {
+        const sdkOpts: Parameters<typeof sdkCompare>[0] = {
+          models,
+          minSample,
+          minFidelity,
+        };
+        if (since !== undefined) sdkOpts.since = since;
+        if (project !== undefined) sdkOpts.project = project;
+        if (session !== undefined) sdkOpts.session = session;
+        if (workflow !== undefined) sdkOpts.workflow = workflow;
+        if (agent !== undefined) sdkOpts.agent = agent;
+        if (providerFilter) sdkOpts.provider = [...providerFilter];
+        sdkOpts.onLog = (msg: string) => task.update(msg);
+        const r = await sdkCompare(sdkOpts);
+        task.succeed(
+          `built compare table from ${formatInt(r.analyzedTurns)} turn` +
+            `${r.analyzedTurns === 1 ? '' : 's'}`,
+        );
+        return r;
+      });
+    } finally {
+      restoreArchiveEnv();
+    }
   }
-  const pricing = await withProgress('loading pricing snapshot', async (task) => {
-    const loaded = await loadPricingFn();
-    task.succeed('loaded pricing snapshot');
-    return loaded;
-  });
-
-  const opts: Parameters<typeof buildCompareTable>[1] = { pricing, minSample, models };
-
-  // Archive path is the default, but it does not yet apply
-  // `attribution_fidelity` filtering at the SQL layer. Fall back to the
-  // in-memory `queryAll` + `buildCompareTable` path whenever fidelity
-  // filtering is in effect (i.e., minFidelity !== 'partial') so the
-  // fidelity gate is correctly applied. `--include-partial` / `--fidelity partial`
-  // disables filtering and reuses the archive's grouped SQL.
-  //
-  // `--provider` likewise bypasses the archive: provider is derived per
-  // turn from (model, source) at query time, and the archive's grouped
-  // SQL doesn't expose that classifier. The in-memory path applies the
-  // filter via `filterTurnsByProvider` before `buildCompareTable`.
-  //
-  // Skip the archive when the caller injected `queryAll` (test mode):
-  // `buildArchive` and `compareFromArchive` are not part of `CompareDeps`
-  // and would hit the real `~/.relayburn/archive.sqlite`, breaking test
-  // isolation. The non-archive branch already handles `--fidelity partial`
-  // correctly (the filter becomes a no-op).
-  const useArchive =
-    !shouldBypassArchive(args) &&
-    minFidelity === 'partial' &&
-    !providerFilter &&
-    !deps.queryAll;
-  let table: CompareTable;
-  let filteredTurns: EnrichedTurn[];
-  let summary: FidelitySummary;
-  if (useArchive) {
-    // Materialize the ledger tail before reading. ingestAll() above only
-    // writes to the JSONL ledger; the archive is a derived read model that
-    // needs an explicit catch-up build to reflect the just-appended turns.
-    await withProgress('updating archive', async (task) => {
-      const archiveResult = await buildArchive();
-      task.succeed(
-        `updated archive: ${formatInt(archiveResult.turnsApplied)} turn` +
-          `${archiveResult.turnsApplied === 1 ? '' : 's'} applied`,
-      );
-    });
-    const result = await withProgress('building compare table from archive', async (task) => {
-      const archiveCompare = await compareFromArchive(q, opts);
-      task.succeed(
-        `built compare table from ${formatInt(archiveCompare.analyzedTurns)} turn` +
-          `${archiveCompare.analyzedTurns === 1 ? '' : 's'}`,
-      );
-      return archiveCompare;
-    });
-    table = result.table;
-    // For fidelity-permissive mode the JSON summary reflects everything in
-    // the queried slice; we still emit a zero-excluded breakdown so the
-    // schema is stable.
-    const turnsForSummary = await withProgress('reading turns for fidelity summary', async (task) => {
-      const turns = await query(q);
-      task.succeed(`read ${formatInt(turns.length)} turn${turns.length === 1 ? '' : 's'}`);
-      return turns;
-    });
-    summary = summarizeFidelity(turnsForSummary);
-    filteredTurns = turnsForSummary;
-    void result.analyzedTurns;
-  } else {
-    // `--provider` narrows the queried slice up front so coverage / fidelity
-    // counts reflect the provider-scoped input, not the cross-provider total
-    // (which would over-count "excluded" turns relative to what's rendered).
-    const queriedTurns = await withProgress('reading ledger turns', async (task) => {
-      const turns = await query(q);
-      task.succeed(`read ${formatInt(turns.length)} turn${turns.length === 1 ? '' : 's'}`);
-      return turns;
-    });
-    const turns = filterTurnsByProvider(queriedTurns, providerFilter);
-    // Summarize fidelity over the *unfiltered* slice (modulo provider) so
-    // coverage notes and the JSON `summary` reflect the input the user
-    // actually queried, not what survived the fidelity gate. The summary
-    // is what tells them why N turns were dropped.
-    summary = summarizeFidelity(turns);
-    // `--fidelity partial` (and its `--include-partial` shorthand) is the
-    // "let everything through" escape hatch. The FidelityClass
-    // ordering used by `hasMinimumFidelity` puts `partial` strictly above
-    // `aggregate-only` / `cost-only`, so the predicate would otherwise
-    // still drop those two buckets. Bypass the gate entirely in that mode.
-    filteredTurns = minFidelity === 'partial'
-      ? turns
-      : turns.filter((t) => hasMinimumFidelity(t.fidelity, minFidelity));
-    table = await withProgress('building compare table', async (task) => {
-      const built = buildCompareTable(filteredTurns, opts);
-      task.succeed(
-        `built compare table from ${formatInt(filteredTurns.length)} turn` +
-          `${filteredTurns.length === 1 ? '' : 's'}`,
-      );
-      return built;
-    });
-  }
-  const excluded = computeExcluded(summary, minFidelity);
 
   if (wantJson) {
-    process.stdout.write(
-      JSON.stringify(
-        toJson(table, filteredTurns.length, {
-          minimum: minFidelity,
-          excluded,
-          summary,
-        }),
-        null,
-        2,
-      ) + '\n',
-    );
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
     return 0;
   }
   if (wantCsv) {
-    process.stdout.write(renderCsv(table));
+    process.stdout.write(renderCsv(result));
     return 0;
   }
 
-  process.stdout.write(
-    renderTty(table, filteredTurns.length, { minimum: minFidelity, excluded }),
-  );
+  process.stdout.write(renderTty(result));
   return 0;
 }
 
-function shouldBypassArchive(args: ParsedArgs): boolean {
-  if (args.flags['no-archive'] === true) return true;
-  const env = process.env['RELAYBURN_ARCHIVE'];
-  if (env === '0' || env === 'false' || env === 'no') return true;
-  return false;
+function applyArchiveOverride(args: ParsedArgs): () => void {
+  if (args.flags['no-archive'] !== true) return () => {};
+  const prev = process.env['RELAYBURN_ARCHIVE'];
+  process.env['RELAYBURN_ARCHIVE'] = '0';
+  return () => {
+    if (prev === undefined) delete process.env['RELAYBURN_ARCHIVE'];
+    else process.env['RELAYBURN_ARCHIVE'] = prev;
+  };
 }
 
 function isFidelityClass(s: string): s is FidelityClass {
   return (FIDELITY_CHOICES as ReadonlyArray<string>).includes(s);
 }
 
-interface ExcludedBreakdown {
-  total: number;
-  aggregateOnly: number;
-  costOnly: number;
-  partial: number;
-  usageOnly: number;
+function shapeCompareResult(
+  table: ReturnType<typeof buildCompareTable>,
+  analyzedTurns: number,
+  minimum: FidelityClass,
+  summary: FidelitySummary,
+): CompareResult {
+  const excluded = computeExcluded(summary, minimum);
+  const cells: CompareCellResult[] = [];
+  for (const m of table.models) {
+    for (const cat of table.categories) {
+      const c = table.cells[m]![cat]!;
+      cells.push({
+        model: m,
+        category: cat,
+        turns: c.turns,
+        editTurns: c.editTurns,
+        oneShotTurns: c.oneShotTurns,
+        pricedTurns: c.pricedTurns,
+        totalCost: round(c.totalCost, 6),
+        costPerTurn: c.costPerTurn !== null ? round(c.costPerTurn, 6) : null,
+        oneShotRate: c.oneShotRate !== null ? round(c.oneShotRate, 4) : null,
+        cacheHitRate: c.cacheHitRate !== null ? round(c.cacheHitRate, 4) : null,
+        medianRetries: c.medianRetries,
+        noData: c.noData,
+        insufficientSample: c.insufficientSample,
+      });
+    }
+  }
+  return {
+    analyzedTurns,
+    minSample: table.minSample,
+    models: table.models,
+    categories: table.categories,
+    totals: table.totals,
+    cells,
+    fidelity: { minimum, excluded, summary: summary as unknown as CompareResult['fidelity']['summary'] },
+  };
 }
 
-// Sum the byClass buckets that fall below the minimum fidelity. We never
-// exclude `unknown` (records without a fidelity field — `hasMinimumFidelity`
-// passes them for backward compat), so they don't get counted here.
-//
-// `--fidelity partial` is the "include everything" escape hatch (matched by
-// the runtime), so it always reports zero excluded — even though the
-// FidelityClass ordering puts `partial` above `aggregate-only` / `cost-only`.
 function computeExcluded(
   summary: FidelitySummary,
   minimum: FidelityClass,
-): ExcludedBreakdown {
-  const out: ExcludedBreakdown = {
+): CompareExcludedBreakdown {
+  const out: CompareExcludedBreakdown = {
     total: 0,
     aggregateOnly: 0,
     costOnly: 0,
@@ -387,50 +374,11 @@ function computeExcluded(
   return out;
 }
 
-interface FidelityJsonBlock {
-  minimum: FidelityClass;
-  excluded: ExcludedBreakdown;
-  summary: FidelitySummary;
+function round(n: number, digits: number): number {
+  return Number(n.toFixed(digits));
 }
 
-function toJson(
-  t: CompareTable,
-  analyzedTurns: number,
-  fidelity: FidelityJsonBlock,
-): object {
-  const cells: Array<Record<string, unknown>> = [];
-  for (const m of t.models) {
-    for (const cat of t.categories) {
-      const c = t.cells[m]![cat]!;
-      cells.push({
-        model: m,
-        category: cat,
-        turns: c.turns,
-        editTurns: c.editTurns,
-        oneShotTurns: c.oneShotTurns,
-        pricedTurns: c.pricedTurns,
-        totalCost: round(c.totalCost, 6),
-        costPerTurn: c.costPerTurn !== null ? round(c.costPerTurn, 6) : null,
-        oneShotRate: c.oneShotRate !== null ? round(c.oneShotRate, 4) : null,
-        cacheHitRate: c.cacheHitRate !== null ? round(c.cacheHitRate, 4) : null,
-        medianRetries: c.medianRetries,
-        noData: c.noData,
-        insufficientSample: c.insufficientSample,
-      });
-    }
-  }
-  return {
-    analyzedTurns,
-    minSample: t.minSample,
-    models: t.models,
-    categories: t.categories,
-    totals: t.totals,
-    cells,
-    fidelity,
-  };
-}
-
-function renderCsv(t: CompareTable): string {
+function renderCsv(r: CompareResult): string {
   const header = [
     'model',
     'category',
@@ -447,9 +395,13 @@ function renderCsv(t: CompareTable): string {
     'insufficientSample',
   ];
   const rows: string[] = [header.join(',')];
-  for (const m of t.models) {
-    for (const cat of t.categories) {
-      const c = t.cells[m]![cat]!;
+  // Iterate by (model × category) in the table order so column structure is
+  // stable across runs; lookup into the flat cells keeps the body identical
+  // to the legacy nested-map walk.
+  const lookup = buildCellLookup(r);
+  for (const m of r.models) {
+    for (const cat of r.categories) {
+      const c = lookup.get(m)!.get(cat)!;
       rows.push(
         [
           csvCell(m),
@@ -483,67 +435,49 @@ function numCsv(n: number, digits: number): string {
   return Number(n.toFixed(digits)).toString();
 }
 
-function round(n: number, digits: number): number {
-  return Number(n.toFixed(digits));
-}
-
 const DASH = '—';
 
 function formatPct(p: number): string {
   return `${Math.round(p * 100)}%`;
 }
 
-function cellFields(c: CompareCell): [string, string, string] {
+function cellFields(c: CompareCellResult): [string, string, string] {
   if (c.noData) return [DASH, DASH, DASH];
   const turns = formatInt(c.turns);
-  // Cost dashes when no turns in the cell were priced (unknown/unpriced model)
-  // — distinct from $0.00 which would be a meaningful "free" claim.
   const cost = c.costPerTurn !== null ? formatUsd(c.costPerTurn) : DASH;
-  // One-shot rate dashes for categories that don't produce edits
-  // (exploration, brainstorming, planning, delegation, testing, git, deps,
-  // format, build-deploy, verification, review, reasoning, conversation).
   const oneShot = c.oneShotRate !== null ? formatPct(c.oneShotRate) : DASH;
   return [turns, cost, oneShot];
 }
 
-interface FidelityRenderInput {
-  minimum: FidelityClass;
-  excluded: ExcludedBreakdown;
-}
-
-function renderTty(
-  t: CompareTable,
-  analyzedTurns: number,
-  fidelity: FidelityRenderInput,
-): string {
+function renderTty(r: CompareResult): string {
   const lines: string[] = [];
   lines.push('');
-  lines.push(`turns analyzed: ${formatInt(analyzedTurns)}`);
-  if (fidelity.excluded.total > 0) {
-    lines.push(formatExcludedNote(fidelity));
+  lines.push(`turns analyzed: ${formatInt(r.analyzedTurns)}`);
+  if (r.fidelity.excluded.total > 0) {
+    lines.push(formatExcludedNote(r.fidelity));
   }
   lines.push('');
 
-  if (t.models.length === 0 || t.categories.length === 0) {
+  if (r.models.length === 0 || r.categories.length === 0) {
     lines.push('no data to compare (need turns spanning ≥1 model and ≥1 activity).');
     return lines.join('\n') + '\n';
   }
 
-  // Build sub-header and data rows first to measure widths.
+  const lookup = buildCellLookup(r);
+
   const subHeader: string[] = ['Activity'];
-  for (let i = 0; i < t.models.length; i++) subHeader.push('Turns', 'Cost/turn', '1-shot');
+  for (let i = 0; i < r.models.length; i++) subHeader.push('Turns', 'Cost/turn', '1-shot');
 
   const dataRows: string[][] = [];
-  for (const cat of t.categories) {
+  for (const cat of r.categories) {
     const row: string[] = [cat];
-    for (const m of t.models) {
-      const [a, b, c] = cellFields(t.cells[m]![cat]!);
+    for (const m of r.models) {
+      const [a, b, c] = cellFields(lookup.get(m)!.get(cat)!);
       row.push(a, b, c);
     }
     dataRows.push(row);
   }
 
-  // Compute column widths across sub-header + data rows.
   const widths = new Array(subHeader.length).fill(0);
   for (const row of [subHeader, ...dataRows]) {
     row.forEach((cell, i) => {
@@ -553,41 +487,36 @@ function renderTty(
 
   const SEP = '  ';
 
-  // If a model display name is wider than its three sub-columns combined,
-  // widen the last sub-column so the group header and sub-header stay aligned.
-  for (let mi = 0; mi < t.models.length; mi++) {
+  for (let mi = 0; mi < r.models.length; mi++) {
     const start = 1 + mi * 3;
     const groupWidth = widths[start]! + SEP.length + widths[start + 1]! + SEP.length + widths[start + 2]!;
-    const name = displayModelName(t.models[mi]!);
+    const name = displayModelName(r.models[mi]!);
     if (name.length > groupWidth) widths[start + 2] += name.length - groupWidth;
   }
 
   const groupLine: string[] = [' '.repeat(widths[0]!)];
-  for (let mi = 0; mi < t.models.length; mi++) {
+  for (let mi = 0; mi < r.models.length; mi++) {
     const start = 1 + mi * 3;
     const groupWidth = widths[start]! + SEP.length + widths[start + 1]! + SEP.length + widths[start + 2]!;
-    const name = displayModelName(t.models[mi]!);
+    const name = displayModelName(r.models[mi]!);
     groupLine.push(name.padEnd(groupWidth));
   }
   lines.push(groupLine.join(SEP).trimEnd());
   lines.push(renderRow(subHeader, widths, SEP));
   for (const row of dataRows) lines.push(renderRow(row, widths, SEP));
 
-  // Coverage notes. Only surface a gap when at least one other model has
-  // data in that category — otherwise the row is already uniformly empty and
-  // the note is noise. Cap at NOTE_LIMIT; overflow gets a summary line.
   const NOTE_LIMIT = 8;
   const notes: string[] = [];
-  for (const cat of t.categories) {
-    const anyHasData = t.models.some((m) => !t.cells[m]![cat]!.noData);
+  for (const cat of r.categories) {
+    const anyHasData = r.models.some((m) => !lookup.get(m)!.get(cat)!.noData);
     if (!anyHasData) continue;
-    for (const m of t.models) {
-      const c = t.cells[m]![cat]!;
+    for (const m of r.models) {
+      const c = lookup.get(m)!.get(cat)!;
       if (c.noData) {
         notes.push(`no ${displayModelName(m)} data in '${cat}' — no comparison available.`);
       } else if (c.insufficientSample) {
         notes.push(
-          `low ${displayModelName(m)} sample in '${cat}' (${c.turns} turns < ${t.minSample}) — treat as indicative.`,
+          `low ${displayModelName(m)} sample in '${cat}' (${c.turns} turns < ${r.minSample}) — treat as indicative.`,
         );
       }
     }
@@ -601,14 +530,11 @@ function renderTty(
     }
   }
 
-  // Per-model totals. A model that survived the filter with zero turns (e.g.
-  // every turn was excluded by --fidelity, or --models pre-seeded a model the
-  // user asked about that has no data in the slice) renders the cost as the
-  // dash sentinel — not "$0.00", which would falsely claim the model ran for
-  // free.
+  // Per-model totals. A model with zero turns renders cost as the dash
+  // sentinel — `$0.00` would falsely claim the model ran for free.
   lines.push('');
-  for (const m of t.models) {
-    const tot = t.totals[m] ?? { turns: 0, totalCost: 0 };
+  for (const m of r.models) {
+    const tot = r.totals[m] ?? { turns: 0, totalCost: 0 };
     const totalCost = tot.turns > 0 ? formatUsd(tot.totalCost) : DASH;
     lines.push(`${displayModelName(m)}: ${formatInt(tot.turns)} turns, ${totalCost} total`);
   }
@@ -616,9 +542,20 @@ function renderTty(
   return lines.join('\n');
 }
 
-// "excluded 12 turns below usage-only fidelity (8 aggregate-only, 3 cost-only, 1 partial)"
-// — only mention non-zero buckets so the parenthetical stays terse.
-function formatExcludedNote(f: FidelityRenderInput): string {
+function buildCellLookup(r: CompareResult): Map<string, Map<string, CompareCellResult>> {
+  const out = new Map<string, Map<string, CompareCellResult>>();
+  for (const cell of r.cells) {
+    let byCat = out.get(cell.model);
+    if (!byCat) {
+      byCat = new Map();
+      out.set(cell.model, byCat);
+    }
+    byCat.set(cell.category, cell);
+  }
+  return out;
+}
+
+function formatExcludedNote(f: CompareResult['fidelity']): string {
   const parts: string[] = [];
   if (f.excluded.aggregateOnly > 0) parts.push(`${f.excluded.aggregateOnly} aggregate-only`);
   if (f.excluded.costOnly > 0) parts.push(`${f.excluded.costOnly} cost-only`);
@@ -636,7 +573,7 @@ function renderRow(row: string[], widths: number[], sep: string): string {
 function displayModelName(m: string): string {
   // Strip provider prefix (e.g. "anthropic/claude-sonnet-4-6" → "claude-sonnet-4-6")
   // for display brevity. Aggregation in buildCompareTable always uses the
-  // raw model name, so two providers that ship a model with the same suffix
+  // raw model name, so two providers shipping a model with the same suffix
   // would still aggregate separately and only collide visually in the TTY
   // header. Use --json for the unambiguous identifier.
   const i = m.indexOf('/');

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `@relayburn/sdk`.
 
 ### Added
 
+- `compare({ models, … })` returns the per-(model, activity) `CompareResult` shape (`analyzedTurns`, `models`, `categories`, `totals`, flat `cells[]`, `fidelity { minimum, excluded, summary }`) — the JSON object `burn compare --json` now emits. Mirrors the CLI's archive-vs-ledger branching: archive when `minFidelity === 'partial'` and no provider filter, ledger walk otherwise. Falls back transparently to the ledger walk when the archive read fails.
 - `sessionCost({ session })` returns the compact per-session cost shape (`totalUSD`, `totalTokens`, `turnCount`, `models`) the MCP `burn__sessionCost` tool now wraps directly.
 - `summary()` result now includes `turnCount`.
 - `summary()` and `sessionCost()` read through the SQLite archive by default with transparent fallback to the JSONL ledger walk on archive failure. Pass `onLog` to capture the fallback reason.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -8,6 +8,7 @@ import {
   ingest,
   summary,
   sessionCost,
+  compare,
   overhead,
   overheadTrim,
   hotspots,
@@ -23,6 +24,13 @@ const stats = await summary({ session: 'session-id', ledgerHome: '/tmp/relayburn
 // Powers the MCP `burn__sessionCost` tool.
 const cost = await sessionCost({ session: 'session-id' });
 
+// Per-(model, activity) comparison shape — the JSON object `burn compare --json` emits.
+const cmp = await compare({
+  models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+  since: '30d',
+  minFidelity: 'usage-only',
+});
+
 // Overhead-file (CLAUDE.md / AGENTS.md / .claude/CLAUDE.md) cost attribution.
 const oh = await overhead({ project: '/path/to/repo', since: '30d' });
 const trim = await overheadTrim({ project: '/path/to/repo', top: 3 });
@@ -30,6 +38,6 @@ const trim = await overheadTrim({ project: '/path/to/repo', top: 3 });
 const findings = await hotspots({ session: 'session-id', patterns: ['retry-loop'] });
 ```
 
-`summary`, `sessionCost`, `overhead`, and `overheadTrim` read through the SQLite archive when available, transparently falling back to the JSONL ledger walk if the archive can't be opened. Pass `onLog` to surface fallback messages in your host's log channel.
+`summary`, `sessionCost`, `compare`, `overhead`, and `overheadTrim` read through the SQLite archive when available, transparently falling back to the JSONL ledger walk if the archive can't be opened. Pass `onLog` to surface fallback messages in your host's log channel.
 
 `overheadTrim` includes a unified-diff string per recommendation by default (matches `burn overhead trim --json`); pass `includeDiff: false` to skip the per-file disk reads when you only need the recommendation rows.

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -156,3 +156,79 @@ export interface HotspotsOptions {
   ledgerHome?: string;
 }
 export declare function hotspots(opts?: HotspotsOptions): Promise<unknown>
+
+export type FidelityClass = 'full' | 'usage-only' | 'aggregate-only' | 'cost-only' | 'partial';
+
+export interface FidelitySummaryShape {
+  total: number;
+  byClass: Record<FidelityClass, number>;
+  unknown: number;
+  missingCoverage: Record<string, number>;
+}
+
+export interface CompareExcludedBreakdown {
+  total: number;
+  aggregateOnly: number;
+  costOnly: number;
+  partial: number;
+  usageOnly: number;
+}
+
+export interface CompareCellResult {
+  model: string;
+  category: string;
+  turns: number;
+  editTurns: number;
+  oneShotTurns: number;
+  pricedTurns: number;
+  totalCost: number;
+  costPerTurn: number | null;
+  oneShotRate: number | null;
+  cacheHitRate: number | null;
+  medianRetries: number | null;
+  noData: boolean;
+  insufficientSample: boolean;
+}
+
+export interface CompareOptions {
+  /** Required: ≥2 model names to compare. */
+  models: string[];
+  session?: string;
+  project?: string;
+  /** ISO timestamp (e.g. `2026-04-01T00:00:00Z`) or relative range (`24h`, `7d`, `4w`, `2m`). */
+  since?: string;
+  workflow?: string;
+  agent?: string;
+  /** Resolved provider filter (e.g. `['anthropic', 'synthetic']`). */
+  provider?: string[];
+  /** Insufficient-sample threshold; cells below this get flagged. Default 5. */
+  minSample?: number;
+  /** Minimum fidelity class to include in the aggregate. Default `'usage-only'`. */
+  minFidelity?: FidelityClass;
+  ledgerHome?: string;
+  onLog?: (msg: string) => void;
+}
+
+export interface CompareResult {
+  analyzedTurns: number;
+  minSample: number;
+  models: string[];
+  categories: string[];
+  totals: Record<string, { turns: number; totalCost: number }>;
+  cells: CompareCellResult[];
+  fidelity: {
+    minimum: FidelityClass;
+    excluded: CompareExcludedBreakdown;
+    summary: FidelitySummaryShape;
+  };
+}
+
+/**
+ * Per-(model, activity) comparison shape. Powers `burn compare` and the
+ * future `burn__compare` MCP tool. Reads through the SQLite archive when
+ * `minFidelity === 'partial'` and no provider filter is set; otherwise
+ * walks the ledger so the fidelity gate / provider filter can be applied
+ * per-turn. Falls back transparently to the ledger walk when the archive
+ * read fails.
+ */
+export declare function compare(opts: CompareOptions): Promise<CompareResult>

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -8,21 +8,27 @@ import {
 } from '@relayburn/ledger';
 import {
   attributeOverhead,
+  buildCompareTable,
   buildGhostSurfaceInputs,
   buildTrimRecommendations,
+  compareFromArchive,
   costForTurn,
+  DEFAULT_MIN_SAMPLE,
   detectGhostSurface,
   detectPatterns,
   detectToolCallPatterns,
   detectToolOutputBloat,
+  filterTurnsByProvider,
   findingsFromPatterns,
   findOverheadFiles,
   ghostSurfaceToFinding,
+  hasMinimumFidelity,
   loadClaudeSettings,
   loadOverheadFile,
   loadPricing,
   projectClaudeSettingsPath,
   renderUnifiedDiffForRecommendation,
+  summarizeFidelity,
   sumCosts,
   attributeHotspots,
   toolCallPatternToFinding,
@@ -453,4 +459,153 @@ function toProjectRelativePath(filePath, projectPath) {
   const rel = path.relative(projectPath, filePath);
   const display = rel && !rel.startsWith('..') ? rel : filePath;
   return display.split(path.sep).join('/');
+}
+
+const FIDELITY_CHOICES = ['full', 'usage-only', 'aggregate-only', 'cost-only', 'partial'];
+
+// Per-(model, activity) comparison shape. Mirrors the archive-vs-ledger
+// branching `runCompare` ships in the CLI: archive when nothing forces a
+// per-turn walk (no fidelity gate, no provider filter), ledger walk
+// otherwise. Returns the same JSON object the CLI's `--json` mode emits so
+// the CLI becomes a thin presenter and a future `burn__compare` MCP tool
+// can wrap this directly.
+export async function compare(opts) {
+  if (!opts || !Array.isArray(opts.models) || opts.models.length < 2) {
+    throw new Error('compare: needs at least 2 models');
+  }
+  if (opts.minFidelity !== undefined && !FIDELITY_CHOICES.includes(opts.minFidelity)) {
+    throw new Error(
+      `compare: invalid minFidelity: ${opts.minFidelity} (expected one of ${FIDELITY_CHOICES.join(', ')})`,
+    );
+  }
+  return withHome(opts.ledgerHome, async () => {
+    const minFidelity = opts.minFidelity ?? 'usage-only';
+    const minSample = opts.minSample ?? DEFAULT_MIN_SAMPLE;
+    const providerFilter = normalizeProviderFilter(opts.provider);
+
+    const q = {};
+    const since = normalizeSince(opts.since);
+    if (since !== undefined) q.since = since;
+    if (opts.session !== undefined) q.sessionId = opts.session;
+    if (opts.project !== undefined) q.project = opts.project;
+    if (opts.workflow !== undefined || opts.agent !== undefined) {
+      q.enrichment = {};
+      if (opts.workflow !== undefined) q.enrichment.workflowId = opts.workflow;
+      if (opts.agent !== undefined) q.enrichment.agentId = opts.agent;
+    }
+
+    const pricing = await loadPricing();
+    const tableOpts = { pricing, minSample, models: opts.models };
+
+    // Archive path is allowed only when nothing forces a per-turn walk: no
+    // fidelity gate (`partial` lets everything through) and no provider
+    // filter (provider is derived per turn from (model, source) at query
+    // time and the archive's grouped SQL doesn't expose that classifier).
+    const useArchive = minFidelity === 'partial' && !providerFilter;
+
+    let table;
+    let analyzedTurns;
+    let summary;
+    if (useArchive) {
+      try {
+        await buildArchive();
+        const archived = await compareFromArchive(q, tableOpts);
+        table = archived.table;
+        // For the fidelity-permissive mode we still emit a zero-excluded
+        // summary so the JSON schema stays stable. summarizeFidelity needs
+        // turn rows; pull them via the same archive-aware loader.
+        const turnsForSummary = await loadTurnsViaArchive(q, opts.onLog);
+        summary = summarizeFidelity(turnsForSummary);
+        analyzedTurns = turnsForSummary.length;
+        return shapeCompareResult(table, analyzedTurns, minFidelity, summary);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        opts.onLog?.(`archive compare failed, falling back to ledger walk: ${msg}`);
+        // Fall through to ledger path.
+      }
+    }
+
+    const queriedTurns = await loadTurnsViaArchive(q, opts.onLog);
+    const turns = providerFilter ? filterTurnsByProvider(queriedTurns, providerFilter) : queriedTurns;
+    summary = summarizeFidelity(turns);
+    const filteredTurns = minFidelity === 'partial'
+      ? turns
+      : turns.filter((t) => hasMinimumFidelity(t.fidelity, minFidelity));
+    table = buildCompareTable(filteredTurns, tableOpts);
+    analyzedTurns = filteredTurns.length;
+    return shapeCompareResult(table, analyzedTurns, minFidelity, summary);
+  });
+}
+
+function normalizeProviderFilter(provider) {
+  if (!provider) return undefined;
+  if (!Array.isArray(provider)) {
+    throw new Error('compare: provider must be an array of strings');
+  }
+  const normalized = provider
+    .map((p) => (typeof p === 'string' ? p.trim().toLowerCase() : ''))
+    .filter(Boolean);
+  if (normalized.length === 0) return undefined;
+  return new Set(normalized);
+}
+
+// Sum the byClass buckets that fall below the minimum fidelity. We never
+// exclude `unknown` (records without a fidelity field — `hasMinimumFidelity`
+// passes them for backward compat), so they don't get counted here.
+// `partial` is the "include everything" escape hatch; it always reports zero
+// excluded.
+export function computeCompareExcluded(summary, minimum) {
+  const out = { total: 0, aggregateOnly: 0, costOnly: 0, partial: 0, usageOnly: 0 };
+  if (minimum === 'partial') return out;
+  const order = ['cost-only', 'aggregate-only', 'partial', 'usage-only', 'full'];
+  const need = order.indexOf(minimum);
+  for (const cls of order) {
+    if (order.indexOf(cls) >= need) continue;
+    const n = summary.byClass[cls];
+    if (!n) continue;
+    out.total += n;
+    if (cls === 'aggregate-only') out.aggregateOnly += n;
+    else if (cls === 'cost-only') out.costOnly += n;
+    else if (cls === 'partial') out.partial += n;
+    else if (cls === 'usage-only') out.usageOnly += n;
+  }
+  return out;
+}
+
+function shapeCompareResult(table, analyzedTurns, minimum, summary) {
+  const excluded = computeCompareExcluded(summary, minimum);
+  const cells = [];
+  for (const m of table.models) {
+    for (const cat of table.categories) {
+      const c = table.cells[m][cat];
+      cells.push({
+        model: m,
+        category: cat,
+        turns: c.turns,
+        editTurns: c.editTurns,
+        oneShotTurns: c.oneShotTurns,
+        pricedTurns: c.pricedTurns,
+        totalCost: round(c.totalCost, 6),
+        costPerTurn: c.costPerTurn !== null ? round(c.costPerTurn, 6) : null,
+        oneShotRate: c.oneShotRate !== null ? round(c.oneShotRate, 4) : null,
+        cacheHitRate: c.cacheHitRate !== null ? round(c.cacheHitRate, 4) : null,
+        medianRetries: c.medianRetries,
+        noData: c.noData,
+        insufficientSample: c.insufficientSample,
+      });
+    }
+  }
+  return {
+    analyzedTurns,
+    minSample: table.minSample,
+    models: table.models,
+    categories: table.categories,
+    totals: table.totals,
+    cells,
+    fidelity: { minimum, excluded, summary },
+  };
+}
+
+function round(n, digits) {
+  return Number(n.toFixed(digits));
 }

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -497,11 +497,19 @@ export async function compare(opts) {
     const pricing = await loadPricing();
     const tableOpts = { pricing, minSample, models: opts.models };
 
-    // Archive path is allowed only when nothing forces a per-turn walk: no
-    // fidelity gate (`partial` lets everything through) and no provider
-    // filter (provider is derived per turn from (model, source) at query
-    // time and the archive's grouped SQL doesn't expose that classifier).
-    const useArchive = minFidelity === 'partial' && !providerFilter;
+    // `RELAYBURN_ARCHIVE=0` (also `false`/`no`) is the documented escape
+    // hatch from the archive path — used by `burn compare --no-archive` for
+    // parity/debug workflows. Honor it before deciding whether to query the
+    // archive at all so the CLI flag actually forces the ledger walk even
+    // when the archive on disk is healthy.
+    const archiveEnabled = !envDisablesArchive();
+
+    // Archive path is additionally restricted to slices where nothing forces
+    // a per-turn walk: no fidelity gate (`partial` lets everything through)
+    // and no provider filter (provider is derived per turn from (model,
+    // source) at query time and the archive's grouped SQL doesn't expose
+    // that classifier).
+    const useArchive = archiveEnabled && minFidelity === 'partial' && !providerFilter;
 
     let table;
     let analyzedTurns;
@@ -525,7 +533,13 @@ export async function compare(opts) {
       }
     }
 
-    const queriedTurns = await loadTurnsViaArchive(q, opts.onLog);
+    // Ledger-walk path. When the archive is disabled we go straight to
+    // `queryAll` (no `buildArchive` side effect); otherwise the
+    // archive-aware loader still wins on the hot path even when the gate
+    // forces post-load filtering.
+    const queriedTurns = archiveEnabled
+      ? await loadTurnsViaArchive(q, opts.onLog)
+      : await queryAll(q);
     const turns = providerFilter ? filterTurnsByProvider(queriedTurns, providerFilter) : queriedTurns;
     summary = summarizeFidelity(turns);
     const filteredTurns = minFidelity === 'partial'
@@ -535,6 +549,11 @@ export async function compare(opts) {
     analyzedTurns = filteredTurns.length;
     return shapeCompareResult(table, analyzedTurns, minFidelity, summary);
   });
+}
+
+function envDisablesArchive() {
+  const v = process.env.RELAYBURN_ARCHIVE;
+  return v === '0' || v === 'false' || v === 'no';
 }
 
 function normalizeProviderFilter(provider) {


### PR DESCRIPTION
Closes #233. Follow-up to #232 / #236 (which moved `summary`, `sessionCost`, `overhead`, and `overheadTrim` into `@relayburn/sdk`).

## Summary

`burn compare` joins the other read verbs as a thin presenter over a new `@relayburn/sdk` `compare()` function. The CLI keeps flag parsing, ingest, and TTY/JSON/CSV rendering; the SDK owns the archive-vs-ledger branching, the fidelity gate, the provider filter, and the result shaping. Returns the same JSON object `burn compare --json` already emits so a future `burn__compare` MCP tool (and embedders) can wrap the call without re-implementing the pipeline.

- **New `compare(opts)` in `@relayburn/sdk`** with `CompareOptions` / `CompareResult` types. Mirrors the CLI's archive path (used when `minFidelity === 'partial'` and no provider filter) with transparent fallback to the ledger walk when the archive read fails.
- **`runCompare` in `@relayburn/cli`** now calls `sdkCompare()` for production. The existing `deps.queryAll` injection seam is preserved so the existing in-memory unit tests remain hermetic against the user's real `~/.relayburn/archive.sqlite`.
- **`renderTty` / `renderCsv` / `--json`** consume the flat `CompareResult.cells` shape per the issue's design. Wire shape (TTY + `--json` + `--csv`) is unchanged.
- **README + changelogs** updated (root, `@relayburn/sdk`, `@relayburn/cli`).

## Test plan

- [x] Full workspace `pnpm run build && pnpm -w run test` — 863 tests, 164 suites, 0 failures.
- [x] New SDK integration tests in `packages/cli/src/commands/compare.test.ts` cover:
  - input validation (`< 2 models`, invalid `minFidelity`)
  - the JSON shape against an isolated tmp ledger
  - archive-vs-ledger parity for the partial-fidelity path
- [x] All existing 24 `runCompare` tests (fidelity gating, provider filter, positional models) continue to pass against the refactored CLI.

## Out of scope

- Adding a `burn__compare` MCP tool — separate PR (will wrap `sdk.compare()` directly, ~30 lines).
- Lifting `parseProviderFilter` into `@relayburn/analyze` — `compare()` accepts the resolved provider list as `string[]`, so the CLI keeps owning the comma-separated parser; an MCP tool can pass `provider` directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NPio1K75weUFxTMw77v6BT)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->