### PR TITLE
Lift hotspots() into @relayburn/sdk as a discriminated union (closes #234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 - **Architecture: `@relayburn/sdk` is now the canonical in-process query surface.** Dependency order moves from `… → mcp → cli → sdk → relayburn` to `… → sdk → mcp → cli → relayburn`; `@relayburn/mcp` now depends on `@relayburn/sdk` and rewrites `burn__sessionCost` as a thin wrapper over the SDK's new `sessionCost()` function. New read verbs should land in the SDK first; MCP and CLI become presenters (tool definitions / table rendering) over the same SDK calls so query logic stops drifting between them.
 
+### Breaking Changes
+
+- `@relayburn/sdk` `hotspots()` now returns a discriminated union (`{ kind: 'attribution' | 'bash' | 'bash-verb' | 'file' | 'subagent' | 'findings' }`) instead of either a raw attribution blob or a flat findings array. CLI / MCP / embedded callers must branch on `kind`. Mirrors the shape `burn hotspots --json` emits and adds four narrow `groupBy` views for single-axis consumers.
+
 ## [1.8.0] - 2026-05-02
 
 ### Added

--- a/packages/cli/src/sdk-hotspots.test.ts
+++ b/packages/cli/src/sdk-hotspots.test.ts
@@ -1,0 +1,291 @@
+// Drives the SDK's expanded `hotspots()` discriminated union directly so
+// non-CLI consumers (MCP, embedders) get coverage of every `kind` the
+// function can return: `attribution`, the four narrow `groupBy` shapes
+// (`bash` / `bash-verb` / `file` / `subagent`), and `findings`.
+//
+// The test mounts a tmp `RELAYBURN_HOME`, appends a small fixture turn slice
+// (a Read + an Edit + a Bash), and queries through the SDK end-to-end. We
+// assert per-`kind` shape (the `kind` discriminator is set; rows are the
+// expected per-axis aggregation) rather than exact dollar values, since
+// pricing snapshots drift over time.
+
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { __resetIndexCacheForTesting, appendTurns } from '@relayburn/ledger';
+import type { TurnRecord } from '@relayburn/reader';
+
+import { hotspots } from '@relayburn/sdk';
+
+const SESSION = 's-sdk-hotspots';
+
+function fakeTurn(overrides: Partial<TurnRecord> = {}): TurnRecord {
+  return {
+    v: 1,
+    source: 'claude-code',
+    sessionId: SESSION,
+    messageId: 'msg-1',
+    turnIndex: 0,
+    ts: '2026-04-29T00:00:00.000Z',
+    model: 'claude-sonnet-4-6',
+    usage: {
+      input: 5000,
+      output: 200,
+      reasoning: 0,
+      cacheRead: 100_000,
+      cacheCreate5m: 0,
+      cacheCreate1h: 0,
+    },
+    toolCalls: [],
+    project: '/tmp/project',
+    ...overrides,
+  };
+}
+
+let tmp: string;
+const originalHome = process.env['RELAYBURN_HOME'];
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'burn-sdk-hotspots-'));
+  process.env['RELAYBURN_HOME'] = tmp;
+  __resetIndexCacheForTesting();
+});
+
+afterEach(async () => {
+  if (originalHome !== undefined) process.env['RELAYBURN_HOME'] = originalHome;
+  else delete process.env['RELAYBURN_HOME'];
+  __resetIndexCacheForTesting();
+  await rm(tmp, { recursive: true, force: true });
+});
+
+async function seedFixtureTurns(): Promise<void> {
+  // Three sequential turns: Read, Edit, Bash. Each carries the coverage
+  // flags `attributeHotspots` requires (`hasToolCalls` + `hasToolResultEvents`)
+  // so they pass the eligibility gate without needing a sized tool-result
+  // sidecar — `attributeHotspots` falls back to even-split.
+  await appendTurns([
+    fakeTurn({
+      messageId: 'msg-1',
+      turnIndex: 0,
+      ts: '2026-04-29T00:00:00.000Z',
+      toolCalls: [
+        { id: 'tu-read', name: 'Read', target: '/tmp/foo.ts', argsHash: 'Read:foo' },
+      ],
+      fidelity: {
+        class: 'full',
+        granularity: 'per-turn',
+        coverage: {
+          hasToolCalls: true,
+          hasToolResultEvents: true,
+          hasSessionRelationships: true,
+          hasRawContent: true,
+          hasInputTokens: true,
+          hasOutputTokens: true,
+          hasReasoningTokens: true,
+          hasCacheReadTokens: true,
+          hasCacheCreateTokens: true,
+        },
+      },
+    }),
+    fakeTurn({
+      messageId: 'msg-2',
+      turnIndex: 1,
+      ts: '2026-04-29T00:00:01.000Z',
+      toolCalls: [
+        { id: 'tu-edit', name: 'Edit', target: '/tmp/foo.ts', argsHash: 'Edit:foo' },
+      ],
+      fidelity: {
+        class: 'full',
+        granularity: 'per-turn',
+        coverage: {
+          hasToolCalls: true,
+          hasToolResultEvents: true,
+          hasSessionRelationships: true,
+          hasRawContent: true,
+          hasInputTokens: true,
+          hasOutputTokens: true,
+          hasReasoningTokens: true,
+          hasCacheReadTokens: true,
+          hasCacheCreateTokens: true,
+        },
+      },
+    }),
+    fakeTurn({
+      messageId: 'msg-3',
+      turnIndex: 2,
+      ts: '2026-04-29T00:00:02.000Z',
+      toolCalls: [
+        { id: 'tu-bash', name: 'Bash', target: 'ls -la /tmp', argsHash: 'Bash:ls' },
+      ],
+      fidelity: {
+        class: 'full',
+        granularity: 'per-turn',
+        coverage: {
+          hasToolCalls: true,
+          hasToolResultEvents: true,
+          hasSessionRelationships: true,
+          hasRawContent: true,
+          hasInputTokens: true,
+          hasOutputTokens: true,
+          hasReasoningTokens: true,
+          hasCacheReadTokens: true,
+          hasCacheCreateTokens: true,
+        },
+      },
+    }),
+  ]);
+}
+
+describe('@relayburn/sdk hotspots() — discriminated union', () => {
+  it('default returns kind:"attribution" with every per-axis aggregation populated', async () => {
+    await seedFixtureTurns();
+    const result = await hotspots({ session: SESSION });
+    assert.equal(result.kind, 'attribution');
+    if (result.kind !== 'attribution') return;
+    assert.equal(result.turnsAnalyzed, 3);
+    assert.equal(typeof result.grandTotal, 'number');
+    assert.equal(typeof result.attributedTotal, 'number');
+    assert.equal(typeof result.unattributedTotal, 'number');
+    assert.equal(typeof result.attributionDegraded, 'boolean');
+    assert.ok(Array.isArray(result.sessions));
+    assert.ok(Array.isArray(result.files));
+    assert.ok(Array.isArray(result.bashVerbs));
+    assert.ok(Array.isArray(result.bash));
+    assert.ok(Array.isArray(result.subagents));
+    assert.equal(result.fidelity.refused, false);
+    assert.equal(result.fidelity.analyzed, 3);
+  });
+
+  it('groupBy:"file" returns kind:"file" with file aggregation rows only', async () => {
+    await seedFixtureTurns();
+    const result = await hotspots({ session: SESSION, groupBy: 'file' });
+    assert.equal(result.kind, 'file');
+    if (result.kind !== 'file') return;
+    // Read+Edit on /tmp/foo.ts collapses to one row.
+    assert.equal(result.rows.length, 1);
+    assert.equal(result.rows[0]!.path, '/tmp/foo.ts');
+  });
+
+  it('groupBy:"bash" returns kind:"bash" with one row per exact command', async () => {
+    await seedFixtureTurns();
+    const result = await hotspots({ session: SESSION, groupBy: 'bash' });
+    assert.equal(result.kind, 'bash');
+    if (result.kind !== 'bash') return;
+    assert.equal(result.rows.length, 1);
+    assert.equal(result.rows[0]!.command, 'ls -la /tmp');
+  });
+
+  it('groupBy:"bash-verb" returns kind:"bash-verb" rolled up by leading verb', async () => {
+    await seedFixtureTurns();
+    const result = await hotspots({ session: SESSION, groupBy: 'bash-verb' });
+    assert.equal(result.kind, 'bash-verb');
+    if (result.kind !== 'bash-verb') return;
+    assert.equal(result.rows.length, 1);
+    assert.equal(result.rows[0]!.verb, 'ls');
+    assert.equal(result.rows[0]!.callCount, 1);
+  });
+
+  it('groupBy:"subagent" returns kind:"subagent" (empty when no Agent/Task tool calls)', async () => {
+    await seedFixtureTurns();
+    const result = await hotspots({ session: SESSION, groupBy: 'subagent' });
+    assert.equal(result.kind, 'subagent');
+    if (result.kind !== 'subagent') return;
+    assert.equal(result.rows.length, 0);
+  });
+
+  it('rejects an invalid groupBy with a clear error', async () => {
+    await assert.rejects(
+      // @ts-expect-error — exercising runtime validation
+      () => hotspots({ session: SESSION, groupBy: 'nope' }),
+      /invalid hotspots groupBy/,
+    );
+  });
+
+  it('passing patterns ignores groupBy and returns kind:"findings" with a flat findings array', async () => {
+    await seedFixtureTurns();
+    const result = await hotspots({
+      session: SESSION,
+      groupBy: 'file', // ignored when patterns is set
+      patterns: ['retry-loop'],
+    });
+    assert.equal(result.kind, 'findings');
+    if (result.kind !== 'findings') return;
+    assert.ok(Array.isArray(result.findings));
+    // Empty fixture has no retry loops; this just asserts the shape.
+    assert.equal(result.findings.length, 0);
+    assert.ok(result.summary, 'findings shape includes a fidelity summary');
+  });
+
+  it('refuses gracefully when every matched turn lacks attribution coverage', async () => {
+    // Append a turn that explicitly fails the attribution coverage gate
+    // (granularity is per-turn but tool-call flag is false).
+    await appendTurns([
+      fakeTurn({
+        messageId: 'msg-bad',
+        turnIndex: 0,
+        ts: '2026-04-29T00:00:00.000Z',
+        sessionId: 's-sdk-hotspots-bad',
+        toolCalls: [],
+        fidelity: {
+          class: 'partial',
+          granularity: 'per-turn',
+          coverage: {
+            hasToolCalls: false,
+            hasToolResultEvents: false,
+            hasSessionRelationships: true,
+            hasRawContent: true,
+            hasInputTokens: true,
+            hasOutputTokens: true,
+            hasReasoningTokens: true,
+            hasCacheReadTokens: true,
+            hasCacheCreateTokens: true,
+          },
+        },
+      }),
+    ]);
+
+    const result = await hotspots({ session: 's-sdk-hotspots-bad' });
+    assert.equal(result.kind, 'attribution');
+    if (result.kind !== 'attribution') return;
+    assert.equal(result.refused, true);
+    assert.match(result.refusalReason ?? '', /lack tool-call\/tool-result coverage/);
+    assert.equal(result.turnsAnalyzed, 0);
+    assert.equal(result.fidelity.refused, true);
+  });
+
+  it('refusal under groupBy:"bash" returns the narrow shape with rows:[] + refused:true', async () => {
+    await appendTurns([
+      fakeTurn({
+        messageId: 'msg-bad',
+        turnIndex: 0,
+        ts: '2026-04-29T00:00:00.000Z',
+        sessionId: 's-sdk-hotspots-bad-2',
+        toolCalls: [],
+        fidelity: {
+          class: 'partial',
+          granularity: 'per-turn',
+          coverage: {
+            hasToolCalls: false,
+            hasToolResultEvents: false,
+            hasSessionRelationships: true,
+            hasRawContent: true,
+            hasInputTokens: true,
+            hasOutputTokens: true,
+            hasReasoningTokens: true,
+            hasCacheReadTokens: true,
+            hasCacheCreateTokens: true,
+          },
+        },
+      }),
+    ]);
+
+    const result = await hotspots({ session: 's-sdk-hotspots-bad-2', groupBy: 'bash' });
+    assert.equal(result.kind, 'bash');
+    if (result.kind !== 'bash') return;
+    assert.deepEqual(result.rows, []);
+    assert.equal(result.refused, true);
+  });
+});

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,8 +4,16 @@ All notable changes to `@relayburn/sdk`.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `hotspots()` now returns a discriminated union (`{ kind: 'attribution' | 'bash' | 'bash-verb' | 'file' | 'subagent' | 'findings' }`) instead of either an attribution blob or a raw findings array. Callers must branch on `kind`. The default (no `groupBy`, no `patterns`) returns the `attribution` shape that mirrors `burn hotspots --json`. Pass `patterns` to get `findings`. Pass `groupBy` to narrow attribution to one axis (`bash` / `bash-verb` / `file` / `subagent`). Warrants the SDK major bump.
+
 ### Added
 
