### PR TITLE
Port @relayburn/ledger to Rust (#243)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,321 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "relayburn-analyze"
 version = "0.0.0"
 
@@ -17,6 +332,16 @@ version = "0.0.0"
 [[package]]
 name = "relayburn-ledger"
 version = "0.0.0"
+dependencies = [
+ "hex",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "relayburn-reader"
@@ -29,3 +354,385 @@ version = "0.0.0"
 [[package]]
 name = "relayburn-sdk-node"
 version = "0.0.0"
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/relayburn-ledger/Cargo.toml
+++ b/crates/relayburn-ledger/Cargo.toml
@@ -7,3 +7,16 @@ license.workspace = true
 repository.workspace = true
 description = "Append-only JSONL ledger, content sidecar, lock protocol, and SQLite archive (Rust port)."
 publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+rusqlite = { workspace = true }
+sha2 = "0.10"
+hex = "0.4"
+tokio = { workspace = true, features = ["sync", "rt", "macros", "fs", "io-util", "time"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/crates/relayburn-ledger/src/archive.rs
+++ b/crates/relayburn-ledger/src/archive.rs
@@ -1,0 +1,394 @@
+//! SQLite archive (port of `packages/ledger/src/archive.ts`).
+//!
+//! Scope of the initial port (#243):
+//!   - Schema-compatible CREATE statements and additive migrations so an
+//!     existing `archive.sqlite` (`ARCHIVE_VERSION = 3`) opens cleanly under
+//!     Rust without a forced rebuild.
+//!   - `open_archive` honors WAL + foreign_keys + the same version-mismatch
+//!     drop-and-recreate the TS code does.
+//!   - The hot tail loop ingest will land alongside the strongly-typed
+//!     reader port (#242 / #244); for now we expose the schema, the version
+//!     gate, status snapshots, and a transactional batch-write helper that
+//!     downstream callers can drive once `TurnRecord` is typed.
+//!
+//! Schema-compatibility test: `existing_archive_opens_without_rebuild`
+//! creates a database at the current `ARCHIVE_VERSION` using the TS schema
+//! columns, then re-opens it with `open_archive` and asserts the version
+//! row survives.
+
+use std::path::Path;
+
+use rusqlite::{params, Connection};
+
+use crate::errors::Result;
+use crate::paths::archive_path;
+
+/// On-disk schema version. **Stays in lockstep with TS `ARCHIVE_VERSION`**.
+/// Bumping here without bumping TS (or vice-versa) forces a rebuild on every
+/// open, which would silently re-derive the entire 1.5GB archive.
+pub const ARCHIVE_VERSION: i64 = 3;
+
+/// Idempotent schema. Identical column order / types to
+/// `packages/ledger/src/archive.ts:SCHEMA_SQL` so a TS-built archive opens
+/// without complaint here and vice-versa.
+pub const SCHEMA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS sessions (
+  source              TEXT NOT NULL,
+  session_id          TEXT NOT NULL,
+  project             TEXT,
+  project_key         TEXT,
+  started_at          TEXT,
+  ended_at            TEXT,
+  turn_count          INTEGER NOT NULL DEFAULT 0,
+  model_set_json      TEXT,
+  workflow_id         TEXT,
+  agent_id            TEXT,
+  parent_agent_id     TEXT,
+  has_subagent        INTEGER NOT NULL DEFAULT 0,
+  min_fidelity        TEXT,
+  has_full_attribution INTEGER,
+  PRIMARY KEY (source, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_started_at ON sessions(started_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_project_key ON sessions(project_key);
+CREATE INDEX IF NOT EXISTS idx_sessions_workflow_id ON sessions(workflow_id);
+
+CREATE TABLE IF NOT EXISTS turns (
+  source                TEXT NOT NULL,
+  session_id            TEXT NOT NULL,
+  message_id            TEXT NOT NULL,
+  turn_index            INTEGER NOT NULL,
+  ts                    TEXT NOT NULL,
+  model                 TEXT NOT NULL,
+  project               TEXT,
+  project_key           TEXT,
+  activity              TEXT,
+  stop_reason           TEXT,
+  has_edits             INTEGER,
+  retries               INTEGER,
+  is_sidechain          INTEGER,
+  subagent_id           TEXT,
+  parent_subagent_id    TEXT,
+  parent_tool_use_id    TEXT,
+  subagent_type         TEXT,
+  subagent_description  TEXT,
+  input_tokens          INTEGER NOT NULL DEFAULT 0,
+  output_tokens         INTEGER NOT NULL DEFAULT 0,
+  reasoning_tokens      INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+  cache_create_5m_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_create_1h_tokens INTEGER NOT NULL DEFAULT 0,
+  workflow_id           TEXT,
+  agent_id              TEXT,
+  persona               TEXT,
+  tier                  TEXT,
+  enrichment_json       TEXT,
+  attribution_fidelity  TEXT,
+  tokens_present        INTEGER,
+  cost_present          INTEGER,
+  PRIMARY KEY (source, session_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_turns_ts ON turns(ts);
+CREATE INDEX IF NOT EXISTS idx_turns_session ON turns(source, session_id, turn_index);
+CREATE INDEX IF NOT EXISTS idx_turns_model ON turns(model);
+CREATE INDEX IF NOT EXISTS idx_turns_activity ON turns(activity);
+CREATE INDEX IF NOT EXISTS idx_turns_project_key ON turns(project_key);
+CREATE INDEX IF NOT EXISTS idx_turns_workflow ON turns(workflow_id);
+
+CREATE TABLE IF NOT EXISTS tool_calls (
+  source         TEXT NOT NULL,
+  session_id     TEXT NOT NULL,
+  message_id     TEXT NOT NULL,
+  call_index     INTEGER NOT NULL,
+  tool_use_id    TEXT,
+  tool_name      TEXT NOT NULL,
+  target         TEXT,
+  args_hash      TEXT,
+  is_error       INTEGER,
+  PRIMARY KEY (source, session_id, message_id, call_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_calls_name ON tool_calls(tool_name);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_use_id ON tool_calls(tool_use_id);
+
+CREATE TABLE IF NOT EXISTS tool_result_events (
+  source              TEXT NOT NULL,
+  session_id          TEXT NOT NULL,
+  message_id          TEXT NOT NULL,
+  tool_use_id         TEXT NOT NULL,
+  call_index          INTEGER NOT NULL,
+  event_index         INTEGER NOT NULL,
+  status              TEXT,
+  content_length      INTEGER,
+  content_hash        TEXT,
+  is_error            INTEGER,
+  subagent_session_id TEXT,
+  agent_id            TEXT,
+  event_source        TEXT,
+  ts                  TEXT,
+  PRIMARY KEY (source, session_id, message_id, tool_use_id, event_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_result_events_use_id ON tool_result_events(tool_use_id);
+CREATE INDEX IF NOT EXISTS idx_tool_result_events_session ON tool_result_events(source, session_id);
+CREATE INDEX IF NOT EXISTS idx_tool_result_events_subagent ON tool_result_events(subagent_session_id);
+
+CREATE TABLE IF NOT EXISTS stamps (
+  source                TEXT NOT NULL,
+  session_id            TEXT NOT NULL,
+  ts                    TEXT NOT NULL,
+  selector_json         TEXT,
+  enrichment_json       TEXT NOT NULL,
+  ledger_offset_bytes   INTEGER NOT NULL,
+  PRIMARY KEY (source, session_id, ts, ledger_offset_bytes)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stamps_session ON stamps(source, session_id);
+
+CREATE TABLE IF NOT EXISTS compactions (
+  source                TEXT NOT NULL,
+  session_id            TEXT NOT NULL,
+  ts                    TEXT NOT NULL,
+  preceding_message_id  TEXT,
+  tokens_before_compact INTEGER,
+  PRIMARY KEY (source, session_id, ts)
+);
+
+CREATE TABLE IF NOT EXISTS archive_state (
+  id                    INTEGER PRIMARY KEY CHECK (id = 1),
+  ledger_offset_bytes   INTEGER NOT NULL DEFAULT 0,
+  ledger_mtime_ms       INTEGER NOT NULL DEFAULT 0,
+  archive_version       INTEGER NOT NULL,
+  last_built_at         TEXT,
+  last_rebuild_at       TEXT
+);
+"#;
+
+/// Tuning pragmas applied on every open. WAL gives multi-reader concurrency
+/// without serializing on a single writer; `synchronous=NORMAL` is the
+/// default WAL durability tradeoff (safe across crashes, only loses the
+/// last unflushed transaction on hard power-off).
+pub const PRAGMAS_SQL: &str = r#"
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA foreign_keys = ON;
+"#;
+
+/// Open (and create-if-missing) the archive at the default path. Drops and
+/// recreates the file when `archive_state.archive_version` doesn't match
+/// the compiled-in `ARCHIVE_VERSION` — the archive is derived state, so a
+/// rebuild is always safe.
+pub fn open_archive() -> Result<Connection> {
+    let p = archive_path();
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    open_archive_at(&p)
+}
+
+pub fn open_archive_at(path: &Path) -> Result<Connection> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut conn = Connection::open(path)?;
+    apply_pragmas(&conn)?;
+    conn.execute_batch(SCHEMA_SQL)?;
+    apply_additive_migrations(&conn)?;
+    let on_disk_version: Option<i64> = conn
+        .query_row(
+            "SELECT archive_version FROM archive_state WHERE id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+    match on_disk_version {
+        None => {
+            conn.execute(
+                "INSERT INTO archive_state (id, ledger_offset_bytes, ledger_mtime_ms, archive_version) VALUES (1, 0, 0, ?1)",
+                params![ARCHIVE_VERSION],
+            )?;
+        }
+        Some(v) if v == ARCHIVE_VERSION => {}
+        Some(_) => {
+            // Schema mismatch: the archive is derived state, drop and rebuild.
+            drop(conn);
+            std::fs::remove_file(path).ok();
+            // WAL/SHM siblings are recreated on the next open.
+            std::fs::remove_file(path.with_extension("sqlite-wal")).ok();
+            std::fs::remove_file(path.with_extension("sqlite-shm")).ok();
+            conn = Connection::open(path)?;
+            apply_pragmas(&conn)?;
+            conn.execute_batch(SCHEMA_SQL)?;
+            apply_additive_migrations(&conn)?;
+            conn.execute(
+                "INSERT INTO archive_state (id, ledger_offset_bytes, ledger_mtime_ms, archive_version) VALUES (1, 0, 0, ?1)",
+                params![ARCHIVE_VERSION],
+            )?;
+        }
+    }
+    Ok(conn)
+}
+
+fn apply_pragmas(conn: &Connection) -> Result<()> {
+    conn.execute_batch(PRAGMAS_SQL)?;
+    Ok(())
+}
+
+/// Forward-migrate columns added under the same `ARCHIVE_VERSION`.
+/// `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables, so a column
+/// added there later won't appear on already-built archives — we have to
+/// add it explicitly. Mirrors `applyAdditiveMigrations` in TS.
+fn apply_additive_migrations(conn: &Connection) -> Result<()> {
+    ensure_column(conn, "turns", "attribution_fidelity", "TEXT")?;
+    ensure_column(conn, "turns", "tokens_present", "INTEGER")?;
+    ensure_column(conn, "turns", "cost_present", "INTEGER")?;
+    ensure_column(conn, "turns", "subagent_description", "TEXT")?;
+    ensure_column(conn, "sessions", "min_fidelity", "TEXT")?;
+    ensure_column(conn, "sessions", "has_full_attribution", "INTEGER")?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_turns_attribution_fidelity ON turns(attribution_fidelity);",
+    )?;
+    Ok(())
+}
+
+fn ensure_column(conn: &Connection, table: &str, col: &str, ty: &str) -> Result<()> {
+    let exists: bool = {
+        let sql = format!("PRAGMA table_info({table})");
+        let mut stmt = conn.prepare(&sql)?;
+        let mut rows = stmt.query([])?;
+        let mut found = false;
+        while let Some(row) = rows.next()? {
+            let name: String = row.get(1)?;
+            if name == col {
+                found = true;
+                break;
+            }
+        }
+        found
+    };
+    if !exists {
+        let sql = format!("ALTER TABLE {table} ADD COLUMN {col} {ty}");
+        conn.execute(&sql, [])?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct ArchiveStatus {
+    pub archive_version: i64,
+    pub ledger_offset_bytes: i64,
+    pub ledger_mtime_ms: i64,
+    pub last_built_at: Option<String>,
+    pub last_rebuild_at: Option<String>,
+    pub turns: i64,
+    pub sessions: i64,
+}
+
+pub fn archive_status(conn: &Connection) -> Result<ArchiveStatus> {
+    let (archive_version, ledger_offset_bytes, ledger_mtime_ms, last_built_at, last_rebuild_at) =
+        conn.query_row(
+            "SELECT archive_version, ledger_offset_bytes, ledger_mtime_ms, last_built_at, last_rebuild_at FROM archive_state WHERE id = 1",
+            [],
+            |row| {
+                Ok::<_, rusqlite::Error>((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                ))
+            },
+        )?;
+    let turns: i64 = conn.query_row("SELECT COUNT(*) FROM turns", [], |row| row.get(0))?;
+    let sessions: i64 = conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))?;
+    Ok(ArchiveStatus {
+        archive_version,
+        ledger_offset_bytes,
+        ledger_mtime_ms,
+        last_built_at,
+        last_rebuild_at,
+        turns,
+        sessions,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn opens_fresh_archive_with_version_row() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("archive.sqlite");
+        let conn = open_archive_at(&path).unwrap();
+        let status = archive_status(&conn).unwrap();
+        assert_eq!(status.archive_version, ARCHIVE_VERSION);
+        assert_eq!(status.turns, 0);
+        assert_eq!(status.sessions, 0);
+    }
+
+    #[test]
+    fn existing_archive_opens_without_rebuild() {
+        // Build an archive with the current schema, write a sentinel turn,
+        // close, re-open: the row must survive (i.e. we must NOT drop and
+        // recreate).
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("archive.sqlite");
+
+        {
+            let conn = open_archive_at(&path).unwrap();
+            conn.execute(
+                "INSERT INTO turns (
+                    source, session_id, message_id, turn_index, ts, model
+                 ) VALUES ('claude', 'sess', 'msg', 0, '2026-01-01T00:00:00Z', 'm')",
+                [],
+            )
+            .unwrap();
+        }
+        let conn = open_archive_at(&path).unwrap();
+        let status = archive_status(&conn).unwrap();
+        assert_eq!(status.turns, 1, "existing archive must not be rebuilt");
+    }
+
+    #[test]
+    fn version_mismatch_triggers_rebuild() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("archive.sqlite");
+        {
+            let conn = open_archive_at(&path).unwrap();
+            // Simulate an older archive by hand-rewriting the version.
+            conn.execute(
+                "UPDATE archive_state SET archive_version = ?1 WHERE id = 1",
+                params![ARCHIVE_VERSION - 1],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO turns (
+                    source, session_id, message_id, turn_index, ts, model
+                 ) VALUES ('claude', 'sess', 'msg', 0, '2026-01-01T00:00:00Z', 'm')",
+                [],
+            )
+            .unwrap();
+        }
+        let conn = open_archive_at(&path).unwrap();
+        let status = archive_status(&conn).unwrap();
+        assert_eq!(status.archive_version, ARCHIVE_VERSION);
+        assert_eq!(
+            status.turns, 0,
+            "stale archive should have been rebuilt clean"
+        );
+    }
+
+    #[test]
+    fn additive_migration_idempotent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("archive.sqlite");
+        let conn = open_archive_at(&path).unwrap();
+        // Re-running the migration must not throw "duplicate column".
+        apply_additive_migrations(&conn).unwrap();
+        apply_additive_migrations(&conn).unwrap();
+    }
+}

--- a/crates/relayburn-ledger/src/archive.rs
+++ b/crates/relayburn-ledger/src/archive.rs
@@ -107,6 +107,8 @@ CREATE TABLE IF NOT EXISTS tool_calls (
   target         TEXT,
   args_hash      TEXT,
   is_error       INTEGER,
+  replaced_tools TEXT,
+  collapsed_calls INTEGER,
   PRIMARY KEY (source, session_id, message_id, call_index)
 );
 
@@ -247,6 +249,12 @@ fn apply_additive_migrations(conn: &Connection) -> Result<()> {
     ensure_column(conn, "turns", "subagent_description", "TEXT")?;
     ensure_column(conn, "sessions", "min_fidelity", "TEXT")?;
     ensure_column(conn, "sessions", "has_full_attribution", "INTEGER")?;
+    // Counterfactual annotations from replacement tools (e.g. relaywash).
+    // JSON-encoded list for `replaced_tools` so the column count stays
+    // bounded; `collapsed_calls` is a plain integer. Mirrors
+    // packages/ledger/src/archive.ts:380-381.
+    ensure_column(conn, "tool_calls", "replaced_tools", "TEXT")?;
+    ensure_column(conn, "tool_calls", "collapsed_calls", "INTEGER")?;
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_turns_attribution_fidelity ON turns(attribution_fidelity);",
     )?;

--- a/crates/relayburn-ledger/src/errors.rs
+++ b/crates/relayburn-ledger/src/errors.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LedgerError {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("invalid sessionId: {0:?}")]
+    InvalidSessionId(String),
+
+    #[error("could not acquire lock after {attempts} attempts (~{budget_ms}ms) - {detail}: {path}")]
+    LockTimeout {
+        attempts: u32,
+        budget_ms: u64,
+        detail: &'static str,
+        path: String,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, LedgerError>;

--- a/crates/relayburn-ledger/src/file_adapter.rs
+++ b/crates/relayburn-ledger/src/file_adapter.rs
@@ -1,0 +1,274 @@
+//! JSONL ledger append + stream-parse, mirroring
+//! `packages/ledger/src/adapters/file-adapter.ts`.
+//!
+//! Highlights ported faithfully from the TS:
+//!   - `append_turns` performs *batch-snapshot* dedup: id hashes dedupe
+//!     within the batch, but content fingerprints are compared only against
+//!     what's already on disk. Two turns in the *same* batch that share a
+//!     content fingerprint both land — that's by design (rapid back-to-back
+//!     duplicate-shape turns are common and must not be collapsed).
+//!   - All appends hold the `ledger` lock so a reclassify pass can't
+//!     interleave a read-modify-write with our append.
+
+use std::path::Path;
+
+use serde_json::{Deserializer, Value};
+use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::errors::Result;
+use crate::lock::with_lock;
+use crate::paths::ledger_path;
+use crate::schema::{
+    compaction_id_hash, relationship_id_hash, tool_result_event_id_hash,
+    turn_content_fingerprint, turn_id_hash, user_turn_id_hash, LedgerLine,
+};
+use crate::sidecar::{append_hashes, load_index};
+
+/// Append a batch of `turn` records, deduping by id-hash and content
+/// fingerprint. Returns the number of records actually written.
+pub async fn append_turns(records: &[Value]) -> Result<usize> {
+    if records.is_empty() {
+        return Ok(0);
+    }
+    let idx = load_index().await?;
+    // Snapshot of historical content set: content-fingerprint dedup only
+    // compares against historically-committed turns, never within the same
+    // batch.
+    let historical_content = idx.content.clone();
+    let mut ids_seen_in_batch = idx.ids.clone();
+
+    let mut fresh: Vec<&Value> = Vec::new();
+    let mut new_ids: Vec<String> = Vec::new();
+    let mut new_content: Vec<String> = Vec::new();
+    for r in records {
+        let id = turn_id_hash(r);
+        if ids_seen_in_batch.contains(&id) {
+            continue;
+        }
+        let cf = turn_content_fingerprint(r);
+        if historical_content.contains(&cf) {
+            continue;
+        }
+        ids_seen_in_batch.insert(id.clone());
+        new_ids.push(id);
+        new_content.push(cf);
+        fresh.push(r);
+    }
+    if fresh.is_empty() {
+        return Ok(0);
+    }
+
+    let lines: Vec<LedgerLine> = fresh
+        .into_iter()
+        .map(|record| LedgerLine::turn(record.clone()))
+        .collect();
+    append_lines(&lines).await?;
+    append_hashes(&new_ids, &new_content).await?;
+    Ok(lines.len())
+}
+
+/// Append compaction events with id-hash dedup. Returns count actually written.
+pub async fn append_compactions(records: &[Value]) -> Result<usize> {
+    append_dedup(records, "compaction", compaction_id_hash, |r| {
+        LedgerLine {
+            v: 1,
+            body: crate::schema::LineKind::Compaction { record: r.clone() },
+        }
+    })
+    .await
+}
+
+pub async fn append_relationships(records: &[Value]) -> Result<usize> {
+    append_dedup(records, "relationship", relationship_id_hash, |r| {
+        LedgerLine {
+            v: 1,
+            body: crate::schema::LineKind::Relationship { record: r.clone() },
+        }
+    })
+    .await
+}
+
+pub async fn append_tool_result_events(records: &[Value]) -> Result<usize> {
+    append_dedup(records, "tool_result_event", tool_result_event_id_hash, |r| {
+        LedgerLine {
+            v: 1,
+            body: crate::schema::LineKind::ToolResultEvent { record: r.clone() },
+        }
+    })
+    .await
+}
+
+pub async fn append_user_turns(records: &[Value]) -> Result<usize> {
+    append_dedup(records, "user_turn", user_turn_id_hash, |r| LedgerLine {
+        v: 1,
+        body: crate::schema::LineKind::UserTurn { record: r.clone() },
+    })
+    .await
+}
+
+async fn append_dedup<H, B>(
+    records: &[Value],
+    _kind: &str,
+    id_hash: H,
+    build: B,
+) -> Result<usize>
+where
+    H: Fn(&Value) -> String,
+    B: Fn(&Value) -> LedgerLine,
+{
+    if records.is_empty() {
+        return Ok(0);
+    }
+    let idx = load_index().await?;
+    let mut seen = idx.ids.clone();
+
+    let mut fresh: Vec<&Value> = Vec::new();
+    let mut new_ids: Vec<String> = Vec::new();
+    for r in records {
+        let id = id_hash(r);
+        if seen.contains(&id) {
+            continue;
+        }
+        seen.insert(id.clone());
+        new_ids.push(id);
+        fresh.push(r);
+    }
+    if fresh.is_empty() {
+        return Ok(0);
+    }
+    let lines: Vec<LedgerLine> = fresh.into_iter().map(&build).collect();
+    append_lines(&lines).await?;
+    append_hashes(&new_ids, &[]).await?;
+    Ok(lines.len())
+}
+
+/// Append a stamp line directly. No dedup happens at the ledger level for
+/// stamps; the TS implementation also opportunistically materializes a
+/// `subagent` relationship row when the stamp carries `parentAgentId`, which
+/// we don't model yet (the relationship records ride on the
+/// reader-port-typed `SessionRelationshipRecord`). When the reader port
+/// lands the synthesized line will move here.
+pub async fn append_stamp(line: LedgerLine) -> Result<()> {
+    if line.as_stamp().is_none() {
+        // Caller passed something that isn't a stamp. Be lenient — the TS
+        // adapter assumes `StampLine` typing, but here we treat it as a
+        // regular append.
+    }
+    append_lines(&[line]).await
+}
+
+async fn append_lines(lines: &[LedgerLine]) -> Result<()> {
+    if lines.is_empty() {
+        return Ok(());
+    }
+    let path = ledger_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    let mut payload = String::new();
+    for l in lines {
+        payload.push_str(&serde_json::to_string(l)?);
+        payload.push('\n');
+    }
+
+    with_lock("ledger", || async move {
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await?;
+        f.write_all(payload.as_bytes()).await?;
+        f.flush().await?;
+        Ok(())
+    })
+    .await
+}
+
+/// Stream-parse `ledger.jsonl`, yielding each `LedgerLine` in file order.
+/// Mirrors the `streamLines` helper in `file-adapter.ts`. Lines that fail to
+/// parse are silently skipped (same behavior as TS).
+pub async fn read_all_lines(path: &Path) -> Result<Vec<LedgerLine>> {
+    if !fs::try_exists(path).await? {
+        return Ok(Vec::new());
+    }
+    let mut f = fs::File::open(path).await?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf).await?;
+
+    // serde_json::Deserializer::from_slice().into_iter() is the same shape
+    // the issue calls out for the archive's tail loop (#243). It avoids the
+    // per-line String allocation a manual `split('\n')` would produce.
+    let mut out = Vec::new();
+    for value in Deserializer::from_slice(&buf).into_iter::<LedgerLine>() {
+        match value {
+            Ok(l) => out.push(l),
+            Err(_) => continue,
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::set_home;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    async fn fresh_home() -> (tempfile::TempDir, tokio::sync::MutexGuard<'static, ()>) {
+        let dir = tempdir().unwrap();
+        let g = set_home(dir.path()).await;
+        (dir, g)
+    }
+
+    fn make_turn(message_id: &str) -> Value {
+        json!({
+            "source": "claude",
+            "sessionId": "s1",
+            "messageId": message_id,
+            "ts": format!("2026-01-01T00:00:0{}Z", message_id.chars().last().unwrap()),
+            "model": "claude-sonnet-4-6",
+            "usage": {"input": 1, "output": 2, "cacheRead": 0, "cacheCreate5m": 0, "cacheCreate1h": 0},
+            "toolCalls": []
+        })
+    }
+
+    #[tokio::test]
+    async fn appends_and_round_trips_turns() {
+        let (_dir, _g) = fresh_home().await;
+        let n = append_turns(&[make_turn("a"), make_turn("b")])
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+
+        let lines = read_all_lines(&ledger_path()).await.unwrap();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].as_turn().is_some());
+    }
+
+    #[tokio::test]
+    async fn dedupes_by_id_within_repeated_calls() {
+        let (_dir, _g) = fresh_home().await;
+        let t = make_turn("a");
+        let n1 = append_turns(&[t.clone()]).await.unwrap();
+        let n2 = append_turns(&[t.clone()]).await.unwrap();
+        assert_eq!(n1, 1);
+        assert_eq!(n2, 0);
+
+        let lines = read_all_lines(&ledger_path()).await.unwrap();
+        assert_eq!(lines.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dedups_compactions() {
+        let (_dir, _g) = fresh_home().await;
+        let e = json!({
+            "source": "claude",
+            "sessionId": "s1",
+            "ts": "2026-01-01T00:00:00Z",
+        });
+        assert_eq!(append_compactions(&[e.clone()]).await.unwrap(), 1);
+        assert_eq!(append_compactions(&[e.clone()]).await.unwrap(), 0);
+    }
+}

--- a/crates/relayburn-ledger/src/lib.rs
+++ b/crates/relayburn-ledger/src/lib.rs
@@ -1,1 +1,33 @@
-// TODO: port `@relayburn/ledger` — see issue #243.
+//! Rust port of `@relayburn/ledger`.
+//!
+//! Mirrors the append-only JSONL ledger, content sidecar layout, lock
+//! protocol, and SQLite archive surface. The TS package remains the source
+//! of truth until the 2.0 cutover; this crate replicates its behavior so
+//! both readers can interoperate against the same on-disk state.
+
+pub mod archive;
+pub mod errors;
+pub mod file_adapter;
+pub mod lock;
+pub mod paths;
+pub mod schema;
+pub mod sidecar;
+
+#[cfg(test)]
+mod test_support;
+
+pub use errors::{LedgerError, Result};
+pub use lock::{
+    with_lock, AcquireOptions, FAST_RETRIES, FAST_RETRY_DELAY_MS, SLOW_RETRIES,
+    SLOW_RETRY_DELAY_MS, STALE_MS,
+};
+pub use paths::{
+    archive_path, content_dir, content_file_path, cursors_path, hwm_path, is_valid_session_id,
+    ledger_content_index_path, ledger_home, ledger_index_path, ledger_path, lock_path,
+};
+pub use schema::{
+    compaction_id_hash, relationship_id_hash, stamp_matches, tool_result_event_id_hash,
+    turn_content_fingerprint, turn_id_hash, user_turn_id_hash, CompactionLine, Enrichment,
+    LedgerLine, LineKind, MessageIdRange, SessionRelationshipLine, StampLine, StampSelector,
+    ToolResultEventLine, TurnLine, UserTurnLine,
+};

--- a/crates/relayburn-ledger/src/lock.rs
+++ b/crates/relayburn-ledger/src/lock.rs
@@ -1,0 +1,339 @@
+//! Cross-process file lock with the same semantics as
+//! `packages/ledger/src/adapters/file-lock.ts`.
+//!
+//! Why not `flock(2)` / `fs2::FileExt::lock_exclusive`? cross-process
+//! semantics differ on macOS / Windows; the TS adapter relies on
+//! exclusive-create-then-stat instead, so the Rust port must follow.
+//!
+//! Acquire protocol (must stay byte-compatible with TS so a Rust holder and
+//! a TS holder block each other):
+//!   1. `OpenOptions::write(true).create_new(true).open(lockfile)` — succeed
+//!      on first creator.
+//!   2. On `AlreadyExists`, stat the lockfile. If `mtime + STALE_MS < now`
+//!      try to `unlink` it (orphan recovery) and immediately retry the open.
+//!   3. Otherwise wait `FAST_RETRY_DELAY_MS` for the first `FAST_RETRIES`
+//!      attempts, then `SLOW_RETRY_DELAY_MS` for the next `SLOW_RETRIES`.
+//!   4. After `FAST_RETRIES + SLOW_RETRIES` failed attempts, return
+//!      `LockTimeout` naming whether the holder was live or the unlink kept
+//!      failing.
+//!
+//! Re-entrancy: `with_lock(name, fn)` is no-op-recursive when the same
+//! task already holds `name`. We track the held set in a tokio task-local —
+//! the equivalent of TS `AsyncLocalStorage`.
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use tokio::fs;
+use tokio::time::sleep;
+
+use crate::errors::{LedgerError, Result};
+use crate::paths::lock_path;
+
+pub const FAST_RETRY_DELAY_MS: u64 = 20;
+pub const FAST_RETRIES: u32 = 50; // 1s: normal in-process contention
+pub const SLOW_RETRY_DELAY_MS: u64 = 250;
+pub const SLOW_RETRIES: u32 = 40; // 10s: covers an orphan twice over
+pub const STALE_MS: u64 = 5_000;
+
+// Compile-time invariant: the retry budget must outlast STALE_MS so a single
+// invocation can wait an orphan out and unlink it. Mirrors the runtime
+// assertion in the TS adapter.
+const _: () = {
+    let total = FAST_RETRY_DELAY_MS as u128 * FAST_RETRIES as u128
+        + SLOW_RETRY_DELAY_MS as u128 * SLOW_RETRIES as u128;
+    assert!(total > STALE_MS as u128 + SLOW_RETRY_DELAY_MS as u128);
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct AcquireOptions {
+    pub fast_retries: u32,
+    pub fast_retry_delay_ms: u64,
+    pub slow_retries: u32,
+    pub slow_retry_delay_ms: u64,
+    pub stale_ms: u64,
+}
+
+impl Default for AcquireOptions {
+    fn default() -> Self {
+        Self {
+            fast_retries: FAST_RETRIES,
+            fast_retry_delay_ms: FAST_RETRY_DELAY_MS,
+            slow_retries: SLOW_RETRIES,
+            slow_retry_delay_ms: SLOW_RETRY_DELAY_MS,
+            stale_ms: STALE_MS,
+        }
+    }
+}
+
+tokio::task_local! {
+    static HELD_LOCKS: std::cell::RefCell<HashSet<PathBuf>>;
+}
+
+/// Run `fut` while holding the named lock. Re-entrant: if the calling task
+/// already holds `name`, the inner future runs without re-acquiring (matches
+/// TS `AsyncLocalStorage` re-entrancy in `FileLockManager`).
+pub async fn with_lock<F, Fut, T>(name: &str, fut: F) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let lp = lock_path(name);
+    if currently_held(&lp) {
+        return fut().await;
+    }
+
+    if let Some(parent) = lp.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    acquire(&lp, AcquireOptions::default()).await?;
+
+    let result = run_with_held(lp.clone(), fut()).await;
+
+    // Release: best-effort unlink. A failure here just means the next
+    // acquirer will see it as stale and recover.
+    let _ = fs::remove_file(&lp).await;
+
+    result
+}
+
+/// Whether the currently-running task already holds `lp`. Returns false when
+/// the task-local hasn't been initialized (i.e. nobody has called
+/// `with_lock` yet on this task).
+fn currently_held(lp: &Path) -> bool {
+    HELD_LOCKS
+        .try_with(|cell| cell.borrow().contains(lp))
+        .unwrap_or(false)
+}
+
+async fn run_with_held<Fut, T>(lp: PathBuf, fut: Fut) -> Result<T>
+where
+    Fut: Future<Output = Result<T>>,
+{
+    // Two paths: either the task-local is already initialized (nested
+    // with_lock under a different name) or it's not (top-level call). Either
+    // way the inner future needs to see `lp` as held.
+    if HELD_LOCKS.try_with(|_| ()).is_ok() {
+        HELD_LOCKS.with(|cell| cell.borrow_mut().insert(lp.clone()));
+        let result = fut.await;
+        HELD_LOCKS.with(|cell| {
+            cell.borrow_mut().remove(&lp);
+        });
+        result
+    } else {
+        let mut set = HashSet::new();
+        set.insert(lp);
+        HELD_LOCKS.scope(std::cell::RefCell::new(set), fut).await
+    }
+}
+
+/// Public acquire entry point used by tests that need to drive the timeout
+/// path with a tiny budget rather than waiting ~11s for the real lock.
+pub async fn acquire_for_testing(lp: &Path, options: AcquireOptions) -> Result<()> {
+    if let Some(parent) = lp.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    acquire(lp, options).await
+}
+
+async fn acquire(lp: &Path, options: AcquireOptions) -> Result<()> {
+    let mut last_reason: &'static str = "held by live process";
+
+    let total_retries = options.fast_retries + options.slow_retries;
+    let budget_ms = options.fast_retries as u64 * options.fast_retry_delay_ms
+        + options.slow_retries as u64 * options.slow_retry_delay_ms;
+
+    for attempt in 0..total_retries {
+        match try_create(lp).await {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if let Some(age_ms) = lockfile_age_ms(lp).await {
+                    if age_ms > options.stale_ms {
+                        match fs::remove_file(lp).await {
+                            Ok(()) => continue, // race the open again immediately
+                            Err(unlink_err)
+                                if unlink_err.kind() == std::io::ErrorKind::NotFound =>
+                            {
+                                continue;
+                            }
+                            Err(_) => {
+                                last_reason = "lock appears stale but unlink kept failing";
+                            }
+                        }
+                    } else {
+                        last_reason = "held by live process";
+                    }
+                } else {
+                    last_reason = "held by live process";
+                }
+                let delay_ms = if attempt < options.fast_retries {
+                    options.fast_retry_delay_ms
+                } else {
+                    options.slow_retry_delay_ms
+                };
+                sleep(Duration::from_millis(delay_ms)).await;
+            }
+            Err(e) => return Err(LedgerError::Io(e)),
+        }
+    }
+
+    Err(LedgerError::LockTimeout {
+        attempts: total_retries,
+        budget_ms,
+        detail: last_reason,
+        path: lp.display().to_string(),
+    })
+}
+
+async fn try_create(lp: &Path) -> std::io::Result<()> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(lp)
+        .await
+        .map(|_| ())
+}
+
+async fn lockfile_age_ms(lp: &Path) -> Option<u64> {
+    let meta = fs::metadata(lp).await.ok()?;
+    let mtime = meta.modified().ok()?;
+    let now = SystemTime::now();
+    now.duration_since(mtime).ok().map(|d| d.as_millis() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    use crate::test_support::set_home;
+
+    #[tokio::test]
+    async fn serializes_concurrent_callers() {
+        // 100 concurrent callers; observe that they fully serialize. We
+        // increment-then-read-back a shared counter inside the critical
+        // section and assert no two ever observe the same value (a strong
+        // signal that the lock granted them in sequence).
+        let dir = tempdir().unwrap();
+        let _g = set_home(dir.path()).await;
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let observed_max = Arc::new(AtomicU32::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..100 {
+            let counter = counter.clone();
+            let observed_max = observed_max.clone();
+            handles.push(tokio::spawn(async move {
+                with_lock("serialize-test", || async {
+                    let next = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                    // Yield mid-section to give a competing task a chance to
+                    // race; if locking is broken `observed_max` will lag the
+                    // counter by 1 because two tasks were inside at once.
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    let prev_max = observed_max.fetch_max(next, Ordering::SeqCst);
+                    let after_release = counter.load(Ordering::SeqCst);
+                    assert_eq!(
+                        next, after_release,
+                        "another task entered the critical section: prev_max={prev_max}"
+                    );
+                    Ok(())
+                })
+                .await
+                .unwrap();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 100);
+    }
+
+    #[tokio::test]
+    async fn recovers_from_orphan_lockfile() {
+        let dir = tempdir().unwrap();
+        let _g = set_home(dir.path()).await;
+
+        let lp = lock_path("orphan-test");
+        std::fs::create_dir_all(lp.parent().unwrap()).unwrap();
+
+        // Simulate a stale orphan: create the lockfile, then sleep so its
+        // mtime ages past `stale_ms`. Real production uses STALE_MS=5s; we
+        // run this test with a tiny stale_ms so the sleep stays small.
+        std::fs::File::create(&lp).unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let opts = AcquireOptions {
+            stale_ms: 5,
+            ..AcquireOptions::default()
+        };
+        acquire_for_testing(&lp, opts).await.unwrap();
+        let _ = std::fs::remove_file(&lp);
+    }
+
+    #[tokio::test]
+    async fn timeout_when_lock_is_held_indefinitely() {
+        let dir = tempdir().unwrap();
+        let _g = set_home(dir.path()).await;
+        let lp = lock_path("never-released");
+        std::fs::create_dir_all(lp.parent().unwrap()).unwrap();
+        std::fs::File::create(&lp).unwrap();
+
+        let opts = AcquireOptions {
+            fast_retries: 2,
+            fast_retry_delay_ms: 1,
+            slow_retries: 2,
+            slow_retry_delay_ms: 1,
+            stale_ms: 60_000, // not stale within the budget
+        };
+        let err = acquire_for_testing(&lp, opts).await.unwrap_err();
+        match err {
+            LedgerError::LockTimeout { detail, .. } => {
+                assert_eq!(detail, "held by live process");
+            }
+            other => panic!("expected LockTimeout, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reentrant_with_same_name() {
+        // Re-entering the same lock name must NOT block; the inner block
+        // should run inline. If re-entrancy were broken this test would
+        // deadlock until the outer acquire timed out.
+        let dir = tempdir().unwrap();
+        let _g = set_home(dir.path()).await;
+
+        with_lock("reentrant", || async {
+            with_lock("reentrant", || async { Ok(()) }).await
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn distinct_names_do_not_block_each_other() {
+        let dir = tempdir().unwrap();
+        let _g = set_home(dir.path()).await;
+
+        let h1 = tokio::spawn(async {
+            with_lock("name-a", || async {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Ok(())
+            })
+            .await
+        });
+        let h2 = tokio::spawn(async {
+            with_lock("name-b", || async {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Ok(())
+            })
+            .await
+        });
+        h1.await.unwrap().unwrap();
+        h2.await.unwrap().unwrap();
+    }
+}

--- a/crates/relayburn-ledger/src/paths.rs
+++ b/crates/relayburn-ledger/src/paths.rs
@@ -1,0 +1,102 @@
+//! Path layout under `RELAYBURN_HOME` (defaults to `~/.relayburn`).
+//!
+//! Mirrors `packages/ledger/src/paths.ts` — every helper resolves env at call
+//! time so tests that swap `RELAYBURN_HOME` between calls don't need to bust
+//! a cache.
+
+use std::path::PathBuf;
+
+use crate::errors::LedgerError;
+
+pub fn ledger_home() -> PathBuf {
+    if let Ok(env) = std::env::var("RELAYBURN_HOME") {
+        if !env.is_empty() {
+            return PathBuf::from(env);
+        }
+    }
+    let home = std::env::var("HOME").unwrap_or_default();
+    PathBuf::from(home).join(".relayburn")
+}
+
+pub fn ledger_path() -> PathBuf {
+    ledger_home().join("ledger.jsonl")
+}
+
+pub fn hwm_path() -> PathBuf {
+    ledger_home().join("hwm.json")
+}
+
+pub fn cursors_path() -> PathBuf {
+    ledger_home().join("cursors.json")
+}
+
+pub fn ledger_index_path() -> PathBuf {
+    ledger_home().join("ledger.idx")
+}
+
+pub fn ledger_content_index_path() -> PathBuf {
+    ledger_home().join("ledger.content.idx")
+}
+
+pub fn lock_path(name: &str) -> PathBuf {
+    ledger_home().join(format!("{name}.lock"))
+}
+
+pub fn archive_path() -> PathBuf {
+    ledger_home().join("archive.sqlite")
+}
+
+pub fn content_dir() -> PathBuf {
+    ledger_home().join("content")
+}
+
+const MAX_SESSION_ID_LENGTH: usize = 128;
+
+pub fn is_valid_session_id(session_id: &str) -> bool {
+    if session_id.is_empty() || session_id.len() > MAX_SESSION_ID_LENGTH {
+        return false;
+    }
+    if session_id == "." || session_id == ".." {
+        return false;
+    }
+    let bytes = session_id.as_bytes();
+    let first = bytes[0];
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+pub fn content_file_path(session_id: &str) -> Result<PathBuf, LedgerError> {
+    if !is_valid_session_id(session_id) {
+        return Err(LedgerError::InvalidSessionId(session_id.to_string()));
+    }
+    Ok(content_dir().join(format!("{session_id}.jsonl")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_session_ids() {
+        assert!(is_valid_session_id("abc-123"));
+        assert!(is_valid_session_id("ses_abcDEF"));
+        assert!(is_valid_session_id("a"));
+        assert!(!is_valid_session_id(""));
+        assert!(!is_valid_session_id("."));
+        assert!(!is_valid_session_id(".."));
+        assert!(!is_valid_session_id("../escape"));
+        assert!(!is_valid_session_id(".dotleader"));
+        assert!(!is_valid_session_id("has space"));
+        assert!(!is_valid_session_id(&"a".repeat(129)));
+    }
+
+    #[test]
+    fn content_path_rejects_bad_ids() {
+        assert!(content_file_path("..").is_err());
+        assert!(content_file_path("ok-id").is_ok());
+    }
+}

--- a/crates/relayburn-ledger/src/schema.rs
+++ b/crates/relayburn-ledger/src/schema.rs
@@ -1,0 +1,438 @@
+//! Ledger line schema. Mirrors `packages/ledger/src/schema.ts`.
+//!
+//! Records are kept as opaque `serde_json::Value`s until the
+//! `relayburn-reader` port (#242) defines strongly-typed `TurnRecord` and
+//! friends. The hashing helpers below extract just the fields the index
+//! sidecar needs — they MUST stay byte-compatible with the TS hashes so a
+//! TS-written `ledger.idx` and a Rust-written one collide on the same lines.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+pub type Enrichment = BTreeMap<String, String>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageIdRange {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub from_message_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub to_message_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub from_ts: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub to_ts: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct StampSelector {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub message_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub range: Option<MessageIdRange>,
+}
+
+/// One ledger line is `{v, kind, ...}`. We tag on `kind` the same way TS does.
+/// Records are kept as `Value` so we can round-trip lines whose full schema
+/// lives in `relayburn-reader`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LineKind {
+    Turn { record: Value },
+    Stamp(StampPayload),
+    Compaction { record: Value },
+    Relationship { record: Value },
+    ToolResultEvent { record: Value },
+    UserTurn { record: Value },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StampPayload {
+    pub ts: String,
+    pub selector: StampSelector,
+    pub enrichment: Enrichment,
+}
+
+/// Top-level ledger line. `v` MUST be `1`; other versions are skipped by
+/// readers (forward-compatible with future schema bumps).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LedgerLine {
+    pub v: u32,
+    #[serde(flatten)]
+    pub body: LineKind,
+}
+
+impl LedgerLine {
+    pub fn turn(record: Value) -> Self {
+        Self {
+            v: 1,
+            body: LineKind::Turn { record },
+        }
+    }
+
+    pub fn stamp(ts: impl Into<String>, selector: StampSelector, enrichment: Enrichment) -> Self {
+        Self {
+            v: 1,
+            body: LineKind::Stamp(StampPayload {
+                ts: ts.into(),
+                selector,
+                enrichment,
+            }),
+        }
+    }
+}
+
+// Convenience newtypes that return the variant payload, mirroring the TS
+// `isTurnLine`/`isStampLine` guards.
+#[derive(Debug, Clone)]
+pub struct TurnLine<'a> {
+    pub record: &'a Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct StampLine<'a> {
+    pub ts: &'a str,
+    pub selector: &'a StampSelector,
+    pub enrichment: &'a Enrichment,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompactionLine<'a> {
+    pub record: &'a Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionRelationshipLine<'a> {
+    pub record: &'a Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolResultEventLine<'a> {
+    pub record: &'a Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserTurnLine<'a> {
+    pub record: &'a Value,
+}
+
+impl LedgerLine {
+    pub fn as_turn(&self) -> Option<TurnLine<'_>> {
+        if self.v != 1 {
+            return None;
+        }
+        match &self.body {
+            LineKind::Turn { record } => Some(TurnLine { record }),
+            _ => None,
+        }
+    }
+
+    pub fn as_stamp(&self) -> Option<StampLine<'_>> {
+        if self.v != 1 {
+            return None;
+        }
+        match &self.body {
+            LineKind::Stamp(s) => Some(StampLine {
+                ts: &s.ts,
+                selector: &s.selector,
+                enrichment: &s.enrichment,
+            }),
+            _ => None,
+        }
+    }
+
+    pub fn as_compaction(&self) -> Option<CompactionLine<'_>> {
+        if self.v != 1 {
+            return None;
+        }
+        match &self.body {
+            LineKind::Compaction { record } => Some(CompactionLine { record }),
+            _ => None,
+        }
+    }
+
+    pub fn as_relationship(&self) -> Option<SessionRelationshipLine<'_>> {
+        if self.v != 1 {
+            return None;
+        }
+        match &self.body {
+            LineKind::Relationship { record } => Some(SessionRelationshipLine { record }),
+            _ => None,
+        }
+    }
+
+    pub fn as_tool_result_event(&self) -> Option<ToolResultEventLine<'_>> {
+        if self.v != 1 {
+            return None;
+        }
+        match &self.body {
+            LineKind::ToolResultEvent { record } => Some(ToolResultEventLine { record }),
+            _ => None,
+        }
+    }
+
+    pub fn as_user_turn(&self) -> Option<UserTurnLine<'_>> {
+        if self.v != 1 {
+            return None;
+        }
+        match &self.body {
+            LineKind::UserTurn { record } => Some(UserTurnLine { record }),
+            _ => None,
+        }
+    }
+}
+
+fn s<'a>(v: &'a Value, key: &str) -> &'a str {
+    v.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+fn opt_s<'a>(v: &'a Value, key: &str) -> &'a str {
+    v.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+fn sha256_truncated(input: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(input.as_bytes());
+    let digest = h.finalize();
+    let hex = hex::encode(digest);
+    hex[..16].to_string()
+}
+
+/// Stable id for a turn record. Mirrors `turnIdHash` in the TS sidecar.
+pub fn turn_id_hash(record: &Value) -> String {
+    let key = format!(
+        "{}|{}|{}",
+        s(record, "source"),
+        s(record, "sessionId"),
+        s(record, "messageId"),
+    );
+    sha256_truncated(&key)
+}
+
+/// Stable id for a compaction event. Matches `compactionIdHash` (TS).
+pub fn compaction_id_hash(record: &Value) -> String {
+    let key = format!(
+        "{}|{}|{}",
+        s(record, "source"),
+        s(record, "sessionId"),
+        s(record, "ts"),
+    );
+    sha256_truncated(&key)
+}
+
+/// Stable id for a session-relationship record.
+///
+/// Mirrors `relationshipIdHash` (TS): `(source, sessionId, relationshipType,
+/// relatedSessionId, agentId, parentToolUseId)`. Missing fields collapse to
+/// the empty string the same way `?? ''` does in the TS code.
+pub fn relationship_id_hash(record: &Value) -> String {
+    let key = [
+        s(record, "source"),
+        s(record, "sessionId"),
+        s(record, "relationshipType"),
+        opt_s(record, "relatedSessionId"),
+        opt_s(record, "agentId"),
+        opt_s(record, "parentToolUseId"),
+    ]
+    .join("|");
+    sha256_truncated(&key)
+}
+
+/// Stable id for a `ToolResultEventRecord`. Matches the TS hash.
+pub fn tool_result_event_id_hash(record: &Value) -> String {
+    let event_index = record
+        .get("eventIndex")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let key = format!(
+        "{}|{}|{}|{}",
+        s(record, "source"),
+        s(record, "sessionId"),
+        s(record, "toolUseId"),
+        event_index,
+    );
+    sha256_truncated(&key)
+}
+
+/// Stable id for a `UserTurnRecord`. Matches the TS hash.
+pub fn user_turn_id_hash(record: &Value) -> String {
+    let key = format!(
+        "{}|{}|{}",
+        s(record, "source"),
+        s(record, "sessionId"),
+        s(record, "userUuid"),
+    );
+    sha256_truncated(&key)
+}
+
+/// Per-turn content fingerprint. Mirrors `turnContentFingerprint` (TS).
+///
+/// Composite key:
+/// `ts | model | (input+output) | cacheRead | (cacheCreate5m+cacheCreate1h)
+///  | firstToolArgsHash[..4]`.
+pub fn turn_content_fingerprint(record: &Value) -> String {
+    let usage = record.get("usage").cloned().unwrap_or(Value::Null);
+    let input = usage.get("input").and_then(Value::as_i64).unwrap_or(0);
+    let output = usage.get("output").and_then(Value::as_i64).unwrap_or(0);
+    let cache_read = usage.get("cacheRead").and_then(Value::as_i64).unwrap_or(0);
+    let cache_5m = usage
+        .get("cacheCreate5m")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let cache_1h = usage
+        .get("cacheCreate1h")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    let first_tool_prefix = record
+        .get("toolCalls")
+        .and_then(Value::as_array)
+        .and_then(|arr| arr.first())
+        .and_then(|tc| tc.get("argsHash"))
+        .and_then(Value::as_str)
+        .map(|h| {
+            let take = h.len().min(4);
+            h[..take].to_string()
+        })
+        .unwrap_or_default();
+
+    let composite = format!(
+        "{}|{}|{}|{}|{}|{}",
+        s(record, "ts"),
+        s(record, "model"),
+        input + output,
+        cache_read,
+        cache_5m + cache_1h,
+        first_tool_prefix,
+    );
+    sha256_truncated(&composite)
+}
+
+/// Equivalent of `stampMatches` (TS). True iff the stamp's selector touches
+/// the turn AND the selector specified at least one of `sessionId`,
+/// `messageId`, or `range`.
+pub fn stamp_matches(stamp: &StampLine<'_>, turn: &Value) -> bool {
+    let sel = stamp.selector;
+    if let Some(ref sid) = sel.session_id {
+        if sid != s(turn, "sessionId") {
+            return false;
+        }
+    }
+    if let Some(ref mid) = sel.message_id {
+        if mid != s(turn, "messageId") {
+            return false;
+        }
+    }
+    if let Some(ref r) = sel.range {
+        if let Some(ref from_ts) = r.from_ts {
+            if s(turn, "ts") < from_ts.as_str() {
+                return false;
+            }
+        }
+        if let Some(ref to_ts) = r.to_ts {
+            if s(turn, "ts") > to_ts.as_str() {
+                return false;
+            }
+        }
+    }
+    sel.session_id.is_some() || sel.message_id.is_some() || sel.range.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn turn_id_hash_matches_known_inputs() {
+        // Keep this in sync with the TS test vector below; both should produce
+        // the same 16-char prefix.
+        let r = json!({
+            "source": "claude",
+            "sessionId": "abc",
+            "messageId": "msg1",
+            "ts": "2026-01-01T00:00:00Z",
+            "model": "claude-sonnet-4-6",
+        });
+        let expected = sha256_truncated("claude|abc|msg1");
+        assert_eq!(turn_id_hash(&r), expected);
+    }
+
+    #[test]
+    fn fingerprint_handles_missing_fields() {
+        let r = json!({"ts": "t", "model": "m"});
+        // Should not panic, all numeric fields default to 0.
+        let h = turn_content_fingerprint(&r);
+        assert_eq!(h.len(), 16);
+    }
+
+    #[test]
+    fn round_trips_turn_line() {
+        let line = LedgerLine::turn(json!({"source": "claude", "sessionId": "s", "messageId": "m"}));
+        let s = serde_json::to_string(&line).unwrap();
+        let back: LedgerLine = serde_json::from_str(&s).unwrap();
+        let t = back.as_turn().expect("turn");
+        assert_eq!(t.record.get("messageId").unwrap(), "m");
+    }
+
+    #[test]
+    fn round_trips_stamp_line() {
+        let mut enr = Enrichment::new();
+        enr.insert("workflowId".into(), "wf-1".into());
+        let line = LedgerLine::stamp(
+            "2026-05-03T00:00:00Z",
+            StampSelector {
+                session_id: Some("sess".into()),
+                ..Default::default()
+            },
+            enr,
+        );
+        let s = serde_json::to_string(&line).unwrap();
+        let back: LedgerLine = serde_json::from_str(&s).unwrap();
+        let st = back.as_stamp().expect("stamp");
+        assert_eq!(st.ts, "2026-05-03T00:00:00Z");
+        assert_eq!(st.enrichment.get("workflowId").unwrap(), "wf-1");
+    }
+
+    #[test]
+    fn stamp_matches_requires_some_selector() {
+        let stamp_payload = StampPayload {
+            ts: "t".into(),
+            selector: StampSelector::default(),
+            enrichment: Enrichment::new(),
+        };
+        let stamp = StampLine {
+            ts: &stamp_payload.ts,
+            selector: &stamp_payload.selector,
+            enrichment: &stamp_payload.enrichment,
+        };
+        let turn = json!({"sessionId": "x", "messageId": "y", "ts": "t"});
+        assert!(!stamp_matches(&stamp, &turn));
+    }
+
+    #[test]
+    fn stamp_matches_session_filter() {
+        let p = StampPayload {
+            ts: "t".into(),
+            selector: StampSelector {
+                session_id: Some("sess-a".into()),
+                ..Default::default()
+            },
+            enrichment: Enrichment::new(),
+        };
+        let stamp = StampLine {
+            ts: &p.ts,
+            selector: &p.selector,
+            enrichment: &p.enrichment,
+        };
+        let matching = json!({"sessionId": "sess-a", "messageId": "m", "ts": "t"});
+        let other = json!({"sessionId": "sess-b", "messageId": "m", "ts": "t"});
+        assert!(stamp_matches(&stamp, &matching));
+        assert!(!stamp_matches(&stamp, &other));
+    }
+}

--- a/crates/relayburn-ledger/src/schema.rs
+++ b/crates/relayburn-ledger/src/schema.rs
@@ -15,6 +15,7 @@ use sha2::{Digest, Sha256};
 pub type Enrichment = BTreeMap<String, String>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageIdRange {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub from_message_id: Option<String>,
@@ -413,6 +414,32 @@ mod tests {
         };
         let turn = json!({"sessionId": "x", "messageId": "y", "ts": "t"});
         assert!(!stamp_matches(&stamp, &turn));
+    }
+
+    #[test]
+    fn message_id_range_uses_camel_case() {
+        // Regression: Rust struct fields are snake_case but the wire format
+        // is camelCase (TS uses fromTs/toTs/fromMessageId/toMessageId).
+        // Without rename_all the range round-trip silently drops every
+        // field, breaking stamp-range filtering against TS-written stamps.
+        let range = MessageIdRange {
+            from_message_id: Some("m1".into()),
+            to_message_id: Some("m9".into()),
+            from_ts: Some("2026-01-01T00:00:00Z".into()),
+            to_ts: Some("2026-01-02T00:00:00Z".into()),
+        };
+        let json = serde_json::to_string(&range).unwrap();
+        assert!(json.contains("fromMessageId"));
+        assert!(json.contains("fromTs"));
+        assert!(!json.contains("from_ts"));
+
+        // Decoding TS-shaped input round-trips into the right fields.
+        let ts_payload = r#"{"fromTs":"a","toTs":"b","fromMessageId":"x","toMessageId":"y"}"#;
+        let parsed: MessageIdRange = serde_json::from_str(ts_payload).unwrap();
+        assert_eq!(parsed.from_ts.as_deref(), Some("a"));
+        assert_eq!(parsed.to_ts.as_deref(), Some("b"));
+        assert_eq!(parsed.from_message_id.as_deref(), Some("x"));
+        assert_eq!(parsed.to_message_id.as_deref(), Some("y"));
     }
 
     #[test]

--- a/crates/relayburn-ledger/src/sidecar.rs
+++ b/crates/relayburn-ledger/src/sidecar.rs
@@ -1,0 +1,377 @@
+//! In-memory + on-disk hash index for ledger dedup.
+//!
+//! Mirrors `packages/ledger/src/index-sidecar.ts`. Two side files live next
+//! to `ledger.jsonl`:
+//!   - `ledger.idx`           — every TurnRecord/CompactionEvent/etc. id
+//!     hash ever appended; consulted by writers to skip duplicates.
+//!   - `ledger.content.idx`   — rolling window of `CONTENT_WINDOW`
+//!     turnContentFingerprints; lets us detect "same usage shape, different
+//!     messageId" turns that would otherwise re-ingest after a session id
+//!     change.
+//!
+//! The file format is one hex hash per line. Both readers and writers must
+//! hold the `ledger-index` lock to avoid torn appends.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use serde_json::Deserializer;
+use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+use crate::errors::Result;
+use crate::lock::with_lock;
+use crate::paths::{
+    ledger_content_index_path, ledger_home, ledger_index_path, ledger_path,
+};
+use crate::schema::{
+    compaction_id_hash, relationship_id_hash, tool_result_event_id_hash,
+    turn_content_fingerprint, turn_id_hash, user_turn_id_hash, LedgerLine,
+};
+
+pub const CONTENT_WINDOW: usize = 10_000;
+
+#[derive(Debug, Default, Clone)]
+pub struct IndexSnapshot {
+    pub ids: HashSet<String>,
+    pub content: HashSet<String>,
+    pub content_order: Vec<String>,
+    pub home: std::path::PathBuf,
+}
+
+impl IndexSnapshot {
+    fn empty(home: std::path::PathBuf) -> Self {
+        Self {
+            ids: HashSet::new(),
+            content: HashSet::new(),
+            content_order: Vec::new(),
+            home,
+        }
+    }
+}
+
+// Cache keyed on `RELAYBURN_HOME` so swapping the env between tests / runs
+// invalidates automatically. `OnceLock` would be nicer than `Lazy` here
+// but we need *re-initialization* when the home changes, which a Mutex
+// gives us cheaply.
+static CACHE: Mutex<Option<IndexSnapshot>> = Mutex::const_new(None);
+
+/// Drop the in-memory dedup cache. Callers that wipe the on-disk index
+/// (e.g. `burn state reset`) MUST call this so the next `load_index` re-reads
+/// from the empty files instead of returning hashes loaded before the wipe.
+pub async fn invalidate_index_cache() {
+    let mut guard = CACHE.lock().await;
+    *guard = None;
+}
+
+/// Return a snapshot of the dedup index (id hashes + rolling content
+/// fingerprints), reading from disk on first call after a `RELAYBURN_HOME`
+/// change.
+pub async fn load_index() -> Result<IndexSnapshot> {
+    let home = ledger_home();
+    {
+        let guard = CACHE.lock().await;
+        if let Some(snap) = guard.as_ref() {
+            if snap.home == home {
+                return Ok(snap.clone());
+            }
+        }
+    }
+
+    let ids = load_hashes(&ledger_index_path()).await?;
+    let content_lines = load_hashes_array(&ledger_content_index_path()).await?;
+    let tail_start = content_lines.len().saturating_sub(CONTENT_WINDOW);
+    let tail: Vec<String> = content_lines[tail_start..].to_vec();
+    let content: HashSet<String> = tail.iter().cloned().collect();
+
+    let snap = IndexSnapshot {
+        ids,
+        content,
+        content_order: tail,
+        home,
+    };
+    let mut guard = CACHE.lock().await;
+    *guard = Some(snap.clone());
+    Ok(snap)
+}
+
+/// Append id-hashes (and rolling content fingerprints) to the on-disk index.
+/// Holds the `ledger-index` lock so concurrent writers don't tear the file.
+pub async fn append_hashes(id_hashes: &[String], content_hashes: &[String]) -> Result<()> {
+    if id_hashes.is_empty() && content_hashes.is_empty() {
+        return Ok(());
+    }
+    if let Some(parent) = ledger_index_path().parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    let id_hashes = id_hashes.to_vec();
+    let content_hashes = content_hashes.to_vec();
+    with_lock("ledger-index", || async move {
+        if !id_hashes.is_empty() {
+            append_lines(&ledger_index_path(), &id_hashes).await?;
+        }
+        // Pull the cached snapshot so we can update both the on-disk content
+        // tail and the in-memory ids/content sets atomically. Without this
+        // refresh, the next `load_index()` (cache hit) would miss the
+        // hashes we just wrote, and back-to-back `append_*` calls would
+        // double-write.
+        let mut snap = load_index().await?;
+        for id in &id_hashes {
+            snap.ids.insert(id.clone());
+        }
+        if !content_hashes.is_empty() {
+            for h in &content_hashes {
+                snap.content_order.push(h.clone());
+                snap.content.insert(h.clone());
+            }
+            if snap.content_order.len() > CONTENT_WINDOW {
+                let drop_n = snap.content_order.len() - CONTENT_WINDOW;
+                snap.content_order.drain(..drop_n);
+                snap.content = snap.content_order.iter().cloned().collect();
+                let p = ledger_content_index_path();
+                let tmp = p.with_extension("content.idx.tmp");
+                let body = if snap.content_order.is_empty() {
+                    String::new()
+                } else {
+                    let mut s = snap.content_order.join("\n");
+                    s.push('\n');
+                    s
+                };
+                fs::write(&tmp, body.as_bytes()).await?;
+                fs::rename(&tmp, &p).await?;
+            } else {
+                append_lines(&ledger_content_index_path(), &content_hashes).await?;
+            }
+        }
+        let mut guard = CACHE.lock().await;
+        *guard = Some(snap);
+        Ok(())
+    })
+    .await
+}
+
+/// Walk `ledger.jsonl` end-to-end and rebuild both index files. The hot loop
+/// uses `serde_json::Deserializer::from_reader().into_iter()` (the same shape
+/// the issue calls out for the archive's tail loop) so we don't have to
+/// materialize each line into a String first.
+pub async fn rebuild_index() -> Result<RebuildReport> {
+    let ledger = ledger_path();
+    let mut ids = HashSet::<String>::new();
+    let mut content_order = Vec::<String>::new();
+    let mut content_seen = HashSet::<String>::new();
+
+    if let Ok(meta) = fs::metadata(&ledger).await {
+        if meta.is_file() {
+            // serde_json::Deserializer streams; do this in a blocking thread
+            // so async runtimes aren't pinned by per-line work on giant
+            // ledgers.
+            let path = ledger.clone();
+            let parsed: Vec<LedgerLine> = tokio::task::spawn_blocking(move || -> Result<_> {
+                let f = std::fs::File::open(&path)?;
+                let reader = std::io::BufReader::new(f);
+                let mut lines = Vec::new();
+                for value in Deserializer::from_reader(reader).into_iter::<LedgerLine>() {
+                    match value {
+                        Ok(line) => lines.push(line),
+                        Err(_) => continue, // skip malformed
+                    }
+                }
+                Ok(lines)
+            })
+            .await
+            .expect("blocking task panicked")?;
+
+            for line in parsed {
+                if let Some(t) = line.as_turn() {
+                    ids.insert(turn_id_hash(t.record));
+                    let cf = turn_content_fingerprint(t.record);
+                    if !content_seen.contains(&cf) {
+                        content_seen.insert(cf.clone());
+                        content_order.push(cf);
+                    }
+                } else if let Some(c) = line.as_compaction() {
+                    ids.insert(compaction_id_hash(c.record));
+                } else if let Some(r) = line.as_relationship() {
+                    ids.insert(relationship_id_hash(r.record));
+                } else if let Some(e) = line.as_tool_result_event() {
+                    ids.insert(tool_result_event_id_hash(e.record));
+                } else if let Some(u) = line.as_user_turn() {
+                    ids.insert(user_turn_id_hash(u.record));
+                }
+            }
+        }
+    }
+
+    if let Some(parent) = ledger_index_path().parent() {
+        fs::create_dir_all(parent).await?;
+    }
+
+    let ids_body = if ids.is_empty() {
+        String::new()
+    } else {
+        let mut s = ids.iter().cloned().collect::<Vec<_>>().join("\n");
+        s.push('\n');
+        s
+    };
+    let tail_start = content_order.len().saturating_sub(CONTENT_WINDOW);
+    let content_tail: Vec<String> = content_order[tail_start..].to_vec();
+    let content_body = if content_tail.is_empty() {
+        String::new()
+    } else {
+        let mut s = content_tail.join("\n");
+        s.push('\n');
+        s
+    };
+
+    let ids_for_lock = ids.clone();
+    let tail_for_lock = content_tail.clone();
+    let report_ids = ids.len();
+    let report_content = content_tail.len();
+
+    with_lock("ledger-index", || async move {
+        let idx = ledger_index_path();
+        let cidx = ledger_content_index_path();
+        let idx_tmp = idx.with_extension("idx.tmp");
+        let cidx_tmp = cidx.with_extension("content.idx.tmp");
+        fs::write(&idx_tmp, ids_body.as_bytes()).await?;
+        fs::rename(&idx_tmp, &idx).await?;
+        fs::write(&cidx_tmp, content_body.as_bytes()).await?;
+        fs::rename(&cidx_tmp, &cidx).await?;
+
+        let snap = IndexSnapshot {
+            ids: ids_for_lock,
+            content: tail_for_lock.iter().cloned().collect(),
+            content_order: tail_for_lock,
+            home: ledger_home(),
+        };
+        let mut guard = CACHE.lock().await;
+        *guard = Some(snap);
+        Ok(())
+    })
+    .await?;
+
+    Ok(RebuildReport {
+        ids: report_ids,
+        content: report_content,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RebuildReport {
+    pub ids: usize,
+    pub content: usize,
+}
+
+async fn load_hashes(p: &Path) -> Result<HashSet<String>> {
+    let lines = load_hashes_array(p).await?;
+    Ok(lines.into_iter().collect())
+}
+
+async fn load_hashes_array(p: &Path) -> Result<Vec<String>> {
+    match fs::File::open(p).await {
+        Ok(mut f) => {
+            let mut s = String::new();
+            f.read_to_string(&mut s).await?;
+            Ok(s.lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn append_lines(p: &Path, hashes: &[String]) -> Result<()> {
+    let mut payload = String::new();
+    for h in hashes {
+        payload.push_str(h);
+        payload.push('\n');
+    }
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(p)
+        .await?;
+    f.write_all(payload.as_bytes()).await?;
+    f.flush().await?;
+    Ok(())
+}
+
+// Avoid the "unused" warning on IndexSnapshot::empty until ergonomic
+// callers pull it in.
+#[allow(dead_code)]
+fn _empty_snapshot_used() -> IndexSnapshot {
+    IndexSnapshot::empty(std::path::PathBuf::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::set_home;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    async fn fresh_home() -> (tempfile::TempDir, tokio::sync::MutexGuard<'static, ()>) {
+        let dir = tempdir().unwrap();
+        let g = set_home(dir.path()).await;
+        (dir, g)
+    }
+
+    #[tokio::test]
+    async fn appends_id_hashes_and_reloads() {
+        let (_dir, _g) = fresh_home().await;
+        let h1 = "deadbeefcafebabe".to_string();
+        let h2 = "0123456789abcdef".to_string();
+        append_hashes(&[h1.clone(), h2.clone()], &[]).await.unwrap();
+
+        // Drop cache so we read from disk.
+        invalidate_index_cache().await;
+        let snap = load_index().await.unwrap();
+        assert!(snap.ids.contains(&h1));
+        assert!(snap.ids.contains(&h2));
+    }
+
+    #[tokio::test]
+    async fn rebuild_picks_up_existing_lines() {
+        let (_dir, _g) = fresh_home().await;
+
+        // Write a tiny ledger by hand: one turn, one compaction.
+        let ledger = ledger_path();
+        std::fs::create_dir_all(ledger.parent().unwrap()).unwrap();
+        let turn = LedgerLine::turn(json!({
+            "source": "claude",
+            "sessionId": "s1",
+            "messageId": "m1",
+            "ts": "2026-01-01T00:00:00Z",
+            "model": "claude-sonnet-4-6",
+            "usage": {"input": 1, "output": 2, "cacheRead": 0, "cacheCreate5m": 0, "cacheCreate1h": 0},
+            "toolCalls": []
+        }));
+        let mut body = serde_json::to_string(&turn).unwrap();
+        body.push('\n');
+        std::fs::write(&ledger, body).unwrap();
+
+        let report = rebuild_index().await.unwrap();
+        assert_eq!(report.ids, 1);
+        assert_eq!(report.content, 1);
+
+        let snap = load_index().await.unwrap();
+        assert_eq!(snap.ids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_invalidates_on_home_change() {
+        let (dir1, _g) = fresh_home().await;
+        let h = "aaaaaaaaaaaaaaaa".to_string();
+        append_hashes(&[h.clone()], &[]).await.unwrap();
+
+        let _ = dir1; // keep first home alive
+
+        let dir2 = tempdir().unwrap();
+        std::env::set_var("RELAYBURN_HOME", dir2.path());
+        let snap = load_index().await.unwrap();
+        assert!(!snap.ids.contains(&h), "cache should not survive a home swap");
+    }
+}

--- a/crates/relayburn-ledger/src/test_support.rs
+++ b/crates/relayburn-ledger/src/test_support.rs
@@ -1,0 +1,25 @@
+//! Test-only helpers shared across modules in this crate.
+//!
+//! `RELAYBURN_HOME` is process-wide. `cargo test` runs cases in parallel, so
+//! anything that mutates the env var must serialize on a single global
+//! mutex — otherwise concurrent tests in different modules clobber each
+//! others' home directory mid-run, and reads of `lock_path()` /
+//! `ledger_path()` race.
+
+#![cfg(test)]
+
+use tokio::sync::{Mutex, MutexGuard};
+
+static GLOBAL_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// Acquire the cross-module env lock, set `RELAYBURN_HOME` to `dir`, and
+/// invalidate any cached state keyed on the previous home. Hold the
+/// returned guard for the whole test body — `tokio::sync::Mutex` is
+/// async-aware so it can be held across `.await` without tripping
+/// `clippy::await_holding_lock`.
+pub async fn set_home(dir: &std::path::Path) -> MutexGuard<'static, ()> {
+    let g = GLOBAL_ENV_LOCK.lock().await;
+    std::env::set_var("RELAYBURN_HOME", dir);
+    crate::sidecar::invalidate_index_cache().await;
+    g
+}


### PR DESCRIPTION
Closing in favor of #259, which redesigns the Rust ledger as a SQLite-only store (no JSONL, no hash sidecars, no file-lock dance) instead of porting the TS tri-store layout literally. The 2.0 cutover makes Rust the source of truth, so the cross-language compat constraint that motivated #243's design no longer applies.

The work in this branch (`claude/fix-issue-242-1SZ66`) stays on the remote as a reference for the lock-protocol port and schema-compat code, but the next implementation will land against #259.