### PR TITLE
relayburn-reader: foundational port (types, hash, fidelity, git, classifier, user_turn)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +280,21 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
@@ -289,7 +346,7 @@ name = "relayburn-reader"
 version = "0.0.0"
 dependencies = [
  "hex",
- "once_cell",
+ "phf",
  "regex",
  "serde",
  "serde_json",
@@ -377,6 +434,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,272 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "relayburn-analyze"
 version = "0.0.0"
 
@@ -21,6 +287,15 @@ version = "0.0.0"
 [[package]]
 name = "relayburn-reader"
 version = "0.0.0"
+dependencies = [
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+]
 
 [[package]]
 name = "relayburn-sdk"
@@ -29,3 +304,291 @@ version = "0.0.0"
 [[package]]
 name = "relayburn-sdk-node"
 version = "0.0.0"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/relayburn-reader/Cargo.toml
+++ b/crates/relayburn-reader/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = { workspace = true }
 sha2 = "0.10"
 hex = "0.4"
 regex = "1"
-once_cell = "1"
+phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/relayburn-reader/Cargo.toml
+++ b/crates/relayburn-reader/Cargo.toml
@@ -7,3 +7,14 @@ license.workspace = true
 repository.workspace = true
 description = "Session-log parsers and activity classifier for relayburn (Rust port)."
 publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = "0.10"
+hex = "0.4"
+regex = "1"
+once_cell = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/relayburn-reader/src/classifier.rs
+++ b/crates/relayburn-reader/src/classifier.rs
@@ -1,12 +1,15 @@
 //! Activity classifier — Rust port of `packages/reader/src/classifier.ts`.
 //!
-//! The classifier is rule-based and deterministic. The rule tables
-//! (`EDIT_TOOLS`, `TOOL_ALIASES`, regex pattern lists) are kept flat so adding
-//! a new harness is a one-file change.
+//! The classifier is rule-based and deterministic. The lookup tables live as
+//! `phf` static maps (perfect-hash, zero allocation, zero startup cost) and
+//! the bash heuristics are expressed as [`BashRule`] data — pattern + optional
+//! `forbid` clause that emulates the TS negative-lookahead idioms — instead of
+//! a stringly-typed post-filter. Adding a new harness is still a single-file
+//! change: drop entries into the relevant table.
 
-use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
+use phf::{phf_map, phf_set};
 use regex::Regex;
 
 use crate::types::{ActivityCategory, ToolCall};
@@ -34,165 +37,155 @@ pub struct BashParse {
 }
 
 // ---------------------------------------------------------------------------
-// Static rule tables.
+// Static tool-name tables (phf — compile-time perfect hashing).
 // ---------------------------------------------------------------------------
 
-static EDIT_TOOLS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    ["Edit", "Write", "NotebookEdit", "MultiEdit"]
-        .into_iter()
-        .collect()
-});
+static EDIT_TOOLS: phf::Set<&'static str> = phf_set! {
+    "Edit", "Write", "NotebookEdit", "MultiEdit",
+};
 
-static DELEGATION_TOOLS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| ["Agent", "Task"].into_iter().collect());
+static DELEGATION_TOOLS: phf::Set<&'static str> = phf_set! { "Agent", "Task" };
 
 // READ_ONLY_TOOLS lived in the TS classifier as commentary on the priority-6
 // branch, but both arms of that branch return `exploration` (see
-// `pick_category` priority 6 below), so the set is unreferenced. Keeping it
-// out of the Rust port avoids a dead-code warning while preserving identical
-// behavior.
+// `pick_category` priority 6 below), so the set is unreferenced. Tracked in
+// AgentWorkforce/burn#254 — keeping it out of the Rust port avoids a dead-code
+// warning while preserving identical behavior.
 
-static TOOL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
-    [
-        // Codex
-        ("apply_patch", "Edit"),
-        ("exec_command", "Bash"),
-        ("shell", "Bash"),
-        ("read_file", "Read"),
-        ("write_file", "Write"),
-        ("update_plan", "ExitPlanMode"),
-        ("spawn_agent", "Agent"),
-        ("send_input", "Task"),
-        ("wait_agent", "Task"),
-        ("close_agent", "Task"),
-        ("resume_agent", "Task"),
-        ("view_image", "Read"),
-        ("read_mcp_resource", "Read"),
-        // OpenCode (lowercase names)
-        ("read", "Read"),
-        ("write", "Write"),
-        ("edit", "Edit"),
-        ("bash", "Bash"),
-        ("grep", "Grep"),
-        ("glob", "Glob"),
-        ("webfetch", "WebFetch"),
-        ("task", "Task"),
-    ]
-    .into_iter()
-    .collect()
-});
+/// Harness-specific tool names mapped to the canonical (Claude Code) names the
+/// rule tables are written against. Adding a new harness is a one-line change
+/// here.
+static TOOL_ALIASES: phf::Map<&'static str, &'static str> = phf_map! {
+    // Codex
+    "apply_patch"       => "Edit",
+    "exec_command"      => "Bash",
+    "shell"             => "Bash",
+    "read_file"         => "Read",
+    "write_file"        => "Write",
+    "update_plan"       => "ExitPlanMode",
+    "spawn_agent"       => "Agent",
+    "send_input"        => "Task",
+    "wait_agent"        => "Task",
+    "close_agent"       => "Task",
+    "resume_agent"      => "Task",
+    "view_image"        => "Read",
+    "read_mcp_resource" => "Read",
+    // OpenCode (lowercase names)
+    "read"     => "Read",
+    "write"    => "Write",
+    "edit"     => "Edit",
+    "bash"     => "Bash",
+    "grep"     => "Grep",
+    "glob"     => "Glob",
+    "webfetch" => "WebFetch",
+    "task"     => "Task",
+};
 
-pub fn normalize_tool_name(name: &str) -> String {
-    TOOL_ALIASES.get(name).copied().unwrap_or(name).to_string()
+pub fn normalize_tool_name(name: &str) -> &str {
+    TOOL_ALIASES.get(name).copied().unwrap_or(name)
 }
 
-static MULTIWORD_BINARIES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    [
-        "git",
-        "gh",
-        "npm",
-        "pnpm",
-        "yarn",
-        "bun",
-        "pip",
-        "pip3",
-        "uv",
-        "poetry",
-        "cargo",
-        "make",
-        "docker",
-        "kubectl",
-        "helm",
-        "terraform",
-        "brew",
-        "apt",
-        "apt-get",
-        "gem",
-        "bundle",
-        "go",
-    ]
-    .into_iter()
-    .collect()
-});
+// ---------------------------------------------------------------------------
+// Bash binary tables.
+// ---------------------------------------------------------------------------
 
-static PACKAGE_RUNNERS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| ["npm", "pnpm", "yarn", "bun"].into_iter().collect());
-static SHELL_BINARIES: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| ["bash", "sh", "zsh"].into_iter().collect());
-static PYTHON_BINARIES: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| ["python", "python3"].into_iter().collect());
+static MULTIWORD_BINARIES: phf::Set<&'static str> = phf_set! {
+    "git", "gh", "npm", "pnpm", "yarn", "bun", "pip", "pip3", "uv", "poetry",
+    "cargo", "make", "docker", "kubectl", "helm", "terraform", "brew", "apt",
+    "apt-get", "gem", "bundle", "go",
+};
 
-static TWO_PART_SUBCOMMANDS: Lazy<HashMap<&'static str, HashSet<&'static str>>> = Lazy::new(|| {
-    let mut m: HashMap<&'static str, HashSet<&'static str>> = HashMap::new();
-    m.insert("docker", ["compose"].into_iter().collect());
-    m.insert(
-        "gh",
-        ["pr", "run", "issue", "repo", "workflow", "release"]
-            .into_iter()
-            .collect(),
-    );
-    m.insert("go", ["mod"].into_iter().collect());
-    m.insert("uv", ["pip"].into_iter().collect());
-    m
-});
+static PACKAGE_RUNNERS: phf::Set<&'static str> = phf_set! { "npm", "pnpm", "yarn", "bun" };
+static SHELL_BINARIES: phf::Set<&'static str> = phf_set! { "bash", "sh", "zsh" };
+static PYTHON_BINARIES: phf::Set<&'static str> = phf_set! { "python", "python3" };
 
-static OPTION_TAKES_VALUE: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    [
-        "-C",
-        "-c",
-        "-F",
-        "--config",
-        "--filter",
-        "--git-dir",
-        "--namespace",
-        "--prefix",
-        "--repo",
-        "--repository",
-        "--work-tree",
-    ]
-    .into_iter()
-    .collect()
-});
+// `binary -> nested first-token subcommands`. Slices instead of a nested set
+// because counts are tiny (1–6 entries) and linear scan is faster than a hash
+// probe at that size.
+static TWO_PART_SUBCOMMANDS: phf::Map<&'static str, &'static [&'static str]> = phf_map! {
+    "docker" => &["compose"],
+    "gh"     => &["pr", "run", "issue", "repo", "workflow", "release"],
+    "go"     => &["mod"],
+    "uv"     => &["pip"],
+};
 
-static PYTHON_OPTION_TAKES_VALUE: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    ["-c", "-m", "-W", "-X", "--check-hash-based-pycs"]
-        .into_iter()
-        .collect()
-});
+static OPTION_TAKES_VALUE: phf::Set<&'static str> = phf_set! {
+    "-C", "-c", "-F", "--config", "--filter", "--git-dir", "--namespace",
+    "--prefix", "--repo", "--repository", "--work-tree",
+};
 
-// Activity-keyword regexes. Word-boundary `\b` and case-insensitive flags match
-// the TS regex literals.
-static DEBUG_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
+static PYTHON_OPTION_TAKES_VALUE: phf::Set<&'static str> = phf_set! {
+    "-c", "-m", "-W", "-X", "--check-hash-based-pycs",
+};
+
+// ---------------------------------------------------------------------------
+// Activity-keyword regexes (case-insensitive, word-boundary).
+// ---------------------------------------------------------------------------
+
+fn build_re(s: &str) -> Regex {
+    Regex::new(s).expect("classifier regex failed to compile")
+}
+
+static DEBUG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    build_re(
         r"(?i)\b(bug|error|crash|traceback|stack\s*trace|failure|failing|broken|fix\s+the|not\s+working|throws?)\b",
     )
-    .unwrap()
 });
-static REVIEW_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?i)\b(review|audit|inspect|look\s+over|code\s+review|pr\s+review)\b").unwrap()
+static REVIEW_RE: LazyLock<Regex> = LazyLock::new(|| {
+    build_re(r"(?i)\b(review|audit|inspect|look\s+over|code\s+review|pr\s+review)\b")
 });
-static REFACTOR_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
+static REFACTOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    build_re(
         r"(?i)\b(refactor|refactoring|cleanup|clean\s+up|rename|extract|restructure|move\s+this|reorganize)\b",
     )
-    .unwrap()
 });
-static FEATURE_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?i)\b(add|create|implement|new\s+feature|build\s+the|introduce|support\s+for)\b")
-        .unwrap()
+static FEATURE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    build_re(r"(?i)\b(add|create|implement|new\s+feature|build\s+the|introduce|support\s+for)\b")
 });
-static BRAINSTORM_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
+static BRAINSTORM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    build_re(
         r"(?i)\b(brainstorm|what\s+if|think\s+through|explore(?:\s+ideas)?|design|should\s+we|approach(?:es)?)\b",
     )
-    .unwrap()
 });
-static PLANNING_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)\b(plan(?:ning)?|outline|roadmap|strategy)\b").unwrap());
+static PLANNING_RE: LazyLock<Regex> =
+    LazyLock::new(|| build_re(r"(?i)\b(plan(?:ning)?|outline|roadmap|strategy)\b"));
+
+// ---------------------------------------------------------------------------
+// BashRule — pattern plus optional `forbid` clause that emulates the TS
+// negative-lookahead idioms (e.g. `(?!.*--check\b)`). Encodes intent as data
+// instead of as a stringly-typed post-filter.
+// ---------------------------------------------------------------------------
+
+struct BashRule {
+    pattern: Regex,
+    forbid: Option<Regex>,
+}
+
+impl BashRule {
+    fn pattern(p: &str) -> Self {
+        Self {
+            pattern: build_re(p),
+            forbid: None,
+        }
+    }
+
+    fn forbidding(mut self, forbid: &str) -> Self {
+        self.forbid = Some(build_re(forbid));
+        self
+    }
+
+    fn matches(&self, cmd: &str) -> bool {
+        self.pattern.is_match(cmd) && !self.forbid.as_ref().is_some_and(|r| r.is_match(cmd))
+    }
+}
+
+fn any_match(rules: &[BashRule], cmd: &str) -> bool {
+    rules.iter().any(|r| r.matches(cmd))
+}
 
 // Bash heuristics — match on the first non-env token after stripping leading
 // `FOO=bar` assignments (e.g. `CI=1 pytest` -> `pytest`).
-static TEST_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+static TEST_RULES: LazyLock<Vec<BashRule>> = LazyLock::new(|| {
     [
         r"\bpytest\b",
         r"\bpython\s+-m\s+pytest\b",
@@ -213,11 +206,11 @@ static TEST_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         r"\bpuppeteer\b",
     ]
     .into_iter()
-    .map(|p| Regex::new(p).unwrap())
+    .map(BashRule::pattern)
     .collect()
 });
 
-static REVIEW_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+static REVIEW_RULES: LazyLock<Vec<BashRule>> = LazyLock::new(|| {
     [
         r"\bgit\s+status\b",
         r"\bgit\s+diff\b",
@@ -228,18 +221,17 @@ static REVIEW_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         r"\bgh\s+run\s+view\b",
     ]
     .into_iter()
-    .map(|p| Regex::new(p).unwrap())
+    .map(BashRule::pattern)
     .collect()
 });
 
-static GIT_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
-    [r"\bgit\s+(?:push|pull|fetch|commit|merge|rebase|checkout|cherry-pick|reset|revert|switch|tag|stash)\b"]
-        .into_iter()
-        .map(|p| Regex::new(p).unwrap())
-        .collect()
+static GIT_RULES: LazyLock<Vec<BashRule>> = LazyLock::new(|| {
+    vec![BashRule::pattern(
+        r"\bgit\s+(?:push|pull|fetch|commit|merge|rebase|checkout|cherry-pick|reset|revert|switch|tag|stash)\b",
+    )]
 });
 
-static DEPS_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+static DEPS_RULES: LazyLock<Vec<BashRule>> = LazyLock::new(|| {
     [
         r"\b(?:npm|yarn|pnpm|bun)\s+(?:install|add|remove|uninstall|update|upgrade|ci)\b",
         r"\bpip\s+(?:install|uninstall)\b",
@@ -255,101 +247,54 @@ static DEPS_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         r"\bapt(?:-get)?\s+(?:install|remove)\b",
     ]
     .into_iter()
-    .map(|p| Regex::new(p).unwrap())
+    .map(BashRule::pattern)
     .collect()
 });
 
-static FORMAT_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
-    [
-        r"\bprettier\b.*(?:--write|-w)(?:\s|$)",
-        r"\beslint\b.*--fix\b",
-        r"\bbiome\s+format\b",
-        r"\bbiome\s+check\b.*--apply\b",
-        // Negative lookaheads aren't supported in the regex crate; emulate
-        // `\bblack\b(?!.*--check\b)` by checking the absence of `--check` at
-        // call sites for the matching patterns. We keep the simple positive
-        // form here and gate via post-filter below.
-        r"\bblack\b",
-        r"\bruff\s+format\b",
-        r"\bisort\b",
-        r"\brustfmt\b",
-        r"\bcargo\s+fmt\b",
-        r"\bgofmt\b",
-        r"\bgoimports\b",
-        r"\bdprint\s+fmt\b",
+// `forbidding(r"--check\b")` encodes the TS `(?!.*--check\b)` negative
+// lookahead — `--check` means "verify, don't mutate" so it should never be
+// classified as `format`.
+static FORMAT_RULES: LazyLock<Vec<BashRule>> = LazyLock::new(|| {
+    vec![
+        BashRule::pattern(r"\bprettier\b.*(?:--write|-w)(?:\s|$)"),
+        BashRule::pattern(r"\beslint\b.*--fix\b"),
+        BashRule::pattern(r"\bbiome\s+format\b"),
+        BashRule::pattern(r"\bbiome\s+check\b.*--apply\b"),
+        BashRule::pattern(r"\bblack\b").forbidding(r"--check\b"),
+        BashRule::pattern(r"\bruff\s+format\b"),
+        BashRule::pattern(r"\bisort\b"),
+        BashRule::pattern(r"\brustfmt\b"),
+        BashRule::pattern(r"\bcargo\s+fmt\b").forbidding(r"--check\b"),
+        BashRule::pattern(r"\bgofmt\b"),
+        BashRule::pattern(r"\bgoimports\b"),
+        BashRule::pattern(r"\bdprint\s+fmt\b"),
     ]
-    .into_iter()
-    .map(|p| Regex::new(p).unwrap())
-    .collect()
 });
 
-// Companion gates: when a format candidate matches, reject it if `--check` is
-// present (TS uses negative lookaheads; we encode the same intent without).
-fn format_reject(cmd: &str) -> bool {
-    static HAS_CHECK: Lazy<Regex> = Lazy::new(|| Regex::new(r"--check\b").unwrap());
-    HAS_CHECK.is_match(cmd)
-        // Only the black/cargo-fmt patterns in the TS list use a negative
-        // lookahead, but applying the exclusion uniformly across format
-        // candidates is conservative — `--check` always means "verify, don't
-        // mutate" so it shouldn't classify as `format`.
-        && (cmd.contains("black") || cmd.contains("cargo fmt"))
-}
-
-static VERIFICATION_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
-    [
-        r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?lint\b",
-        r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?typecheck\b",
-        r"\bprettier\b.*--check\b",
-        // `\beslint\b(?!.*--fix\b)` — emulated below in `verification_match`.
-        r"\beslint\b",
-        // `\bbiome\s+check\b(?!.*--apply\b)` — emulated below.
-        r"\bbiome\s+check\b",
-        r"\bblack\b.*--check\b",
-        r"\bruff\s+check\b",
-        r"\bflake8\b",
-        r"\bmypy\b",
-        r"\bpyright\b",
-        // `\btsc\b(?!\s+--build\b)` — emulated below.
-        r"\btsc\b",
-        r"\bcargo\s+check\b",
-        r"\bcargo\s+fmt\b.*--check\b",
-        r"\bgolangci-lint\b",
-        r"\bshellcheck\b",
-        r"\bhadolint\b",
-        r"\bterraform\s+validate\b",
-        r"\bmake\s+(?:lint|check|typecheck|verify)\b",
+static VERIFICATION_RULES: LazyLock<Vec<BashRule>> = LazyLock::new(|| {
+    vec![
+        BashRule::pattern(r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?lint\b"),
+        BashRule::pattern(r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?typecheck\b"),
+        BashRule::pattern(r"\bprettier\b.*--check\b"),
+        BashRule::pattern(r"\beslint\b").forbidding(r"--fix\b"),
+        BashRule::pattern(r"\bbiome\s+check\b").forbidding(r"--apply\b"),
+        BashRule::pattern(r"\bblack\b.*--check\b"),
+        BashRule::pattern(r"\bruff\s+check\b"),
+        BashRule::pattern(r"\bflake8\b"),
+        BashRule::pattern(r"\bmypy\b"),
+        BashRule::pattern(r"\bpyright\b"),
+        BashRule::pattern(r"\btsc\b").forbidding(r"\btsc\s+--build\b"),
+        BashRule::pattern(r"\bcargo\s+check\b"),
+        BashRule::pattern(r"\bcargo\s+fmt\b.*--check\b"),
+        BashRule::pattern(r"\bgolangci-lint\b"),
+        BashRule::pattern(r"\bshellcheck\b"),
+        BashRule::pattern(r"\bhadolint\b"),
+        BashRule::pattern(r"\bterraform\s+validate\b"),
+        BashRule::pattern(r"\bmake\s+(?:lint|check|typecheck|verify)\b"),
     ]
-    .into_iter()
-    .map(|p| Regex::new(p).unwrap())
-    .collect()
 });
 
-fn verification_match(cmd: &str) -> bool {
-    static FIX_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"--fix\b").unwrap());
-    static APPLY_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"--apply\b").unwrap());
-    static TSC_BUILD_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\btsc\s+--build\b").unwrap());
-
-    for re in VERIFICATION_PATTERNS.iter() {
-        if !re.is_match(cmd) {
-            continue;
-        }
-        // eslint without --fix; biome check without --apply; tsc without --build.
-        let s = re.as_str();
-        if s == r"\beslint\b" && FIX_RE.is_match(cmd) {
-            continue;
-        }
-        if s == r"\bbiome\s+check\b" && APPLY_RE.is_match(cmd) {
-            continue;
-        }
-        if s == r"\btsc\b" && TSC_BUILD_RE.is_match(cmd) {
-            continue;
-        }
-        return true;
-    }
-    false
-}
-
-static BUILD_DEPLOY_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+static BUILD_DEPLOY_RULES: LazyLock<Vec<BashRule>> = LazyLock::new(|| {
     [
         r"\bdocker\s+(?:build|compose\s+build|push)\b",
         r"\bcargo\s+build\b",
@@ -367,11 +312,11 @@ static BUILD_DEPLOY_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         r"\b(?:vercel|netlify|flyctl|railway|sst)\s+(?:deploy|up)\b",
     ]
     .into_iter()
-    .map(|p| Regex::new(p).unwrap())
+    .map(BashRule::pattern)
     .collect()
 });
 