+- `hotspots({ groupBy })` narrows attribution to one aggregation axis: `bash`, `bash-verb`, `file`, or `subagent`. Useful for MCP tools and embedders that only want a single per-axis cut.
+- `hotspots({ project, since })` accept the same forwarded options the other SDK queries do (project filter + ISO/relative `since` window normalization).
+- `hotspots()` reads through the SQLite archive by default with transparent fallback to the JSONL ledger walk on archive failure. Pass `onLog` to capture the fallback reason.
+- `hotspots()` surfaces a coverage-refusal shape (`refused: true` + `refusalReason`) when every matched turn lacks the tool-call/tool-result coverage `attributeHotspots` needs, so presenters can map it to the user-facing exit-2 + stderr message.
 - `sessionCost({ session })` returns the compact per-session cost shape (`totalUSD`, `totalTokens`, `turnCount`, `models`) the MCP `burn__sessionCost` tool now wraps directly.
 - `summary()` result now includes `turnCount`.
 - `summary()` and `sessionCost()` read through the SQLite archive by default with transparent fallback to the JSONL ledger walk on archive failure. Pass `onLog` to capture the fallback reason.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -27,9 +27,16 @@ const cost = await sessionCost({ session: 'session-id' });
 const oh = await overhead({ project: '/path/to/repo', since: '30d' });
 const trim = await overheadTrim({ project: '/path/to/repo', top: 3 });
 
+// Per-axis hotspot attribution + pattern findings. Returns a discriminated
+// union — branch on `kind`:
+//   { kind: 'attribution', files, bashVerbs, bash, subagents, sessions, … }
+//   { kind: 'bash' | 'bash-verb' | 'file' | 'subagent', rows: [...] }
+//   { kind: 'findings', findings: WasteFinding[], summary }
+const attribution = await hotspots({ session: 'session-id' });
+const fileRows = await hotspots({ session: 'session-id', groupBy: 'file' });
 const findings = await hotspots({ session: 'session-id', patterns: ['retry-loop'] });
 ```
 
-`summary`, `sessionCost`, `overhead`, and `overheadTrim` read through the SQLite archive when available, transparently falling back to the JSONL ledger walk if the archive can't be opened. Pass `onLog` to surface fallback messages in your host's log channel.
+`summary`, `sessionCost`, `overhead`, `overheadTrim`, and `hotspots` read through the SQLite archive when available, transparently falling back to the JSONL ledger walk if the archive can't be opened. Pass `onLog` to surface fallback messages in your host's log channel.
 
 `overheadTrim` includes a unified-diff string per recommendation by default (matches `burn overhead trim --json`); pass `includeDiff: false` to skip the per-file disk reads when you only need the recommendation rows.

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -181,7 +181,7 @@ export interface HotspotsFileRow {
 
 /** Per-axis aggregation row (bash, exact command). */
 export interface HotspotsBashRow {
-  command: string | null;
+  command: string | undefined;
   argsHash: string;
   callCount: number;
   initialTokens: number;

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -140,8 +140,19 @@ export interface OverheadTrimResult {
 /** Trim recommendations for high-cost overhead-file sections. Powers `burn overhead trim`. */
 export declare function overheadTrim(opts?: OverheadTrimOptions): Promise<OverheadTrimResult>
 
+export type HotspotsGroupBy = 'attribution' | 'bash' | 'bash-verb' | 'file' | 'subagent';
+
 export interface HotspotsOptions {
   session?: string;
+  project?: string;
+  /** ISO timestamp (e.g. `2026-04-01T00:00:00Z`) or relative range (`24h`, `7d`, `4w`, `2m`). */
+  since?: string;
+  /**
+   * Narrow the attribution result to a single aggregation axis. When omitted
+   * (or `'attribution'`), the full attribution shape is returned. Ignored
+   * when `patterns` is set — patterns always returns the `findings` shape.
+   */
+  groupBy?: HotspotsGroupBy;
   /**
    * Pattern kinds to detect. Supported kinds:
    *   - core (via `detectPatterns`): `retry-loop`, `failure-run`,
@@ -149,10 +160,123 @@ export interface HotspotsOptions {
    *     `skill-recall-dup`, `skill-pruning-protection`, `system-prompt-tax`
    *   - side-channel: `tool-output-bloat`, `ghost-surface`, `tool-call-pattern`
    *
-   * When omitted or empty, returns the attribution result instead of a
-   * findings array.
+   * When omitted or empty, returns the attribution result instead of the
+   * findings shape.
    */
   patterns?: string[];
   ledgerHome?: string;
+  /** Optional logger invoked when the SQLite archive read fails and the SDK falls back to a full ledger walk. */
+  onLog?: (msg: string) => void;
 }
-export declare function hotspots(opts?: HotspotsOptions): Promise<unknown>
+
+/** Per-axis aggregation row (file). */
+export interface HotspotsFileRow {
+  path: string;
+  firstEmitTurnIndex: number;
+  initialTokens: number;
+  persistenceTokens: number;
+  ridingTurns: number;
+  totalCost: number;
+}
+
+/** Per-axis aggregation row (bash, exact command). */
+export interface HotspotsBashRow {
+  command: string | null;
+  argsHash: string;
+  callCount: number;
+  initialTokens: number;
+  persistenceTokens: number;
+  totalCost: number;
+}
+
+/** Per-axis aggregation row (bash, by leading verb). */
+export interface HotspotsBashVerbRow {
+  verb: string;
+  callCount: number;
+  distinctCommands: number;
+  initialTokens: number;
+  persistenceTokens: number;
+  avgPersistenceTurns: number;
+  totalCost: number;
+  topExamples: string[];
+}
+
+/** Per-axis aggregation row (subagent / Agent / Task). */
+export interface HotspotsSubagentRow {
+  subagentType: string;
+  callCount: number;
+  initialTokens: number;
+  persistenceTokens: number;
+  totalCost: number;
+}
+
+export interface HotspotsSessionTotal {
+  sessionId: string;
+  grandCost: number;
+  attributedCost: number;
+  unattributedCost: number;
+  attributionMethod: 'sized' | 'even-split';
+}
+
+export interface HotspotsFidelityBlock {
+  analyzed: number;
+  excluded: number;
+  /** Aggregate fidelity summary for the matched-window turns (analyzed + excluded). */
+  summary: unknown;
+  refused: boolean;
+}
+
+/** Full attribution shape — mirrors the CLI's `burn hotspots --json`. */
+export interface HotspotsAttributionResult {
+  kind: 'attribution';
+  turnsAnalyzed: number;
+  grandTotal: number;
+  attributedTotal: number;
+  unattributedTotal: number;
+  attributionDegraded: boolean;
+  sessions: HotspotsSessionTotal[];
+  files: HotspotsFileRow[];
+  bashVerbs: HotspotsBashVerbRow[];
+  bash: HotspotsBashRow[];
+  subagents: HotspotsSubagentRow[];
+  fidelity: HotspotsFidelityBlock;
+  /** Set when every matched turn lacked the coverage attribution needs. */
+  refused?: boolean;
+  refusalReason?: string;
+}
+
+/** Narrowed shapes — one aggregation axis only. */
+export interface HotspotsBashResult { kind: 'bash'; rows: HotspotsBashRow[]; refused?: boolean; refusalReason?: string }
+export interface HotspotsBashVerbResult { kind: 'bash-verb'; rows: HotspotsBashVerbRow[]; refused?: boolean; refusalReason?: string }
+export interface HotspotsFileResult { kind: 'file'; rows: HotspotsFileRow[]; refused?: boolean; refusalReason?: string }
+export interface HotspotsSubagentResult { kind: 'subagent'; rows: HotspotsSubagentRow[]; refused?: boolean; refusalReason?: string }
+
+export interface HotspotsFinding {
+  kind: string;
+  severity: string;
+  sessionId: string;
+  title: string;
+  estimatedSavings: { usdPerSession?: number; [k: string]: unknown };
+  [k: string]: unknown;
+}
+
+export interface HotspotsFindingsResult {
+  kind: 'findings';
+  findings: HotspotsFinding[];
+  /** Aggregate fidelity summary for the matched-window turns. */
+  summary: unknown;
+}
+
+export type HotspotsResult =
+  | HotspotsAttributionResult
+  | HotspotsBashResult
+  | HotspotsBashVerbResult
+  | HotspotsFileResult
+  | HotspotsSubagentResult
+  | HotspotsFindingsResult;
+
+/**
+ * Per-axis hotspot attribution + pattern-finding queries. Returns a
+ * discriminated union — see `HotspotsResult`.
+ */
+export declare function hotspots(opts?: HotspotsOptions): Promise<HotspotsResult>

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -7,6 +7,10 @@ import {
   queryToolResultEvents,
 } from '@relayburn/ledger';
 import {
+  aggregateByBash,
+  aggregateByBashVerb,
+  aggregateByFile,
+  aggregateBySubagent,
   attributeOverhead,
   buildGhostSurfaceInputs,
   buildTrimRecommendations,
@@ -23,6 +27,7 @@ import {
   loadPricing,
   projectClaudeSettingsPath,
   renderUnifiedDiffForRecommendation,
+  summarizeFidelity,
   sumCosts,
   attributeHotspots,
   toolCallPatternToFinding,
@@ -30,7 +35,7 @@ import {
   userClaudeSettingsPath,
 } from '@relayburn/analyze';
 import { ingestAll } from '@relayburn/ingest';
-import { resolveProject } from '@relayburn/reader';
+import { parseBashCommand, resolveProject } from '@relayburn/reader';
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
@@ -222,59 +227,245 @@ export async function sessionCost(opts = {}) {
   });
 }
 
+// Coverage flags `attributeHotspots` and the matching aggregators need.
+// Records without `fidelity` (older ledger writers, foreign sources) are
+// treated as best-effort full and pass the gate. Mirrors
+// `ATTRIBUTION_REQUIRED` + `turnPassesCoverage` in the CLI.
+const HOTSPOTS_ATTRIBUTION_REQUIRED = ['hasToolCalls', 'hasToolResultEvents'];
+
+function turnPassesCoverage(turn, required) {
+  const f = turn.fidelity;
+  if (!f) return true;
+  for (const key of required) {
+    if (!f.coverage[key]) return false;
+  }
+  return true;
+}
+
+const VALID_HOTSPOTS_GROUP_BY = ['attribution', 'bash', 'bash-verb', 'file', 'subagent'];
+
+// Expanded hotspots(): returns a discriminated union covering every shape the
+// CLI's `burn hotspots --json` (and a few narrower programmatic cuts) need.
+//
+//   { kind: 'attribution' }                       — full per-axis aggregations
+//   { kind: 'bash' | 'bash-verb' | 'file' |
+//          'subagent' }                           — narrow to one aggregation
+//   { kind: 'findings' }                          — pattern findings (when
+//                                                   `patterns` is set)
+//
+// `groupBy` and `patterns` are mutually exclusive: passing `patterns` always
+// returns the findings shape and `groupBy` is ignored.
+//
+// Pattern detectors that need extra data (Claude settings, tool-result events,
+// on-disk ghost surface) are loaded lazily based on the requested patterns,
+// the same way the CLI does — so passing only `['retry-loop']` won't pay for
+// a settings.json read.
 export async function hotspots(opts = {}) {
   return withHome(opts.ledgerHome, async () => {
-    const turns = await queryAll({ sessionId: opts.session });
-    const userTurns = await queryUserTurns({ sessionId: opts.session });
+    if (
+      opts.groupBy !== undefined &&
+      !VALID_HOTSPOTS_GROUP_BY.includes(opts.groupBy)
+    ) {
+      throw new Error(
+        `invalid hotspots groupBy: ${JSON.stringify(opts.groupBy)} ` +
+          `(expected one of: ${VALID_HOTSPOTS_GROUP_BY.join(', ')})`,
+      );
+    }
+
+    const q = {};
+    if (opts.session) q.sessionId = opts.session;
+    if (opts.project) q.project = opts.project;
+    const since = normalizeSince(opts.since);
+    if (since) q.since = since;
+
+    const turns = await loadTurnsViaArchive(q, opts.onLog);
     const pricing = await loadPricing();
-    const userTurnsBySession = bucketBySession(userTurns);
-    const attribution = attributeHotspots(turns, { pricing, userTurnsBySession });
 
-    if (!opts.patterns || opts.patterns.length === 0) return attribution;
-
-    const wanted = new Set(opts.patterns);
-    const findings = [];
-
-    // Core patterns (retries, failures, edit-heavy, etc.) flow through
-    // detectPatterns + findingsFromPatterns; non-matching kinds are filtered.
-    const detected = detectPatterns(turns, { pricing, userTurnsBySession });
-    for (const f of findingsFromPatterns(detected)) {
-      if (wanted.has(f.kind)) findings.push(f);
+    if (opts.patterns && opts.patterns.length > 0) {
+      return runHotspotsFindings(turns, pricing, opts);
     }
 
-    // Side-channel detectors live outside detectPatterns. Each one reads its
-    // own slice of state, so we run them lazily based on `wanted`.
-
-    if (wanted.has('tool-output-bloat')) {
-      const settings = [];
-      const userLoaded = await loadClaudeSettings(userClaudeSettingsPath());
-      if (userLoaded) settings.push(userLoaded);
-      const projectLoaded = await loadClaudeSettings(projectClaudeSettingsPath());
-      if (projectLoaded) settings.push(projectLoaded);
-      const toolResultEvents = await queryToolResultEvents({ sessionId: opts.session });
-      const bloats = detectToolOutputBloat({
-        settings,
-        toolResultEvents,
-        userTurns,
-        turns,
-        pricing,
-      });
-      for (const b of bloats) findings.push(toolOutputBloatToFinding(b));
-    }
-
-    if (wanted.has('ghost-surface')) {
-      const ghostInputs = await buildGhostSurfaceInputs(turns, pricing);
-      const ghosts = await detectGhostSurface(ghostInputs);
-      for (const g of ghosts) findings.push(ghostSurfaceToFinding(g));
-    }
-
-    if (wanted.has('tool-call-pattern')) {
-      const patterns = detectToolCallPatterns(turns, { pricing });
-      for (const p of patterns) findings.push(toolCallPatternToFinding(p));
-    }
-
-    return findings;
+    return runHotspotsAttribution(turns, pricing, opts);
   });
+}
+
+async function runHotspotsAttribution(turns, pricing, opts) {
+  const eligible = [];
+  const excluded = [];
+  for (const t of turns) {
+    if (turnPassesCoverage(t, HOTSPOTS_ATTRIBUTION_REQUIRED)) eligible.push(t);
+    else excluded.push(t);
+  }
+
+  const fidelitySummary = summarizeFidelity(turns);
+
+  // Refusal: nothing to attribute. Mirror the CLI's refused-shape so callers
+  // can branch on `refused` without re-deriving the reason.
+  if (turns.length > 0 && eligible.length === 0) {
+    const refusalReason =
+      `${turns.length}/${turns.length} turns lack tool-call/tool-result coverage required for hotspots attribution`;
+    const groupBy = opts.groupBy ?? 'attribution';
+    if (groupBy !== 'attribution') {
+      return { kind: groupBy, rows: [], refused: true, refusalReason };
+    }
+    return {
+      kind: 'attribution',
+      turnsAnalyzed: 0,
+      grandTotal: 0,
+      attributedTotal: 0,
+      unattributedTotal: 0,
+      attributionDegraded: false,
+      sessions: [],
+      files: [],
+      bashVerbs: [],
+      bash: [],
+      subagents: [],
+      fidelity: {
+        analyzed: 0,
+        excluded: turns.length,
+        summary: fidelitySummary,
+        refused: true,
+      },
+      refused: true,
+      refusalReason,
+    };
+  }
+
+  const sessionIds = new Set(eligible.map((t) => t.sessionId));
+  const userTurnsBySession = await bulkUserTurnsBySession(sessionIds, q_(opts));
+  const result = attributeHotspots(eligible, { pricing, userTurnsBySession });
+
+  const groupBy = opts.groupBy ?? 'attribution';
+  if (groupBy === 'bash') {
+    return { kind: 'bash', rows: aggregateByBash(result.attributions) };
+  }
+  if (groupBy === 'bash-verb') {
+    return {
+      kind: 'bash-verb',
+      rows: aggregateByBashVerb(result.attributions, parseBashCommand),
+    };
+  }
+  if (groupBy === 'file') {
+    return { kind: 'file', rows: aggregateByFile(result.attributions) };
+  }
+  if (groupBy === 'subagent') {
+    return { kind: 'subagent', rows: aggregateBySubagent(result.attributions) };
+  }
+
+  const files = aggregateByFile(result.attributions);
+  const bashVerbs = aggregateByBashVerb(result.attributions, parseBashCommand);
+  const bash = aggregateByBash(result.attributions);
+  const subagents = aggregateBySubagent(result.attributions);
+  const evenSplit = result.sessionTotals.filter(
+    (s) => s.attributionMethod === 'even-split',
+  ).length;
+  const attributionDegraded =
+    result.sessionTotals.length > 0 &&
+    evenSplit / result.sessionTotals.length >= 0.5;
+
+  return {
+    kind: 'attribution',
+    turnsAnalyzed: eligible.length,
+    grandTotal: result.grandTotal,
+    attributedTotal: result.attributedTotal,
+    unattributedTotal: result.unattributedTotal,
+    attributionDegraded,
+    sessions: result.sessionTotals,
+    files,
+    bashVerbs,
+    bash,
+    subagents,
+    fidelity: {
+      analyzed: eligible.length,
+      excluded: excluded.length,
+      summary: fidelitySummary,
+      refused: false,
+    },
+  };
+}
+
+async function runHotspotsFindings(turns, pricing, opts) {
+  const wanted = new Set(opts.patterns);
+  const findings = [];
+  const userTurns = await queryUserTurns({ sessionId: opts.session });
+  const userTurnsBySession = bucketBySession(userTurns);
+
+  // Core patterns (retries, failures, edit-heavy, etc.) flow through
+  // detectPatterns + findingsFromPatterns; non-matching kinds are filtered.
+  const detected = detectPatterns(turns, { pricing, userTurnsBySession });
+  for (const f of findingsFromPatterns(detected)) {
+    if (wanted.has(f.kind)) findings.push(f);
+  }
+
+  // Side-channel detectors live outside detectPatterns. Each one reads its
+  // own slice of state, so we run them lazily based on `wanted`.
+
+  if (wanted.has('tool-output-bloat')) {
+    const settings = [];
+    const userLoaded = await loadClaudeSettings(userClaudeSettingsPath());
+    if (userLoaded) settings.push(userLoaded);
+    const projectLoaded = await loadClaudeSettings(projectClaudeSettingsPath());
+    if (projectLoaded) settings.push(projectLoaded);
+    const toolResultEvents = await queryToolResultEvents({ sessionId: opts.session });
+    const bloats = detectToolOutputBloat({
+      settings,
+      toolResultEvents,
+      userTurns,
+      turns,
+      pricing,
+    });
+    for (const b of bloats) findings.push(toolOutputBloatToFinding(b));
+  }
+
+  if (wanted.has('ghost-surface')) {
+    const ghostInputs = await buildGhostSurfaceInputs(turns, pricing);
+    const ghosts = await detectGhostSurface(ghostInputs);
+    for (const g of ghosts) findings.push(ghostSurfaceToFinding(g));
+  }
+
+  if (wanted.has('tool-call-pattern')) {
+    const patterns = detectToolCallPatterns(turns, { pricing });
+    for (const p of patterns) findings.push(toolCallPatternToFinding(p));
+  }
+
+  return {
+    kind: 'findings',
+    findings,
+    summary: summarizeFidelity(turns),
+  };
+}
+
+// Build the ledger Query from SDK opts. Used by the bulk user-turn loader so
+// it narrows by `since`/`source` during streaming rather than buffering the
+// entire historical ledger. Mirrors the CLI's same trick.
+function q_(opts) {
+  const q = {};
+  if (opts.session) q.sessionId = opts.session;
+  if (opts.project) q.project = opts.project;
+  const since = normalizeSince(opts.since);
+  if (since) q.since = since;
+  return q;
+}
+
+// One ledger pass + in-memory bucket. Mirrors the CLI's `bulkUserTurnsBySession`:
+// the per-session form `queryUserTurns({sessionId})` re-streams the entire
+// ledger.jsonl on every call, so we issue a single bulk pass here and bucket
+// by sessionId. `since`/`source` are forwarded so the streaming filter narrows
+// the in-memory buffer to the same window the eligible turns live in.
+async function bulkUserTurnsBySession(sessionIds, q = {}) {
+  const out = new Map();
+  if (sessionIds.size === 0) return out;
+  const filter = {};
+  if (q.since !== undefined) filter.since = q.since;
+  if (q.source !== undefined) filter.source = q.source;
+  const all = await queryUserTurns(filter);
+  for (const ut of all) {
+    if (!sessionIds.has(ut.sessionId)) continue;
+    const list = out.get(ut.sessionId);
+    if (list) list.push(ut);
+    else out.set(ut.sessionId, [ut]);
+  }
+  return out;
 }
 
 function bucketBySession(userTurns) {

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -262,7 +262,15 @@ const VALID_HOTSPOTS_GROUP_BY = ['attribution', 'bash', 'bash-verb', 'file', 'su
 // a settings.json read.
 export async function hotspots(opts = {}) {
   return withHome(opts.ledgerHome, async () => {
+    const usingPatterns = opts.patterns && opts.patterns.length > 0;
+
+    // Only validate `groupBy` when it actually steers the result. Per the
+    // documented mutual-exclusivity, passing `patterns` always returns
+    // findings and `groupBy` is ignored — including when its value is
+    // unknown — so callers that pass through a stale `groupBy` alongside
+    // `patterns` keep working.
     if (
+      !usingPatterns &&
       opts.groupBy !== undefined &&
       !VALID_HOTSPOTS_GROUP_BY.includes(opts.groupBy)
     ) {
@@ -272,17 +280,12 @@ export async function hotspots(opts = {}) {
       );
     }
 
-    const q = {};
-    if (opts.session) q.sessionId = opts.session;
-    if (opts.project) q.project = opts.project;
-    const since = normalizeSince(opts.since);
-    if (since) q.since = since;
-
+    const q = q_(opts);
     const turns = await loadTurnsViaArchive(q, opts.onLog);
     const pricing = await loadPricing();
 
-    if (opts.patterns && opts.patterns.length > 0) {
-      return runHotspotsFindings(turns, pricing, opts);
+    if (usingPatterns) {
+      return runHotspotsFindings(turns, pricing, opts, q);
     }
 
     return runHotspotsAttribution(turns, pricing, opts);
@@ -384,10 +387,19 @@ async function runHotspotsAttribution(turns, pricing, opts) {
   };
 }
 
-async function runHotspotsFindings(turns, pricing, opts) {
+async function runHotspotsFindings(turns, pricing, opts, q = {}) {
   const wanted = new Set(opts.patterns);
   const findings = [];
-  const userTurns = await queryUserTurns({ sessionId: opts.session });
+  // Forward `since` (and `sessionId`) so the user-turn + tool-result-event
+  // streams stay inside the same matched window the turn slice uses.
+  // Without this, detectors that read user-turn or tool-result-event state
+  // (system-prompt-tax, tool-output-bloat, retry/failure/cancellation graph
+  // walks) would mix older pre-window events into windowed analysis and
+  // surface false findings on long-lived sessions.
+  const sideQuery = {};
+  if (q.sessionId !== undefined) sideQuery.sessionId = q.sessionId;
+  if (q.since !== undefined) sideQuery.since = q.since;
+  const userTurns = await queryUserTurns(sideQuery);
   const userTurnsBySession = bucketBySession(userTurns);
 
   // Core patterns (retries, failures, edit-heavy, etc.) flow through
@@ -406,7 +418,7 @@ async function runHotspotsFindings(turns, pricing, opts) {
     if (userLoaded) settings.push(userLoaded);
     const projectLoaded = await loadClaudeSettings(projectClaudeSettingsPath());
     if (projectLoaded) settings.push(projectLoaded);
-    const toolResultEvents = await queryToolResultEvents({ sessionId: opts.session });
+    const toolResultEvents = await queryToolResultEvents(sideQuery);
     const bloats = detectToolOutputBloat({
       settings,
       toolResultEvents,

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -288,11 +288,11 @@ export async function hotspots(opts = {}) {
       return runHotspotsFindings(turns, pricing, opts, q);
     }
 
-    return runHotspotsAttribution(turns, pricing, opts);
+    return runHotspotsAttribution(turns, pricing, opts, q);
   });
 }
 
-async function runHotspotsAttribution(turns, pricing, opts) {
+async function runHotspotsAttribution(turns, pricing, opts, q = {}) {
   const eligible = [];
   const excluded = [];
   for (const t of turns) {
@@ -335,7 +335,11 @@ async function runHotspotsAttribution(turns, pricing, opts) {
   }
 
   const sessionIds = new Set(eligible.map((t) => t.sessionId));
-  const userTurnsBySession = await bulkUserTurnsBySession(sessionIds, q_(opts));
+  // Reuse the precomputed `q` from the caller — `normalizeSince()` calls
+  // `Date.now()` for relative ranges, so re-deriving here would cut the
+  // user-turn window at a slightly later boundary than the turn slice and
+  // drop borderline records.
+  const userTurnsBySession = await bulkUserTurnsBySession(sessionIds, q);
   const result = attributeHotspots(eligible, { pricing, userTurnsBySession });
 
   const groupBy = opts.groupBy ?? 'attribution';


### PR DESCRIPTION
## Summary

Closes #234.

`@relayburn/sdk` `hotspots()` now returns a discriminated union covering every shape `burn hotspots --json` (and several narrower programmatic cuts) need:

```ts
type HotspotsResult =
  | { kind: 'attribution'; turnsAnalyzed; grandTotal; sessions; files; bashVerbs; bash; subagents; fidelity; … }
  | { kind: 'bash';        rows: HotspotsBashRow[] }
  | { kind: 'bash-verb';   rows: HotspotsBashVerbRow[] }
  | { kind: 'file';        rows: HotspotsFileRow[] }
  | { kind: 'subagent';    rows: HotspotsSubagentRow[] }
  | { kind: 'findings';    findings: HotspotsFinding[]; summary }