-static DOC_FILE_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+static DOC_FILE_RULES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     [
         r"(?i)\.md$",
         r"(?i)\.mdx$",
@@ -383,7 +328,7 @@ static DOC_FILE_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         r"(?:^|/)docs/",
     ]
     .into_iter()
-    .map(|p| Regex::new(p).unwrap())
+    .map(build_re)
     .collect()
 });
 
@@ -399,37 +344,37 @@ fn parse_bash_command_inner(command: &str, depth: u32) -> Option<BashParse> {
     if depth > 5 {
         return Some(shell_parse());
     }
-    let cmd = command.trim().to_string();
+    let cmd = command.trim();
     if cmd.is_empty() {
         return None;
     }
-    if has_heredoc(&cmd) || starts_with_compound_shell_syntax(&cmd) {
+    if has_heredoc(cmd) || starts_with_compound_shell_syntax(cmd) {
         return Some(shell_parse());
     }
-    if !has_balanced_shell_delimiters(&cmd) {
+    if !has_balanced_shell_delimiters(cmd) {
         return Some(shell_parse());
     }
 
-    if let Some(unwrapped) = unwrap_subshell(&cmd) {
+    if let Some(unwrapped) = unwrap_subshell(cmd) {
         return parse_bash_command_inner(&unwrapped, depth + 1);
     }
-    if let Some(rest) = strip_leading_cd_prefix(&cmd) {
+    if let Some(rest) = strip_leading_cd_prefix(cmd) {
         return parse_bash_command_inner(&rest, depth + 1);
     }
 
-    let first = first_top_level_segment(&cmd)?;
-    let cmd = first.trim().to_string();
+    let first = first_top_level_segment(cmd)?;
+    let cmd = first.trim();
     if cmd.is_empty() {
         return None;
     }
-    if has_heredoc(&cmd) || starts_with_compound_shell_syntax(&cmd) {
+    if has_heredoc(cmd) || starts_with_compound_shell_syntax(cmd) {
         return Some(shell_parse());
     }
-    if let Some(unwrapped) = unwrap_subshell(&cmd) {
+    if let Some(unwrapped) = unwrap_subshell(cmd) {
         return parse_bash_command_inner(&unwrapped, depth + 1);
     }
 
-    let tokens = match shell_words(&cmd) {
+    let tokens = match shell_words(cmd) {
         Some(t) => t,
         None => return Some(shell_parse()),
     };
@@ -478,7 +423,7 @@ fn parse_bash_command_inner(command: &str, depth: u32) -> Option<BashParse> {
     {
         subcommand = tokens[sub_index + 1].clone();
     } else if let Some(nested) = TWO_PART_SUBCOMMANDS.get(binary.as_str()) {
-        if nested.contains(subcommand.as_str()) && sub_index + 1 < tokens.len() {
+        if nested.contains(&subcommand.as_str()) && sub_index + 1 < tokens.len() {
             subcommand = format!("{} {}", subcommand, tokens[sub_index + 1]);
         }
     }
@@ -496,7 +441,7 @@ fn verb(binary: &str, subcommand: Option<&str>) -> BashParse {
         Some(sub) => BashParse {
             binary: binary.to_string(),
             subcommand: Some(sub.to_string()),
-            normalized: format!("{} {}", binary, sub),
+            normalized: format!("{binary} {sub}"),
         },
     }
 }
@@ -510,23 +455,22 @@ fn shell_parse() -> BashParse {
 }
 
 fn has_heredoc(cmd: &str) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"<<-?\s*\S+").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"<<-?\s*\S+"));
     RE.is_match(cmd)
 }
 
 fn starts_with_compound_shell_syntax(cmd: &str) -> bool {
-    static RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^(?:for|while|until|if|case|select|function)\b").unwrap());
-    static BRACE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\{\s").unwrap());
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| build_re(r"^(?:for|while|until|if|case|select|function)\b"));
+    static BRACE_RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"^\{\s"));
     RE.is_match(cmd) || BRACE_RE.is_match(cmd)
 }
 
 fn has_balanced_shell_delimiters(cmd: &str) -> bool {
-    let bytes = cmd.as_bytes();
     let mut quote: Option<u8> = None;
     let mut escaped = false;
     let mut depth: i32 = 0;
-    for &b in bytes {
+    for &b in cmd.as_bytes() {
         if escaped {
             escaped = false;
             continue;
@@ -604,8 +548,7 @@ fn unwrap_subshell(cmd: &str) -> Option<String> {
 
 fn strip_leading_cd_prefix(cmd: &str) -> Option<String> {
     let op = first_top_level_operator(cmd, &["&&", ";"])?;
-    let before = cmd[..op.index].trim();
-    let words = shell_words(before)?;
+    let words = shell_words(cmd[..op.index].trim())?;
     let cmd_idx = skip_env_assignments(&words, 0);
     if words.get(cmd_idx).map(String::as_str) != Some("cd") {
         return None;
@@ -735,7 +678,7 @@ fn shell_words(segment: &str) -> Option<Vec<String>> {
 }
 
 fn skip_env_assignments(tokens: &[String], start: usize) -> usize {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*=").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"^[A-Za-z_][A-Za-z0-9_]*="));
     let mut i = start;
     while i < tokens.len() && RE.is_match(&tokens[i]) {
         i += 1;
@@ -780,7 +723,7 @@ fn shell_command_arg(tokens: &[String], start: usize) -> Option<String> {
 }
 
 fn env_command_args(tokens: &[String], start: usize) -> Vec<String> {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*=").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"^[A-Za-z_][A-Za-z0-9_]*="));
     let mut i = start;
     while i < tokens.len() {
         let token = &tokens[i];
@@ -858,14 +801,14 @@ fn normalize_binary(raw: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// classifyActivity priority ladder.
+// classify_activity priority ladder.
 // ---------------------------------------------------------------------------
 
 pub fn classify_activity(input: ClassificationInput<'_>) -> ClassificationResult {
     let has_edits = input
         .tool_calls
         .iter()
-        .any(|t| EDIT_TOOLS.contains(normalize_tool_name(&t.name).as_str()));
+        .any(|t| EDIT_TOOLS.contains(normalize_tool_name(&t.name)));
     let retries = count_retries(input.tool_calls);
     let activity = pick_category(PickInput {
         tool_calls: input.tool_calls,
@@ -895,7 +838,7 @@ fn pick_category(p: PickInput<'_>) -> ActivityCategory {
     // Priority 1: delegation
     if p.tool_calls
         .iter()
-        .any(|t| DELEGATION_TOOLS.contains(normalize_tool_name(&t.name).as_str()))
+        .any(|t| DELEGATION_TOOLS.contains(normalize_tool_name(&t.name)))
     {
         return ActivityCategory::Delegation;
     }
@@ -927,36 +870,34 @@ fn pick_category(p: PickInput<'_>) -> ActivityCategory {
         return ActivityCategory::Debugging;
     }
     // Priority 5: bash heuristics
-    let bash_calls: Vec<&ToolCall> = p
+    for tc in p
         .tool_calls
         .iter()
         .filter(|t| normalize_tool_name(&t.name) == "Bash")
-        .collect();
-    for call in &bash_calls {
-        let raw = call.target.as_deref().unwrap_or("");
-        let cmd = strip_env(raw);
+    {
+        let cmd = strip_env(tc.target.as_deref().unwrap_or(""));
         if cmd.is_empty() {
             continue;
         }
-        if TEST_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+        if any_match(&TEST_RULES, &cmd) {
             return ActivityCategory::Testing;
         }
-        if REVIEW_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+        if any_match(&REVIEW_RULES, &cmd) {
             return ActivityCategory::Review;
         }
-        if GIT_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+        if any_match(&GIT_RULES, &cmd) {
             return ActivityCategory::Git;
         }
-        if DEPS_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+        if any_match(&DEPS_RULES, &cmd) {
             return ActivityCategory::Deps;
         }
-        if FORMAT_PATTERNS.iter().any(|re| re.is_match(&cmd)) && !format_reject(&cmd) {
+        if any_match(&FORMAT_RULES, &cmd) {
             return ActivityCategory::Format;
         }
-        if verification_match(&cmd) {
+        if any_match(&VERIFICATION_RULES, &cmd) {
             return ActivityCategory::Verification;
         }
-        if BUILD_DEPLOY_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+        if any_match(&BUILD_DEPLOY_RULES, &cmd) {
             return ActivityCategory::BuildDeploy;
         }
     }
@@ -987,19 +928,20 @@ fn pick_category(p: PickInput<'_>) -> ActivityCategory {
 }
 
 fn all_edits_are_docs(tool_calls: &[ToolCall]) -> bool {
-    let edits: Vec<&ToolCall> = tool_calls
+    let mut saw_edit = false;
+    for tc in tool_calls
         .iter()
-        .filter(|t| EDIT_TOOLS.contains(normalize_tool_name(&t.name).as_str()))
-        .collect();
-    if edits.is_empty() {
-        return false;
-    }
-    edits.iter().all(|t| match &t.target {
-        Some(target) if !target.is_empty() => {
-            DOC_FILE_PATTERNS.iter().any(|re| re.is_match(target))
+        .filter(|t| EDIT_TOOLS.contains(normalize_tool_name(&t.name)))
+    {
+        saw_edit = true;
+        let Some(target) = tc.target.as_deref() else {
+            return false;
+        };
+        if target.is_empty() || !DOC_FILE_RULES.iter().any(|re| re.is_match(target)) {
+            return false;
         }
-        _ => false,
-    })
+    }
+    saw_edit
 }
 
 fn refine_edit_by_keywords(text: &str) -> Option<ActivityCategory> {
@@ -1038,7 +980,7 @@ fn refine_intent_by_keywords(text: &str) -> Option<ActivityCategory> {
 }
 
 fn strip_env(cmd: &str) -> String {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(?:\s*[A-Z_][A-Z0-9_]*=\S+\s+)+").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"^(?:\s*[A-Z_][A-Z0-9_]*=\S+\s+)+"));
     RE.replace(cmd, "").into_owned()
 }
 
@@ -1048,7 +990,7 @@ pub fn count_retries(tool_calls: &[ToolCall]) -> u64 {
     let mut seen_bash_after_edit = false;
     for tc in tool_calls {
         let name = normalize_tool_name(&tc.name);
-        if EDIT_TOOLS.contains(name.as_str()) {
+        if EDIT_TOOLS.contains(name) {
             if seen_edit && seen_bash_after_edit {
                 retries += 1;
                 seen_bash_after_edit = false;
@@ -1324,5 +1266,13 @@ mod tests {
     fn empty_input_is_conversation() {
         let r = classify(&[]);
         assert_eq!(r.activity, ActivityCategory::Conversation);
+    }
+
+    #[test]
+    fn bash_rule_forbid_clause_excludes_match() {
+        // BashRule's `forbid` clause emulates the TS negative-lookahead idiom.
+        let rule = BashRule::pattern(r"\bblack\b").forbidding(r"--check\b");
+        assert!(rule.matches("black ."));
+        assert!(!rule.matches("black --check ."));
     }
 }

--- a/crates/relayburn-reader/src/classifier.rs
+++ b/crates/relayburn-reader/src/classifier.rs
@@ -1,0 +1,1313 @@
+//! Activity classifier — Rust port of `packages/reader/src/classifier.ts`.
+//!
+//! The classifier is rule-based and deterministic. The rule tables
+//! (`EDIT_TOOLS`, `TOOL_ALIASES`, regex pattern lists) are kept flat so adding
+//! a new harness is a one-file change.
+
+use std::collections::{HashMap, HashSet};
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::types::{ActivityCategory, ToolCall};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassificationInput<'a> {
+    pub tool_calls: &'a [ToolCall],
+    pub text: &'a str,
+    pub has_failed_tool: bool,
+    pub reasoning_tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassificationResult {
+    pub activity: ActivityCategory,
+    pub retries: u64,
+    pub has_edits: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BashParse {
+    pub binary: String,
+    pub subcommand: Option<String>,
+    pub normalized: String,
+}
+
+// ---------------------------------------------------------------------------
+// Static rule tables.
+// ---------------------------------------------------------------------------
+
+static EDIT_TOOLS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    ["Edit", "Write", "NotebookEdit", "MultiEdit"]
+        .into_iter()
+        .collect()
+});
+
+static DELEGATION_TOOLS: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| ["Agent", "Task"].into_iter().collect());
+
+// READ_ONLY_TOOLS lived in the TS classifier as commentary on the priority-6
+// branch, but both arms of that branch return `exploration` (see
+// `pick_category` priority 6 below), so the set is unreferenced. Keeping it
+// out of the Rust port avoids a dead-code warning while preserving identical
+// behavior.
+
+static TOOL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+    [
+        // Codex
+        ("apply_patch", "Edit"),
+        ("exec_command", "Bash"),
+        ("shell", "Bash"),
+        ("read_file", "Read"),
+        ("write_file", "Write"),
+        ("update_plan", "ExitPlanMode"),
+        ("spawn_agent", "Agent"),
+        ("send_input", "Task"),
+        ("wait_agent", "Task"),
+        ("close_agent", "Task"),
+        ("resume_agent", "Task"),
+        ("view_image", "Read"),
+        ("read_mcp_resource", "Read"),
+        // OpenCode (lowercase names)
+        ("read", "Read"),
+        ("write", "Write"),
+        ("edit", "Edit"),
+        ("bash", "Bash"),
+        ("grep", "Grep"),
+        ("glob", "Glob"),
+        ("webfetch", "WebFetch"),
+        ("task", "Task"),
+    ]
+    .into_iter()
+    .collect()
+});
+
+pub fn normalize_tool_name(name: &str) -> String {
+    TOOL_ALIASES.get(name).copied().unwrap_or(name).to_string()
+}
+
+static MULTIWORD_BINARIES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    [
+        "git",
+        "gh",
+        "npm",
+        "pnpm",
+        "yarn",
+        "bun",
+        "pip",
+        "pip3",
+        "uv",
+        "poetry",
+        "cargo",
+        "make",
+        "docker",
+        "kubectl",
+        "helm",
+        "terraform",
+        "brew",
+        "apt",
+        "apt-get",
+        "gem",
+        "bundle",
+        "go",
+    ]
+    .into_iter()
+    .collect()
+});
+
+static PACKAGE_RUNNERS: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| ["npm", "pnpm", "yarn", "bun"].into_iter().collect());
+static SHELL_BINARIES: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| ["bash", "sh", "zsh"].into_iter().collect());
+static PYTHON_BINARIES: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| ["python", "python3"].into_iter().collect());
+
+static TWO_PART_SUBCOMMANDS: Lazy<HashMap<&'static str, HashSet<&'static str>>> = Lazy::new(|| {
+    let mut m: HashMap<&'static str, HashSet<&'static str>> = HashMap::new();
+    m.insert("docker", ["compose"].into_iter().collect());
+    m.insert(
+        "gh",
+        ["pr", "run", "issue", "repo", "workflow", "release"]
+            .into_iter()
+            .collect(),
+    );
+    m.insert("go", ["mod"].into_iter().collect());
+    m.insert("uv", ["pip"].into_iter().collect());
+    m
+});
+
+static OPTION_TAKES_VALUE: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    [
+        "-C",
+        "-c",
+        "-F",
+        "--config",
+        "--filter",
+        "--git-dir",
+        "--namespace",
+        "--prefix",
+        "--repo",
+        "--repository",
+        "--work-tree",
+    ]
+    .into_iter()
+    .collect()
+});
+
+static PYTHON_OPTION_TAKES_VALUE: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    ["-c", "-m", "-W", "-X", "--check-hash-based-pycs"]
+        .into_iter()
+        .collect()
+});
+
+// Activity-keyword regexes. Word-boundary `\b` and case-insensitive flags match
+// the TS regex literals.
+static DEBUG_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)\b(bug|error|crash|traceback|stack\s*trace|failure|failing|broken|fix\s+the|not\s+working|throws?)\b",
+    )
+    .unwrap()
+});
+static REVIEW_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(review|audit|inspect|look\s+over|code\s+review|pr\s+review)\b").unwrap()
+});
+static REFACTOR_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)\b(refactor|refactoring|cleanup|clean\s+up|rename|extract|restructure|move\s+this|reorganize)\b",
+    )
+    .unwrap()
+});
+static FEATURE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(add|create|implement|new\s+feature|build\s+the|introduce|support\s+for)\b")
+        .unwrap()
+});
+static BRAINSTORM_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)\b(brainstorm|what\s+if|think\s+through|explore(?:\s+ideas)?|design|should\s+we|approach(?:es)?)\b",
+    )
+    .unwrap()
+});
+static PLANNING_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)\b(plan(?:ning)?|outline|roadmap|strategy)\b").unwrap());
+
+// Bash heuristics — match on the first non-env token after stripping leading
+// `FOO=bar` assignments (e.g. `CI=1 pytest` -> `pytest`).
+static TEST_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [
+        r"\bpytest\b",
+        r"\bpython\s+-m\s+pytest\b",
+        r"\bvitest\b",
+        r"\bbun\s+test\b",
+        r"\bjest\b",
+        r"\bmocha\b",
+        r"\brspec\b",
+        r"\bphpunit\b",
+        r"\bgo\s+test\b",
+        r"\bcargo\s+test\b",
+        r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?test\b",
+        r"\bnode\s+--test\b",
+        r"\bmake\s+test\b",
+        r"\bctest\b",
+        r"\bplaywright\b",
+        r"\bcypress\b",
+        r"\bpuppeteer\b",
+    ]
+    .into_iter()
+    .map(|p| Regex::new(p).unwrap())
+    .collect()
+});
+
+static REVIEW_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [
+        r"\bgit\s+status\b",
+        r"\bgit\s+diff\b",
+        r"\bgit\s+show\b",
+        r"\bgit\s+log\b",
+        r"\bgit\s+blame\b",
+        r"\bgh\s+pr\s+(?:view|diff|checks)\b",
+        r"\bgh\s+run\s+view\b",
+    ]
+    .into_iter()
+    .map(|p| Regex::new(p).unwrap())
+    .collect()
+});
+
+static GIT_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [r"\bgit\s+(?:push|pull|fetch|commit|merge|rebase|checkout|cherry-pick|reset|revert|switch|tag|stash)\b"]
+        .into_iter()
+        .map(|p| Regex::new(p).unwrap())
+        .collect()
+});
+
+static DEPS_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [
+        r"\b(?:npm|yarn|pnpm|bun)\s+(?:install|add|remove|uninstall|update|upgrade|ci)\b",
+        r"\bpip\s+(?:install|uninstall)\b",
+        r"\bpip3\s+(?:install|uninstall)\b",
+        r"\bpython\s+-m\s+pip\s+(?:install|uninstall)\b",
+        r"\buv\s+(?:add|remove|sync|pip\s+install)\b",
+        r"\bpoetry\s+(?:add|remove|install|update)\b",
+        r"\bcargo\s+(?:add|remove|update)\b",
+        r"\bgo\s+(?:get|mod\s+(?:tidy|download))\b",
+        r"\bbundle\s+(?:install|update|add)\b",
+        r"\bgem\s+(?:install|uninstall)\b",
+        r"\bbrew\s+(?:install|uninstall|upgrade|update)\b",
+        r"\bapt(?:-get)?\s+(?:install|remove)\b",
+    ]
+    .into_iter()
+    .map(|p| Regex::new(p).unwrap())
+    .collect()
+});
+
+static FORMAT_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [
+        r"\bprettier\b.*(?:--write|-w)(?:\s|$)",
+        r"\beslint\b.*--fix\b",
+        r"\bbiome\s+format\b",
+        r"\bbiome\s+check\b.*--apply\b",
+        // Negative lookaheads aren't supported in the regex crate; emulate
+        // `\bblack\b(?!.*--check\b)` by checking the absence of `--check` at
+        // call sites for the matching patterns. We keep the simple positive
+        // form here and gate via post-filter below.
+        r"\bblack\b",
+        r"\bruff\s+format\b",
+        r"\bisort\b",
+        r"\brustfmt\b",
+        r"\bcargo\s+fmt\b",
+        r"\bgofmt\b",
+        r"\bgoimports\b",
+        r"\bdprint\s+fmt\b",
+    ]
+    .into_iter()
+    .map(|p| Regex::new(p).unwrap())
+    .collect()
+});
+
+// Companion gates: when a format candidate matches, reject it if `--check` is
+// present (TS uses negative lookaheads; we encode the same intent without).
+fn format_reject(cmd: &str) -> bool {
+    static HAS_CHECK: Lazy<Regex> = Lazy::new(|| Regex::new(r"--check\b").unwrap());
+    HAS_CHECK.is_match(cmd)
+        // Only the black/cargo-fmt patterns in the TS list use a negative
+        // lookahead, but applying the exclusion uniformly across format
+        // candidates is conservative — `--check` always means "verify, don't
+        // mutate" so it shouldn't classify as `format`.
+        && (cmd.contains("black") || cmd.contains("cargo fmt"))
+}
+
+static VERIFICATION_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [
+        r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?lint\b",
+        r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?typecheck\b",
+        r"\bprettier\b.*--check\b",
+        // `\beslint\b(?!.*--fix\b)` — emulated below in `verification_match`.
+        r"\beslint\b",
+        // `\bbiome\s+check\b(?!.*--apply\b)` — emulated below.
+        r"\bbiome\s+check\b",
+        r"\bblack\b.*--check\b",
+        r"\bruff\s+check\b",
+        r"\bflake8\b",
+        r"\bmypy\b",
+        r"\bpyright\b",
+        // `\btsc\b(?!\s+--build\b)` — emulated below.
+        r"\btsc\b",
+        r"\bcargo\s+check\b",
+        r"\bcargo\s+fmt\b.*--check\b",
+        r"\bgolangci-lint\b",
+        r"\bshellcheck\b",
+        r"\bhadolint\b",
+        r"\bterraform\s+validate\b",
+        r"\bmake\s+(?:lint|check|typecheck|verify)\b",
+    ]
+    .into_iter()
+    .map(|p| Regex::new(p).unwrap())
+    .collect()
+});
+
+fn verification_match(cmd: &str) -> bool {
+    static FIX_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"--fix\b").unwrap());
+    static APPLY_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"--apply\b").unwrap());
+    static TSC_BUILD_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\btsc\s+--build\b").unwrap());
+
+    for re in VERIFICATION_PATTERNS.iter() {
+        if !re.is_match(cmd) {
+            continue;
+        }
+        // eslint without --fix; biome check without --apply; tsc without --build.
+        let s = re.as_str();
+        if s == r"\beslint\b" && FIX_RE.is_match(cmd) {
+            continue;
+        }
+        if s == r"\bbiome\s+check\b" && APPLY_RE.is_match(cmd) {
+            continue;
+        }
+        if s == r"\btsc\b" && TSC_BUILD_RE.is_match(cmd) {
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+static BUILD_DEPLOY_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [
+        r"\bdocker\s+(?:build|compose\s+build|push)\b",
+        r"\bcargo\s+build\b",
+        r"\bgo\s+build\b",
+        r"\bmake\s+(?:build|release|dist|package|deploy)\b",
+        r"\b(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?build\b",
+        r"\b(?:webpack|vite|next|rollup|esbuild)\s+build\b",
+        r"\btsc\s+--build\b",
+        r"\bpm2\s+",
+        r"\bkubectl\s+(?:apply|rollout|set)\b",
+        r"\bhelm\s+(?:install|upgrade)\b",
+        r"\bterraform\s+(?:apply|plan)\b",
+        r"\bterraform\s+destroy\b",
+        r"\bserverless\s+deploy\b",
+        r"\b(?:vercel|netlify|flyctl|railway|sst)\s+(?:deploy|up)\b",
+    ]
+    .into_iter()
+    .map(|p| Regex::new(p).unwrap())
+    .collect()
+});
+
+static DOC_FILE_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    [
+        r"(?i)\.md$",
+        r"(?i)\.mdx$",
+        r"(?i)\.rst$",
+        r"(?i)\.adoc$",
+        r"(?i)\.txt$",
+        r"(?i)(?:^|/)README(?:\.[^/]*)?$",
+        r"(?i)(?:^|/)CHANGELOG(?:\.[^/]*)?$",
+        r"(?:^|/)docs/",
+    ]
+    .into_iter()
+    .map(|p| Regex::new(p).unwrap())
+    .collect()
+});
+
+// ---------------------------------------------------------------------------
+// Bash command parsing.
+// ---------------------------------------------------------------------------
+
+pub fn parse_bash_command(command: &str) -> Option<BashParse> {
+    parse_bash_command_inner(command, 0)
+}
+
+fn parse_bash_command_inner(command: &str, depth: u32) -> Option<BashParse> {
+    if depth > 5 {
+        return Some(shell_parse());
+    }
+    let cmd = command.trim().to_string();
+    if cmd.is_empty() {
+        return None;
+    }
+    if has_heredoc(&cmd) || starts_with_compound_shell_syntax(&cmd) {
+        return Some(shell_parse());
+    }
+    if !has_balanced_shell_delimiters(&cmd) {
+        return Some(shell_parse());
+    }
+
+    if let Some(unwrapped) = unwrap_subshell(&cmd) {
+        return parse_bash_command_inner(&unwrapped, depth + 1);
+    }
+    if let Some(rest) = strip_leading_cd_prefix(&cmd) {
+        return parse_bash_command_inner(&rest, depth + 1);
+    }
+
+    let first = first_top_level_segment(&cmd)?;
+    let cmd = first.trim().to_string();
+    if cmd.is_empty() {
+        return None;
+    }
+    if has_heredoc(&cmd) || starts_with_compound_shell_syntax(&cmd) {
+        return Some(shell_parse());
+    }
+    if let Some(unwrapped) = unwrap_subshell(&cmd) {
+        return parse_bash_command_inner(&unwrapped, depth + 1);
+    }
+
+    let tokens = match shell_words(&cmd) {
+        Some(t) => t,
+        None => return Some(shell_parse()),
+    };
+    let i = skip_env_assignments(&tokens, 0);
+    if i >= tokens.len() {
+        return None;
+    }
+
+    let raw_binary = &tokens[i];
+    let binary = normalize_binary(raw_binary);
+
+    if SHELL_BINARIES.contains(binary.as_str()) {
+        if let Some(shell_cmd) = shell_command_arg(&tokens, i + 1) {
+            return parse_bash_command_inner(&shell_cmd, depth + 1);
+        }
+        return Some(verb(&binary, None));
+    }
+
+    if binary == "env" {
+        let env_args = env_command_args(&tokens, i + 1);
+        if env_args.is_empty() {
+            return None;
+        }
+        return parse_bash_command_inner(&env_args.join(" "), depth + 1);
+    }
+
+    if PYTHON_BINARIES.contains(binary.as_str()) {
+        if let Some(parsed) = parse_python_module(&tokens, i + 1) {
+            return Some(parsed);
+        }
+    }
+
+    if binary == "node" && tokens[i + 1..].iter().any(|t| t == "--test") {
+        return Some(verb(&binary, Some("--test")));
+    }
+
+    let sub_index = skip_leading_options(&tokens, i + 1);
+    if sub_index >= tokens.len() || !MULTIWORD_BINARIES.contains(binary.as_str()) {
+        return Some(verb(&binary, None));
+    }
+
+    let mut subcommand = tokens[sub_index].clone();
+    if PACKAGE_RUNNERS.contains(binary.as_str())
+        && subcommand == "run"
+        && sub_index + 1 < tokens.len()
+    {
+        subcommand = tokens[sub_index + 1].clone();
+    } else if let Some(nested) = TWO_PART_SUBCOMMANDS.get(binary.as_str()) {
+        if nested.contains(subcommand.as_str()) && sub_index + 1 < tokens.len() {
+            subcommand = format!("{} {}", subcommand, tokens[sub_index + 1]);
+        }
+    }
+
+    Some(verb(&binary, Some(&subcommand)))
+}
+
+fn verb(binary: &str, subcommand: Option<&str>) -> BashParse {
+    match subcommand {
+        None => BashParse {
+            binary: binary.to_string(),
+            subcommand: None,
+            normalized: binary.to_string(),
+        },
+        Some(sub) => BashParse {
+            binary: binary.to_string(),
+            subcommand: Some(sub.to_string()),
+            normalized: format!("{} {}", binary, sub),
+        },
+    }
+}
+
+fn shell_parse() -> BashParse {
+    BashParse {
+        binary: "(shell)".to_string(),
+        subcommand: None,
+        normalized: "(shell)".to_string(),
+    }
+}
+
+fn has_heredoc(cmd: &str) -> bool {
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"<<-?\s*\S+").unwrap());
+    RE.is_match(cmd)
+}
+
+fn starts_with_compound_shell_syntax(cmd: &str) -> bool {
+    static RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(?:for|while|until|if|case|select|function)\b").unwrap());
+    static BRACE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\{\s").unwrap());
+    RE.is_match(cmd) || BRACE_RE.is_match(cmd)
+}
+
+fn has_balanced_shell_delimiters(cmd: &str) -> bool {
+    let bytes = cmd.as_bytes();
+    let mut quote: Option<u8> = None;
+    let mut escaped = false;
+    let mut depth: i32 = 0;
+    for &b in bytes {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if b == b'\\' && quote != Some(b'\'') {
+            escaped = true;
+            continue;
+        }
+        if let Some(q) = quote {
+            if b == q {
+                quote = None;
+            }
+            continue;
+        }
+        if b == b'"' || b == b'\'' {
+            quote = Some(b);
+            continue;
+        }
+        if b == b'(' {
+            depth += 1;
+        } else if b == b')' {
+            depth -= 1;
+            if depth < 0 {
+                return false;
+            }
+        }
+    }
+    quote.is_none() && depth == 0
+}
+
+fn unwrap_subshell(cmd: &str) -> Option<String> {
+    if !cmd.starts_with('(') || !cmd.ends_with(')') {
+        return None;
+    }
+    let bytes = cmd.as_bytes();
+    let mut quote: Option<u8> = None;
+    let mut escaped = false;
+    let mut depth: i32 = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if b == b'\\' && quote != Some(b'\'') {
+            escaped = true;
+            continue;
+        }
+        if let Some(q) = quote {
+            if b == q {
+                quote = None;
+            }
+            continue;
+        }
+        if b == b'"' || b == b'\'' {
+            quote = Some(b);
+            continue;
+        }
+        if b == b'(' {
+            depth += 1;
+        } else if b == b')' {
+            depth -= 1;
+            if depth == 0 && i != bytes.len() - 1 {
+                return None;
+            }
+            if depth < 0 {
+                return None;
+            }
+        }
+    }
+    if quote.is_some() || depth != 0 {
+        return None;
+    }
+    Some(cmd[1..cmd.len() - 1].trim().to_string())
+}
+
+fn strip_leading_cd_prefix(cmd: &str) -> Option<String> {
+    let op = first_top_level_operator(cmd, &["&&", ";"])?;
+    let before = cmd[..op.index].trim();
+    let words = shell_words(before)?;
+    let cmd_idx = skip_env_assignments(&words, 0);
+    if words.get(cmd_idx).map(String::as_str) != Some("cd") {
+        return None;
+    }
+    Some(cmd[op.index + op.operator.len()..].trim().to_string())
+}
+
+fn first_top_level_segment(cmd: &str) -> Option<String> {
+    match first_top_level_operator(cmd, &["&&", "||", ";", "|", "\n"]) {
+        Some(op) => Some(cmd[..op.index].to_string()),
+        None => Some(cmd.to_string()),
+    }
+}
+
+struct OpHit {
+    index: usize,
+    operator: &'static str,
+}
+
+fn first_top_level_operator(cmd: &str, operators: &[&'static str]) -> Option<OpHit> {
+    let bytes = cmd.as_bytes();
+    let mut quote: Option<u8> = None;
+    let mut escaped = false;
+    let mut depth: i32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if escaped {
+            escaped = false;
+            i += 1;
+            continue;
+        }
+        if b == b'\\' && quote != Some(b'\'') {
+            escaped = true;
+            i += 1;
+            continue;
+        }
+        if let Some(q) = quote {
+            if b == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'"' || b == b'\'' {
+            quote = Some(b);
+            i += 1;
+            continue;
+        }
+        if b == b'(' {
+            depth += 1;
+            i += 1;
+            continue;
+        }
+        if b == b')' {
+            depth -= 1;
+            if depth < 0 {
+                return None;
+            }
+            i += 1;
+            continue;
+        }
+        if depth == 0 {
+            for op in operators {
+                if cmd[i..].starts_with(op) {
+                    return Some(OpHit {
+                        index: i,
+                        operator: op,
+                    });
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn shell_words(segment: &str) -> Option<Vec<String>> {
+    let mut words = Vec::new();
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    let mut current = String::new();
+    for ch in segment.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && quote != Some('\'') {
+            escaped = true;
+            continue;
+        }
+        if let Some(q) = quote {
+            if ch == q {
+                quote = None;
+            } else {
+                current.push(ch);
+            }
+            continue;
+        }
+        if ch == '"' || ch == '\'' {
+            quote = Some(ch);
+            continue;
+        }
+        if ch.is_whitespace() {
+            if !current.is_empty() {
+                words.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+        current.push(ch);
+    }
+    if escaped {
+        current.push('\\');
+    }
+    if quote.is_some() {
+        return None;
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    Some(words)
+}
+
+fn skip_env_assignments(tokens: &[String], start: usize) -> usize {
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*=").unwrap());
+    let mut i = start;
+    while i < tokens.len() && RE.is_match(&tokens[i]) {
+        i += 1;
+    }
+    i
+}
+
+fn skip_leading_options(tokens: &[String], start: usize) -> usize {
+    let mut i = start;
+    while i < tokens.len() {
+        let token = &tokens[i];
+        if token == "--" {
+            return i + 1;
+        }
+        if !token.starts_with('-') {
+            return i;
+        }
+        let has_eq = token.contains('=');
+        let option_name = if has_eq {
+            token.split('=').next().unwrap()
+        } else {
+            token.as_str()
+        };
+        i += 1;
+        if !has_eq && OPTION_TAKES_VALUE.contains(option_name) && i < tokens.len() {
+            i += 1;
+        }
+    }
+    i
+}
+
+fn shell_command_arg(tokens: &[String], start: usize) -> Option<String> {
+    for (offset, token) in tokens[start..].iter().enumerate() {
+        let i = start + offset;
+        if token == "-c"
+            || (token.starts_with('-') && !token.starts_with("--") && token.contains('c'))
+        {
+            return tokens.get(i + 1).cloned();
+        }
+    }
+    None
+}
+
+fn env_command_args(tokens: &[String], start: usize) -> Vec<String> {
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*=").unwrap());
+    let mut i = start;
+    while i < tokens.len() {
+        let token = &tokens[i];
+        if token == "--" {
+            i += 1;
+            break;
+        }
+        if RE.is_match(token) {
+            i += 1;
+            continue;
+        }
+        if token.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    tokens[i..].to_vec()
+}
+
+fn parse_python_module(tokens: &[String], start: usize) -> Option<BashParse> {
+    let module_flag = find_python_module_flag(tokens, start)?;
+    if module_flag + 1 >= tokens.len() {
+        return None;
+    }
+    let module = normalize_binary(&tokens[module_flag + 1]);
+    if module == "pytest" {
+        return Some(verb("pytest", None));
+    }
+    if module == "pip" || module == "pip3" {
+        let sub_index = skip_leading_options(tokens, module_flag + 2);
+        if sub_index < tokens.len() {
+            return Some(verb(&module, Some(&tokens[sub_index])));
+        }
+        return Some(verb(&module, None));
+    }
+    Some(verb(&module, None))
+}
+
+fn find_python_module_flag(tokens: &[String], start: usize) -> Option<usize> {
+    let mut i = start;
+    while i < tokens.len() {
+        let token = &tokens[i];
+        if token == "--" {
+            return None;
+        }
+        if token == "-m" {
+            return Some(i);
+        }
+        if token == "-c" {
+            return None;
+        }
+        if !token.starts_with('-') || token == "-" {
+            return None;
+        }
+        let has_eq = token.contains('=');
+        let option_name = if has_eq {
+            token.split('=').next().unwrap()
+        } else {
+            token.as_str()
+        };
+        if !has_eq && PYTHON_OPTION_TAKES_VALUE.contains(option_name) {
+            i += 1;
+        }
+        i += 1;
+    }
+    None
+}
+
+fn normalize_binary(raw: &str) -> String {
+    raw.split('/')
+        .rfind(|s| !s.is_empty())
+        .unwrap_or(raw)
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// classifyActivity priority ladder.
+// ---------------------------------------------------------------------------
+
+pub fn classify_activity(input: ClassificationInput<'_>) -> ClassificationResult {
+    let has_edits = input
+        .tool_calls
+        .iter()
+        .any(|t| EDIT_TOOLS.contains(normalize_tool_name(&t.name).as_str()));
+    let retries = count_retries(input.tool_calls);
+    let activity = pick_category(PickInput {
+        tool_calls: input.tool_calls,
+        text: input.text,
+        has_failed_tool: input.has_failed_tool,
+        has_edits,
+        retries,
+        reasoning_tokens: input.reasoning_tokens,
+    });
+    ClassificationResult {
+        activity,
+        retries,
+        has_edits,
+    }
+}
+
+struct PickInput<'a> {
+    tool_calls: &'a [ToolCall],
+    text: &'a str,
+    has_failed_tool: bool,
+    has_edits: bool,
+    retries: u64,
+    reasoning_tokens: u64,
+}
+
+fn pick_category(p: PickInput<'_>) -> ActivityCategory {
+    // Priority 1: delegation
+    if p.tool_calls
+        .iter()
+        .any(|t| DELEGATION_TOOLS.contains(normalize_tool_name(&t.name).as_str()))
+    {
+        return ActivityCategory::Delegation;
+    }
+    // Priority 2: explicit plan-mode marker
+    if p.tool_calls
+        .iter()
+        .any(|t| normalize_tool_name(&t.name) == "ExitPlanMode")
+    {
+        return ActivityCategory::Planning;
+    }
+    // Priority 3: edits present
+    if p.has_edits {
+        if p.has_failed_tool {
+            return ActivityCategory::Debugging;
+        }
+        if p.retries >= 2 {
+            return ActivityCategory::Debugging;
+        }
+        if all_edits_are_docs(p.tool_calls) {
+            return ActivityCategory::Docs;
+        }
+        if let Some(refined) = refine_edit_by_keywords(p.text) {
+            return refined;
+        }
+        return ActivityCategory::Coding;
+    }
+    // Priority 4: failed tool on a non-edit turn
+    if p.has_failed_tool {
+        return ActivityCategory::Debugging;
+    }
+    // Priority 5: bash heuristics
+    let bash_calls: Vec<&ToolCall> = p
+        .tool_calls
+        .iter()
+        .filter(|t| normalize_tool_name(&t.name) == "Bash")
+        .collect();
+    for call in &bash_calls {
+        let raw = call.target.as_deref().unwrap_or("");
+        let cmd = strip_env(raw);
+        if cmd.is_empty() {
+            continue;
+        }
+        if TEST_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+            return ActivityCategory::Testing;
+        }
+        if REVIEW_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+            return ActivityCategory::Review;
+        }
+        if GIT_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+            return ActivityCategory::Git;
+        }
+        if DEPS_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+            return ActivityCategory::Deps;
+        }
+        if FORMAT_PATTERNS.iter().any(|re| re.is_match(&cmd)) && !format_reject(&cmd) {
+            return ActivityCategory::Format;
+        }
+        if verification_match(&cmd) {
+            return ActivityCategory::Verification;
+        }
+        if BUILD_DEPLOY_PATTERNS.iter().any(|re| re.is_match(&cmd)) {
+            return ActivityCategory::BuildDeploy;
+        }
+    }
+    // Priority 6: any tools used at all
+    if !p.tool_calls.is_empty() {
+        if let Some(refined) = refine_intent_by_keywords(p.text) {
+            return refined;
+        }
+        return ActivityCategory::Exploration;
+    }
+    // Priority 7: keyword-only
+    if p.has_failed_tool {
+        return ActivityCategory::Debugging;
+    }
+    if let Some(refined) = refine_intent_by_keywords(p.text) {
+        return refined;
+    }
+    if BRAINSTORM_RE.is_match(p.text) {
+        return ActivityCategory::Brainstorming;
+    }
+    if PLANNING_RE.is_match(p.text) {
+        return ActivityCategory::Planning;
+    }
+    if p.reasoning_tokens > 0 {
+        return ActivityCategory::Reasoning;
+    }
+    ActivityCategory::Conversation
+}
+
+fn all_edits_are_docs(tool_calls: &[ToolCall]) -> bool {
+    let edits: Vec<&ToolCall> = tool_calls
+        .iter()
+        .filter(|t| EDIT_TOOLS.contains(normalize_tool_name(&t.name).as_str()))
+        .collect();
+    if edits.is_empty() {
+        return false;
+    }
+    edits.iter().all(|t| match &t.target {
+        Some(target) if !target.is_empty() => {
+            DOC_FILE_PATTERNS.iter().any(|re| re.is_match(target))
+        }
+        _ => false,
+    })
+}
+
+fn refine_edit_by_keywords(text: &str) -> Option<ActivityCategory> {
+    if text.is_empty() {
+        return None;
+    }
+    if DEBUG_RE.is_match(text) {
+        return Some(ActivityCategory::Debugging);
+    }
+    if REFACTOR_RE.is_match(text) {
+        return Some(ActivityCategory::Refactoring);
+    }
+    if FEATURE_RE.is_match(text) {
+        return Some(ActivityCategory::Feature);
+    }
+    None
+}
+
+fn refine_intent_by_keywords(text: &str) -> Option<ActivityCategory> {
+    if text.is_empty() {
+        return None;
+    }
+    if DEBUG_RE.is_match(text) {
+        return Some(ActivityCategory::Debugging);
+    }
+    if REVIEW_RE.is_match(text) {
+        return Some(ActivityCategory::Review);
+    }
+    if REFACTOR_RE.is_match(text) {
+        return Some(ActivityCategory::Refactoring);
+    }
+    if FEATURE_RE.is_match(text) {
+        return Some(ActivityCategory::Feature);
+    }
+    None
+}
+
+fn strip_env(cmd: &str) -> String {
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(?:\s*[A-Z_][A-Z0-9_]*=\S+\s+)+").unwrap());
+    RE.replace(cmd, "").into_owned()
+}
+
+pub fn count_retries(tool_calls: &[ToolCall]) -> u64 {
+    let mut retries: u64 = 0;
+    let mut seen_edit = false;
+    let mut seen_bash_after_edit = false;
+    for tc in tool_calls {
+        let name = normalize_tool_name(&tc.name);
+        if EDIT_TOOLS.contains(name.as_str()) {
+            if seen_edit && seen_bash_after_edit {
+                retries += 1;
+                seen_bash_after_edit = false;
+            }
+            seen_edit = true;
+        } else if name == "Bash" && seen_edit {
+            seen_bash_after_edit = true;
+        }
+    }
+    retries
+}
+
+// ---------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tc(name: &str, target: Option<&str>) -> ToolCall {
+        ToolCall {
+            id: name.to_string(),
+            name: name.to_string(),
+            target: target.map(|t| t.to_string()),
+            args_hash: "h".to_string(),
+            is_error: None,
+            edit_pre_hash: None,
+            edit_post_hash: None,
+            skill_name: None,
+            replaced_tools: None,
+            collapsed_calls: None,
+        }
+    }
+
+    fn classify(tools: &[ToolCall]) -> ClassificationResult {
+        classify_activity(ClassificationInput {
+            tool_calls: tools,
+            text: "",
+            has_failed_tool: false,
+            reasoning_tokens: 0,
+        })
+    }
+
+    #[test]
+    fn delegation_dominates_even_with_edits() {
+        let r = classify(&[tc("Agent", Some("Explore")), tc("Edit", Some("/a.ts"))]);
+        assert_eq!(r.activity, ActivityCategory::Delegation);
+    }
+
+    #[test]
+    fn exit_plan_mode_is_planning() {
+        let r = classify(&[tc("ExitPlanMode", None)]);
+        assert_eq!(r.activity, ActivityCategory::Planning);
+    }
+
+    #[test]
+    fn bash_test_runners_are_testing() {
+        let cases = [
+            "pytest",
+            "vitest run",
+            "bun test",
+            "npm test",
+            "go test ./...",
+            "cargo test",
+            "node --test",
+            "make test",
+        ];
+        for cmd in cases {
+            let r = classify(&[tc("Bash", Some(cmd))]);
+            assert_eq!(r.activity, ActivityCategory::Testing, "case: {cmd}");
+        }
+    }
+
+    #[test]
+    fn read_only_git_inspection_is_review() {
+        for cmd in [
+            "git status",
+            "git diff --stat",
+            "git show HEAD~1",
+            "gh pr diff 123",
+            "gh pr view 123",
+        ] {
+            let r = classify(&[tc("Bash", Some(cmd))]);
+            assert_eq!(r.activity, ActivityCategory::Review, "case: {cmd}");
+        }
+    }
+
+    #[test]
+    fn ignores_leading_env_assignments() {
+        let r = classify(&[tc("Bash", Some("CI=1 NODE_ENV=test pytest -q"))]);
+        assert_eq!(r.activity, ActivityCategory::Testing);
+    }
+
+    #[test]
+    fn git_state_change_is_git() {
+        for cmd in [
+            "git push origin main",
+            r#"git commit -m "x""#,
+            "git rebase main",
+        ] {
+            let r = classify(&[tc("Bash", Some(cmd))]);
+            assert_eq!(r.activity, ActivityCategory::Git, "case: {cmd}");
+        }
+    }
+
+    #[test]
+    fn build_deploy_commands() {
+        for cmd in [
+            "npm run build",
+            "docker build .",
+            "cargo build --release",
+            "kubectl apply -f k8s/",
+            "terraform apply",
+            "make build",
+        ] {
+            let r = classify(&[tc("Bash", Some(cmd))]);
+            assert_eq!(r.activity, ActivityCategory::BuildDeploy, "case: {cmd}");
+        }
+    }
+
+    #[test]
+    fn lint_typecheck_is_verification() {
+        for cmd in [
+            "npm run lint",
+            "eslint .",
+            "ruff check src/",
+            "cargo check",
+            "tsc --noEmit",
+            "make lint",
+            "prettier --check .",
+            "cargo fmt --check",
+        ] {
+            let r = classify(&[tc("Bash", Some(cmd))]);
+            assert_eq!(r.activity, ActivityCategory::Verification, "case: {cmd}");
+        }
+    }
+
+    #[test]
+    fn make_lint_beats_build_deploy() {
+        let r = classify(&[tc("Bash", Some("make lint"))]);
+        assert_eq!(r.activity, ActivityCategory::Verification);
+    }
+
+    #[test]
+    fn kubectl_logs_is_exploration() {
+        let r = classify(&[tc("Bash", Some("kubectl logs deploy/api"))]);
+        assert_eq!(r.activity, ActivityCategory::Exploration);
+    }
+
+    #[test]
+    fn plain_edit_is_coding() {
+        let r = classify(&[tc("Edit", Some("/a.ts")), tc("Write", Some("/b.ts"))]);
+        assert_eq!(r.activity, ActivityCategory::Coding);
+        assert!(r.has_edits);
+    }
+
+    #[test]
+    fn read_only_tool_turns_are_exploration() {
+        let r = classify(&[tc("Read", Some("/a.ts")), tc("Grep", Some("foo"))]);
+        assert_eq!(r.activity, ActivityCategory::Exploration);
+    }
+
+    #[test]
+    fn count_retries_counts_edit_bash_edit_cycles() {
+        let calls = [tc("Edit", None), tc("Bash", None), tc("Edit", None)];
+        assert_eq!(count_retries(&calls), 1);
+        let calls = [
+            tc("Edit", None),
+            tc("Bash", None),
+            tc("Edit", None),
+            tc("Bash", None),
+            tc("Edit", None),
+        ];
+        assert_eq!(count_retries(&calls), 2);
+        let calls = [tc("Edit", None), tc("Edit", None)];
+        assert_eq!(count_retries(&calls), 0);
+        let calls = [tc("Bash", None), tc("Edit", None), tc("Edit", None)];
+        assert_eq!(count_retries(&calls), 0);
+    }
+
+    #[test]
+    fn parse_bash_normalizes_examples() {
+        let cases = [
+            ("pytest", "pytest"),
+            ("python -m pytest -q", "pytest"),
+            ("python -I -X dev -m pytest -q", "pytest"),
+            ("vitest run", "vitest"),
+            ("bun test", "bun test"),
+            ("npm test", "npm test"),
+            ("go test ./...", "go test"),
+            ("cargo test", "cargo test"),
+            ("node --test", "node --test"),
+            ("make test", "make test"),
+            ("git status", "git status"),
+            ("git push origin main", "git push"),
+            ("npm run build", "npm build"),
+            ("docker build .", "docker build"),
+            ("docker compose build", "docker compose build"),
+            ("gh pr view 123", "gh pr view"),
+            ("gh run view 123", "gh run view"),
+            ("kubectl logs deploy/api", "kubectl logs"),
+        ];
+        for (cmd, expected) in cases {
+            let parsed = parse_bash_command(cmd).expect("parse");
+            assert_eq!(parsed.normalized, expected, "case: {cmd}");
+        }
+    }
+
+    #[test]
+    fn parse_bash_detects_compound_shell_syntax() {
+        let parsed = parse_bash_command("if [ -f foo ]; then echo y; fi").expect("parse");
+        assert_eq!(parsed.normalized, "(shell)");
+    }
+
+    #[test]
+    fn parse_bash_strips_leading_cd() {
+        let parsed = parse_bash_command("cd /tmp && pytest -q").expect("parse");
+        assert_eq!(parsed.normalized, "pytest");
+    }
+
+    #[test]
+    fn normalize_tool_name_aliases() {
+        assert_eq!(normalize_tool_name("apply_patch"), "Edit");
+        assert_eq!(normalize_tool_name("exec_command"), "Bash");
+        assert_eq!(normalize_tool_name("read"), "Read");
+        assert_eq!(normalize_tool_name("Bash"), "Bash");
+        assert_eq!(normalize_tool_name("UnknownTool"), "UnknownTool");
+    }
+
+    #[test]
+    fn doc_only_edits_classify_as_docs() {
+        let r = classify(&[
+            tc("Edit", Some("README.md")),
+            tc("Write", Some("docs/foo.md")),
+        ]);
+        assert_eq!(r.activity, ActivityCategory::Docs);
+    }
+
+    #[test]
+    fn failed_edit_classifies_as_debugging() {
+        let r = classify_activity(ClassificationInput {
+            tool_calls: &[tc("Edit", Some("/a.ts"))],
+            text: "",
+            has_failed_tool: true,
+            reasoning_tokens: 0,
+        });
+        assert_eq!(r.activity, ActivityCategory::Debugging);
+    }
+
+    #[test]
+    fn reasoning_only_no_tools_no_text_is_reasoning() {
+        let r = classify_activity(ClassificationInput {
+            tool_calls: &[],
+            text: "",
+            has_failed_tool: false,
+            reasoning_tokens: 1234,
+        });
+        assert_eq!(r.activity, ActivityCategory::Reasoning);
+    }
+
+    #[test]
+    fn empty_input_is_conversation() {
+        let r = classify(&[]);
+        assert_eq!(r.activity, ActivityCategory::Conversation);
+    }
+}

--- a/crates/relayburn-reader/src/classifier.rs
+++ b/crates/relayburn-reader/src/classifier.rs
@@ -670,7 +670,11 @@ fn first_top_level_operator(cmd: &str, operators: &[&'static str]) -> Option<OpH
         }
         if depth == 0 {
             for op in operators {
-                if cmd[i..].starts_with(op) {
+                // Compare against the byte slice rather than `cmd[i..]` —
+                // operators are all ASCII, and `i` may sit inside a multi-byte
+                // UTF-8 sequence (e.g. when `cmd` contains a path like
+                // `café.txt`), where `&str` slicing would panic.
+                if bytes[i..].starts_with(op.as_bytes()) {
                     return Some(OpHit {
                         index: i,
                         operator: op,
@@ -1263,6 +1267,17 @@ mod tests {
     fn parse_bash_strips_leading_cd() {
         let parsed = parse_bash_command("cd /tmp && pytest -q").expect("parse");
         assert_eq!(parsed.normalized, "pytest");
+    }
+
+    #[test]
+    fn parse_bash_handles_multibyte_utf8_arguments() {
+        // Regression: the operator scanner used to slice `cmd[i..]` at byte
+        // offsets, which panics when `i` lands inside a multi-byte sequence
+        // (e.g. an `é` in a path). Verify the parser stays alive.
+        let parsed = parse_bash_command("cat café.txt && pytest -q").expect("parse");
+        assert_eq!(parsed.normalized, "cat");
+        let parsed = parse_bash_command("git commit -m \"日本語\"").expect("parse");
+        assert_eq!(parsed.normalized, "git commit");
     }
 
     #[test]

--- a/crates/relayburn-reader/src/claude.rs
+++ b/crates/relayburn-reader/src/claude.rs
@@ -1,0 +1,5 @@
+//! Claude Code session parser — Rust port stub.
+//!
+//! TODO(#242): port `packages/reader/src/claude.ts` (Claude session JSONL
+//! parser, sidechain reconciliation, etc.). The TS implementation is ~2.3k
+//! lines; landing it in a follow-up keeps the foundation review tractable.

--- a/crates/relayburn-reader/src/codex.rs
+++ b/crates/relayburn-reader/src/codex.rs
@@ -1,0 +1,4 @@
+//! Codex session parser — Rust port stub.
+//!
+//! TODO(#242): port `packages/reader/src/codex.ts` (Codex JSONL parser,
+//! resume-state reconstruction, user-turn slot persistence).

--- a/crates/relayburn-reader/src/fidelity.rs
+++ b/crates/relayburn-reader/src/fidelity.rs
@@ -1,50 +1,49 @@
 //! Coverage / fidelity helpers — Rust port of `packages/reader/src/fidelity.ts`.
 //!
-//! Same policy as the TS helper: parsers default every coverage flag to `false`
-//! and explicitly opt fields into `true`. `classify_fidelity` derives the
-//! higher-level summary from `granularity` + `coverage`.
+//! Construction lives on the types: `Coverage::EMPTY` / `Coverage::is_full()`
+//! ([`crate::types`]) and [`Fidelity::new`] here. `classify_fidelity` is
+//! exposed as a free function and as [`Fidelity::classify`] — same logic,
+//! pick the form that reads better at the call site.
 
 use crate::types::{Coverage, Fidelity, FidelityClass, UsageGranularity};
 
-/// Coverage value with every flag defaulted to `false`. Parsers should clone
-/// this and flip the flags they actually populate.
-pub const fn empty_coverage() -> Coverage {
-    Coverage {
-        has_input_tokens: false,
-        has_output_tokens: false,
-        has_reasoning_tokens: false,
-        has_cache_read_tokens: false,
-        has_cache_create_tokens: false,
-        has_tool_calls: false,
-        has_tool_result_events: false,
-        has_session_relationships: false,
-        has_raw_content: false,
+impl Fidelity {
+    /// Build a `Fidelity` from a granularity + coverage pair. Equivalent to
+    /// the TS `makeFidelity`; the derived `class` field is filled in via
+    /// [`classify_fidelity`].
+    pub fn new(granularity: UsageGranularity, coverage: Coverage) -> Self {
+        let class = classify_fidelity(granularity, &coverage);
+        Self {
+            granularity,
+            coverage,
+            class,
+        }
+    }
+
+    /// Pure derivation of `FidelityClass` from a granularity + coverage pair.
+    /// Method form of [`classify_fidelity`].
+    pub fn classify(granularity: UsageGranularity, coverage: &Coverage) -> FidelityClass {
+        classify_fidelity(granularity, coverage)
     }
 }
 
-fn full_required(c: &Coverage) -> bool {
-    c.has_input_tokens
-        && c.has_output_tokens
-        && c.has_cache_read_tokens
-        && c.has_tool_calls
-        && c.has_tool_result_events
-        && c.has_session_relationships
-}
-
-fn usage_required(c: &Coverage) -> bool {
-    c.has_input_tokens && c.has_output_tokens
-}
-
 /// Pure derivation of `FidelityClass` from a `granularity` + `coverage` pair.
-/// No I/O, no allocation; safe to call from any layer.
+/// No I/O, no allocation; safe to call from any layer (reader during
+/// construction, analyze for re-derivation, CLI for post-hoc filters).
+///
+///   - `cost-only`        → granularity says we only have a price, not tokens
+///   - `aggregate-only`   → per-session totals; per-turn fields are estimates
+///   - `usage-only`       → per-turn input/output but no tool-result chronology
+///   - `full`             → meets `Coverage::is_full`
+///   - `partial`          → has *something* useful but less than usage-only
 pub fn classify_fidelity(granularity: UsageGranularity, coverage: &Coverage) -> FidelityClass {
     match granularity {
         UsageGranularity::CostOnly => FidelityClass::CostOnly,
         UsageGranularity::PerSessionAggregate => FidelityClass::AggregateOnly,
         UsageGranularity::PerTurn | UsageGranularity::PerMessage => {
-            if full_required(coverage) {
+            if coverage.is_full() {
                 FidelityClass::Full
-            } else if usage_required(coverage) {
+            } else if coverage.has_per_turn_usage() {
                 FidelityClass::UsageOnly
             } else {
                 FidelityClass::Partial
@@ -53,23 +52,12 @@ pub fn classify_fidelity(granularity: UsageGranularity, coverage: &Coverage) -> 
     }
 }
 
-/// Convenience constructor — parsers build a `Coverage`, declare their
-/// granularity, and get a fully-populated `Fidelity` with the derived class.
-pub fn make_fidelity(granularity: UsageGranularity, coverage: Coverage) -> Fidelity {
-    let class = classify_fidelity(granularity, &coverage);
-    Fidelity {
-        granularity,
-        coverage,
-        class,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn with_flags(set: impl FnOnce(&mut Coverage)) -> Coverage {
-        let mut c = empty_coverage();
+        let mut c = Coverage::EMPTY;
         set(&mut c);
         c
     }
@@ -85,12 +73,12 @@ mod tests {
             c.has_session_relationships = true;
         });
         assert_eq!(
-            classify_fidelity(UsageGranularity::CostOnly, &all_on),
-            FidelityClass::CostOnly
+            Fidelity::classify(UsageGranularity::CostOnly, &all_on),
+            FidelityClass::CostOnly,
         );
         assert_eq!(
-            classify_fidelity(UsageGranularity::CostOnly, &empty_coverage()),
-            FidelityClass::CostOnly
+            Fidelity::classify(UsageGranularity::CostOnly, &Coverage::EMPTY),
+            FidelityClass::CostOnly,
         );
     }
 
@@ -101,8 +89,8 @@ mod tests {
             c.has_output_tokens = true;
         });
         assert_eq!(
-            classify_fidelity(UsageGranularity::PerSessionAggregate, &cov),
-            FidelityClass::AggregateOnly
+            Fidelity::classify(UsageGranularity::PerSessionAggregate, &cov),
+            FidelityClass::AggregateOnly,
         );
     }
 
@@ -117,8 +105,8 @@ mod tests {
             c.has_session_relationships = true;
         });
         assert_eq!(
-            classify_fidelity(UsageGranularity::PerTurn, &cov),
-            FidelityClass::Full
+            Fidelity::classify(UsageGranularity::PerTurn, &cov),
+            FidelityClass::Full,
         );
     }
 
@@ -131,8 +119,8 @@ mod tests {
             c.has_session_relationships = true;
         });
         assert_eq!(
-            classify_fidelity(UsageGranularity::PerTurn, &cov),
-            FidelityClass::UsageOnly
+            Fidelity::classify(UsageGranularity::PerTurn, &cov),
+            FidelityClass::UsageOnly,
         );
     }
 
@@ -146,8 +134,8 @@ mod tests {
             c.has_session_relationships = true;
         });
         assert_eq!(
-            classify_fidelity(UsageGranularity::PerTurn, &cov),
-            FidelityClass::Partial
+            Fidelity::classify(UsageGranularity::PerTurn, &cov),
+            FidelityClass::Partial,
         );
     }
 
@@ -162,18 +150,18 @@ mod tests {
             c.has_session_relationships = true;
         });
         assert_eq!(
-            classify_fidelity(UsageGranularity::PerMessage, &cov),
-            FidelityClass::Full
+            Fidelity::classify(UsageGranularity::PerMessage, &cov),
+            FidelityClass::Full,
         );
     }
 
     #[test]
-    fn make_fidelity_packs_class() {
+    fn fidelity_new_packs_class() {
         let cov = with_flags(|c| {
             c.has_input_tokens = true;
             c.has_output_tokens = true;
         });
-        let f = make_fidelity(UsageGranularity::PerTurn, cov.clone());
+        let f = Fidelity::new(UsageGranularity::PerTurn, cov.clone());
         assert_eq!(f.granularity, UsageGranularity::PerTurn);
         assert_eq!(f.coverage, cov);
         assert_eq!(f.class, FidelityClass::UsageOnly);

--- a/crates/relayburn-reader/src/fidelity.rs
+++ b/crates/relayburn-reader/src/fidelity.rs
@@ -1,0 +1,181 @@
+//! Coverage / fidelity helpers — Rust port of `packages/reader/src/fidelity.ts`.
+//!
+//! Same policy as the TS helper: parsers default every coverage flag to `false`
+//! and explicitly opt fields into `true`. `classify_fidelity` derives the
+//! higher-level summary from `granularity` + `coverage`.
+
+use crate::types::{Coverage, Fidelity, FidelityClass, UsageGranularity};
+
+/// Coverage value with every flag defaulted to `false`. Parsers should clone
+/// this and flip the flags they actually populate.
+pub const fn empty_coverage() -> Coverage {
+    Coverage {
+        has_input_tokens: false,
+        has_output_tokens: false,
+        has_reasoning_tokens: false,
+        has_cache_read_tokens: false,
+        has_cache_create_tokens: false,
+        has_tool_calls: false,
+        has_tool_result_events: false,
+        has_session_relationships: false,
+        has_raw_content: false,
+    }
+}
+
+fn full_required(c: &Coverage) -> bool {
+    c.has_input_tokens
+        && c.has_output_tokens
+        && c.has_cache_read_tokens
+        && c.has_tool_calls
+        && c.has_tool_result_events
+        && c.has_session_relationships
+}
+
+fn usage_required(c: &Coverage) -> bool {
+    c.has_input_tokens && c.has_output_tokens
+}
+
+/// Pure derivation of `FidelityClass` from a `granularity` + `coverage` pair.
+/// No I/O, no allocation; safe to call from any layer.
+pub fn classify_fidelity(granularity: UsageGranularity, coverage: &Coverage) -> FidelityClass {
+    match granularity {
+        UsageGranularity::CostOnly => FidelityClass::CostOnly,
+        UsageGranularity::PerSessionAggregate => FidelityClass::AggregateOnly,
+        UsageGranularity::PerTurn | UsageGranularity::PerMessage => {
+            if full_required(coverage) {
+                FidelityClass::Full
+            } else if usage_required(coverage) {
+                FidelityClass::UsageOnly
+            } else {
+                FidelityClass::Partial
+            }
+        }
+    }
+}
+
+/// Convenience constructor — parsers build a `Coverage`, declare their
+/// granularity, and get a fully-populated `Fidelity` with the derived class.
+pub fn make_fidelity(granularity: UsageGranularity, coverage: Coverage) -> Fidelity {
+    let class = classify_fidelity(granularity, &coverage);
+    Fidelity {
+        granularity,
+        coverage,
+        class,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_flags(set: impl FnOnce(&mut Coverage)) -> Coverage {
+        let mut c = empty_coverage();
+        set(&mut c);
+        c
+    }
+
+    #[test]
+    fn cost_only_dominates_coverage() {
+        let all_on = with_flags(|c| {
+            c.has_input_tokens = true;
+            c.has_output_tokens = true;
+            c.has_cache_read_tokens = true;
+            c.has_tool_calls = true;
+            c.has_tool_result_events = true;
+            c.has_session_relationships = true;
+        });
+        assert_eq!(
+            classify_fidelity(UsageGranularity::CostOnly, &all_on),
+            FidelityClass::CostOnly
+        );
+        assert_eq!(
+            classify_fidelity(UsageGranularity::CostOnly, &empty_coverage()),
+            FidelityClass::CostOnly
+        );
+    }
+
+    #[test]
+    fn per_session_aggregate_returns_aggregate_only() {
+        let cov = with_flags(|c| {
+            c.has_input_tokens = true;
+            c.has_output_tokens = true;
+        });
+        assert_eq!(
+            classify_fidelity(UsageGranularity::PerSessionAggregate, &cov),
+            FidelityClass::AggregateOnly
+        );
+    }
+
+    #[test]
+    fn per_turn_full_when_all_required_set() {
+        let cov = with_flags(|c| {
+            c.has_input_tokens = true;
+            c.has_output_tokens = true;
+            c.has_cache_read_tokens = true;
+            c.has_tool_calls = true;
+            c.has_tool_result_events = true;
+            c.has_session_relationships = true;
+        });
+        assert_eq!(
+            classify_fidelity(UsageGranularity::PerTurn, &cov),
+            FidelityClass::Full
+        );
+    }
+
+    #[test]
+    fn usage_only_when_input_output_present_but_tools_missing() {
+        let cov = with_flags(|c| {
+            c.has_input_tokens = true;
+            c.has_output_tokens = true;
+            c.has_cache_read_tokens = true;
+            c.has_session_relationships = true;
+        });
+        assert_eq!(
+            classify_fidelity(UsageGranularity::PerTurn, &cov),
+            FidelityClass::UsageOnly
+        );
+    }
+
+    #[test]
+    fn partial_when_output_missing() {
+        let cov = with_flags(|c| {
+            c.has_input_tokens = true;
+            c.has_cache_read_tokens = true;
+            c.has_tool_calls = true;
+            c.has_tool_result_events = true;
+            c.has_session_relationships = true;
+        });
+        assert_eq!(
+            classify_fidelity(UsageGranularity::PerTurn, &cov),
+            FidelityClass::Partial
+        );
+    }
+
+    #[test]
+    fn per_message_with_full_required_is_full() {
+        let cov = with_flags(|c| {
+            c.has_input_tokens = true;
+            c.has_output_tokens = true;
+            c.has_cache_read_tokens = true;
+            c.has_tool_calls = true;
+            c.has_tool_result_events = true;
+            c.has_session_relationships = true;
+        });
+        assert_eq!(
+            classify_fidelity(UsageGranularity::PerMessage, &cov),
+            FidelityClass::Full
+        );
+    }
+
+    #[test]
+    fn make_fidelity_packs_class() {
+        let cov = with_flags(|c| {
+            c.has_input_tokens = true;
+            c.has_output_tokens = true;
+        });
+        let f = make_fidelity(UsageGranularity::PerTurn, cov.clone());
+        assert_eq!(f.granularity, UsageGranularity::PerTurn);
+        assert_eq!(f.coverage, cov);
+        assert_eq!(f.class, FidelityClass::UsageOnly);
+    }
+}

--- a/crates/relayburn-reader/src/git.rs
+++ b/crates/relayburn-reader/src/git.rs
@@ -1,0 +1,436 @@
+//! Git config / remote-url helpers — Rust port of `packages/reader/src/git.ts`.
+//!
+//! Mirrors the TS behavior:
+//!   - `parse_git_config` reads `.git/config` INI-ish text into a section map,
+//!     handling `[remote "origin"]`-style subsections and stripping inline
+//!     `#` / `;` comments outside quotes.
+//!   - `canonicalize_remote_url` normalizes scp / https / ssh remote URLs into
+//!     a stable `host/path` key, lowercasing the host but preserving owner/repo
+//!     case.
+//!   - `resolve_project` walks up from a cwd, opens `.git/config` (or follows
+//!     a `.git` worktree pointer), and returns `{project, projectKey}` with
+//!     a per-process memoization keyed by cwd.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedProject {
+    pub project: String,
+    pub project_key: Option<String>,
+}
+
+static CACHE: Lazy<Mutex<HashMap<String, ResolvedProject>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub fn resolve_project(cwd: &str) -> ResolvedProject {
+    {
+        let cache = CACHE.lock().unwrap();
+        if let Some(hit) = cache.get(cwd) {
+            return hit.clone();
+        }
+    }
+    let result = resolve_uncached(cwd);
+    let mut cache = CACHE.lock().unwrap();
+    cache
+        .entry(cwd.to_string())
+        .or_insert_with(|| result.clone());
+    result
+}
+
+#[doc(hidden)]
+pub fn __reset_resolve_project_cache_for_testing() {
+    CACHE.lock().unwrap().clear();
+}
+
+fn resolve_uncached(cwd: &str) -> ResolvedProject {
+    let Some(git_dir) = find_git_dir(Path::new(cwd)) else {
+        return ResolvedProject {
+            project: cwd.to_string(),
+            project_key: None,
+        };
+    };
+    let config_path = git_dir.join("config");
+    let Ok(text) = fs::read_to_string(&config_path) else {
+        return ResolvedProject {
+            project: cwd.to_string(),
+            project_key: None,
+        };
+    };
+    let cfg = parse_git_config(&text);
+    let url = cfg
+        .get("remote \"origin\"")
+        .and_then(|m| m.get("url"))
+        .cloned();
+    let Some(url) = url else {
+        return ResolvedProject {
+            project: cwd.to_string(),
+            project_key: None,
+        };
+    };
+    match canonicalize_remote_url(&url) {
+        Some(key) => ResolvedProject {
+            project: cwd.to_string(),
+            project_key: Some(key),
+        },
+        None => ResolvedProject {
+            project: cwd.to_string(),
+            project_key: None,
+        },
+    }
+}
+
+fn find_git_dir(start: &Path) -> Option<PathBuf> {
+    let mut dir: PathBuf = match start.canonicalize() {
+        Ok(p) => p,
+        Err(_) => start.to_path_buf(),
+    };
+    for _ in 0..100 {
+        let candidate = dir.join(".git");
+        if let Ok(meta) = fs::metadata(&candidate) {
+            if meta.is_dir() {
+                return Some(candidate);
+            }
+            if meta.is_file() {
+                if let Some(resolved) = resolve_worktree_git_dir(&candidate) {
+                    return Some(resolved);
+                }
+            }
+        }
+        match dir.parent() {
+            Some(parent) if parent != dir => dir = parent.to_path_buf(),
+            _ => return None,
+        }
+    }
+    None
+}
+
+fn resolve_worktree_git_dir(git_file: &Path) -> Option<PathBuf> {
+    static GITDIR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)^gitdir:\s*(.+?)\s*$").unwrap());
+    let text = fs::read_to_string(git_file).ok()?;
+    let raw = GITDIR_RE.captures(&text)?.get(1)?.as_str().to_string();
+    let raw_path = Path::new(&raw);
+    let gitdir = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else {
+        git_file.parent()?.join(raw_path)
+    };
+    let commondir_file = gitdir.join("commondir");
+    if let Ok(text) = fs::read_to_string(&commondir_file) {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            let p = Path::new(trimmed);
+            return Some(if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                gitdir.join(p)
+            });
+        }
+    }
+    Some(gitdir)
+}
+
+/// Parse `.git/config` text into `{section -> {key -> value}}`. Handles
+/// `[section]` and `[section "subsection"]` headers and ignores `#` / `;`
+/// comments + blank lines. Inline comments outside quotes are stripped.
+pub fn parse_git_config(text: &str) -> HashMap<String, HashMap<String, String>> {
+    let mut out: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut current_key: Option<String> = None;
+    for raw_line in text.split('\n') {
+        let line = raw_line.trim_end_matches('\r');
+        let line = line
+            .trim_start_matches([' ', '\t'])
+            .trim_end_matches([' ', '\t']);
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            let name = section_name(&line[1..line.len() - 1]);
+            out.entry(name.clone()).or_default();
+            current_key = Some(name);
+            continue;
+        }
+        let Some(section) = current_key.as_ref() else {
+            continue;
+        };
+        let Some(eq) = line.find('=') else { continue };
+        let key = line[..eq].trim().to_string();
+        let value = strip_inline_comment(line[eq + 1..].trim());
+        if key.is_empty() {
+            continue;
+        }
+        out.get_mut(section).unwrap().insert(key, value);
+    }
+    out
+}
+
+fn section_name(raw: &str) -> String {
+    static SUBSECTION_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r#"^([A-Za-z0-9._-]+)\s+"(.*)"$"#).unwrap());
+    let trimmed = raw.trim();
+    if let Some(c) = SUBSECTION_RE.captures(trimmed) {
+        return format!("{} \"{}\"", &c[1], &c[2]);
+    }
+    trimmed.to_string()
+}
+
+fn strip_inline_comment(value: &str) -> String {
+    let mut out = String::new();
+    let mut in_quotes = false;
+    for ch in value.chars() {
+        if ch == '"' {
+            in_quotes = !in_quotes;
+            continue;
+        }
+        if !in_quotes && (ch == '#' || ch == ';') {
+            break;
+        }
+        out.push(ch);
+    }
+    out.trim().to_string()
+}
+
+/// Canonicalize a remote URL into `host/path` form. Returns `None` for inputs
+/// that aren't recognizable git URLs.
+pub fn canonicalize_remote_url(url: &str) -> Option<String> {
+    static SCP_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(?:[A-Za-z0-9_-]+)@([^:\s]+):(.+)$").unwrap());
+    static SCHEME_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^([A-Za-z][A-Za-z0-9+.\-]*)://(.+)$").unwrap());
+
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(c) = SCP_RE.captures(trimmed) {
+        let host = c.get(1).unwrap().as_str().to_lowercase();
+        let raw_path = c.get(2).unwrap().as_str();
+        let path_part = strip_dot_git(raw_path.trim_start_matches('/').trim_end_matches('/'));
+        if path_part.is_empty() {
+            return None;
+        }
+        return Some(format!("{host}/{path_part}"));
+    }
+
+    if let Some(c) = SCHEME_RE.captures(trimmed) {
+        let rest = c.get(2).unwrap().as_str();
+        let after_auth = match rest.find('@') {
+            Some(idx) => &rest[idx + 1..],
+            None => rest,
+        };
+        let slash = after_auth.find('/')?;
+        let host_part = &after_auth[..slash];
+        let host = strip_port(host_part).to_lowercase();
+        if host.is_empty() {
+            return None;
+        }
+        let path_part = strip_dot_git(after_auth[slash + 1..].trim_end_matches('/'));
+        if path_part.is_empty() {
+            return None;
+        }
+        return Some(format!("{host}/{path_part}"));
+    }
+
+    None
+}
+
+fn strip_dot_git(p: &str) -> String {
+    p.strip_suffix(".git").unwrap_or(p).to_string()
+}
+
+fn strip_port(host: &str) -> &str {
+    match host.find(':') {
+        Some(idx) => &host[..idx],
+        None => host,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    use once_cell::sync::Lazy;
+    use tempfile::tempdir;
+
+    // resolve_project shares a process-global cache; serialize the tests that
+    // touch it so they don't race the cache-reset call.
+    static RESOLVE_PROJECT_TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    #[test]
+    fn canonicalize_scp_form() {
+        assert_eq!(
+            canonicalize_remote_url("git@github.com:AgentWorkforce/burn.git").as_deref(),
+            Some("github.com/AgentWorkforce/burn"),
+        );
+    }
+
+    #[test]
+    fn canonicalize_https_with_dot_git() {
+        assert_eq!(
+            canonicalize_remote_url("https://github.com/AgentWorkforce/burn.git").as_deref(),
+            Some("github.com/AgentWorkforce/burn"),
+        );
+    }
+
+    #[test]
+    fn canonicalize_https_without_dot_git_with_subgroup() {
+        assert_eq!(
+            canonicalize_remote_url("https://gitlab.com/group/sub/repo").as_deref(),
+            Some("gitlab.com/group/sub/repo"),
+        );
+    }
+
+    #[test]
+    fn canonicalize_https_with_user() {
+        assert_eq!(
+            canonicalize_remote_url("https://user:token@github.com/foo/bar.git").as_deref(),
+            Some("github.com/foo/bar"),
+        );
+    }
+
+    #[test]
+    fn canonicalize_ssh_with_port() {
+        assert_eq!(
+            canonicalize_remote_url("ssh://git@github.com:22/AgentWorkforce/burn.git").as_deref(),
+            Some("github.com/AgentWorkforce/burn"),
+        );
+    }
+
+    #[test]
+    fn canonicalize_lowercases_host_only() {
+        assert_eq!(
+            canonicalize_remote_url("git@GitHub.COM:AgentWorkforce/Burn.git").as_deref(),
+            Some("github.com/AgentWorkforce/Burn"),
+        );
+    }
+
+    #[test]
+    fn canonicalize_returns_none_on_junk() {
+        assert_eq!(canonicalize_remote_url(""), None);
+        assert_eq!(canonicalize_remote_url("not a url"), None);
+        assert_eq!(canonicalize_remote_url("https://example.com/"), None);
+    }
+
+    #[test]
+    fn canonicalize_strips_trailing_slash() {
+        assert_eq!(
+            canonicalize_remote_url("https://github.com/foo/bar/").as_deref(),
+            Some("github.com/foo/bar"),
+        );
+    }
+
+    #[test]
+    fn parse_simple_sections() {
+        let cfg = parse_git_config(
+            "\n[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = git@github.com:foo/bar.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n",
+        );
+        assert_eq!(cfg["core"]["repositoryformatversion"], "0");
+        assert_eq!(
+            cfg["remote \"origin\""]["url"],
+            "git@github.com:foo/bar.git"
+        );
+    }
+
+    #[test]
+    fn parse_ignores_comments_and_blanks() {
+        let cfg = parse_git_config(
+            "\n# a comment\n; another comment\n[remote \"origin\"]\n\turl = https://github.com/foo/bar ; inline comment\n",
+        );
+        assert_eq!(
+            cfg["remote \"origin\""]["url"],
+            "https://github.com/foo/bar"
+        );
+    }
+
+    #[test]
+    fn resolve_project_no_git() {
+        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
+        __reset_resolve_project_cache_for_testing();
+        let dir = tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+        let got = resolve_project(&path);
+        assert_eq!(got.project, path);
+        assert_eq!(got.project_key, None);
+    }
+
+    #[test]
+    fn resolve_project_with_git_dir() {
+        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
+        __reset_resolve_project_cache_for_testing();
+        let root = tempdir().unwrap();
+        let git_dir = root.path().join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:foo/bar.git\n",
+        )
+        .unwrap();
+        let nested = root.path().join("packages").join("a");
+        fs::create_dir_all(&nested).unwrap();
+        let got = resolve_project(&nested.to_string_lossy());
+        assert_eq!(got.project_key.as_deref(), Some("github.com/foo/bar"));
+    }
+
+    #[test]
+    fn resolve_project_worktree() {
+        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
+        __reset_resolve_project_cache_for_testing();
+        let root = tempdir().unwrap();
+        let common_git = root.path().join("main").join(".git");
+        fs::create_dir_all(&common_git).unwrap();
+        fs::write(
+            common_git.join("config"),
+            "[remote \"origin\"]\n\turl = https://github.com/foo/bar\n",
+        )
+        .unwrap();
+        let worktree_dir = common_git.join("worktrees").join("branch-a");
+        fs::create_dir_all(&worktree_dir).unwrap();
+        fs::write(worktree_dir.join("commondir"), "../..\n").unwrap();
+
+        let worktree = root.path().join("worktree-a");
+        fs::create_dir_all(&worktree).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", worktree_dir.display()),
+        )
+        .unwrap();
+
+        let got = resolve_project(&worktree.to_string_lossy());
+        assert_eq!(got.project_key.as_deref(), Some("github.com/foo/bar"));
+    }
+
+    #[test]
+    fn resolve_project_memoizes() {
+        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
+        __reset_resolve_project_cache_for_testing();
+        let root = tempdir().unwrap();
+        let git_dir = root.path().join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:foo/bar.git\n",
+        )
+        .unwrap();
+        let key = root.path().to_string_lossy().to_string();
+        let a = resolve_project(&key);
+        // Mutate the config; cache should still return the original answer.
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:zzz/zzz.git\n",
+        )
+        .unwrap();
+        let b = resolve_project(&key);
+        assert_eq!(a.project_key, b.project_key);
+    }
+}

--- a/crates/relayburn-reader/src/git.rs
+++ b/crates/relayburn-reader/src/git.rs
@@ -1,22 +1,24 @@
 //! Git config / remote-url helpers — Rust port of `packages/reader/src/git.ts`.
 //!
-//! Mirrors the TS behavior:
-//!   - `parse_git_config` reads `.git/config` INI-ish text into a section map,
+//! Three pieces:
+//!
+//!   - [`parse_git_config`] reads `.git/config` text into a section map,
 //!     handling `[remote "origin"]`-style subsections and stripping inline
 //!     `#` / `;` comments outside quotes.
-//!   - `canonicalize_remote_url` normalizes scp / https / ssh remote URLs into
-//!     a stable `host/path` key, lowercasing the host but preserving owner/repo
-//!     case.
-//!   - `resolve_project` walks up from a cwd, opens `.git/config` (or follows
-//!     a `.git` worktree pointer), and returns `{project, projectKey}` with
-//!     a per-process memoization keyed by cwd.
+//!   - [`canonicalize_remote_url`] normalizes scp / https / ssh remote URLs
+//!     into a stable `host/path` key, lowercasing the host but preserving
+//!     owner/repo case.
+//!   - [`ProjectResolver`] walks up from a cwd, opens `.git/config` (or
+//!     follows a `.git` worktree pointer), and returns `{project, project_key}`
+//!     with a per-instance cache. The free [`resolve_project`] uses a process
+//!     global resolver for the common case; tests construct their own to
+//!     avoid sharing global state.
 
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,27 +27,44 @@ pub struct ResolvedProject {
     pub project_key: Option<String>,
 }
 
-static CACHE: Lazy<Mutex<HashMap<String, ResolvedProject>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
-
-pub fn resolve_project(cwd: &str) -> ResolvedProject {
-    {
-        let cache = CACHE.lock().unwrap();
-        if let Some(hit) = cache.get(cwd) {
-            return hit.clone();
-        }
-    }
-    let result = resolve_uncached(cwd);
-    let mut cache = CACHE.lock().unwrap();
-    cache
-        .entry(cwd.to_string())
-        .or_insert_with(|| result.clone());
-    result
+/// Cached resolver. Construct one per scope (CLI, test, embedding) to avoid
+/// sharing a process-global cache.
+#[derive(Debug, Default)]
+pub struct ProjectResolver {
+    cache: Mutex<HashMap<String, ResolvedProject>>,
 }
 
-#[doc(hidden)]
-pub fn __reset_resolve_project_cache_for_testing() {
-    CACHE.lock().unwrap().clear();
+impl ProjectResolver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve a project for `cwd`, consulting (and populating) the cache.
+    pub fn resolve(&self, cwd: &str) -> ResolvedProject {
+        if let Some(hit) = self.cache.lock().unwrap().get(cwd) {
+            return hit.clone();
+        }
+        let result = resolve_uncached(cwd);
+        self.cache
+            .lock()
+            .unwrap()
+            .entry(cwd.to_string())
+            .or_insert_with(|| result.clone());
+        result
+    }
+
+    pub fn clear(&self) {
+        self.cache.lock().unwrap().clear();
+    }
+}
+
+static GLOBAL_RESOLVER: LazyLock<ProjectResolver> = LazyLock::new(ProjectResolver::new);
+
+/// Convenience wrapper around a process-global [`ProjectResolver`]. Embedders
+/// that want their own cache (notably tests) should construct their own
+/// `ProjectResolver` directly.
+pub fn resolve_project(cwd: &str) -> ResolvedProject {
+    GLOBAL_RESOLVER.resolve(cwd)
 }
 
 fn resolve_uncached(cwd: &str) -> ResolvedProject {
@@ -55,41 +74,24 @@ fn resolve_uncached(cwd: &str) -> ResolvedProject {
             project_key: None,
         };
     };
-    let config_path = git_dir.join("config");
-    let Ok(text) = fs::read_to_string(&config_path) else {
+    let Ok(text) = fs::read_to_string(git_dir.join("config")) else {
         return ResolvedProject {
             project: cwd.to_string(),
             project_key: None,
         };
     };
-    let cfg = parse_git_config(&text);
-    let url = cfg
+    let key = parse_git_config(&text)
         .get("remote \"origin\"")
         .and_then(|m| m.get("url"))
-        .cloned();
-    let Some(url) = url else {
-        return ResolvedProject {
-            project: cwd.to_string(),
-            project_key: None,
-        };
-    };
-    match canonicalize_remote_url(&url) {
-        Some(key) => ResolvedProject {
-            project: cwd.to_string(),
-            project_key: Some(key),
-        },
-        None => ResolvedProject {
-            project: cwd.to_string(),
-            project_key: None,
-        },
+        .and_then(|url| canonicalize_remote_url(url));
+    ResolvedProject {
+        project: cwd.to_string(),
+        project_key: key,
     }
 }
 
 fn find_git_dir(start: &Path) -> Option<PathBuf> {
-    let mut dir: PathBuf = match start.canonicalize() {
-        Ok(p) => p,
-        Err(_) => start.to_path_buf(),
-    };
+    let mut dir: PathBuf = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
     for _ in 0..100 {
         let candidate = dir.join(".git");
         if let Ok(meta) = fs::metadata(&candidate) {
@@ -111,7 +113,8 @@ fn find_git_dir(start: &Path) -> Option<PathBuf> {
 }
 
 fn resolve_worktree_git_dir(git_file: &Path) -> Option<PathBuf> {
-    static GITDIR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)^gitdir:\s*(.+?)\s*$").unwrap());
+    static GITDIR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?m)^gitdir:\s*(.+?)\s*$").unwrap());
     let text = fs::read_to_string(git_file).ok()?;
     let raw = GITDIR_RE.captures(&text)?.get(1)?.as_str().to_string();
     let raw_path = Path::new(&raw);
@@ -120,8 +123,7 @@ fn resolve_worktree_git_dir(git_file: &Path) -> Option<PathBuf> {
     } else {
         git_file.parent()?.join(raw_path)
     };
-    let commondir_file = gitdir.join("commondir");
-    if let Ok(text) = fs::read_to_string(&commondir_file) {
+    if let Ok(text) = fs::read_to_string(gitdir.join("commondir")) {
         let trimmed = text.trim();
         if !trimmed.is_empty() {
             let p = Path::new(trimmed);
@@ -139,26 +141,30 @@ fn resolve_worktree_git_dir(git_file: &Path) -> Option<PathBuf> {
 /// `[section]` and `[section "subsection"]` headers and ignores `#` / `;`
 /// comments + blank lines. Inline comments outside quotes are stripped.
 pub fn parse_git_config(text: &str) -> HashMap<String, HashMap<String, String>> {
+    static SUBSECTION_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"^([A-Za-z0-9._-]+)\s+"(.*)"$"#).unwrap());
+
     let mut out: HashMap<String, HashMap<String, String>> = HashMap::new();
-    let mut current_key: Option<String> = None;
+    let mut current: Option<String> = None;
     for raw_line in text.split('\n') {
-        let line = raw_line.trim_end_matches('\r');
-        let line = line
+        let line = raw_line
+            .trim_end_matches('\r')
             .trim_start_matches([' ', '\t'])
             .trim_end_matches([' ', '\t']);
-        if line.is_empty() {
-            continue;
-        }
-        if line.starts_with('#') || line.starts_with(';') {
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
             continue;
         }
         if line.starts_with('[') && line.ends_with(']') {
-            let name = section_name(&line[1..line.len() - 1]);
+            let raw = line[1..line.len() - 1].trim();
+            let name = match SUBSECTION_RE.captures(raw) {
+                Some(c) => format!("{} \"{}\"", &c[1], &c[2]),
+                None => raw.to_string(),
+            };
             out.entry(name.clone()).or_default();
-            current_key = Some(name);
+            current = Some(name);
             continue;
         }
-        let Some(section) = current_key.as_ref() else {
+        let Some(section) = current.as_ref() else {
             continue;
         };
         let Some(eq) = line.find('=') else { continue };
@@ -170,16 +176,6 @@ pub fn parse_git_config(text: &str) -> HashMap<String, HashMap<String, String>> 
         out.get_mut(section).unwrap().insert(key, value);
     }
     out
-}
-
-fn section_name(raw: &str) -> String {
-    static SUBSECTION_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r#"^([A-Za-z0-9._-]+)\s+"(.*)"$"#).unwrap());
-    let trimmed = raw.trim();
-    if let Some(c) = SUBSECTION_RE.captures(trimmed) {
-        return format!("{} \"{}\"", &c[1], &c[2]);
-    }
-    trimmed.to_string()
 }
 
 fn strip_inline_comment(value: &str) -> String {
@@ -201,10 +197,10 @@ fn strip_inline_comment(value: &str) -> String {
 /// Canonicalize a remote URL into `host/path` form. Returns `None` for inputs
 /// that aren't recognizable git URLs.
 pub fn canonicalize_remote_url(url: &str) -> Option<String> {
-    static SCP_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^(?:[A-Za-z0-9_-]+)@([^:\s]+):(.+)$").unwrap());
-    static SCHEME_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^([A-Za-z][A-Za-z0-9+.\-]*)://(.+)$").unwrap());
+    static SCP_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^(?:[A-Za-z0-9_-]+)@([^:\s]+):(.+)$").unwrap());
+    static SCHEME_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^([A-Za-z][A-Za-z0-9+.\-]*)://(.+)$").unwrap());
 
     let trimmed = url.trim();
     if trimmed.is_empty() {
@@ -212,9 +208,13 @@ pub fn canonicalize_remote_url(url: &str) -> Option<String> {
     }
 
     if let Some(c) = SCP_RE.captures(trimmed) {
-        let host = c.get(1).unwrap().as_str().to_lowercase();
-        let raw_path = c.get(2).unwrap().as_str();
-        let path_part = strip_dot_git(raw_path.trim_start_matches('/').trim_end_matches('/'));
+        let host = c.get(1)?.as_str().to_lowercase();
+        let path_part = strip_dot_git(
+            c.get(2)?
+                .as_str()
+                .trim_start_matches('/')
+                .trim_end_matches('/'),
+        );
         if path_part.is_empty() {
             return None;
         }
@@ -222,14 +222,13 @@ pub fn canonicalize_remote_url(url: &str) -> Option<String> {
     }
 
     if let Some(c) = SCHEME_RE.captures(trimmed) {
-        let rest = c.get(2).unwrap().as_str();
+        let rest = c.get(2)?.as_str();
         let after_auth = match rest.find('@') {
             Some(idx) => &rest[idx + 1..],
             None => rest,
         };
         let slash = after_auth.find('/')?;
-        let host_part = &after_auth[..slash];
-        let host = strip_port(host_part).to_lowercase();
+        let host = strip_port(&after_auth[..slash]).to_lowercase();
         if host.is_empty() {
             return None;
         }
@@ -258,14 +257,8 @@ fn strip_port(host: &str) -> &str {
 mod tests {
     use super::*;
     use std::fs;
-    use std::sync::Mutex;
 
-    use once_cell::sync::Lazy;
     use tempfile::tempdir;
-
-    // resolve_project shares a process-global cache; serialize the tests that
-    // touch it so they don't race the cache-reset call.
-    static RESOLVE_PROJECT_TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     #[test]
     fn canonicalize_scp_form() {
@@ -355,19 +348,17 @@ mod tests {
 
     #[test]
     fn resolve_project_no_git() {
-        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
-        __reset_resolve_project_cache_for_testing();
+        let resolver = ProjectResolver::new();
         let dir = tempdir().unwrap();
         let path = dir.path().to_string_lossy().to_string();
-        let got = resolve_project(&path);
+        let got = resolver.resolve(&path);
         assert_eq!(got.project, path);
         assert_eq!(got.project_key, None);
     }
 
     #[test]
     fn resolve_project_with_git_dir() {
-        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
-        __reset_resolve_project_cache_for_testing();
+        let resolver = ProjectResolver::new();
         let root = tempdir().unwrap();
         let git_dir = root.path().join(".git");
         fs::create_dir_all(&git_dir).unwrap();
@@ -378,14 +369,13 @@ mod tests {
         .unwrap();
         let nested = root.path().join("packages").join("a");
         fs::create_dir_all(&nested).unwrap();
-        let got = resolve_project(&nested.to_string_lossy());
+        let got = resolver.resolve(&nested.to_string_lossy());
         assert_eq!(got.project_key.as_deref(), Some("github.com/foo/bar"));
     }
 
     #[test]
     fn resolve_project_worktree() {
-        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
-        __reset_resolve_project_cache_for_testing();
+        let resolver = ProjectResolver::new();
         let root = tempdir().unwrap();
         let common_git = root.path().join("main").join(".git");
         fs::create_dir_all(&common_git).unwrap();
@@ -406,14 +396,13 @@ mod tests {
         )
         .unwrap();
 
-        let got = resolve_project(&worktree.to_string_lossy());
+        let got = resolver.resolve(&worktree.to_string_lossy());
         assert_eq!(got.project_key.as_deref(), Some("github.com/foo/bar"));
     }
 
     #[test]
     fn resolve_project_memoizes() {
-        let _guard = RESOLVE_PROJECT_TEST_LOCK.lock().unwrap();
-        __reset_resolve_project_cache_for_testing();
+        let resolver = ProjectResolver::new();
         let root = tempdir().unwrap();
         let git_dir = root.path().join(".git");
         fs::create_dir_all(&git_dir).unwrap();
@@ -423,14 +412,14 @@ mod tests {
         )
         .unwrap();
         let key = root.path().to_string_lossy().to_string();
-        let a = resolve_project(&key);
-        // Mutate the config; cache should still return the original answer.
+        let a = resolver.resolve(&key);
+        // Mutating the config should not change the cached result.
         fs::write(
             git_dir.join("config"),
             "[remote \"origin\"]\n\turl = git@github.com:zzz/zzz.git\n",
         )
         .unwrap();
-        let b = resolve_project(&key);
+        let b = resolver.resolve(&key);
         assert_eq!(a.project_key, b.project_key);
     }
 }

--- a/crates/relayburn-reader/src/hash.rs
+++ b/crates/relayburn-reader/src/hash.rs
@@ -1,21 +1,24 @@
 //! Stable JSON serialization + sha256 hashing helpers — Rust port of
 //! `packages/reader/src/hash.ts`.
 //!
-//! `stable_stringify` matches `JSON.stringify` byte-for-byte under the same
-//! sorted-keys policy the TS helper uses: arrays preserve order, object keys
-//! are sorted lexicographically, primitives serialize the same way `serde_json`
-//! emits them. The 16-character truncation on `args_hash` / `content_hash`
-//! mirrors the TS slice so detector output stays visually consistent.
+//! The TS helper takes any value (`unknown`) and reduces it to a canonical
+//! string before hashing. The Rust API mirrors that flexibility by being
+//! generic over `Serialize`: any record type or `serde_json::Value` works
+//! without callers having to convert first. The 16-character truncation on
+//! [`args_hash`] / [`content_hash`] mirrors the TS slice so detector output
+//! stays visually consistent.
 
+use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 /// Stable JSON stringification: object keys are sorted, arrays keep order,
 /// primitives serialize the way `serde_json` does. Mirrors the TS
-/// `stableStringify` so hash inputs are identical across the two ports.
-pub fn stable_stringify(value: &Value) -> String {
+/// `stableStringify` so hash inputs are byte-identical across the two ports.
+pub fn stable_stringify<T: Serialize + ?Sized>(value: &T) -> String {
+    let v = serde_json::to_value(value).unwrap_or(Value::Null);
     let mut out = String::new();
-    write_stable(value, &mut out);
+    write_stable(&v, &mut out);
     out
 }
 
@@ -52,25 +55,22 @@ fn write_stable(value: &Value, out: &mut String) {
     }
 }
 
-/// Short hash of an arbitrary JSON-serializable value. Mirrors TS `argsHash`
-/// (sha256 over `stable_stringify`, hex-encoded, sliced to 16 chars).
-pub fn args_hash(input: &Value) -> String {
-    let canonical = stable_stringify(input);
-    let mut hasher = Sha256::new();
-    hasher.update(canonical.as_bytes());
-    let digest = hasher.finalize();
-    let mut hex = hex::encode(digest);
-    hex.truncate(16);
-    hex
+/// Short hash of any serializable value. Mirrors TS `argsHash`: sha256 over
+/// [`stable_stringify`], hex-encoded, truncated to 16 chars.
+pub fn args_hash<T: Serialize + ?Sized>(input: &T) -> String {
+    short_sha256(stable_stringify(input).as_bytes())
 }
 
-/// Short hash of a raw string (Edit pre/post, Write content). Same 16-char
-/// truncation as `args_hash`.
-pub fn content_hash(s: &str) -> String {
+/// Short hash of a raw byte sequence (Edit pre/post, Write content). Same
+/// 16-char truncation as [`args_hash`].
+pub fn content_hash(s: impl AsRef<[u8]>) -> String {
+    short_sha256(s.as_ref())
+}
+
+fn short_sha256(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(s.as_bytes());
-    let digest = hasher.finalize();
-    let mut hex = hex::encode(digest);
+    hasher.update(bytes);
+    let mut hex = hex::encode(hasher.finalize());
     hex.truncate(16);
     hex
 }
@@ -99,8 +99,20 @@ mod tests {
 
     #[test]
     fn stable_stringify_preserves_array_order() {
-        let v = json!([3, 1, 2]);
-        assert_eq!(stable_stringify(&v), "[3,1,2]");
+        assert_eq!(stable_stringify(&json!([3, 1, 2])), "[3,1,2]");
+    }
+
+    #[test]
+    fn stable_stringify_accepts_typed_records() {
+        // Generic over `Serialize`: typed records work without an explicit
+        // `to_value` round-trip.
+        #[derive(serde::Serialize)]
+        struct Args {
+            a: u32,
+            b: &'static str,
+        }
+        let s = stable_stringify(&Args { a: 1, b: "two" });
+        assert_eq!(s, r#"{"a":1,"b":"two"}"#);
     }
 
     #[test]
@@ -112,14 +124,15 @@ mod tests {
 
     #[test]
     fn args_hash_is_stable_under_key_reordering() {
-        let a = args_hash(&json!({ "a": 1, "b": 2 }));
-        let b = args_hash(&json!({ "b": 2, "a": 1 }));
-        assert_eq!(a, b);
+        assert_eq!(
+            args_hash(&json!({ "a": 1, "b": 2 })),
+            args_hash(&json!({ "b": 2, "a": 1 })),
+        );
     }
 
     #[test]
     fn content_hash_of_empty_string_is_well_known() {
-        // sha256("") = e3b0c44298fc1c14...; first 16 chars must match.
         assert_eq!(content_hash(""), "e3b0c44298fc1c14");
+        assert_eq!(content_hash(b"" as &[u8]), "e3b0c44298fc1c14");
     }
 }

--- a/crates/relayburn-reader/src/hash.rs
+++ b/crates/relayburn-reader/src/hash.rs
@@ -1,0 +1,125 @@
+//! Stable JSON serialization + sha256 hashing helpers — Rust port of
+//! `packages/reader/src/hash.ts`.
+//!
+//! `stable_stringify` matches `JSON.stringify` byte-for-byte under the same
+//! sorted-keys policy the TS helper uses: arrays preserve order, object keys
+//! are sorted lexicographically, primitives serialize the same way `serde_json`
+//! emits them. The 16-character truncation on `args_hash` / `content_hash`
+//! mirrors the TS slice so detector output stays visually consistent.
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Stable JSON stringification: object keys are sorted, arrays keep order,
+/// primitives serialize the way `serde_json` does. Mirrors the TS
+/// `stableStringify` so hash inputs are identical across the two ports.
+pub fn stable_stringify(value: &Value) -> String {
+    let mut out = String::new();
+    write_stable(value, &mut out);
+    out
+}
+
+fn write_stable(value: &Value, out: &mut String) {
+    match value {
+        Value::Null => out.push_str("null"),
+        Value::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+        Value::Number(n) => out.push_str(&n.to_string()),
+        Value::String(s) => out.push_str(&serde_json::to_string(s).unwrap()),
+        Value::Array(arr) => {
+            out.push('[');
+            for (i, v) in arr.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_stable(v, out);
+            }
+            out.push(']');
+        }
+        Value::Object(obj) => {
+            let mut keys: Vec<&String> = obj.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&serde_json::to_string(k).unwrap());
+                out.push(':');
+                write_stable(&obj[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+
+/// Short hash of an arbitrary JSON-serializable value. Mirrors TS `argsHash`
+/// (sha256 over `stable_stringify`, hex-encoded, sliced to 16 chars).
+pub fn args_hash(input: &Value) -> String {
+    let canonical = stable_stringify(input);
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = hex::encode(digest);
+    hex.truncate(16);
+    hex
+}
+
+/// Short hash of a raw string (Edit pre/post, Write content). Same 16-char
+/// truncation as `args_hash`.
+pub fn content_hash(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = hex::encode(digest);
+    hex.truncate(16);
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn stable_stringify_sorts_object_keys() {
+        let v = json!({ "b": 1, "a": 2, "c": [3, { "y": 1, "x": 2 }] });
+        assert_eq!(
+            stable_stringify(&v),
+            r#"{"a":2,"b":1,"c":[3,{"x":2,"y":1}]}"#
+        );
+    }
+
+    #[test]
+    fn stable_stringify_handles_primitives() {
+        assert_eq!(stable_stringify(&json!(null)), "null");
+        assert_eq!(stable_stringify(&json!(true)), "true");
+        assert_eq!(stable_stringify(&json!(42)), "42");
+        assert_eq!(stable_stringify(&json!("hello")), r#""hello""#);
+    }
+
+    #[test]
+    fn stable_stringify_preserves_array_order() {
+        let v = json!([3, 1, 2]);
+        assert_eq!(stable_stringify(&v), "[3,1,2]");
+    }
+
+    #[test]
+    fn args_hash_is_16_chars_hex() {
+        let h = args_hash(&json!({ "command": "ls", "cwd": "/tmp" }));
+        assert_eq!(h.len(), 16);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn args_hash_is_stable_under_key_reordering() {
+        let a = args_hash(&json!({ "a": 1, "b": 2 }));
+        let b = args_hash(&json!({ "b": 2, "a": 1 }));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn content_hash_of_empty_string_is_well_known() {
+        // sha256("") = e3b0c44298fc1c14...; first 16 chars must match.
+        assert_eq!(content_hash(""), "e3b0c44298fc1c14");
+    }
+}

--- a/crates/relayburn-reader/src/lib.rs
+++ b/crates/relayburn-reader/src/lib.rs
@@ -1,10 +1,10 @@
-// Rust port of `@relayburn/reader`. See issue #242.
-//
-// This crate is a work-in-progress port of the TS reader package. Foundational
-// modules (types, hash, fidelity, git, classifier, user_turn) are ported with
-// native conformance tests; the per-harness parsers (claude, codex, opencode,
-// opencode-stream) are scaffolded but not yet implemented — see TODO markers
-// in their respective modules.
+//! Rust port of `@relayburn/reader`. See AgentWorkforce/burn#242.
+//!
+//! This crate is a work-in-progress port of the TS reader package. Foundational
+//! modules (`types`, `hash`, `fidelity`, `git`, `classifier`, `user_turn`) are
+//! ported with native conformance tests; the per-harness parsers (`claude`,
+//! `codex`, `opencode`, `opencode_stream`) are scaffolded but not yet
+//! implemented — see #255–#258.
 
 pub mod classifier;
 pub mod fidelity;
@@ -22,8 +22,10 @@ pub use classifier::{
     classify_activity, count_retries, normalize_tool_name, parse_bash_command, BashParse,
     ClassificationInput, ClassificationResult,
 };
-pub use fidelity::{classify_fidelity, empty_coverage, make_fidelity};
-pub use git::{canonicalize_remote_url, parse_git_config, resolve_project, ResolvedProject};
+pub use fidelity::classify_fidelity;
+pub use git::{
+    canonicalize_remote_url, parse_git_config, resolve_project, ProjectResolver, ResolvedProject,
+};
 pub use hash::{args_hash, content_hash, stable_stringify};
 pub use types::{
     ActivityCategory, CompactionEvent, ContentKind, ContentRecord, ContentRole, ContentStoreMode,
@@ -33,6 +35,6 @@ pub use types::{
     UsageGranularity, UserTurnBlock, UserTurnRecord,
 };
 pub use user_turn::{
-    bytes_to_approx_tokens, make_text_block, make_tool_result_block, measure_content_bytes,
-    stringify_measured_content, UserTurnTokenCounter, UserTurnTokenizer,
+    bytes_to_approx_tokens, measure_content_bytes, stringify_measured_content, HeuristicCounter,
+    TokenCounter, UserTurnTokenizer,
 };

--- a/crates/relayburn-reader/src/lib.rs
+++ b/crates/relayburn-reader/src/lib.rs
@@ -1,1 +1,38 @@
-// TODO: port `@relayburn/reader` (parsers + classifier) — see issue #242.
+// Rust port of `@relayburn/reader`. See issue #242.
+//
+// This crate is a work-in-progress port of the TS reader package. Foundational
+// modules (types, hash, fidelity, git, classifier, user_turn) are ported with
+// native conformance tests; the per-harness parsers (claude, codex, opencode,
+// opencode-stream) are scaffolded but not yet implemented — see TODO markers
+// in their respective modules.
+
+pub mod classifier;
+pub mod fidelity;
+pub mod git;
+pub mod hash;
+pub mod types;
+pub mod user_turn;
+
+pub mod claude;
+pub mod codex;
+pub mod opencode;
+pub mod opencode_stream;
+
+pub use classifier::{
+    classify_activity, count_retries, normalize_tool_name, parse_bash_command, BashParse,
+    ClassificationInput, ClassificationResult,
+};
+pub use fidelity::{classify_fidelity, empty_coverage, make_fidelity};
+pub use git::{canonicalize_remote_url, parse_git_config, resolve_project, ResolvedProject};
+pub use hash::{args_hash, content_hash, stable_stringify};
+pub use types::{
+    ActivityCategory, CompactionEvent, ContentKind, ContentRecord, ContentRole, ContentStoreMode,
+    ContentToolResult, ContentToolUse, Coverage, Fidelity, FidelityClass, Harness,
+    RelationshipSourceKind, RelationshipType, SessionRelationshipRecord, SourceKind, Subagent,
+    ToolCall, ToolResultEventRecord, ToolResultEventSource, ToolResultStatus, TurnRecord, Usage,
+    UsageGranularity, UserTurnBlock, UserTurnRecord,
+};
+pub use user_turn::{
+    bytes_to_approx_tokens, make_text_block, make_tool_result_block, measure_content_bytes,
+    stringify_measured_content, UserTurnTokenCounter, UserTurnTokenizer,
+};

--- a/crates/relayburn-reader/src/opencode.rs
+++ b/crates/relayburn-reader/src/opencode.rs
@@ -1,0 +1,3 @@
+//! OpenCode session parser — Rust port stub.
+//!
+//! TODO(#242): port `packages/reader/src/opencode.ts`.

--- a/crates/relayburn-reader/src/opencode_stream.rs
+++ b/crates/relayburn-reader/src/opencode_stream.rs
@@ -1,0 +1,3 @@
+//! OpenCode streaming ingestor — Rust port stub.
+//!
+//! TODO(#242): port `packages/reader/src/opencode-stream.ts`.

--- a/crates/relayburn-reader/src/types.rs
+++ b/crates/relayburn-reader/src/types.rs
@@ -1,10 +1,11 @@
 //! Ledger / record types — Rust port of `packages/reader/src/types.ts`.
 //!
-//! Records are designed to round-trip with the TypeScript schemas: optional
-//! fields use `Option<T>` with `#[serde(skip_serializing_if = "Option::is_none")]`
-//! so that absent fields stay absent on the wire (TS treats `undefined` and
-//! "missing" identically and the ledger is JSONL — preserving missingness is
-//! how Rust output stays byte-identical to TS output).
+//! Each record uses `#[serde(rename_all = "camelCase")]` so the on-wire JSONL
+//! shape stays aligned with the TypeScript schemas without per-field
+//! `rename` attributes. Optional fields use `Option<T>` plus
+//! `skip_serializing_if = "Option::is_none"` so missing-vs-null on the wire
+//! continues to mean "absent" rather than "explicit null" — the ledger is
+//! append-only JSONL and we want byte-identical output to the TS writer.
 
 use std::collections::BTreeMap;
 
@@ -48,79 +49,49 @@ pub enum Harness {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Usage {
     pub input: u64,
     pub output: u64,
     pub reasoning: u64,
-    #[serde(rename = "cacheRead")]
     pub cache_read: u64,
-    #[serde(rename = "cacheCreate5m")]
     pub cache_create_5m: u64,
-    #[serde(rename = "cacheCreate1h")]
     pub cache_create_1h: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ToolCall {
     pub id: String,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
-    #[serde(rename = "argsHash")]
     pub args_hash: String,
-    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
-    #[serde(
-        default,
-        rename = "editPreHash",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edit_pre_hash: Option<String>,
-    #[serde(
-        default,
-        rename = "editPostHash",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edit_post_hash: Option<String>,
-    #[serde(default, rename = "skillName", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skill_name: Option<String>,
-    #[serde(
-        default,
-        rename = "replacedTools",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replaced_tools: Option<Vec<String>>,
-    #[serde(
-        default,
-        rename = "collapsedCalls",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collapsed_calls: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Subagent {
-    #[serde(rename = "isSidechain")]
     pub is_sidechain: bool,
-    #[serde(
-        default,
-        rename = "parentToolUseId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_tool_use_id: Option<String>,
-    #[serde(default, rename = "agentId", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
-    #[serde(
-        default,
-        rename = "parentAgentId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_agent_id: Option<String>,
-    #[serde(
-        default,
-        rename = "subagentType",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subagent_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -136,25 +107,56 @@ pub enum UsageGranularity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Coverage {
-    #[serde(rename = "hasInputTokens")]
     pub has_input_tokens: bool,
-    #[serde(rename = "hasOutputTokens")]
     pub has_output_tokens: bool,
-    #[serde(rename = "hasReasoningTokens")]
     pub has_reasoning_tokens: bool,
-    #[serde(rename = "hasCacheReadTokens")]
     pub has_cache_read_tokens: bool,
-    #[serde(rename = "hasCacheCreateTokens")]
     pub has_cache_create_tokens: bool,
-    #[serde(rename = "hasToolCalls")]
     pub has_tool_calls: bool,
-    #[serde(rename = "hasToolResultEvents")]
     pub has_tool_result_events: bool,
-    #[serde(rename = "hasSessionRelationships")]
     pub has_session_relationships: bool,
-    #[serde(rename = "hasRawContent")]
     pub has_raw_content: bool,
+}
+
+impl Coverage {
+    /// All-false coverage. Parsers should clone this and flip the flags they
+    /// actually populate — defaulting to `false` keeps "do we know X?" honest.
+    pub const EMPTY: Self = Self {
+        has_input_tokens: false,
+        has_output_tokens: false,
+        has_reasoning_tokens: false,
+        has_cache_read_tokens: false,
+        has_cache_create_tokens: false,
+        has_tool_calls: false,
+        has_tool_result_events: false,
+        has_session_relationships: false,
+        has_raw_content: false,
+    };
+
+    /// True iff every field required for command-level "full" fidelity is
+    /// populated. See `FidelityClass::Full` for what this gates.
+    pub fn is_full(&self) -> bool {
+        self.has_input_tokens
+            && self.has_output_tokens
+            && self.has_cache_read_tokens
+            && self.has_tool_calls
+            && self.has_tool_result_events
+            && self.has_session_relationships
+    }
+
+    /// True iff per-turn input/output tokens are reported. Coarser bar than
+    /// `is_full` — usable for usage-only commands like `summary`.
+    pub fn has_per_turn_usage(&self) -> bool {
+        self.has_input_tokens && self.has_output_tokens
+    }
+}
+
+impl Default for Coverage {
+    fn default() -> Self {
+        Self::EMPTY
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -168,6 +170,7 @@ pub enum FidelityClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Fidelity {
     pub granularity: UsageGranularity,
     pub coverage: Coverage,
@@ -198,53 +201,34 @@ pub enum ActivityCategory {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TurnRecord {
-    pub v: u32, // schema version (always 1 today)
+    pub v: u32,
     pub source: SourceKind,
-    #[serde(rename = "sessionId")]
     pub session_id: String,
-    #[serde(
-        default,
-        rename = "sessionPath",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_path: Option<String>,
-    #[serde(rename = "messageId")]
     pub message_id: String,
-    #[serde(rename = "turnIndex")]
     pub turn_index: u64,
     pub ts: String,
     pub model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project: Option<String>,
-    #[serde(
-        default,
-        rename = "projectKey",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_key: Option<String>,
     pub usage: Usage,
-    #[serde(rename = "toolCalls")]
     pub tool_calls: Vec<ToolCall>,
-    #[serde(
-        default,
-        rename = "filesTouched",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files_touched: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subagent: Option<Subagent>,
-    #[serde(
-        default,
-        rename = "stopReason",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub activity: Option<ActivityCategory>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retries: Option<u64>,
-    #[serde(default, rename = "hasEdits", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub has_edits: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fidelity: Option<Fidelity>,
@@ -258,38 +242,28 @@ pub enum UserTurnBlockKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserTurnBlock {
     pub kind: UserTurnBlockKind,
-    #[serde(default, rename = "toolUseId", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_use_id: Option<String>,
-    #[serde(rename = "byteLen")]
     pub byte_len: u64,
-    #[serde(rename = "approxTokens")]
     pub approx_tokens: u64,
-    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserTurnRecord {
     pub v: u32,
     pub source: SourceKind,
-    #[serde(rename = "sessionId")]
     pub session_id: String,
-    #[serde(rename = "userUuid")]
     pub user_uuid: String,
     pub ts: String,
-    #[serde(
-        default,
-        rename = "precedingMessageId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preceding_message_id: Option<String>,
-    #[serde(
-        default,
-        rename = "followingMessageId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub following_message_id: Option<String>,
     pub blocks: Vec<UserTurnBlock>,
 }
@@ -304,46 +278,25 @@ pub enum RelationshipType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SessionRelationshipRecord {
     pub v: u32,
     pub source: RelationshipSourceKind,
-    #[serde(rename = "sessionId")]
     pub session_id: String,
-    #[serde(
-        default,
-        rename = "relatedSessionId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub related_session_id: Option<String>,
-    #[serde(rename = "relationshipType")]
     pub relationship_type: RelationshipType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ts: Option<String>,
-    #[serde(
-        default,
-        rename = "sourceSessionId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_session_id: Option<String>,
-    #[serde(
-        default,
-        rename = "sourceVersion",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_version: Option<String>,
-    #[serde(
-        default,
-        rename = "parentToolUseId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_tool_use_id: Option<String>,
-    #[serde(default, rename = "agentId", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
-    #[serde(
-        default,
-        rename = "subagentType",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subagent_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -377,86 +330,51 @@ pub enum UsageAttribution {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ToolResultEventRecord {
     pub v: u32,
     pub source: SourceKind,
-    #[serde(rename = "sessionId")]
     pub session_id: String,
-    #[serde(default, rename = "messageId", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
-    #[serde(rename = "toolUseId")]
     pub tool_use_id: String,
-    #[serde(default, rename = "callIndex", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_index: Option<u64>,
-    #[serde(rename = "eventIndex")]
     pub event_index: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ts: Option<String>,
     pub status: ToolResultStatus,
-    #[serde(rename = "eventSource")]
     pub event_source: ToolResultEventSource,
-    #[serde(
-        default,
-        rename = "contentLength",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_length: Option<u64>,
-    #[serde(
-        default,
-        rename = "contentHash",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_hash: Option<String>,
-    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
-    #[serde(
-        default,
-        rename = "usageAttribution",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage_attribution: Option<UsageAttribution>,
-    #[serde(
-        default,
-        rename = "subagentSessionId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subagent_session_id: Option<String>,
-    #[serde(default, rename = "agentId", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
-    #[serde(
-        default,
-        rename = "replacedTools",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replaced_tools: Option<Vec<String>>,
-    #[serde(
-        default,
-        rename = "collapsedCalls",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collapsed_calls: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompactionEvent {
     pub v: u32,
     pub source: SourceKind,
-    #[serde(rename = "sessionId")]
     pub session_id: String,
     pub ts: String,
-    #[serde(
-        default,
-        rename = "precedingMessageId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preceding_message_id: Option<String>,
-    #[serde(
-        default,
-        rename = "tokensBeforeCompact",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokens_before_compact: Option<u64>,
 }
 
@@ -485,34 +403,29 @@ pub struct ContentToolUse {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ContentToolResult {
-    #[serde(rename = "toolUseId")]
     pub tool_use_id: String,
     pub content: Value,
-    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ContentRecord {
     pub v: u32,
     pub source: SourceKind,
-    #[serde(rename = "sessionId")]
     pub session_id: String,
-    #[serde(rename = "messageId")]
     pub message_id: String,
     pub ts: String,
     pub role: ContentRole,
     pub kind: ContentKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
-    #[serde(default, rename = "toolUse", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_use: Option<ContentToolUse>,
-    #[serde(
-        default,
-        rename = "toolResult",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_result: Option<ContentToolResult>,
 }
 
@@ -532,14 +445,34 @@ mod tests {
     fn source_kind_round_trips_kebab_case() {
         let s = serde_json::to_string(&SourceKind::ClaudeCode).unwrap();
         assert_eq!(s, "\"claude-code\"");
-        let back: SourceKind = serde_json::from_str(&s).unwrap();
-        assert_eq!(back, SourceKind::ClaudeCode);
+        assert_eq!(
+            serde_json::from_str::<SourceKind>(&s).unwrap(),
+            SourceKind::ClaudeCode
+        );
     }
 
     #[test]
     fn activity_category_serializes_kebab_case() {
-        let s = serde_json::to_string(&ActivityCategory::BuildDeploy).unwrap();
-        assert_eq!(s, "\"build-deploy\"");
+        assert_eq!(
+            serde_json::to_string(&ActivityCategory::BuildDeploy).unwrap(),
+            "\"build-deploy\"",
+        );
+    }
+
+    #[test]
+    fn usage_field_names_are_camel_case() {
+        let u = Usage {
+            input: 1,
+            output: 2,
+            reasoning: 3,
+            cache_read: 4,
+            cache_create_5m: 5,
+            cache_create_1h: 6,
+        };
+        let s = serde_json::to_string(&u).unwrap();
+        assert!(s.contains("\"cacheRead\":4"), "got {s}");
+        assert!(s.contains("\"cacheCreate5m\":5"), "got {s}");
+        assert!(s.contains("\"cacheCreate1h\":6"), "got {s}");
     }
 
     #[test]
@@ -566,28 +499,48 @@ mod tests {
             fidelity: None,
         };
         let s = serde_json::to_string(&rec).unwrap();
-        // Match TS shape: optional fields are omitted, not emitted as null.
         assert!(!s.contains("null"));
         assert!(!s.contains("sessionPath"));
         assert!(!s.contains("subagent"));
         assert!(s.contains("\"toolCalls\":[]"));
+        assert!(s.contains("\"sessionId\":\"abc\""));
+        assert!(s.contains("\"messageId\":\"m1\""));
+        assert!(s.contains("\"turnIndex\":0"));
     }
 
     #[test]
-    fn coverage_all_off_round_trips() {
-        let cov = Coverage {
-            has_input_tokens: false,
-            has_output_tokens: false,
-            has_reasoning_tokens: false,
-            has_cache_read_tokens: false,
-            has_cache_create_tokens: false,
-            has_tool_calls: false,
-            has_tool_result_events: false,
-            has_session_relationships: false,
-            has_raw_content: false,
+    fn coverage_default_is_empty_const() {
+        assert_eq!(Coverage::default(), Coverage::EMPTY);
+    }
+
+    #[test]
+    fn coverage_methods_match_field_logic() {
+        let mut c = Coverage::EMPTY;
+        assert!(!c.is_full());
+        assert!(!c.has_per_turn_usage());
+        c.has_input_tokens = true;
+        c.has_output_tokens = true;
+        assert!(!c.is_full());
+        assert!(c.has_per_turn_usage());
+        c.has_cache_read_tokens = true;
+        c.has_tool_calls = true;
+        c.has_tool_result_events = true;
+        c.has_session_relationships = true;
+        assert!(c.is_full());
+    }
+
+    #[test]
+    fn coverage_round_trips_camel_case() {
+        let c = Coverage {
+            has_input_tokens: true,
+            has_output_tokens: true,
+            has_cache_create_tokens: true,
+            ..Coverage::EMPTY
         };
-        let s = serde_json::to_string(&cov).unwrap();
+        let s = serde_json::to_string(&c).unwrap();
+        assert!(s.contains("\"hasInputTokens\":true"));
+        assert!(s.contains("\"hasCacheCreateTokens\":true"));
         let back: Coverage = serde_json::from_str(&s).unwrap();
-        assert_eq!(cov, back);
+        assert_eq!(back, c);
     }
 }

--- a/crates/relayburn-reader/src/types.rs
+++ b/crates/relayburn-reader/src/types.rs
@@ -1,0 +1,593 @@
+//! Ledger / record types — Rust port of `packages/reader/src/types.ts`.
+//!
+//! Records are designed to round-trip with the TypeScript schemas: optional
+//! fields use `Option<T>` with `#[serde(skip_serializing_if = "Option::is_none")]`
+//! so that absent fields stay absent on the wire (TS treats `undefined` and
+//! "missing" identically and the ledger is JSONL — preserving missingness is
+//! how Rust output stays byte-identical to TS output).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SourceKind {
+    ClaudeCode,
+    Codex,
+    Opencode,
+    AnthropicApi,
+    OpenaiApi,
+    GeminiApi,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RelationshipSourceKind {
+    ClaudeCode,
+    Codex,
+    Opencode,
+    AnthropicApi,
+    OpenaiApi,
+    GeminiApi,
+    SpawnEnv,
+    NativeClaude,
+    NativeOpencode,
+}
+
+/// Coarse harness identity. Mirrors `SourceKind` but exists as a separate type
+/// because some downstream consumers (CLI/SDK) want to talk about a "harness"
+/// without forcing an opinion on the underlying log format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Harness {
+    ClaudeCode,
+    Codex,
+    Opencode,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Usage {
+    pub input: u64,
+    pub output: u64,
+    pub reasoning: u64,
+    #[serde(rename = "cacheRead")]
+    pub cache_read: u64,
+    #[serde(rename = "cacheCreate5m")]
+    pub cache_create_5m: u64,
+    #[serde(rename = "cacheCreate1h")]
+    pub cache_create_1h: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(rename = "argsHash")]
+    pub args_hash: String,
+    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+    #[serde(
+        default,
+        rename = "editPreHash",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edit_pre_hash: Option<String>,
+    #[serde(
+        default,
+        rename = "editPostHash",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edit_post_hash: Option<String>,
+    #[serde(default, rename = "skillName", skip_serializing_if = "Option::is_none")]
+    pub skill_name: Option<String>,
+    #[serde(
+        default,
+        rename = "replacedTools",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replaced_tools: Option<Vec<String>>,
+    #[serde(
+        default,
+        rename = "collapsedCalls",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub collapsed_calls: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Subagent {
+    #[serde(rename = "isSidechain")]
+    pub is_sidechain: bool,
+    #[serde(
+        default,
+        rename = "parentToolUseId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_tool_use_id: Option<String>,
+    #[serde(default, rename = "agentId", skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(
+        default,
+        rename = "parentAgentId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_agent_id: Option<String>,
+    #[serde(
+        default,
+        rename = "subagentType",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub subagent_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UsageGranularity {
+    PerTurn,
+    PerMessage,
+    PerSessionAggregate,
+    CostOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Coverage {
+    #[serde(rename = "hasInputTokens")]
+    pub has_input_tokens: bool,
+    #[serde(rename = "hasOutputTokens")]
+    pub has_output_tokens: bool,
+    #[serde(rename = "hasReasoningTokens")]
+    pub has_reasoning_tokens: bool,
+    #[serde(rename = "hasCacheReadTokens")]
+    pub has_cache_read_tokens: bool,
+    #[serde(rename = "hasCacheCreateTokens")]
+    pub has_cache_create_tokens: bool,
+    #[serde(rename = "hasToolCalls")]
+    pub has_tool_calls: bool,
+    #[serde(rename = "hasToolResultEvents")]
+    pub has_tool_result_events: bool,
+    #[serde(rename = "hasSessionRelationships")]
+    pub has_session_relationships: bool,
+    #[serde(rename = "hasRawContent")]
+    pub has_raw_content: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FidelityClass {
+    Full,
+    UsageOnly,
+    AggregateOnly,
+    CostOnly,
+    Partial,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Fidelity {
+    pub granularity: UsageGranularity,
+    pub coverage: Coverage,
+    pub class: FidelityClass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ActivityCategory {
+    Planning,
+    Delegation,
+    Testing,
+    Review,
+    Git,
+    BuildDeploy,
+    Deps,
+    Format,
+    Verification,
+    Coding,
+    Docs,
+    Debugging,
+    Refactoring,
+    Feature,
+    Exploration,
+    Reasoning,
+    Brainstorming,
+    Conversation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnRecord {
+    pub v: u32, // schema version (always 1 today)
+    pub source: SourceKind,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(
+        default,
+        rename = "sessionPath",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub session_path: Option<String>,
+    #[serde(rename = "messageId")]
+    pub message_id: String,
+    #[serde(rename = "turnIndex")]
+    pub turn_index: u64,
+    pub ts: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(
+        default,
+        rename = "projectKey",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub project_key: Option<String>,
+    pub usage: Usage,
+    #[serde(rename = "toolCalls")]
+    pub tool_calls: Vec<ToolCall>,
+    #[serde(
+        default,
+        rename = "filesTouched",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub files_touched: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subagent: Option<Subagent>,
+    #[serde(
+        default,
+        rename = "stopReason",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub stop_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity: Option<ActivityCategory>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retries: Option<u64>,
+    #[serde(default, rename = "hasEdits", skip_serializing_if = "Option::is_none")]
+    pub has_edits: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fidelity: Option<Fidelity>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UserTurnBlockKind {
+    ToolResult,
+    Text,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserTurnBlock {
+    pub kind: UserTurnBlockKind,
+    #[serde(default, rename = "toolUseId", skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
+    #[serde(rename = "byteLen")]
+    pub byte_len: u64,
+    #[serde(rename = "approxTokens")]
+    pub approx_tokens: u64,
+    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserTurnRecord {
+    pub v: u32,
+    pub source: SourceKind,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "userUuid")]
+    pub user_uuid: String,
+    pub ts: String,
+    #[serde(
+        default,
+        rename = "precedingMessageId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub preceding_message_id: Option<String>,
+    #[serde(
+        default,
+        rename = "followingMessageId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub following_message_id: Option<String>,
+    pub blocks: Vec<UserTurnBlock>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RelationshipType {
+    Root,
+    Continuation,
+    Fork,
+    Subagent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionRelationshipRecord {
+    pub v: u32,
+    pub source: RelationshipSourceKind,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(
+        default,
+        rename = "relatedSessionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub related_session_id: Option<String>,
+    #[serde(rename = "relationshipType")]
+    pub relationship_type: RelationshipType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ts: Option<String>,
+    #[serde(
+        default,
+        rename = "sourceSessionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub source_session_id: Option<String>,
+    #[serde(
+        default,
+        rename = "sourceVersion",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub source_version: Option<String>,
+    #[serde(
+        default,
+        rename = "parentToolUseId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_tool_use_id: Option<String>,
+    #[serde(default, rename = "agentId", skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(
+        default,
+        rename = "subagentType",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub subagent_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ToolResultStatus {
+    Running,
+    Completed,
+    Errored,
+    Cancelled,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolResultEventSource {
+    ToolResult,
+    SubagentNotification,
+    QueueEvent,
+    ProgressEvent,
+    FunctionCallOutput,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UsageAttribution {
+    SingleToolTurn,
+    EvenSplitTurn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolResultEventRecord {
+    pub v: u32,
+    pub source: SourceKind,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(default, rename = "messageId", skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(rename = "toolUseId")]
+    pub tool_use_id: String,
+    #[serde(default, rename = "callIndex", skip_serializing_if = "Option::is_none")]
+    pub call_index: Option<u64>,
+    #[serde(rename = "eventIndex")]
+    pub event_index: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ts: Option<String>,
+    pub status: ToolResultStatus,
+    #[serde(rename = "eventSource")]
+    pub event_source: ToolResultEventSource,
+    #[serde(
+        default,
+        rename = "contentLength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub content_length: Option<u64>,
+    #[serde(
+        default,
+        rename = "contentHash",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub content_hash: Option<String>,
+    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+    #[serde(
+        default,
+        rename = "usageAttribution",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub usage_attribution: Option<UsageAttribution>,
+    #[serde(
+        default,
+        rename = "subagentSessionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub subagent_session_id: Option<String>,
+    #[serde(default, rename = "agentId", skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(
+        default,
+        rename = "replacedTools",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replaced_tools: Option<Vec<String>>,
+    #[serde(
+        default,
+        rename = "collapsedCalls",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub collapsed_calls: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompactionEvent {
+    pub v: u32,
+    pub source: SourceKind,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    pub ts: String,
+    #[serde(
+        default,
+        rename = "precedingMessageId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub preceding_message_id: Option<String>,
+    #[serde(
+        default,
+        rename = "tokensBeforeCompact",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tokens_before_compact: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentRole {
+    User,
+    Assistant,
+    ToolResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentKind {
+    Text,
+    Thinking,
+    ToolUse,
+    ToolResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContentToolUse {
+    pub id: String,
+    pub name: String,
+    pub input: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContentToolResult {
+    #[serde(rename = "toolUseId")]
+    pub tool_use_id: String,
+    pub content: Value,
+    #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContentRecord {
+    pub v: u32,
+    pub source: SourceKind,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "messageId")]
+    pub message_id: String,
+    pub ts: String,
+    pub role: ContentRole,
+    pub kind: ContentKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(default, rename = "toolUse", skip_serializing_if = "Option::is_none")]
+    pub tool_use: Option<ContentToolUse>,
+    #[serde(
+        default,
+        rename = "toolResult",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tool_result: Option<ContentToolResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContentStoreMode {
+    Full,
+    HashOnly,
+    Off,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_kind_round_trips_kebab_case() {
+        let s = serde_json::to_string(&SourceKind::ClaudeCode).unwrap();
+        assert_eq!(s, "\"claude-code\"");
+        let back: SourceKind = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, SourceKind::ClaudeCode);
+    }
+
+    #[test]
+    fn activity_category_serializes_kebab_case() {
+        let s = serde_json::to_string(&ActivityCategory::BuildDeploy).unwrap();
+        assert_eq!(s, "\"build-deploy\"");
+    }
+
+    #[test]
+    fn turn_record_omits_optional_fields_when_none() {
+        let rec = TurnRecord {
+            v: 1,
+            source: SourceKind::ClaudeCode,
+            session_id: "abc".into(),
+            session_path: None,
+            message_id: "m1".into(),
+            turn_index: 0,
+            ts: "2025-01-01T00:00:00Z".into(),
+            model: "claude-sonnet-4-6".into(),
+            project: None,
+            project_key: None,
+            usage: Usage::default(),
+            tool_calls: vec![],
+            files_touched: None,
+            subagent: None,
+            stop_reason: None,
+            activity: None,
+            retries: None,
+            has_edits: None,
+            fidelity: None,
+        };
+        let s = serde_json::to_string(&rec).unwrap();
+        // Match TS shape: optional fields are omitted, not emitted as null.
+        assert!(!s.contains("null"));
+        assert!(!s.contains("sessionPath"));
+        assert!(!s.contains("subagent"));
+        assert!(s.contains("\"toolCalls\":[]"));
+    }
+
+    #[test]
+    fn coverage_all_off_round_trips() {
+        let cov = Coverage {
+            has_input_tokens: false,
+            has_output_tokens: false,
+            has_reasoning_tokens: false,
+            has_cache_read_tokens: false,
+            has_cache_create_tokens: false,
+            has_tool_calls: false,
+            has_tool_result_events: false,
+            has_session_relationships: false,
+            has_raw_content: false,
+        };
+        let s = serde_json::to_string(&cov).unwrap();
+        let back: Coverage = serde_json::from_str(&s).unwrap();
+        assert_eq!(cov, back);
+    }
+}

--- a/crates/relayburn-reader/src/user_turn.rs
+++ b/crates/relayburn-reader/src/user_turn.rs
@@ -1,0 +1,142 @@
+//! User-turn block helpers — Rust port of `packages/reader/src/userTurn.ts`.
+//!
+//! The TS module exposes both a heuristic counter and a cl100k-backed counter
+//! (via `@dqbd/tiktoken`). This port covers the heuristic path; the cl100k
+//! tokenizer hookup is deferred — when a parser ports over it can pass any
+//! `UserTurnTokenCounter` impl that satisfies the trait.
+
+use serde_json::Value;
+
+use crate::types::{UserTurnBlock, UserTurnBlockKind};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserTurnTokenizer {
+    Heuristic,
+    Cl100k,
+}
+
+pub trait UserTurnTokenCounter {
+    fn tokenizer(&self) -> UserTurnTokenizer;
+    fn count(&self, content: &Value, byte_len: u64) -> u64;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HeuristicCounter;
+
+impl UserTurnTokenCounter for HeuristicCounter {
+    fn tokenizer(&self) -> UserTurnTokenizer {
+        UserTurnTokenizer::Heuristic
+    }
+    fn count(&self, _content: &Value, byte_len: u64) -> u64 {
+        bytes_to_approx_tokens(byte_len)
+    }
+}
+
+pub fn make_text_block(text: &str, counter: &dyn UserTurnTokenCounter) -> UserTurnBlock {
+    let byte_len = text.len() as u64;
+    let approx = counter.count(&Value::String(text.to_string()), byte_len);
+    UserTurnBlock {
+        kind: UserTurnBlockKind::Text,
+        tool_use_id: None,
+        byte_len,
+        approx_tokens: approx,
+        is_error: None,
+    }
+}
+
+pub fn make_tool_result_block(
+    tool_use_id: &str,
+    content: &Value,
+    is_error: Option<bool>,
+    counter: &dyn UserTurnTokenCounter,
+) -> UserTurnBlock {
+    let byte_len = measure_content_bytes(content);
+    let approx = counter.count(content, byte_len);
+    UserTurnBlock {
+        kind: UserTurnBlockKind::ToolResult,
+        tool_use_id: Some(tool_use_id.to_string()),
+        byte_len,
+        approx_tokens: approx,
+        // TS only sets is_error when it's true; preserve that wire shape.
+        is_error: if is_error == Some(true) {
+            Some(true)
+        } else {
+            None
+        },
+    }
+}
+
+pub fn measure_content_bytes(content: &Value) -> u64 {
+    stringify_measured_content(content).len() as u64
+}
+
+pub fn stringify_measured_content(content: &Value) -> String {
+    match content {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        // Mirror TS `JSON.stringify`. `serde_json::to_string` emits the same
+        // bytes for the shapes we care about (objects, arrays, numbers,
+        // booleans).
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+pub fn bytes_to_approx_tokens(byte_len: u64) -> u64 {
+    if byte_len == 0 {
+        return 0;
+    }
+    byte_len.div_ceil(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn heuristic_text_block_counts_bytes_div_4_ceil() {
+        let block = make_text_block("hello", &HeuristicCounter);
+        assert_eq!(block.byte_len, 5);
+        assert_eq!(block.approx_tokens, 2); // ceil(5/4) = 2
+        assert_eq!(block.kind, UserTurnBlockKind::Text);
+    }
+
+    #[test]
+    fn tool_result_block_with_string_content() {
+        let block =
+            make_tool_result_block("tool_1", &json!("hello world"), None, &HeuristicCounter);
+        assert_eq!(block.kind, UserTurnBlockKind::ToolResult);
+        assert_eq!(block.tool_use_id.as_deref(), Some("tool_1"));
+        assert_eq!(block.byte_len, "hello world".len() as u64);
+        assert!(block.is_error.is_none());
+    }
+
+    #[test]
+    fn tool_result_block_with_structured_content_uses_json_stringify() {
+        let content = json!({"a": 1, "b": "two"});
+        let block = make_tool_result_block("t", &content, Some(false), &HeuristicCounter);
+        let expected = serde_json::to_string(&content).unwrap();
+        assert_eq!(block.byte_len, expected.len() as u64);
+        // is_error: Some(false) is treated as missing on the wire.
+        assert!(block.is_error.is_none());
+    }
+
+    #[test]
+    fn tool_result_block_preserves_is_error_true() {
+        let block = make_tool_result_block("t", &json!("err"), Some(true), &HeuristicCounter);
+        assert_eq!(block.is_error, Some(true));
+    }
+
+    #[test]
+    fn measure_null_is_zero() {
+        assert_eq!(measure_content_bytes(&Value::Null), 0);
+    }
+
+    #[test]
+    fn bytes_to_approx_tokens_zero_for_empty() {
+        assert_eq!(bytes_to_approx_tokens(0), 0);
+        assert_eq!(bytes_to_approx_tokens(1), 1);
+        assert_eq!(bytes_to_approx_tokens(4), 1);
+        assert_eq!(bytes_to_approx_tokens(5), 2);
+    }
+}

--- a/crates/relayburn-reader/src/user_turn.rs
+++ b/crates/relayburn-reader/src/user_turn.rs
@@ -1,9 +1,11 @@
 //! User-turn block helpers — Rust port of `packages/reader/src/userTurn.ts`.
 //!
-//! The TS module exposes both a heuristic counter and a cl100k-backed counter
-//! (via `@dqbd/tiktoken`). This port covers the heuristic path; the cl100k
-//! tokenizer hookup is deferred — when a parser ports over it can pass any
-//! `UserTurnTokenCounter` impl that satisfies the trait.
+//! Construction lives on the type itself: [`UserTurnBlock::text`] and
+//! [`UserTurnBlock::tool_result`] take any [`TokenCounter`]. The default
+//! [`HeuristicCounter`] reproduces the bytes/4 estimate the TS port falls
+//! back to; the cl100k tokenizer hookup is deferred until a parser actually
+//! needs it (no `tiktoken` crate in the dep tree yet — when it lands, plug
+//! in a counter that satisfies the trait).
 
 use serde_json::Value;
 
@@ -15,15 +17,17 @@ pub enum UserTurnTokenizer {
     Cl100k,
 }
 
-pub trait UserTurnTokenCounter {
+pub trait TokenCounter {
     fn tokenizer(&self) -> UserTurnTokenizer;
     fn count(&self, content: &Value, byte_len: u64) -> u64;
 }
 
+/// Bytes/4 ceiling estimate. Cheap, no dependencies, good enough for
+/// proportional allocation across tool calls within one user turn.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct HeuristicCounter;
 
-impl UserTurnTokenCounter for HeuristicCounter {
+impl TokenCounter for HeuristicCounter {
     fn tokenizer(&self) -> UserTurnTokenizer {
         UserTurnTokenizer::Heuristic
     }
@@ -32,37 +36,45 @@ impl UserTurnTokenCounter for HeuristicCounter {
     }
 }
 
-pub fn make_text_block(text: &str, counter: &dyn UserTurnTokenCounter) -> UserTurnBlock {
-    let byte_len = text.len() as u64;
-    let approx = counter.count(&Value::String(text.to_string()), byte_len);
-    UserTurnBlock {
-        kind: UserTurnBlockKind::Text,
-        tool_use_id: None,
-        byte_len,
-        approx_tokens: approx,
-        is_error: None,
+impl UserTurnBlock {
+    /// Build a `text` block — plain user input or a harness-injected text
+    /// block. `byteLen` is the UTF-8 byte length of `text`; `approxTokens`
+    /// comes from the supplied counter.
+    pub fn text<C: TokenCounter + ?Sized>(text: &str, counter: &C) -> Self {
+        let byte_len = text.len() as u64;
+        let approx = counter.count(&Value::String(text.to_string()), byte_len);
+        Self {
+            kind: UserTurnBlockKind::Text,
+            tool_use_id: None,
+            byte_len,
+            approx_tokens: approx,
+            is_error: None,
+        }
     }
-}
 
-pub fn make_tool_result_block(
-    tool_use_id: &str,
-    content: &Value,
-    is_error: Option<bool>,
-    counter: &dyn UserTurnTokenCounter,
-) -> UserTurnBlock {
-    let byte_len = measure_content_bytes(content);
-    let approx = counter.count(content, byte_len);
-    UserTurnBlock {
-        kind: UserTurnBlockKind::ToolResult,
-        tool_use_id: Some(tool_use_id.to_string()),
-        byte_len,
-        approx_tokens: approx,
-        // TS only sets is_error when it's true; preserve that wire shape.
-        is_error: if is_error == Some(true) {
-            Some(true)
-        } else {
-            None
-        },
+    /// Build a `tool_result` block. `byte_len` matches how the content would
+    /// be serialized into the request body (UTF-8 for plain strings,
+    /// `JSON.stringify`'d for structured content). Following the TS shape,
+    /// `is_error` is only emitted on the wire when it's `Some(true)`.
+    pub fn tool_result<C: TokenCounter + ?Sized>(
+        tool_use_id: impl Into<String>,
+        content: &Value,
+        is_error: Option<bool>,
+        counter: &C,
+    ) -> Self {
+        let byte_len = measure_content_bytes(content);
+        let approx = counter.count(content, byte_len);
+        Self {
+            kind: UserTurnBlockKind::ToolResult,
+            tool_use_id: Some(tool_use_id.into()),
+            byte_len,
+            approx_tokens: approx,
+            is_error: if is_error == Some(true) {
+                Some(true)
+            } else {
+                None
+            },
+        }
     }
 }
 
@@ -74,7 +86,7 @@ pub fn stringify_measured_content(content: &Value) -> String {
     match content {
         Value::Null => String::new(),
         Value::String(s) => s.clone(),
-        // Mirror TS `JSON.stringify`. `serde_json::to_string` emits the same
+        // Mirrors TS `JSON.stringify`. `serde_json::to_string` emits the same
         // bytes for the shapes we care about (objects, arrays, numbers,
         // booleans).
         other => serde_json::to_string(other).unwrap_or_default(),
@@ -83,9 +95,10 @@ pub fn stringify_measured_content(content: &Value) -> String {
 
 pub fn bytes_to_approx_tokens(byte_len: u64) -> u64 {
     if byte_len == 0 {
-        return 0;
+        0
+    } else {
+        byte_len.div_ceil(4)
     }
-    byte_len.div_ceil(4)
 }
 
 #[cfg(test)]
@@ -95,7 +108,7 @@ mod tests {
 
     #[test]
     fn heuristic_text_block_counts_bytes_div_4_ceil() {
-        let block = make_text_block("hello", &HeuristicCounter);
+        let block = UserTurnBlock::text("hello", &HeuristicCounter);
         assert_eq!(block.byte_len, 5);
         assert_eq!(block.approx_tokens, 2); // ceil(5/4) = 2
         assert_eq!(block.kind, UserTurnBlockKind::Text);
@@ -104,7 +117,7 @@ mod tests {
     #[test]
     fn tool_result_block_with_string_content() {
         let block =
-            make_tool_result_block("tool_1", &json!("hello world"), None, &HeuristicCounter);
+            UserTurnBlock::tool_result("tool_1", &json!("hello world"), None, &HeuristicCounter);
         assert_eq!(block.kind, UserTurnBlockKind::ToolResult);
         assert_eq!(block.tool_use_id.as_deref(), Some("tool_1"));
         assert_eq!(block.byte_len, "hello world".len() as u64);
@@ -114,16 +127,15 @@ mod tests {
     #[test]
     fn tool_result_block_with_structured_content_uses_json_stringify() {
         let content = json!({"a": 1, "b": "two"});
-        let block = make_tool_result_block("t", &content, Some(false), &HeuristicCounter);
+        let block = UserTurnBlock::tool_result("t", &content, Some(false), &HeuristicCounter);
         let expected = serde_json::to_string(&content).unwrap();
         assert_eq!(block.byte_len, expected.len() as u64);
-        // is_error: Some(false) is treated as missing on the wire.
         assert!(block.is_error.is_none());
     }
 
     #[test]
     fn tool_result_block_preserves_is_error_true() {
-        let block = make_tool_result_block("t", &json!("err"), Some(true), &HeuristicCounter);
+        let block = UserTurnBlock::tool_result("t", &json!("err"), Some(true), &HeuristicCounter);
         assert_eq!(block.is_error, Some(true));
     }
 
@@ -138,5 +150,21 @@ mod tests {
         assert_eq!(bytes_to_approx_tokens(1), 1);
         assert_eq!(bytes_to_approx_tokens(4), 1);
         assert_eq!(bytes_to_approx_tokens(5), 2);
+    }
+
+    #[test]
+    fn token_counter_dispatches_via_generics() {
+        // Use a custom counter to verify dispatch is generic, not virtual.
+        struct Constant(u64);
+        impl TokenCounter for Constant {
+            fn tokenizer(&self) -> UserTurnTokenizer {
+                UserTurnTokenizer::Heuristic
+            }
+            fn count(&self, _content: &Value, _byte_len: u64) -> u64 {
+                self.0
+            }
+        }
+        let block = UserTurnBlock::text("anything", &Constant(7));
+        assert_eq!(block.approx_tokens, 7);
     }
 }


### PR DESCRIPTION
First slice of the `@relayburn/reader` Rust port for #242. Lands the shared substrate that the per-harness parsers will sit on, with native Rust tests. Per-harness parsers are tracked as separate follow-up issues so this PR stays reviewable.

## What's in this PR

| Module | TS source | Status |
|---|---|---|
| `types.rs` | `types.ts` | Ported. Serde-tagged enums (`SourceKind`, `ActivityCategory`, `RelationshipType`, `ToolResultStatus`, …) using `rename_all = "kebab-case"` / `"snake_case"` to match TS literals. Optional fields use `#[serde(skip_serializing_if = "Option::is_none")]` so `undefined`-vs-missing wire shape matches. |
| `hash.rs` | `hash.ts` | Ported. `stable_stringify`, `args_hash`, `content_hash` (sha256 → hex → 16-char truncation, byte-identical to TS). |
| `fidelity.rs` | `fidelity.ts` | Ported. `empty_coverage()`, `classify_fidelity`, `make_fidelity` with the same FULL_REQUIRED / USAGE_REQUIRED ladder. |
| `git.rs` | `git.ts` | Ported. `parse_git_config`, `canonicalize_remote_url`, `resolve_project` (incl. .git-file worktree resolution + per-process memoization). |
| `classifier.rs` | `classifier.ts` | Ported. Tool aliases, `parse_bash_command` recursive descent (heredoc / subshell / `cd` prefix / shell binaries / `env` / python `-m` / multiword binaries / package-runner `run`), all regex pattern tables, `classify_activity` priority ladder, `count_retries`. |
| `user_turn.rs` | `userTurn.ts` | Heuristic counter ported. cl100k tokenizer hookup is deferred until a parser needs it (no `tiktoken` crate in the dep tree yet). |
| `claude.rs` / `codex.rs` / `opencode.rs` / `opencode_stream.rs` | `claude.ts` / `codex.ts` / `opencode.ts` / `opencode-stream.ts` | **Stubs only** — see follow-ups below. |

## Follow-ups (parser ports)

The per-harness parsers (~5.7k LoC of TS combined) get their own PRs against the parent issue:

- #255 — Claude Code parser (`claude.rs`)
- #256 — Codex parser (`codex.rs`)
- #257 — OpenCode parser (`opencode.rs`)
- #258 — OpenCode streaming ingestor (`opencode_stream.rs`)
- #254 — Investigation: dead `READ_ONLY_TOOLS` check in TS classifier (surfaced during this port; not a blocker)

## Notes for review

- **Negative lookaheads.** A few TS regexes use `(?!.*--check\b)` / `(?!.*--apply\b)` / `(?!\s+--build\b)`. The Rust `regex` crate doesn't support those, so `format_reject` / `verification_match` apply the same intent as a post-filter on the matched string.
- **`READ_ONLY_TOOLS` removed.** Both arms of the priority-6 branch in TS return `'exploration'`, so the set was dead. Tracked in #254 — comment in `classifier.rs` calls out the decision so it doesn't look like an oversight.
- **`resolve_project` cache + tests.** The cache is a process-global `Mutex<HashMap>`; the four tests that touch it serialize via a per-module test mutex so `__reset_resolve_project_cache_for_testing()` doesn't race other tests in parallel runs.
- **Conformance gate.** The acceptance criterion in #242 is "all 8 reader test fixtures pass against the Rust crate with byte-identical output." This PR ports six of them as native Rust tests over the same logical inputs (classifier, fidelity, git — the parsers' four fixture sets land with their respective parsers in #255–#258). Plan: extract the larger fixture inputs into shared JSON files both runtimes can read so the byte-identical check is mechanical.

## Verification

```
cargo build --workspace                                # green
cargo test  --workspace                                # green (58 reader tests)
cargo clippy -p relayburn-reader --all-targets -- -D warnings  # clean
cargo fmt --all -- --check                             # clean
```

Refs #242, #240.

https://claude.ai/code/session_01KsTp122qkyjJLZvv9aZfqA