```

The default (`groupBy` unset, `patterns` unset) returns `attribution` — the same shape `burn hotspots --json` emits today, sourced from one place. `groupBy` narrows attribution to one axis. `patterns` continues to drive `findings` (existing behavior, slotted into the discriminator). `project` / `since` / `onLog` match the other SDK queries; `since` accepts ISO timestamps or relative ranges (`24h` / `7d` / `4w` / `2m`). Reads through the SQLite archive with transparent ledger-walk fallback (`loadTurnsViaArchive`, per #232).

When every matched turn lacks the tool-call/tool-result coverage `attributeHotspots` needs, the result carries `refused: true` + `refusalReason` so presenters (CLI exit-2 + stderr, MCP error payloads) can map without re-deriving the reason.

## Breaking change

Old `hotspots()` returned either an attribution blob or a flat findings array. New shape always carries a `kind` discriminator. Callers must branch on `kind`. Warrants the SDK major bump (CHANGELOG callout in both `packages/sdk/CHANGELOG.md` and root `CHANGELOG.md`).

## Out of scope (per issue)

- `burn__hotspots` MCP tool wrapping the new SDK function (separate PR)
- CLI rendering changes — the CLI's `runHotspots` / `runPatternsMode` still own table rendering and progress UI; routing the CLI's `--json` emit through SDK can land as a follow-up once the CLI test surface migrates with it.

## Test plan

- [x] `pnpm run build` — clean across the workspace.
- [x] `pnpm run test` — 868/868 pass.
- [x] New `packages/cli/src/sdk-hotspots.test.ts` exercises every `kind` (attribution + 4 narrow `groupBy` modes + findings) and the refusal shape, against an isolated tmp `RELAYBURN_HOME` ledger.

https://claude.ai/code/session_01NbwFghgomVK4wrqqbf6XLK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbwFghgomVK4wrqqbf6XLK)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->