### PR TITLE
relayburn-reader: port Codex parser to Rust (#256)

### DIFF
--- a/crates/relayburn-reader/src/codex.rs
+++ b/crates/relayburn-reader/src/codex.rs
@@ -167,6 +167,11 @@ pub fn parse_codex_session_incremental(
     file_path: impl AsRef<Path>,
     options: &ParseCodexIncrementalOptions,
 ) -> std::io::Result<ParseCodexIncrementalResult> {
+    // The TS parser defaults to cl100k; the Rust port only ships
+    // `HeuristicCounter` until a tiktoken-equivalent lands (#246). Honor the
+    // option by accepting `None` / `Some(Heuristic)` and rejecting
+    // `Some(Cl100k)` with a clear error rather than silently falling back.
+    resolve_token_counter(options.tokenizer)?;
     let start_offset = options.start_offset.unwrap_or(0);
     let mut file = File::open(file_path.as_ref())?;
     let size = file.metadata()?.len();
@@ -332,7 +337,8 @@ fn parse_codex_buffer(
     project_resolver: &ProjectResolver,
 ) -> ParseCodexIncrementalResult {
     let capture_content = matches!(options.content_mode, Some(ContentStoreMode::Full));
-    let counter = HeuristicCounter; // see TODO above re: cl100k
+    // Validated by `resolve_token_counter` at the public entry point.
+    let counter = HeuristicCounter;
 
     let resume = options.resume.as_ref();
     let mut session_id = resume.map(|r| r.session_id.clone()).unwrap_or_default();
@@ -1205,6 +1211,22 @@ fn parse_codex_buffer(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Resolves the requested tokenizer to a concrete counter. `None` and
+/// `Some(Heuristic)` map to [`HeuristicCounter`]; `Some(Cl100k)` is rejected
+/// with an explicit error until the cl100k counter is wired up (see #246) so
+/// callers don't silently get bytes/4 sizing when they asked for cl100k.
+fn resolve_token_counter(
+    tokenizer: Option<UserTurnTokenizer>,
+) -> std::io::Result<HeuristicCounter> {
+    match tokenizer {
+        None | Some(UserTurnTokenizer::Heuristic) => Ok(HeuristicCounter),
+        Some(UserTurnTokenizer::Cl100k) => Err(std::io::Error::other(
+            "cl100k tokenizer is not yet available in the Rust port; \
+             omit `tokenizer` or pass `Some(Heuristic)` (see AgentWorkforce/burn#246)",
+        )),
+    }
+}
 
 fn memchr_newline(buf: &[u8]) -> Option<usize> {
     buf.iter().position(|&b| b == b'\n')

--- a/crates/relayburn-reader/src/codex.rs
+++ b/crates/relayburn-reader/src/codex.rs
@@ -1,4 +1,1691 @@
-//! Codex session parser — Rust port stub.
+//! Codex session parser — Rust port of `packages/reader/src/codex.ts`.
 //!
-//! TODO(#242): port `packages/reader/src/codex.ts` (Codex JSONL parser,
-//! resume-state reconstruction, user-turn slot persistence).
+//! Mirrors the TS state-machine field-for-field: a single forward pass over
+//! line-delimited JSON records, with all per-turn output buffered and only
+//! committed at `task_complete` boundaries. Resume state is round-tripped as
+//! [`CodexResumeState`] so an incremental ingest can pick up where the last
+//! committed turn left off without re-reading prior bytes.
+//!
+//! Note: the TS parser defaults to a `cl100k` tokenizer for `UserTurnBlock`
+//! sizing. The Rust port uses [`HeuristicCounter`] (bytes/4) — see #246 for
+//! the cl100k hookup.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::classifier::{classify_activity, ClassificationInput};
+use crate::fidelity::classify_fidelity;
+use crate::git::ProjectResolver;
+use crate::hash::{args_hash, content_hash};
+use crate::types::{
+    CompactionEvent, ContentKind, ContentRecord, ContentRole, ContentStoreMode, ContentToolResult,
+    ContentToolUse, Coverage, Fidelity, RelationshipSourceKind, RelationshipType,
+    SessionRelationshipRecord, SourceKind, ToolCall, ToolResultEventRecord, ToolResultEventSource,
+    ToolResultStatus, TurnRecord, Usage, UsageGranularity, UserTurnBlock, UserTurnBlockKind,
+    UserTurnRecord,
+};
+use crate::user_turn::{HeuristicCounter, UserTurnTokenizer};
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseCodexOptions {
+    pub session_path: Option<String>,
+    pub content_mode: Option<ContentStoreMode>,
+    pub tokenizer: Option<UserTurnTokenizer>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseCodexIncrementalOptions {
+    pub session_path: Option<String>,
+    pub content_mode: Option<ContentStoreMode>,
+    pub tokenizer: Option<UserTurnTokenizer>,
+    pub start_offset: Option<u64>,
+    pub resume: Option<CodexResumeState>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CumulativeUsage {
+    pub input: i64,
+    pub output: i64,
+    pub cache_read: i64,
+    pub reasoning: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PersistedUserTurnSlot {
+    pub blocks: Vec<UserTurnBlock>,
+    pub preceding_message_id: Option<String>,
+    pub ts: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexLastCompletedTurn {
+    pub message_id: String,
+    pub cache_read: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CodexTurnContext {
+    pub turn_id: Option<String>,
+    pub cwd: Option<String>,
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CodexResumeState {
+    pub cumulative: CumulativeUsage,
+    pub session_id: String,
+    pub session_cwd: Option<String>,
+    pub turn_contexts: HashMap<String, CodexTurnContext>,
+    pub user_turn_slot: Option<PersistedUserTurnSlot>,
+    pub root_session_emitted: bool,
+    pub session_meta_relationship_keys: Vec<String>,
+    pub next_event_index: u64,
+    pub tool_result_counters: HashMap<String, u64>,
+    pub last_completed_turn: Option<CodexLastCompletedTurn>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseCodexResult {
+    pub turns: Vec<TurnRecord>,
+    pub content: Vec<ContentRecord>,
+    pub events: Vec<CompactionEvent>,
+    pub user_turns: Vec<UserTurnRecord>,
+    pub relationships: Vec<SessionRelationshipRecord>,
+    pub tool_result_events: Vec<ToolResultEventRecord>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseCodexIncrementalResult {
+    pub turns: Vec<TurnRecord>,
+    pub content: Vec<ContentRecord>,
+    pub events: Vec<CompactionEvent>,
+    pub user_turns: Vec<UserTurnRecord>,
+    pub relationships: Vec<SessionRelationshipRecord>,
+    pub tool_result_events: Vec<ToolResultEventRecord>,
+    pub end_offset: u64,
+    pub resume: CodexResumeState,
+}
+
+/// Best-effort sniff of the `session_meta.payload.id` from the first JSONL
+/// line. Used by ingest to map a renamed-on-disk rollout file back to its
+/// canonical session id without parsing the full file.
+pub fn read_codex_session_id_hint(file_path: impl AsRef<Path>) -> Option<String> {
+    let mut file = File::open(file_path.as_ref()).ok()?;
+    let mut buf = vec![0u8; 8192];
+    let n = file.read(&mut buf).ok()?;
+    if n == 0 {
+        return None;
+    }
+    let raw = std::str::from_utf8(&buf[..n]).ok()?;
+    let first = match raw.find('\n') {
+        Some(idx) => &raw[..idx],
+        None => raw,
+    };
+    let first = first.trim_end_matches('\r').trim();
+    if first.is_empty() {
+        return None;
+    }
+    let parsed: Value = serde_json::from_str(first).ok()?;
+    if parsed.get("type")?.as_str()? != "session_meta" {
+        return None;
+    }
+    let payload = parsed.get("payload")?;
+    session_meta_payload_id(payload)
+}
+
+pub fn parse_codex_session(
+    file_path: impl AsRef<Path>,
+    options: &ParseCodexOptions,
+) -> std::io::Result<ParseCodexResult> {
+    let inc_opts = ParseCodexIncrementalOptions {
+        session_path: options.session_path.clone(),
+        content_mode: options.content_mode,
+        tokenizer: options.tokenizer,
+        start_offset: Some(0),
+        resume: None,
+    };
+    let r = parse_codex_session_incremental(file_path, &inc_opts)?;
+    Ok(ParseCodexResult {
+        turns: r.turns,
+        content: r.content,
+        events: r.events,
+        user_turns: r.user_turns,
+        relationships: r.relationships,
+        tool_result_events: r.tool_result_events,
+    })
+}
+
+pub fn parse_codex_session_incremental(
+    file_path: impl AsRef<Path>,
+    options: &ParseCodexIncrementalOptions,
+) -> std::io::Result<ParseCodexIncrementalResult> {
+    let start_offset = options.start_offset.unwrap_or(0);
+    let mut file = File::open(file_path.as_ref())?;
+    let size = file.metadata()?.len();
+    if start_offset >= size {
+        return Ok(ParseCodexIncrementalResult {
+            turns: vec![],
+            content: vec![],
+            events: vec![],
+            user_turns: vec![],
+            relationships: vec![],
+            tool_result_events: vec![],
+            end_offset: start_offset,
+            resume: clone_resume(options.resume.as_ref()),
+        });
+    }
+    let mut buf = vec![0u8; (size - start_offset) as usize];
+    file.seek(SeekFrom::Start(start_offset))?;
+    file.read_exact(&mut buf)?;
+
+    let project_resolver = ProjectResolver::new();
+    Ok(parse_codex_buffer(
+        &buf,
+        start_offset,
+        options,
+        &project_resolver,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Internal parser state
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default)]
+struct UserTurnSlot {
+    blocks: Vec<UserTurnBlock>,
+    preceding_message_id: Option<String>,
+    ts: String,
+}
+
+impl UserTurnSlot {
+    fn from_persisted(p: &PersistedUserTurnSlot) -> Self {
+        Self {
+            blocks: p.blocks.clone(),
+            preceding_message_id: p.preceding_message_id.clone(),
+            ts: p.ts.clone(),
+        }
+    }
+    fn to_persisted(&self) -> PersistedUserTurnSlot {
+        PersistedUserTurnSlot {
+            blocks: self.blocks.clone(),
+            preceding_message_id: self.preceding_message_id.clone(),
+            ts: self.ts.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SpawnCallInfo {
+    call_id: String,
+    ts: String,
+    subagent_type: Option<String>,
+    description: Option<String>,
+    spawned_agent_id: Option<String>,
+    emitted: bool,
+}
+
+#[derive(Debug, Clone)]
+struct OpenTurn {
+    turn_id: String,
+    ts: String,
+    model: String,
+    project: Option<String>,
+    start_cumulative: CumulativeUsage,
+    tool_calls: Vec<ToolCall>,
+    seen_call_ids: BTreeSet<String>,
+    files_touched: BTreeSet<String>,
+    user_text: String,
+    assistant_text: String,
+    errored_call_ids: BTreeSet<String>,
+    content: Vec<ContentRecord>,
+    pending_tool_result_events: Vec<ToolResultEventRecord>,
+    pending_relationships: Vec<SessionRelationshipRecord>,
+    spawn_calls: HashMap<String, SpawnCallInfo>,
+    usage_observed: bool,
+}
+
+struct FinalizedTurn {
+    turn_id: String,
+    ts: String,
+    model: String,
+    project: Option<String>,
+    tool_calls: Vec<ToolCall>,
+    files_touched: Vec<String>,
+    user_text: String,
+    assistant_text: String,
+    errored_call_ids: BTreeSet<String>,
+    content: Vec<ContentRecord>,
+    usage: Usage,
+    fidelity: Fidelity,
+}
+
+fn finalize_turn(open: OpenTurn, cumulative: &CumulativeUsage) -> FinalizedTurn {
+    let usage = Usage {
+        input: (cumulative.input - open.start_cumulative.input).max(0) as u64,
+        output: (cumulative.output - open.start_cumulative.output).max(0) as u64,
+        reasoning: (cumulative.reasoning - open.start_cumulative.reasoning).max(0) as u64,
+        cache_read: (cumulative.cache_read - open.start_cumulative.cache_read).max(0) as u64,
+        cache_create_5m: 0,
+        cache_create_1h: 0,
+    };
+    let mut files: Vec<String> = open.files_touched.into_iter().collect();
+    files.sort();
+    FinalizedTurn {
+        turn_id: open.turn_id,
+        ts: open.ts,
+        model: open.model,
+        project: open.project,
+        tool_calls: open.tool_calls,
+        files_touched: files,
+        user_text: open.user_text,
+        assistant_text: open.assistant_text,
+        errored_call_ids: open.errored_call_ids,
+        content: open.content,
+        usage,
+        fidelity: build_codex_fidelity(open.usage_observed),
+    }
+}
+
+fn build_codex_fidelity(usage_observed: bool) -> Fidelity {
+    let coverage = Coverage {
+        has_input_tokens: usage_observed,
+        has_output_tokens: usage_observed,
+        has_reasoning_tokens: usage_observed,
+        has_cache_read_tokens: usage_observed,
+        has_cache_create_tokens: false,
+        has_tool_calls: true,
+        has_tool_result_events: true,
+        has_session_relationships: true,
+        has_raw_content: true,
+    };
+    let class = classify_fidelity(UsageGranularity::PerTurn, &coverage);
+    Fidelity {
+        granularity: UsageGranularity::PerTurn,
+        coverage,
+        class,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core parser loop
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Pending<T> {
+    offset: u64,
+    record: T,
+}
+
+fn parse_codex_buffer(
+    buf: &[u8],
+    start_offset: u64,
+    options: &ParseCodexIncrementalOptions,
+    project_resolver: &ProjectResolver,
+) -> ParseCodexIncrementalResult {
+    let capture_content = matches!(options.content_mode, Some(ContentStoreMode::Full));
+    let counter = HeuristicCounter; // see TODO above re: cl100k
+
+    let resume = options.resume.as_ref();
+    let mut session_id = resume.map(|r| r.session_id.clone()).unwrap_or_default();
+    let mut session_cwd: Option<String> = resume.and_then(|r| r.session_cwd.clone());
+    let mut turn_contexts: HashMap<String, CodexTurnContext> =
+        resume.map(|r| r.turn_contexts.clone()).unwrap_or_default();
+    let mut cumulative = resume.map(|r| r.cumulative.clone()).unwrap_or_default();
+
+    let mut open_turn: Option<OpenTurn> = None;
+    let mut pending_user_text = String::new();
+    let mut pending_content: Vec<ContentRecord> = Vec::new();
+    let mut finalized: Vec<FinalizedTurn> = Vec::new();
+
+    let mut user_turn_slot: UserTurnSlot = resume
+        .and_then(|r| r.user_turn_slot.as_ref())
+        .map(UserTurnSlot::from_persisted)
+        .unwrap_or_default();
+    let mut user_turns: Vec<UserTurnRecord> = Vec::new();
+
+    let mut root_session_emitted = resume.map(|r| r.root_session_emitted).unwrap_or(false);
+    let mut seen_session_meta_keys: BTreeSet<String> = resume
+        .map(|r| r.session_meta_relationship_keys.iter().cloned().collect())
+        .unwrap_or_default();
+    let mut next_event_index = resume.map(|r| r.next_event_index).unwrap_or(0);
+    let mut tool_result_counters: HashMap<String, u64> = resume
+        .map(|r| r.tool_result_counters.clone())
+        .unwrap_or_default();
+    let mut last_completed_turn: Option<CodexLastCompletedTurn> =
+        resume.and_then(|r| r.last_completed_turn.clone());
+
+    let mut pending_tool_result_events: Vec<Pending<ToolResultEventRecord>> = Vec::new();
+    let mut pending_relationships: Vec<Pending<SessionRelationshipRecord>> = Vec::new();
+    let mut pending_compactions: Vec<Pending<CompactionEvent>> = Vec::new();
+
+    let mut committed_end_offset = start_offset;
+    let mut committed_cumulative = cumulative.clone();
+    let mut committed_session_id = session_id.clone();
+    let mut committed_session_cwd = session_cwd.clone();
+    let mut committed_turn_contexts = turn_contexts.clone();
+    let mut committed_finalized_count: usize = 0;
+    let mut committed_user_turns_count: usize = 0;
+    let mut committed_user_turn_slot = user_turn_slot.clone();
+    let mut committed_root_session_emitted = root_session_emitted;
+    let mut committed_seen_session_meta_keys = seen_session_meta_keys.clone();
+    let mut committed_next_event_index = next_event_index;
+    let mut committed_tool_result_counters = tool_result_counters.clone();
+    let mut committed_last_completed_turn = last_completed_turn.clone();
+
+    let mut p: usize = 0;
+    while p < buf.len() {
+        let nl_idx = match memchr_newline(&buf[p..]) {
+            Some(idx) => p + idx,
+            None => break,
+        };
+        let line_end_offset = start_offset + (nl_idx as u64) + 1;
+        let raw = &buf[p..nl_idx];
+        p = nl_idx + 1;
+        let text = std::str::from_utf8(raw).unwrap_or("").trim();
+        if text.is_empty() {
+            continue;
+        }
+        let parsed: Value = match serde_json::from_str(text) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if !parsed.is_object() {
+            continue;
+        }
+        let rec_type = parsed.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let rec_timestamp = parsed
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let payload = match parsed.get("payload") {
+            Some(p) if p.is_object() => p,
+            _ => continue,
+        };
+
+        match rec_type {
+            "session_meta" => {
+                if let Some(id) = session_meta_payload_id(payload) {
+                    session_id = id;
+                }
+                if let Some(cwd) = payload.get("cwd").and_then(|v| v.as_str()) {
+                    session_cwd = Some(cwd.to_string());
+                    if let Some(open) = open_turn.as_mut() {
+                        if open.project.is_none() {
+                            open.project = Some(cwd.to_string());
+                        }
+                    }
+                }
+                if !session_id.is_empty() && !root_session_emitted {
+                    root_session_emitted = true;
+                    let ts = payload
+                        .get("timestamp")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(rec_timestamp);
+                    pending_relationships.push(Pending {
+                        offset: line_end_offset,
+                        record: build_root_relationship(&session_id, ts, payload),
+                    });
+                }
+                if !session_id.is_empty() {
+                    for row in build_session_meta_relationships(&session_id, payload, rec_timestamp)
+                    {
+                        let key = codex_relationship_key(&row);
+                        if seen_session_meta_keys.contains(&key) {
+                            continue;
+                        }
+                        seen_session_meta_keys.insert(key);
+                        pending_relationships.push(Pending {
+                            offset: line_end_offset,
+                            record: row,
+                        });
+                    }
+                }
+                continue;
+            }
+            "turn_context" => {
+                let ctx = CodexTurnContext {
+                    turn_id: payload
+                        .get("turn_id")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    cwd: payload
+                        .get("cwd")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    model: payload
+                        .get("model")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                };
+                if let Some(tid) = ctx.turn_id.clone() {
+                    turn_contexts.insert(tid.clone(), ctx.clone());
+                    if let Some(open) = open_turn.as_mut() {
+                        if open.turn_id == tid {
+                            if open.model.is_empty() {
+                                if let Some(m) = ctx.model.as_deref() {
+                                    open.model = m.to_string();
+                                }
+                            }
+                            if open.project.is_none() {
+                                if let Some(c) = ctx.cwd.as_deref() {
+                                    open.project = Some(c.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+                continue;
+            }
+            "compacted" => {
+                if !session_id.is_empty() {
+                    pending_compactions.push(Pending {
+                        offset: line_end_offset,
+                        record: build_codex_compaction_event(
+                            &session_id,
+                            rec_timestamp,
+                            last_completed_turn.as_ref(),
+                        ),
+                    });
+                }
+                continue;
+            }
+            "event_msg" => {
+                let pl_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                match pl_type {
+                    "token_count" => {
+                        if let Some(total) = payload.get("info").and_then(|i| {
+                            if i.is_null() {
+                                None
+                            } else {
+                                i.get("total_token_usage")
+                            }
+                        }) {
+                            let input_total = total
+                                .get("input_tokens")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(0);
+                            let cached = total
+                                .get("cached_input_tokens")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(0);
+                            cumulative.input = input_total - cached;
+                            cumulative.cache_read = cached;
+                            cumulative.output = total
+                                .get("output_tokens")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(0);
+                            cumulative.reasoning = total
+                                .get("reasoning_output_tokens")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(0);
+                            if let Some(open) = open_turn.as_mut() {
+                                open.usage_observed = true;
+                            }
+                        }
+                    }
+                    "task_started" => {
+                        let ts = rec_timestamp;
+                        let turn_id = match payload.get("turn_id").and_then(|v| v.as_str()) {
+                            Some(t) => t.to_string(),
+                            None => continue,
+                        };
+                        if let Some(open) = open_turn.take() {
+                            finalized.push(finalize_turn(open, &cumulative));
+                        }
+                        if !user_turn_slot.blocks.is_empty() {
+                            user_turns.push(build_codex_user_turn_record(
+                                &user_turn_slot,
+                                &session_id,
+                                &turn_id,
+                                ts,
+                            ));
+                        }
+                        user_turn_slot = UserTurnSlot::default();
+                        let ctx = turn_contexts.get(&turn_id).cloned();
+                        let project = ctx
+                            .as_ref()
+                            .and_then(|c| c.cwd.clone())
+                            .or_else(|| session_cwd.clone());
+                        let mut open = OpenTurn {
+                            turn_id: turn_id.clone(),
+                            ts: ts.to_string(),
+                            model: ctx
+                                .as_ref()
+                                .and_then(|c| c.model.clone())
+                                .unwrap_or_default(),
+                            project,
+                            start_cumulative: cumulative.clone(),
+                            tool_calls: vec![],
+                            seen_call_ids: BTreeSet::new(),
+                            files_touched: BTreeSet::new(),
+                            user_text: std::mem::take(&mut pending_user_text),
+                            assistant_text: String::new(),
+                            errored_call_ids: BTreeSet::new(),
+                            content: vec![],
+                            pending_tool_result_events: vec![],
+                            pending_relationships: vec![],
+                            spawn_calls: HashMap::new(),
+                            usage_observed: false,
+                        };
+                        if capture_content && !pending_content.is_empty() {
+                            for c in pending_content.iter_mut() {
+                                c.message_id = turn_id.clone();
+                            }
+                            open.content.append(&mut pending_content);
+                        }
+                        open_turn = Some(open);
+                    }
+                    "task_complete" => {
+                        let payload_turn_id = payload
+                            .get("turn_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        let mut took: Option<OpenTurn> = None;
+                        if let Some(open) = open_turn.as_ref() {
+                            if open.turn_id == payload_turn_id {
+                                took = open_turn.take();
+                            }
+                        }
+                        if let Some(mut open) = took {
+                            // Patch isError on tool-result blocks accumulated this turn
+                            for b in user_turn_slot.blocks.iter_mut() {
+                                if matches!(b.kind, UserTurnBlockKind::ToolResult) {
+                                    if let Some(id) = &b.tool_use_id {
+                                        if open.errored_call_ids.contains(id) {
+                                            b.is_error = Some(true);
+                                        }
+                                    }
+                                }
+                            }
+                            // Drain pending tool result events / relationships
+                            let mut events = std::mem::take(&mut open.pending_tool_result_events);
+                            for ev in events.iter_mut() {
+                                if open.errored_call_ids.contains(&ev.tool_use_id) {
+                                    ev.status = ToolResultStatus::Errored;
+                                    ev.is_error = Some(true);
+                                } else if matches!(ev.status, ToolResultStatus::Unknown) {
+                                    ev.status = ToolResultStatus::Completed;
+                                }
+                            }
+                            for ev in events {
+                                pending_tool_result_events.push(Pending {
+                                    offset: line_end_offset,
+                                    record: ev,
+                                });
+                            }
+                            let rels = std::mem::take(&mut open.pending_relationships);
+                            for r in rels {
+                                pending_relationships.push(Pending {
+                                    offset: line_end_offset,
+                                    record: r,
+                                });
+                            }
+                            user_turn_slot.preceding_message_id = Some(open.turn_id.clone());
+                            let closed = finalize_turn(open, &cumulative);
+                            last_completed_turn = Some(CodexLastCompletedTurn {
+                                message_id: closed.turn_id.clone(),
+                                cache_read: closed.usage.cache_read,
+                            });
+                            finalized.push(closed);
+                            // Commit snapshot
+                            committed_end_offset = line_end_offset;
+                            committed_cumulative = cumulative.clone();
+                            committed_session_id = session_id.clone();
+                            committed_session_cwd = session_cwd.clone();
+                            committed_turn_contexts = turn_contexts.clone();
+                            committed_finalized_count = finalized.len();
+                            committed_user_turns_count = user_turns.len();
+                            committed_user_turn_slot = user_turn_slot.clone();
+                            committed_root_session_emitted = root_session_emitted;
+                            committed_seen_session_meta_keys = seen_session_meta_keys.clone();
+                            committed_next_event_index = next_event_index;
+                            committed_tool_result_counters = tool_result_counters.clone();
+                            committed_last_completed_turn = last_completed_turn.clone();
+                        }
+                    }
+                    "patch_apply_end" => {
+                        if let Some(open) = open_turn.as_mut() {
+                            let turn_id = payload.get("turn_id").and_then(|v| v.as_str());
+                            if turn_id != Some(open.turn_id.as_str()) {
+                                continue;
+                            }
+                            let success = payload.get("success").and_then(|v| v.as_bool());
+                            if success == Some(false) {
+                                if let Some(call_id) =
+                                    payload.get("call_id").and_then(|v| v.as_str())
+                                {
+                                    open.errored_call_ids.insert(call_id.to_string());
+                                }
+                                continue;
+                            }
+                            if let Some(changes) =
+                                payload.get("changes").and_then(|v| v.as_object())
+                            {
+                                for file in changes.keys() {
+                                    open.files_touched.insert(file.clone());
+                                }
+                            }
+                        }
+                    }
+                    "exec_command_end" => {
+                        if let Some(open) = open_turn.as_mut() {
+                            let turn_id = payload.get("turn_id").and_then(|v| v.as_str());
+                            if turn_id != Some(open.turn_id.as_str()) {
+                                continue;
+                            }
+                            let exit_code = payload.get("exit_code").and_then(|v| v.as_i64());
+                            if let (Some(code), Some(call_id)) =
+                                (exit_code, payload.get("call_id").and_then(|v| v.as_str()))
+                            {
+                                if code != 0 {
+                                    open.errored_call_ids.insert(call_id.to_string());
+                                }
+                            }
+                        }
+                    }
+                    other if is_subagent_terminal_notification(other) => {
+                        let call_id = match payload.get("call_id").and_then(|v| v.as_str()) {
+                            Some(c) if !c.is_empty() => c.to_string(),
+                            _ => continue,
+                        };
+                        let call_index = *tool_result_counters.get(&call_id).unwrap_or(&0);
+                        tool_result_counters.insert(call_id.clone(), call_index + 1);
+                        let status = subagent_notification_status(payload);
+                        let mut ev = ToolResultEventRecord {
+                            v: 1,
+                            source: SourceKind::Codex,
+                            session_id: session_id.clone(),
+                            message_id: open_turn.as_ref().map(|o| o.turn_id.clone()),
+                            tool_use_id: call_id.clone(),
+                            call_index: Some(call_index),
+                            event_index: next_event_index,
+                            ts: if rec_timestamp.is_empty() {
+                                None
+                            } else {
+                                Some(rec_timestamp.to_string())
+                            },
+                            status,
+                            event_source: ToolResultEventSource::SubagentNotification,
+                            content_length: None,
+                            content_hash: None,
+                            is_error: matches!(status, ToolResultStatus::Errored).then_some(true),
+                            usage: None,
+                            usage_attribution: None,
+                            subagent_session_id: None,
+                            agent_id: None,
+                            replaced_tools: None,
+                            collapsed_calls: None,
+                        };
+                        next_event_index += 1;
+                        let spawned_id =
+                            pick_string_field(payload, &["agent_id", "subagent_id", "session_id"]);
+                        if let Some(sid) = spawned_id.as_ref() {
+                            ev.agent_id = Some(sid.clone());
+                            ev.subagent_session_id = Some(sid.clone());
+                            if let Some(open) = open_turn.as_mut() {
+                                if let Some(spawn) = open.spawn_calls.get_mut(&call_id) {
+                                    if spawn.spawned_agent_id.is_none() {
+                                        spawn.spawned_agent_id = Some(sid.clone());
+                                        let info = spawn.clone();
+                                        maybe_emit_spawn_relationship(
+                                            open,
+                                            &session_id,
+                                            &info,
+                                            rec_timestamp,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        if let Some(open) = open_turn.as_mut() {
+                            open.pending_tool_result_events.push(ev);
+                        } else {
+                            pending_tool_result_events.push(Pending {
+                                offset: line_end_offset,
+                                record: ev,
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+            "response_item" => {
+                let item_ts = rec_timestamp;
+                let pl_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                match pl_type {
+                    "message" => {
+                        let role = payload
+                            .get("role")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let text = collect_message_text(payload, &role);
+                        if text.is_empty() {
+                            continue;
+                        }
+                        if role == "user" {
+                            if let Some(open) = open_turn.as_mut() {
+                                open.user_text = append_text(&open.user_text, &text);
+                            } else {
+                                pending_user_text = append_text(&pending_user_text, &text);
+                            }
+                            user_turn_slot
+                                .blocks
+                                .push(UserTurnBlock::text(&text, &counter));
+                            if user_turn_slot.ts.is_empty() && !item_ts.is_empty() {
+                                user_turn_slot.ts = item_ts.to_string();
+                            }
+                            if capture_content {
+                                let rec = ContentRecord {
+                                    v: 1,
+                                    source: SourceKind::Codex,
+                                    session_id: session_id.clone(),
+                                    message_id: open_turn
+                                        .as_ref()
+                                        .map(|o| o.turn_id.clone())
+                                        .unwrap_or_default(),
+                                    ts: item_ts.to_string(),
+                                    role: ContentRole::User,
+                                    kind: ContentKind::Text,
+                                    text: Some(text.clone()),
+                                    tool_use: None,
+                                    tool_result: None,
+                                };
+                                push_content(&mut open_turn, &mut pending_content, rec);
+                            }
+                        } else if role == "assistant" {
+                            if let Some(open) = open_turn.as_mut() {
+                                open.assistant_text = append_text(&open.assistant_text, &text);
+                                if capture_content {
+                                    open.content.push(ContentRecord {
+                                        v: 1,
+                                        source: SourceKind::Codex,
+                                        session_id: session_id.clone(),
+                                        message_id: open.turn_id.clone(),
+                                        ts: item_ts.to_string(),
+                                        role: ContentRole::Assistant,
+                                        kind: ContentKind::Text,
+                                        text: Some(text),
+                                        tool_use: None,
+                                        tool_result: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    "reasoning" => {
+                        if !capture_content {
+                            continue;
+                        }
+                        let Some(open) = open_turn.as_mut() else {
+                            continue;
+                        };
+                        let text = collect_reasoning_text(payload);
+                        if !text.is_empty() {
+                            open.content.push(ContentRecord {
+                                v: 1,
+                                source: SourceKind::Codex,
+                                session_id: session_id.clone(),
+                                message_id: open.turn_id.clone(),
+                                ts: item_ts.to_string(),
+                                role: ContentRole::Assistant,
+                                kind: ContentKind::Thinking,
+                                text: Some(text),
+                                tool_use: None,
+                                tool_result: None,
+                            });
+                        }
+                    }
+                    "function_call_output" | "custom_tool_call_output" => {
+                        let call_id = match payload.get("call_id").and_then(|v| v.as_str()) {
+                            Some(c) => c.to_string(),
+                            None => continue,
+                        };
+                        let output = payload.get("output").cloned().unwrap_or(Value::Null);
+                        user_turn_slot.blocks.push(UserTurnBlock::tool_result(
+                            call_id.clone(),
+                            &output,
+                            None,
+                            &counter,
+                        ));
+                        if user_turn_slot.ts.is_empty() && !item_ts.is_empty() {
+                            user_turn_slot.ts = item_ts.to_string();
+                        }
+                        let call_index = *tool_result_counters.get(&call_id).unwrap_or(&0);
+                        tool_result_counters.insert(call_id.clone(), call_index + 1);
+                        let initial_status = if open_turn
+                            .as_ref()
+                            .map(|o| o.errored_call_ids.contains(&call_id))
+                            .unwrap_or(false)
+                        {
+                            ToolResultStatus::Errored
+                        } else {
+                            ToolResultStatus::Unknown
+                        };
+                        let measured = measure_tool_output(&output);
+                        let mut ev = ToolResultEventRecord {
+                            v: 1,
+                            source: SourceKind::Codex,
+                            session_id: session_id.clone(),
+                            message_id: open_turn.as_ref().map(|o| o.turn_id.clone()),
+                            tool_use_id: call_id.clone(),
+                            call_index: Some(call_index),
+                            event_index: next_event_index,
+                            ts: if item_ts.is_empty() {
+                                None
+                            } else {
+                                Some(item_ts.to_string())
+                            },
+                            status: initial_status,
+                            event_source: ToolResultEventSource::FunctionCallOutput,
+                            content_length: measured.length,
+                            content_hash: measured.hash,
+                            is_error: matches!(initial_status, ToolResultStatus::Errored)
+                                .then_some(true),
+                            usage: None,
+                            usage_attribution: None,
+                            subagent_session_id: None,
+                            agent_id: None,
+                            replaced_tools: None,
+                            collapsed_calls: None,
+                        };
+                        next_event_index += 1;
+                        if let Some(open) = open_turn.as_mut() {
+                            if let Some(spawn) = open.spawn_calls.get_mut(&call_id) {
+                                if let Some(sid) = extract_spawned_agent_id(&output) {
+                                    spawn.spawned_agent_id = Some(sid.clone());
+                                    ev.agent_id = Some(sid.clone());
+                                    ev.subagent_session_id = Some(sid);
+                                }
+                                let info = spawn.clone();
+                                maybe_emit_spawn_relationship(open, &session_id, &info, item_ts);
+                            }
+                            open.pending_tool_result_events.push(ev);
+                        } else {
+                            pending_tool_result_events.push(Pending {
+                                offset: line_end_offset,
+                                record: ev,
+                            });
+                        }
+                        if capture_content {
+                            let rec = ContentRecord {
+                                v: 1,
+                                source: SourceKind::Codex,
+                                session_id: session_id.clone(),
+                                message_id: open_turn
+                                    .as_ref()
+                                    .map(|o| o.turn_id.clone())
+                                    .unwrap_or_default(),
+                                ts: item_ts.to_string(),
+                                role: ContentRole::ToolResult,
+                                kind: ContentKind::ToolResult,
+                                text: None,
+                                tool_use: None,
+                                tool_result: Some(ContentToolResult {
+                                    tool_use_id: call_id,
+                                    content: output,
+                                    is_error: None,
+                                }),
+                            };
+                            push_content(&mut open_turn, &mut pending_content, rec);
+                        }
+                    }
+                    "function_call" => {
+                        let Some(open) = open_turn.as_mut() else {
+                            continue;
+                        };
+                        let name = match payload.get("name").and_then(|v| v.as_str()) {
+                            Some(n) => n.to_string(),
+                            None => continue,
+                        };
+                        let call_id = match payload.get("call_id").and_then(|v| v.as_str()) {
+                            Some(c) => c.to_string(),
+                            None => continue,
+                        };
+                        if open.seen_call_ids.contains(&call_id) {
+                            continue;
+                        }
+                        open.seen_call_ids.insert(call_id.clone());
+                        let arg_str = payload.get("arguments").and_then(|v| v.as_str());
+                        let parsed_args = arg_str.and_then(safe_parse_json_object);
+                        let hash_input = parsed_args
+                            .clone()
+                            .map(Value::Object)
+                            .unwrap_or_else(|| Value::Object(Default::default()));
+                        let target = pick_function_call_target(&name, parsed_args.as_ref());
+                        let call = ToolCall {
+                            id: call_id.clone(),
+                            name: name.clone(),
+                            target,
+                            args_hash: args_hash(&hash_input),
+                            is_error: None,
+                            edit_pre_hash: None,
+                            edit_post_hash: None,
+                            skill_name: None,
+                            replaced_tools: None,
+                            collapsed_calls: None,
+                        };
+                        open.tool_calls.push(call);
+                        if name == "spawn_agent" {
+                            let mut info = SpawnCallInfo {
+                                call_id: call_id.clone(),
+                                ts: item_ts.to_string(),
+                                subagent_type: None,
+                                description: None,
+                                spawned_agent_id: None,
+                                emitted: false,
+                            };
+                            if let Some(args) = parsed_args.as_ref() {
+                                let v = Value::Object(args.clone());
+                                info.subagent_type =
+                                    pick_string_field(&v, &["subagent_type", "agent_type", "type"]);
+                                info.description =
+                                    pick_string_field(&v, &["description", "task", "prompt"]);
+                                info.spawned_agent_id = pick_string_field(
+                                    &v,
+                                    &["agent_id", "subagent_id", "session_id"],
+                                );
+                            }
+                            open.spawn_calls.insert(call_id.clone(), info.clone());
+                            maybe_emit_spawn_relationship(open, &session_id, &info, item_ts);
+                        }
+                        if capture_content {
+                            let input = parsed_args
+                                .map(|m| m.into_iter().collect())
+                                .unwrap_or_default();
+                            open.content.push(ContentRecord {
+                                v: 1,
+                                source: SourceKind::Codex,
+                                session_id: session_id.clone(),
+                                message_id: open.turn_id.clone(),
+                                ts: item_ts.to_string(),
+                                role: ContentRole::Assistant,
+                                kind: ContentKind::ToolUse,
+                                text: None,
+                                tool_use: Some(ContentToolUse {
+                                    id: call_id,
+                                    name,
+                                    input,
+                                }),
+                                tool_result: None,
+                            });
+                        }
+                    }
+                    "custom_tool_call" => {
+                        let Some(open) = open_turn.as_mut() else {
+                            continue;
+                        };
+                        let name = match payload.get("name").and_then(|v| v.as_str()) {
+                            Some(n) => n.to_string(),
+                            None => continue,
+                        };
+                        let call_id = match payload.get("call_id").and_then(|v| v.as_str()) {
+                            Some(c) => c.to_string(),
+                            None => continue,
+                        };
+                        if open.seen_call_ids.contains(&call_id) {
+                            continue;
+                        }
+                        open.seen_call_ids.insert(call_id.clone());
+                        let input = payload
+                            .get("input")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let hash_input = serde_json::json!({ "input": input });
+                        let target = pick_custom_tool_target(&name, &input);
+                        let call = ToolCall {
+                            id: call_id.clone(),
+                            name: name.clone(),
+                            target,
+                            args_hash: args_hash(&hash_input),
+                            is_error: None,
+                            edit_pre_hash: None,
+                            edit_post_hash: None,
+                            skill_name: None,
+                            replaced_tools: None,
+                            collapsed_calls: None,
+                        };
+                        open.tool_calls.push(call);
+                        if capture_content {
+                            let mut input_map = BTreeMap::new();
+                            input_map.insert("input".to_string(), Value::String(input));
+                            open.content.push(ContentRecord {
+                                v: 1,
+                                source: SourceKind::Codex,
+                                session_id: session_id.clone(),
+                                message_id: open.turn_id.clone(),
+                                ts: item_ts.to_string(),
+                                role: ContentRole::Assistant,
+                                kind: ContentKind::ToolUse,
+                                text: None,
+                                tool_use: Some(ContentToolUse {
+                                    id: call_id,
+                                    name,
+                                    input: input_map,
+                                }),
+                                tool_result: None,
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+            _ => continue,
+        }
+    }
+
+    // Suppress unused warnings: these are kept for parity with the TS state
+    // machine even when their values aren't read after the loop.
+    let _ = (next_event_index, tool_result_counters);
+
+    // Emit only committed turns.
+    let committed = &finalized[..committed_finalized_count];
+    let mut turns: Vec<TurnRecord> = Vec::with_capacity(committed.len());
+    let mut content_out: Vec<ContentRecord> = Vec::new();
+    for (i, f) in committed.iter().enumerate() {
+        let mut record = TurnRecord {
+            v: 1,
+            source: SourceKind::Codex,
+            session_id: committed_session_id.clone(),
+            session_path: options.session_path.clone(),
+            message_id: f.turn_id.clone(),
+            turn_index: i as u64,
+            ts: f.ts.clone(),
+            model: f.model.clone(),
+            project: None,
+            project_key: None,
+            usage: f.usage.clone(),
+            tool_calls: f.tool_calls.clone(),
+            files_touched: if f.files_touched.is_empty() {
+                None
+            } else {
+                Some(f.files_touched.clone())
+            },
+            subagent: None,
+            stop_reason: None,
+            activity: None,
+            retries: None,
+            has_edits: None,
+            fidelity: Some(f.fidelity.clone()),
+        };
+        if let Some(p) = f.project.as_ref() {
+            let resolved = project_resolver.resolve(p);
+            record.project = Some(resolved.project);
+            record.project_key = resolved.project_key;
+        }
+        let combined_text = join_nonempty(&[f.user_text.as_str(), f.assistant_text.as_str()], "\n");
+        let has_failed_tool = f
+            .tool_calls
+            .iter()
+            .any(|tc| f.errored_call_ids.contains(&tc.id));
+        let classified = classify_activity(ClassificationInput {
+            tool_calls: &f.tool_calls,
+            text: &combined_text,
+            has_failed_tool,
+            reasoning_tokens: f.usage.reasoning,
+        });
+        record.activity = Some(classified.activity);
+        record.retries = Some(classified.retries);
+        record.has_edits = Some(classified.has_edits);
+        turns.push(record);
+        if capture_content {
+            content_out.extend(f.content.clone());
+        }
+    }
+
+    let resume = CodexResumeState {
+        cumulative: committed_cumulative.clone(),
+        session_id: committed_session_id.clone(),
+        session_cwd: committed_session_cwd.clone(),
+        turn_contexts: committed_turn_contexts.clone(),
+        user_turn_slot: Some(committed_user_turn_slot.to_persisted()),
+        root_session_emitted: committed_root_session_emitted,
+        session_meta_relationship_keys: committed_seen_session_meta_keys.iter().cloned().collect(),
+        next_event_index: committed_next_event_index,
+        tool_result_counters: committed_tool_result_counters.clone(),
+        last_completed_turn: committed_last_completed_turn.clone(),
+    };
+
+    let user_turns_out = user_turns[..committed_user_turns_count].to_vec();
+    let mut events_out: Vec<CompactionEvent> = Vec::new();
+    for e in pending_compactions {
+        if e.offset <= committed_end_offset {
+            events_out.push(e.record);
+        }
+    }
+    let mut relationships_out: Vec<SessionRelationshipRecord> = Vec::new();
+    for r in pending_relationships {
+        if r.offset <= committed_end_offset {
+            relationships_out.push(r.record);
+        }
+    }
+    let mut tool_events_out: Vec<ToolResultEventRecord> = Vec::new();
+    for ev in pending_tool_result_events {
+        if ev.offset <= committed_end_offset {
+            tool_events_out.push(ev.record);
+        }
+    }
+
+    // Silence unused-mutable warnings for snapshot mirrors that are written
+    // but only read indirectly.
+    let _ = (
+        cumulative,
+        session_id,
+        session_cwd,
+        turn_contexts,
+        seen_session_meta_keys,
+        root_session_emitted,
+        last_completed_turn,
+    );
+
+    ParseCodexIncrementalResult {
+        turns,
+        content: content_out,
+        events: events_out,
+        user_turns: user_turns_out,
+        relationships: relationships_out,
+        tool_result_events: tool_events_out,
+        end_offset: committed_end_offset,
+        resume,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn memchr_newline(buf: &[u8]) -> Option<usize> {
+    buf.iter().position(|&b| b == b'\n')
+}
+
+fn session_meta_payload_id(payload: &Value) -> Option<String> {
+    let id = payload.get("id")?.as_str()?;
+    if id.is_empty() {
+        None
+    } else {
+        Some(id.to_string())
+    }
+}
+
+fn collect_message_text(payload: &Value, role: &str) -> String {
+    let Some(content) = payload.get("content").and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for block in content {
+        let Some(text) = block.get("text").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if text.is_empty() {
+            continue;
+        }
+        if role == "user" && is_codex_boilerplate(text) {
+            continue;
+        }
+        parts.push(text.to_string());
+    }
+    parts.join("\n")
+}
+
+fn is_codex_boilerplate(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    let lower_first16: String = trimmed.chars().take(32).collect::<String>().to_lowercase();
+    if lower_first16.starts_with("<environment_context")
+        || lower_first16.starts_with("<permissions")
+        || lower_first16.starts_with("<collaboration_mode")
+    {
+        return true;
+    }
+    if trimmed.starts_with("<INSTRUCTIONS>") {
+        return true;
+    }
+    // `^\s*#\s*AGENTS\.md`/i — case-insensitive.
+    let after_hash = trimmed.strip_prefix('#').map(str::trim_start);
+    if let Some(rest) = after_hash {
+        let rest_lower: String = rest.chars().take(16).collect::<String>().to_lowercase();
+        if rest_lower.starts_with("agents.md") {
+            return true;
+        }
+    }
+    false
+}
+
+fn collect_reasoning_text(payload: &Value) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(arr) = payload.get("summary").and_then(|v| v.as_array()) {
+        for s in arr {
+            if let Some(text) = s.get("text").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    parts.push(text.to_string());
+                }
+            }
+        }
+    }
+    if let Some(arr) = payload.get("content").and_then(|v| v.as_array()) {
+        for c in arr {
+            if let Some(text) = c.get("text").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    parts.push(text.to_string());
+                }
+            }
+        }
+    }
+    parts.join("\n")
+}
+
+fn append_text(existing: &str, next: &str) -> String {
+    if existing.is_empty() {
+        next.to_string()
+    } else {
+        format!("{}\n{}", existing, next)
+    }
+}
+
+fn join_nonempty(parts: &[&str], sep: &str) -> String {
+    let mut out: Vec<&str> = Vec::with_capacity(parts.len());
+    for p in parts {
+        if !p.is_empty() {
+            out.push(p);
+        }
+    }
+    out.join(sep)
+}
+
+fn safe_parse_json_object(s: &str) -> Option<serde_json::Map<String, Value>> {
+    if s.is_empty() {
+        return None;
+    }
+    let v: Value = serde_json::from_str(s).ok()?;
+    match v {
+        Value::Object(m) => Some(m),
+        _ => None,
+    }
+}
+
+fn pick_function_call_target(
+    name: &str,
+    args: Option<&serde_json::Map<String, Value>>,
+) -> Option<String> {
+    let args = args?;
+    let s =
+        |k: &str| -> Option<String> { args.get(k).and_then(|v| v.as_str()).map(|x| x.to_string()) };
+    match name {
+        "exec_command" | "shell" => s("cmd").or_else(|| s("command")),
+        "read_file" => s("path").or_else(|| s("file_path")),
+        "write_file" => s("path").or_else(|| s("file_path")),
+        _ => s("path")
+            .or_else(|| s("file_path"))
+            .or_else(|| s("cmd"))
+            .or_else(|| s("command"))
+            .or_else(|| s("url")),
+    }
+}
+
+fn pick_custom_tool_target(name: &str, input: &str) -> Option<String> {
+    if name != "apply_patch" {
+        return None;
+    }
+    // Match `^***\s+(?:Update|Add|Delete)\s+File:\s+(\S.*?)\s*$` per-line.
+    for line in input.lines() {
+        let l = line.trim_start();
+        if !l.starts_with("***") {
+            continue;
+        }
+        let rest = l.trim_start_matches('*').trim_start();
+        for verb in ["Update", "Add", "Delete"] {
+            if let Some(rest) = rest.strip_prefix(verb) {
+                let rest = rest.trim_start();
+                if let Some(rest) = rest.strip_prefix("File:") {
+                    let rest = rest.trim();
+                    if !rest.is_empty() {
+                        return Some(rest.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn pick_string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    let obj = value.as_object()?;
+    for k in keys {
+        if let Some(s) = obj.get(*k).and_then(|v| v.as_str()) {
+            if !s.is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn extract_spawned_agent_id(output: &Value) -> Option<String> {
+    let obj_owner;
+    let obj = match output {
+        Value::Object(_) => output,
+        Value::String(s) => {
+            obj_owner = serde_json::from_str::<Value>(s).ok()?;
+            if !obj_owner.is_object() {
+                return None;
+            }
+            &obj_owner
+        }
+        _ => return None,
+    };
+    pick_string_field(obj, &["agent_id", "subagent_id", "session_id"])
+}
+
+#[derive(Default)]
+struct Measured {
+    length: Option<u64>,
+    hash: Option<String>,
+}
+
+fn measure_tool_output(output: &Value) -> Measured {
+    match output {
+        Value::Null => Measured::default(),
+        Value::String(s) => Measured {
+            length: Some(s.len() as u64),
+            hash: Some(content_hash(s)),
+        },
+        other => match serde_json::to_string(other) {
+            Ok(serialized) => Measured {
+                length: Some(serialized.len() as u64),
+                hash: Some(content_hash(&serialized)),
+            },
+            Err(_) => Measured::default(),
+        },
+    }
+}
+
+fn is_subagent_terminal_notification(t: &str) -> bool {
+    if !t.starts_with("subagent_") {
+        return false;
+    }
+    t.ends_with("_complete")
+        || t.ends_with("_done")
+        || t.ends_with("_finished")
+        || t.ends_with("_terminated")
+}
+
+fn subagent_notification_status(payload: &Value) -> ToolResultStatus {
+    if let Some(b) = payload.get("success").and_then(|v| v.as_bool()) {
+        return if b {
+            ToolResultStatus::Completed
+        } else {
+            ToolResultStatus::Errored
+        };
+    }
+    if let Some(s) = payload.get("status").and_then(|v| v.as_str()) {
+        let s = s.to_ascii_lowercase();
+        if s == "errored" || s == "failed" || s == "error" {
+            return ToolResultStatus::Errored;
+        }
+        if s == "cancelled" || s == "canceled" {
+            return ToolResultStatus::Cancelled;
+        }
+        if s == "completed" || s == "success" || s == "succeeded" {
+            return ToolResultStatus::Completed;
+        }
+    }
+    ToolResultStatus::Completed
+}
+
+fn build_root_relationship(session_id: &str, ts: &str, meta: &Value) -> SessionRelationshipRecord {
+    let mut row = SessionRelationshipRecord {
+        v: 1,
+        source: RelationshipSourceKind::Codex,
+        session_id: session_id.to_string(),
+        related_session_id: None,
+        relationship_type: RelationshipType::Root,
+        ts: if ts.is_empty() {
+            None
+        } else {
+            Some(ts.to_string())
+        },
+        source_session_id: None,
+        source_version: None,
+        parent_tool_use_id: None,
+        agent_id: None,
+        subagent_type: None,
+        description: None,
+    };
+    apply_codex_session_meta_provenance(&mut row, meta);
+    row
+}
+
+fn build_session_meta_relationships(
+    session_id: &str,
+    meta: &Value,
+    fallback_ts: &str,
+) -> Vec<SessionRelationshipRecord> {
+    let mut rows = Vec::new();
+    let ts = pick_string_field(meta, &["timestamp"]).unwrap_or_else(|| fallback_ts.to_string());
+    if let Some(fork_id) = pick_string_field(meta, &["forkSessionId", "fork_session_id"]) {
+        if fork_id != session_id {
+            let mut row = SessionRelationshipRecord {
+                v: 1,
+                source: RelationshipSourceKind::Codex,
+                session_id: session_id.to_string(),
+                related_session_id: Some(fork_id),
+                relationship_type: RelationshipType::Fork,
+                ts: if ts.is_empty() {
+                    None
+                } else {
+                    Some(ts.clone())
+                },
+                source_session_id: None,
+                source_version: None,
+                parent_tool_use_id: None,
+                agent_id: None,
+                subagent_type: None,
+                description: None,
+            };
+            apply_codex_session_meta_provenance(&mut row, meta);
+            rows.push(row);
+        }
+    }
+    if let Some(prev_id) = pick_string_field(
+        meta,
+        &["continuedFromSessionId", "continued_from_session_id"],
+    ) {
+        if prev_id != session_id {
+            let mut row = SessionRelationshipRecord {
+                v: 1,
+                source: RelationshipSourceKind::Codex,
+                session_id: session_id.to_string(),
+                related_session_id: Some(prev_id),
+                relationship_type: RelationshipType::Continuation,
+                ts: if ts.is_empty() {
+                    None
+                } else {
+                    Some(ts.clone())
+                },
+                source_session_id: None,
+                source_version: None,
+                parent_tool_use_id: None,
+                agent_id: None,
+                subagent_type: None,
+                description: None,
+            };
+            apply_codex_session_meta_provenance(&mut row, meta);
+            rows.push(row);
+        }
+    }
+    rows
+}
+
+fn apply_codex_session_meta_provenance(row: &mut SessionRelationshipRecord, meta: &Value) {
+    if let Some(s) = pick_string_field(meta, &["sourceSessionId", "source_session_id"]) {
+        row.source_session_id = Some(s);
+    }
+    if let Some(s) = pick_string_field(meta, &["cli_version", "version"]) {
+        row.source_version = Some(s);
+    }
+}
+
+fn codex_relationship_key(row: &SessionRelationshipRecord) -> String {
+    let source = match row.source {
+        RelationshipSourceKind::Codex => "codex",
+        RelationshipSourceKind::ClaudeCode => "claude-code",
+        RelationshipSourceKind::Opencode => "opencode",
+        RelationshipSourceKind::AnthropicApi => "anthropic-api",
+        RelationshipSourceKind::OpenaiApi => "openai-api",
+        RelationshipSourceKind::GeminiApi => "gemini-api",
+        RelationshipSourceKind::SpawnEnv => "spawn-env",
+        RelationshipSourceKind::NativeClaude => "native-claude",
+        RelationshipSourceKind::NativeOpencode => "native-opencode",
+    };
+    let rel = match row.relationship_type {
+        RelationshipType::Root => "root",
+        RelationshipType::Continuation => "continuation",
+        RelationshipType::Fork => "fork",
+        RelationshipType::Subagent => "subagent",
+    };
+    format!(
+        "{}|{}|{}|{}|{}|{}",
+        source,
+        row.session_id,
+        rel,
+        row.related_session_id.as_deref().unwrap_or(""),
+        row.agent_id.as_deref().unwrap_or(""),
+        row.parent_tool_use_id.as_deref().unwrap_or(""),
+    )
+}
+
+fn maybe_emit_spawn_relationship(
+    open_turn: &mut OpenTurn,
+    session_id: &str,
+    info: &SpawnCallInfo,
+    ts: &str,
+) {
+    let already = match open_turn.spawn_calls.get(&info.call_id) {
+        Some(s) => s.emitted,
+        None => false,
+    };
+    if already {
+        return;
+    }
+    let Some(spawned_id) = info.spawned_agent_id.as_ref() else {
+        return;
+    };
+    let stamp = if ts.is_empty() {
+        info.ts.clone()
+    } else {
+        ts.to_string()
+    };
+    let row = SessionRelationshipRecord {
+        v: 1,
+        source: RelationshipSourceKind::Codex,
+        session_id: spawned_id.clone(),
+        related_session_id: Some(session_id.to_string()),
+        relationship_type: RelationshipType::Subagent,
+        ts: if stamp.is_empty() { None } else { Some(stamp) },
+        source_session_id: None,
+        source_version: None,
+        parent_tool_use_id: Some(info.call_id.clone()),
+        agent_id: Some(spawned_id.clone()),
+        subagent_type: info.subagent_type.clone(),
+        description: info.description.clone(),
+    };
+    open_turn.pending_relationships.push(row);
+    if let Some(s) = open_turn.spawn_calls.get_mut(&info.call_id) {
+        s.emitted = true;
+    }
+}
+
+fn push_content(
+    open_turn: &mut Option<OpenTurn>,
+    pending: &mut Vec<ContentRecord>,
+    record: ContentRecord,
+) {
+    if let Some(open) = open_turn.as_mut() {
+        open.content.push(record);
+    } else {
+        pending.push(record);
+    }
+}
+
+fn build_codex_user_turn_record(
+    slot: &UserTurnSlot,
+    session_id: &str,
+    following_message_id: &str,
+    fallback_ts: &str,
+) -> UserTurnRecord {
+    let preceding_tag = slot.preceding_message_id.as_deref().unwrap_or("start");
+    let user_uuid = format!("{}:{}->{}", session_id, preceding_tag, following_message_id);
+    let ts = if !slot.ts.is_empty() {
+        slot.ts.clone()
+    } else {
+        fallback_ts.to_string()
+    };
+    UserTurnRecord {
+        v: 1,
+        source: SourceKind::Codex,
+        session_id: session_id.to_string(),
+        user_uuid,
+        ts,
+        preceding_message_id: slot.preceding_message_id.clone(),
+        following_message_id: Some(following_message_id.to_string()),
+        blocks: slot.blocks.clone(),
+    }
+}
+
+fn build_codex_compaction_event(
+    session_id: &str,
+    ts: &str,
+    preceding: Option<&CodexLastCompletedTurn>,
+) -> CompactionEvent {
+    let mut event = CompactionEvent {
+        v: 1,
+        source: SourceKind::Codex,
+        session_id: session_id.to_string(),
+        ts: ts.to_string(),
+        preceding_message_id: None,
+        tokens_before_compact: None,
+    };
+    if let Some(prev) = preceding {
+        event.preceding_message_id = Some(prev.message_id.clone());
+        event.tokens_before_compact = Some(prev.cache_read);
+    }
+    event
+}
+
+fn clone_resume(r: Option<&CodexResumeState>) -> CodexResumeState {
+    match r {
+        None => CodexResumeState {
+            user_turn_slot: Some(PersistedUserTurnSlot::default()),
+            ..Default::default()
+        },
+        Some(r) => CodexResumeState {
+            cumulative: r.cumulative.clone(),
+            session_id: r.session_id.clone(),
+            session_cwd: r.session_cwd.clone(),
+            turn_contexts: r.turn_contexts.clone(),
+            user_turn_slot: r
+                .user_turn_slot
+                .clone()
+                .or_else(|| Some(PersistedUserTurnSlot::default())),
+            root_session_emitted: r.root_session_emitted,
+            session_meta_relationship_keys: r.session_meta_relationship_keys.clone(),
+            next_event_index: r.next_event_index,
+            tool_result_counters: r.tool_result_counters.clone(),
+            last_completed_turn: r.last_completed_turn.clone(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/relayburn-reader/src/codex/tests.rs
+++ b/crates/relayburn-reader/src/codex/tests.rs
@@ -619,6 +619,29 @@ fn empty_user_turns_for_sessions_without_user_blocks() {
     assert!(r.user_turns.is_empty());
 }
 
+#[test]
+fn cl100k_tokenizer_is_rejected_until_implemented() {
+    let err = parse_codex_session(
+        fixture("simple-turn.jsonl"),
+        &ParseCodexOptions {
+            tokenizer: Some(UserTurnTokenizer::Cl100k),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("cl100k"), "error mentions cl100k: {msg}");
+    let err = parse_codex_session_incremental(
+        fixture("simple-turn.jsonl"),
+        &ParseCodexIncrementalOptions {
+            tokenizer: Some(UserTurnTokenizer::Cl100k),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("cl100k"));
+}
+
 // ---------------------------------------------------------------------------
 // Execution graph (#42 / #87)
 // ---------------------------------------------------------------------------

--- a/crates/relayburn-reader/src/codex/tests.rs
+++ b/crates/relayburn-reader/src/codex/tests.rs
@@ -1,0 +1,1124 @@
+//! Codex parser conformance tests. The fixtures live at the repo root
+//! (`tests/fixtures/codex/*.jsonl`) and are shared with the TS test suite —
+//! mirroring the expectations in `packages/reader/src/codex.test.ts`.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde_json::json;
+use tempfile::tempdir;
+
+use super::*;
+use crate::types::{
+    ContentKind, ContentRole, FidelityClass, RelationshipType, SourceKind, ToolResultEventSource,
+    ToolResultStatus, UsageGranularity, UserTurnBlockKind,
+};
+use crate::user_turn::UserTurnTokenizer;
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/relayburn-reader/ -> repo root
+    p.pop();
+    p.pop();
+    p.push("tests/fixtures/codex");
+    p.push(name);
+    p
+}
+
+fn parse(name: &str) -> ParseCodexResult {
+    parse_codex_session(fixture(name), &ParseCodexOptions::default()).unwrap()
+}
+
+fn parse_with(name: &str, opts: ParseCodexOptions) -> ParseCodexResult {
+    parse_codex_session(fixture(name), &opts).unwrap()
+}
+
+fn write_jsonl(dir: &std::path::Path, name: &str, lines: &[serde_json::Value]) -> PathBuf {
+    let path = dir.join(name);
+    let mut s = String::new();
+    for v in lines {
+        s.push_str(&serde_json::to_string(v).unwrap());
+        s.push('\n');
+    }
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(s.as_bytes()).unwrap();
+    path
+}
+
+// ---------------------------------------------------------------------------
+// readCodexSessionIdHint
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_session_id_hint_from_session_meta() {
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("rollout.jsonl");
+    std::fs::write(
+        &path,
+        b"{\"timestamp\":\"2026-04-20T00:00:00.000Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"sess_hint_1\",\"cwd\":\"/tmp\"}}\n",
+    )
+    .unwrap();
+    assert_eq!(
+        read_codex_session_id_hint(&path),
+        Some("sess_hint_1".to_string()),
+    );
+}
+
+#[test]
+fn read_session_id_hint_returns_none_for_malformed() {
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("rollout.jsonl");
+    std::fs::write(
+        &path,
+        b"{\"type\":\"session_meta\",\"payload\":\n{\"type\":\"session_meta\",\"payload\":{\"id\":\"x\"}}\n",
+    )
+    .unwrap();
+    assert_eq!(read_codex_session_id_hint(&path), None);
+}
+
+#[test]
+fn read_session_id_hint_returns_none_for_empty() {
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("empty.jsonl");
+    std::fs::write(&path, b"").unwrap();
+    assert_eq!(read_codex_session_id_hint(&path), None);
+}
+
+// ---------------------------------------------------------------------------
+// parseCodexSession — basic shapes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parses_simple_one_turn_session() {
+    let r = parse("simple-turn.jsonl");
+    assert_eq!(r.turns.len(), 1);
+    let t = &r.turns[0];
+    assert_eq!(t.v, 1);
+    assert!(matches!(t.source, SourceKind::Codex));
+    assert_eq!(t.session_id, "sess_simple_1");
+    assert_eq!(t.message_id, "turn_simple_1");
+    assert_eq!(t.turn_index, 0);
+    assert_eq!(t.model, "gpt-5.4");
+    assert_eq!(t.ts, "2026-04-20T00:00:00.200Z");
+    assert_eq!(t.usage.input, 600);
+    assert_eq!(t.usage.output, 120);
+    assert_eq!(t.usage.reasoning, 30);
+    assert_eq!(t.usage.cache_read, 400);
+    assert_eq!(t.usage.cache_create_5m, 0);
+    assert_eq!(t.tool_calls.len(), 0);
+    assert!(t.files_touched.is_none());
+}
+
+#[test]
+fn extracts_function_and_custom_tool_calls_with_files_touched() {
+    let r = parse("with-tool-call.jsonl");
+    assert_eq!(r.turns.len(), 1);
+    let t = &r.turns[0];
+    assert_eq!(t.model, "gpt-5.3-codex");
+    assert_eq!(t.usage.input, 3000);
+    assert_eq!(t.usage.output, 800);
+    assert_eq!(t.usage.reasoning, 200);
+    assert_eq!(t.usage.cache_read, 2000);
+    assert_eq!(t.tool_calls.len(), 3);
+    let exec = &t.tool_calls[0];
+    assert_eq!(exec.name, "exec_command");
+    assert_eq!(exec.target.as_deref(), Some("git status"));
+    let p1 = &t.tool_calls[1];
+    assert_eq!(p1.name, "apply_patch");
+    assert_eq!(p1.target.as_deref(), Some("/tmp/project/README.md"));
+    let p2 = &t.tool_calls[2];
+    assert_eq!(p2.name, "apply_patch");
+    assert_eq!(p2.target.as_deref(), Some("/tmp/project/NEW.md"));
+    let mut files = t.files_touched.clone().unwrap();
+    files.sort();
+    assert_eq!(files, vec!["/tmp/project/NEW.md", "/tmp/project/README.md"]);
+}
+
+#[test]
+fn computes_per_turn_usage_as_delta_of_cumulative_totals() {
+    let r = parse("multi-turn.jsonl");
+    assert_eq!(r.turns.len(), 2);
+    let t1 = &r.turns[0];
+    assert_eq!(t1.message_id, "turn_multi_1");
+    assert_eq!(t1.turn_index, 0);
+    assert_eq!(t1.model, "gpt-5.4");
+    assert_eq!(t1.usage.input, 2000);
+    assert_eq!(t1.usage.output, 200);
+    assert_eq!(t1.usage.reasoning, 50);
+    assert_eq!(t1.usage.cache_read, 1000);
+    let t2 = &r.turns[1];
+    assert_eq!(t2.message_id, "turn_multi_2");
+    assert_eq!(t2.turn_index, 1);
+    assert_eq!(t2.model, "gpt-5.3-codex");
+    assert_eq!(t2.usage.input, 2500);
+    assert_eq!(t2.usage.output, 500);
+    assert_eq!(t2.usage.reasoning, 50);
+    assert_eq!(t2.usage.cache_read, 2500);
+    assert_eq!(t2.tool_calls.len(), 1);
+    assert_eq!(t2.tool_calls[0].name, "exec_command");
+    assert_eq!(t2.tool_calls[0].target.as_deref(), Some("ls"));
+}
+
+#[test]
+fn emits_compaction_event_anchored_to_preceding_turn() {
+    let r = parse("compaction.jsonl");
+    assert_eq!(r.turns.len(), 2);
+    assert_eq!(r.events.len(), 1);
+    let ev = &r.events[0];
+    assert!(matches!(ev.source, SourceKind::Codex));
+    assert_eq!(ev.session_id, "sess_codex_compact");
+    assert_eq!(ev.ts, "2026-04-20T03:00:03.000Z");
+    assert_eq!(ev.preceding_message_id.as_deref(), Some("turn_compact_1"));
+    let preceding = r
+        .turns
+        .iter()
+        .find(|t| t.message_id == "turn_compact_1")
+        .unwrap();
+    assert_eq!(ev.tokens_before_compact, Some(preceding.usage.cache_read));
+    assert_eq!(ev.tokens_before_compact, Some(1000));
+}
+
+#[test]
+fn produces_stable_args_hash_for_identical_inputs() {
+    let a = parse("with-tool-call.jsonl");
+    let b = parse("with-tool-call.jsonl");
+    assert_eq!(
+        a.turns[0].tool_calls[0].args_hash,
+        b.turns[0].tool_calls[0].args_hash
+    );
+    assert_ne!(
+        a.turns[0].tool_calls[0].args_hash,
+        a.turns[0].tool_calls[1].args_hash
+    );
+}
+
+#[test]
+fn respects_session_path_option() {
+    let path = fixture("simple-turn.jsonl");
+    let r = parse_with(
+        "simple-turn.jsonl",
+        ParseCodexOptions {
+            session_path: Some(path.to_string_lossy().into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        r.turns[0].session_path.as_deref(),
+        Some(path.to_string_lossy().as_ref())
+    );
+}
+
+#[test]
+fn classifies_activity_and_fills_retries_has_edits() {
+    let r = parse("with-tool-call.jsonl");
+    let t = &r.turns[0];
+    // apply_patch normalizes to Edit → has_edits true; .md targets → docs.
+    assert_eq!(t.has_edits, Some(true));
+    assert!(matches!(
+        t.activity,
+        Some(crate::types::ActivityCategory::Docs)
+    ));
+    assert!(t.retries.is_some());
+}
+
+#[test]
+fn marks_failed_exec_command_as_debugging() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(
+        tmp.path(),
+        "fail.jsonl",
+        &[
+            json!({"timestamp":"2026-04-22T00:00:00.000Z","type":"session_meta","payload":{"id":"sess_fail","cwd":"/tmp/proj","timestamp":"2026-04-22T00:00:00.000Z"}}),
+            json!({"timestamp":"2026-04-22T00:00:00.100Z","type":"turn_context","payload":{"turn_id":"turn_fail_1","cwd":"/tmp/proj","model":"gpt-5.4"}}),
+            json!({"timestamp":"2026-04-22T00:00:00.200Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"run the tests please"}]}}),
+            json!({"timestamp":"2026-04-22T00:00:00.300Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_fail_1"}}),
+            json!({"timestamp":"2026-04-22T00:00:01.000Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"pytest -q\"}","call_id":"call_fail_1"}}),
+            json!({"timestamp":"2026-04-22T00:00:01.500Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_fail_1","turn_id":"turn_fail_1","exit_code":1}}),
+            json!({"timestamp":"2026-04-22T00:00:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":50}}}}),
+            json!({"timestamp":"2026-04-22T00:00:02.100Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_fail_1"}}),
+        ],
+    );
+    let r = parse_codex_session(&path, &ParseCodexOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), 1);
+    assert!(matches!(
+        r.turns[0].activity,
+        Some(crate::types::ActivityCategory::Debugging)
+    ));
+    assert_eq!(r.turns[0].has_edits, Some(false));
+}
+
+#[test]
+fn user_prompt_drives_keyword_refinement_skipping_boilerplate() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(
+        tmp.path(),
+        "kw.jsonl",
+        &[
+            json!({"timestamp":"2026-04-22T00:00:00.000Z","type":"session_meta","payload":{"id":"sess_kw","cwd":"/tmp/proj","timestamp":"2026-04-22T00:00:00.000Z"}}),
+            json!({"timestamp":"2026-04-22T00:00:00.050Z","type":"turn_context","payload":{"turn_id":"turn_kw_1","cwd":"/tmp/proj","model":"gpt-5.4"}}),
+            json!({"timestamp":"2026-04-22T00:00:00.100Z","type":"response_item","payload":{"type":"message","role":"user","content":[
+                {"type":"input_text","text":"<environment_context><cwd>/tmp/proj</cwd></environment_context>"},
+                {"type":"input_text","text":"refactor the auth module to extract the token helper"}
+            ]}}),
+            json!({"timestamp":"2026-04-22T00:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_kw_1"}}),
+            json!({"timestamp":"2026-04-22T00:00:01.000Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":"*** Begin Patch\n*** Update File: /tmp/proj/auth.ts\n@@\n+ok\n*** End Patch\n","call_id":"call_kw_1"}}),
+            json!({"timestamp":"2026-04-22T00:00:01.200Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"call_kw_1","turn_id":"turn_kw_1","success":true,"changes":{"/tmp/proj/auth.ts":{"type":"update"}}}}),
+            json!({"timestamp":"2026-04-22T00:00:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":50}}}}),
+            json!({"timestamp":"2026-04-22T00:00:02.100Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_kw_1"}}),
+        ],
+    );
+    let r = parse_codex_session(&path, &ParseCodexOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), 1);
+    assert!(matches!(
+        r.turns[0].activity,
+        Some(crate::types::ActivityCategory::Refactoring)
+    ));
+    assert_eq!(r.turns[0].has_edits, Some(true));
+}
+
+// ---------------------------------------------------------------------------
+// Incremental
+// ---------------------------------------------------------------------------
+
+#[test]
+fn incremental_full_parse_matches_full_parse() {
+    let path = fixture("multi-turn.jsonl");
+    let expected = parse("multi-turn.jsonl");
+    let r =
+        parse_codex_session_incremental(&path, &ParseCodexIncrementalOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), expected.turns.len());
+    let raw = std::fs::read(&path).unwrap();
+    assert_eq!(r.end_offset, raw.len() as u64);
+}
+
+#[test]
+fn splits_at_task_complete_and_resumes_with_cumulative_snapshot() {
+    let path = fixture("multi-turn.jsonl");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = raw.split('\n').collect();
+    // Cut after the first task_complete (line index 5, zero-based).
+    let cutoff: usize = (lines[..6].join("\n") + "\n").len();
+
+    let tmp = tempdir().unwrap();
+    let partial_path = tmp.path().join("partial.jsonl");
+    std::fs::write(&partial_path, &raw[..cutoff]).unwrap();
+    let partial =
+        parse_codex_session_incremental(&partial_path, &ParseCodexIncrementalOptions::default())
+            .unwrap();
+    assert_eq!(partial.turns.len(), 1);
+    assert_eq!(partial.turns[0].message_id, "turn_multi_1");
+    assert_eq!(partial.end_offset as usize, cutoff);
+
+    let full_path = tmp.path().join("full.jsonl");
+    std::fs::write(&full_path, &raw).unwrap();
+    let resumed = parse_codex_session_incremental(
+        &full_path,
+        &ParseCodexIncrementalOptions {
+            start_offset: Some(partial.end_offset),
+            resume: Some(partial.resume.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(resumed.turns.len(), 1);
+    assert_eq!(resumed.turns[0].message_id, "turn_multi_2");
+    let full = parse_codex_session(&full_path, &ParseCodexOptions::default()).unwrap();
+    assert_eq!(resumed.turns[0].usage, full.turns[1].usage);
+}
+
+#[test]
+fn incremental_anchors_resumed_compaction_to_previous_cursor_turn() {
+    let path = fixture("compaction.jsonl");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = raw.split('\n').collect();
+    // Cut after first task_complete at index 4 (zero-based).
+    let cutoff: usize = (lines[..5].join("\n") + "\n").len();
+
+    let tmp = tempdir().unwrap();
+    let partial_path = tmp.path().join("partial.jsonl");
+    std::fs::write(&partial_path, &raw[..cutoff]).unwrap();
+    let partial =
+        parse_codex_session_incremental(&partial_path, &ParseCodexIncrementalOptions::default())
+            .unwrap();
+    assert_eq!(partial.turns.len(), 1);
+    assert_eq!(partial.events.len(), 0);
+    assert_eq!(
+        partial.resume.last_completed_turn,
+        Some(CodexLastCompletedTurn {
+            message_id: "turn_compact_1".into(),
+            cache_read: 1000,
+        })
+    );
+
+    let full_path = tmp.path().join("full.jsonl");
+    std::fs::write(&full_path, &raw).unwrap();
+    let resumed = parse_codex_session_incremental(
+        &full_path,
+        &ParseCodexIncrementalOptions {
+            start_offset: Some(partial.end_offset),
+            resume: Some(partial.resume.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(resumed.turns.len(), 1);
+    assert_eq!(resumed.turns[0].message_id, "turn_compact_2");
+    assert_eq!(resumed.events.len(), 1);
+    assert_eq!(
+        resumed.events[0].preceding_message_id.as_deref(),
+        Some("turn_compact_1")
+    );
+    assert_eq!(resumed.events[0].tokens_before_compact, Some(1000));
+}
+
+#[test]
+fn incremental_does_not_advance_end_offset_without_task_complete() {
+    let path = fixture("simple-turn.jsonl");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = raw.split('\n').collect();
+    let truncated = lines[..3].join("\n") + "\n";
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("trunc.jsonl");
+    std::fs::write(&path, &truncated).unwrap();
+    let r =
+        parse_codex_session_incremental(&path, &ParseCodexIncrementalOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), 0);
+    assert_eq!(r.end_offset, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Content capture
+// ---------------------------------------------------------------------------
+
+fn content_fixture_lines() -> Vec<serde_json::Value> {
+    vec![
+        json!({"timestamp":"2026-04-20T01:00:00.000Z","type":"session_meta","payload":{"id":"sess_content_1","cwd":"/tmp/project","timestamp":"2026-04-20T01:00:00.000Z"}}),
+        json!({"timestamp":"2026-04-20T01:00:00.050Z","type":"turn_context","payload":{"turn_id":"turn_content_1","cwd":"/tmp/project","model":"gpt-5.3-codex"}}),
+        json!({"timestamp":"2026-04-20T01:00:00.100Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]}}),
+        json!({"timestamp":"2026-04-20T01:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_content_1"}}),
+        json!({"timestamp":"2026-04-20T01:00:00.300Z","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"planning the ls"}],"content":null}}),
+        json!({"timestamp":"2026-04-20T01:00:00.400Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"cmd\":\"ls\"}","call_id":"call_fc_1"}}),
+        json!({"timestamp":"2026-04-20T01:00:00.500Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_fc_1","output":"README.md\npackage.json\n"}}),
+        json!({"timestamp":"2026-04-20T01:00:00.600Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":"*** Begin Patch\n*** Add File: /tmp/project/X\n","call_id":"call_ct_1"}}),
+        json!({"timestamp":"2026-04-20T01:00:00.700Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_ct_1","output":"{\"success\":true}"}}),
+        json!({"timestamp":"2026-04-20T01:00:00.800Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done."}]}}),
+        json!({"timestamp":"2026-04-20T01:00:00.900Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":20,"reasoning_output_tokens":10}}}}),
+        json!({"timestamp":"2026-04-20T01:00:01.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_content_1"}}),
+    ]
+}
+
+#[test]
+fn content_default_off_returns_empty() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(tmp.path(), "session.jsonl", &content_fixture_lines());
+    let r = parse_codex_session(&path, &ParseCodexOptions::default()).unwrap();
+    assert!(r.content.is_empty());
+}
+
+#[test]
+fn content_hash_only_returns_empty() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(tmp.path(), "session.jsonl", &content_fixture_lines());
+    let r = parse_codex_session(
+        &path,
+        &ParseCodexOptions {
+            content_mode: Some(ContentStoreMode::HashOnly),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(r.content.is_empty());
+}
+
+#[test]
+fn content_full_emits_user_assistant_thinking_tool_use_and_tool_result() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(tmp.path(), "session.jsonl", &content_fixture_lines());
+    let r = parse_codex_session(
+        &path,
+        &ParseCodexOptions {
+            content_mode: Some(ContentStoreMode::Full),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(r.turns.len(), 1);
+    let user = r
+        .content
+        .iter()
+        .find(|c| matches!(c.role, ContentRole::User) && matches!(c.kind, ContentKind::Text))
+        .unwrap();
+    assert_eq!(user.text.as_deref(), Some("list files"));
+    assert_eq!(user.message_id, "turn_content_1");
+    let asst = r
+        .content
+        .iter()
+        .find(|c| matches!(c.role, ContentRole::Assistant) && matches!(c.kind, ContentKind::Text))
+        .unwrap();
+    assert_eq!(asst.text.as_deref(), Some("done."));
+    let thinking = r
+        .content
+        .iter()
+        .find(|c| matches!(c.kind, ContentKind::Thinking))
+        .unwrap();
+    assert_eq!(thinking.text.as_deref(), Some("planning the ls"));
+    let tool_uses: Vec<_> = r
+        .content
+        .iter()
+        .filter(|c| matches!(c.kind, ContentKind::ToolUse))
+        .collect();
+    assert_eq!(tool_uses.len(), 2);
+    let mut names: Vec<&str> = tool_uses
+        .iter()
+        .map(|c| c.tool_use.as_ref().unwrap().name.as_str())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["apply_patch", "shell"]);
+    let tr_fc = r
+        .content
+        .iter()
+        .find(|c| {
+            matches!(c.kind, ContentKind::ToolResult)
+                && c.tool_result.as_ref().map(|t| t.tool_use_id.as_str()) == Some("call_fc_1")
+        })
+        .unwrap();
+    assert_eq!(
+        tr_fc.tool_result.as_ref().unwrap().content,
+        json!("README.md\npackage.json\n")
+    );
+    let tr_ct = r
+        .content
+        .iter()
+        .find(|c| {
+            matches!(c.kind, ContentKind::ToolResult)
+                && c.tool_result.as_ref().map(|t| t.tool_use_id.as_str()) == Some("call_ct_1")
+        })
+        .unwrap();
+    assert_eq!(
+        tr_ct.tool_result.as_ref().unwrap().content,
+        json!("{\"success\":true}")
+    );
+}
+
+#[test]
+fn drops_content_when_turn_never_commits() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(
+        tmp.path(),
+        "uncommitted.jsonl",
+        &[
+            json!({"timestamp":"2026-04-20T01:00:00.000Z","type":"session_meta","payload":{"id":"sess_u","cwd":"/tmp","timestamp":"2026-04-20T01:00:00.000Z"}}),
+            json!({"timestamp":"2026-04-20T01:00:00.050Z","type":"turn_context","payload":{"turn_id":"turn_u","cwd":"/tmp","model":"gpt-5.4"}}),
+            json!({"timestamp":"2026-04-20T01:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_u"}}),
+            json!({"timestamp":"2026-04-20T01:00:00.400Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"cmd\":\"ls\"}","call_id":"call_u_1"}}),
+            json!({"timestamp":"2026-04-20T01:00:00.500Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_u_1","output":"should-be-dropped"}}),
+        ],
+    );
+    let r = parse_codex_session(
+        &path,
+        &ParseCodexOptions {
+            content_mode: Some(ContentStoreMode::Full),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(r.turns.len(), 0);
+    assert_eq!(r.content.len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// User-turn block sizes (issue #81)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn emits_one_user_turn_per_inter_assistant_gap() {
+    let r = parse("user-turn-blocks.jsonl");
+    assert_eq!(r.turns.len(), 3);
+    assert_eq!(r.user_turns.len(), 3);
+    for u in &r.user_turns {
+        assert_eq!(u.v, 1);
+        assert!(matches!(u.source, SourceKind::Codex));
+        assert_eq!(u.session_id, "sess_codex_utb");
+        assert!(!u.user_uuid.is_empty());
+        assert!(!u.ts.is_empty());
+        assert!(!u.blocks.is_empty());
+    }
+    let pre = &r.user_turns[0];
+    assert!(pre.preceding_message_id.is_none());
+    assert_eq!(pre.following_message_id.as_deref(), Some("turn_utb_1"));
+    assert_eq!(pre.blocks.len(), 1);
+    assert!(matches!(pre.blocks[0].kind, UserTurnBlockKind::Text));
+    assert_eq!(pre.blocks[0].byte_len, "fix the build".len() as u64);
+    // bytes/4 ceil for 13 = 4
+    assert_eq!(pre.blocks[0].approx_tokens, 4);
+
+    let between12 = &r.user_turns[1];
+    assert_eq!(
+        between12.preceding_message_id.as_deref(),
+        Some("turn_utb_1")
+    );
+    assert_eq!(
+        between12.following_message_id.as_deref(),
+        Some("turn_utb_2")
+    );
+    assert_eq!(between12.blocks.len(), 2);
+    let tr1 = between12
+        .blocks
+        .iter()
+        .find(|b| matches!(b.kind, UserTurnBlockKind::ToolResult))
+        .unwrap();
+    assert_eq!(tr1.tool_use_id.as_deref(), Some("call_b1"));
+    assert_eq!(tr1.byte_len, "a\n".len() as u64);
+    assert!(tr1.is_error.is_none());
+
+    let between23 = &r.user_turns[2];
+    assert_eq!(
+        between23.preceding_message_id.as_deref(),
+        Some("turn_utb_2")
+    );
+    assert_eq!(
+        between23.following_message_id.as_deref(),
+        Some("turn_utb_3")
+    );
+    assert_eq!(between23.blocks.len(), 2);
+    let fail_block = between23
+        .blocks
+        .iter()
+        .find(|b| b.tool_use_id.as_deref() == Some("call_b2"))
+        .unwrap();
+    assert!(matches!(fail_block.kind, UserTurnBlockKind::ToolResult));
+    assert_eq!(fail_block.byte_len, "FAIL: 1 test broke".len() as u64);
+    assert_eq!(fail_block.is_error, Some(true));
+    let patch_block = between23
+        .blocks
+        .iter()
+        .find(|b| b.tool_use_id.as_deref() == Some("call_p1"))
+        .unwrap();
+    assert!(matches!(patch_block.kind, UserTurnBlockKind::ToolResult));
+    assert_eq!(patch_block.byte_len, "patched".len() as u64);
+    assert!(patch_block.is_error.is_none());
+}
+
+#[test]
+fn heuristic_tokenizer_uses_bytes_div_4_ceil() {
+    let r = parse_with(
+        "user-turn-blocks.jsonl",
+        ParseCodexOptions {
+            tokenizer: Some(UserTurnTokenizer::Heuristic),
+            ..Default::default()
+        },
+    );
+    let first = &r.user_turns[0];
+    assert_eq!(first.blocks[0].byte_len, "fix the build".len() as u64);
+    assert_eq!(first.blocks[0].approx_tokens, 13_u64.div_ceil(4));
+}
+
+#[test]
+fn empty_user_turns_for_sessions_without_user_blocks() {
+    let r = parse("simple-turn.jsonl");
+    assert!(r.user_turns.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Execution graph (#42 / #87)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn emits_exactly_one_root_relationship_per_session() {
+    let r = parse("simple-turn.jsonl");
+    let roots: Vec<_> = r
+        .relationships
+        .iter()
+        .filter(|x| matches!(x.relationship_type, RelationshipType::Root))
+        .collect();
+    assert_eq!(roots.len(), 1);
+    assert!(matches!(roots[0].source, RelationshipSourceKind::Codex));
+    assert_eq!(roots[0].session_id, "sess_simple_1");
+    assert!(roots[0].related_session_id.is_none());
+    assert_eq!(roots[0].ts.as_deref(), Some("2026-04-20T00:00:00.000Z"));
+    assert_eq!(roots[0].source_version.as_deref(), Some("0.121.0"));
+}
+
+#[test]
+fn emits_fork_and_continuation_rows_from_session_meta() {
+    let r = parse("session-meta-relationships.jsonl");
+    let count = |t: RelationshipType| {
+        r.relationships
+            .iter()
+            .filter(|x| std::mem::discriminant(&x.relationship_type) == std::mem::discriminant(&t))
+            .count()
+    };
+    assert_eq!(count(RelationshipType::Root), 1);
+    assert_eq!(count(RelationshipType::Fork), 1);
+    assert_eq!(count(RelationshipType::Continuation), 1);
+
+    let fork = r
+        .relationships
+        .iter()
+        .find(|x| matches!(x.relationship_type, RelationshipType::Fork))
+        .unwrap();
+    let cont = r
+        .relationships
+        .iter()
+        .find(|x| matches!(x.relationship_type, RelationshipType::Continuation))
+        .unwrap();
+    let root = r
+        .relationships
+        .iter()
+        .find(|x| matches!(x.relationship_type, RelationshipType::Root))
+        .unwrap();
+    for row in [root, fork, cont] {
+        assert!(matches!(row.source, RelationshipSourceKind::Codex));
+        assert_eq!(row.session_id, "sess_meta_child");
+        assert_eq!(row.source_session_id.as_deref(), Some("sess_original"));
+        assert_eq!(row.source_version.as_deref(), Some("0.130.0"));
+        assert_eq!(row.ts.as_deref(), Some("2026-04-24T00:00:00.000Z"));
+    }
+    assert_eq!(fork.related_session_id.as_deref(), Some("sess_fork_base"));
+    assert_eq!(cont.related_session_id.as_deref(), Some("sess_previous"));
+}
+
+#[test]
+fn emits_tool_result_event_per_function_call_output() {
+    let r = parse("user-turn-blocks.jsonl");
+    let mut by_call: std::collections::HashMap<&str, u32> = Default::default();
+    for ev in &r.tool_result_events {
+        *by_call.entry(ev.tool_use_id.as_str()).or_insert(0) += 1;
+    }
+    assert_eq!(by_call.get("call_b1"), Some(&1));
+    assert_eq!(by_call.get("call_b2"), Some(&1));
+    assert_eq!(by_call.get("call_p1"), Some(&1));
+    assert_eq!(by_call.get("call_b3"), Some(&1));
+    for ev in &r.tool_result_events {
+        assert_eq!(ev.v, 1);
+        assert!(matches!(ev.source, SourceKind::Codex));
+        assert!(matches!(
+            ev.event_source,
+            ToolResultEventSource::FunctionCallOutput
+        ));
+        assert!(ev.content_length.is_some());
+        assert!(ev.content_hash.is_some());
+    }
+}
+
+#[test]
+fn event_index_unique_and_session_monotonic() {
+    let r = parse("user-turn-blocks.jsonl");
+    let indices: Vec<u64> = r.tool_result_events.iter().map(|e| e.event_index).collect();
+    let mut sorted = indices.clone();
+    sorted.sort();
+    assert_eq!(indices, sorted);
+    let unique: std::collections::HashSet<_> = indices.iter().collect();
+    assert_eq!(unique.len(), indices.len());
+}
+
+#[test]
+fn tool_result_status_reflects_exit_codes() {
+    let r = parse("user-turn-blocks.jsonl");
+    let failed = r
+        .tool_result_events
+        .iter()
+        .find(|e| e.tool_use_id == "call_b2")
+        .unwrap();
+    assert!(matches!(failed.status, ToolResultStatus::Errored));
+    assert_eq!(failed.is_error, Some(true));
+    let ok = r
+        .tool_result_events
+        .iter()
+        .find(|e| e.tool_use_id == "call_b1")
+        .unwrap();
+    assert!(matches!(ok.status, ToolResultStatus::Completed));
+    assert!(ok.is_error.is_none());
+}
+
+#[test]
+fn patch_apply_end_success_marks_completed() {
+    let r = parse("user-turn-blocks.jsonl");
+    let p = r
+        .tool_result_events
+        .iter()
+        .find(|e| e.tool_use_id == "call_p1")
+        .unwrap();
+    assert!(matches!(p.status, ToolResultStatus::Completed));
+    assert!(p.is_error.is_none());
+}
+
+#[test]
+fn emits_subagent_relationship_with_parent_call_id() {
+    let r = parse("with-spawn-agent.jsonl");
+    let subs: Vec<_> = r
+        .relationships
+        .iter()
+        .filter(|x| matches!(x.relationship_type, RelationshipType::Subagent))
+        .collect();
+    assert_eq!(subs.len(), 1);
+    let sub = subs[0];
+    assert!(matches!(sub.source, RelationshipSourceKind::Codex));
+    assert_eq!(sub.session_id, "agent_inv_42");
+    assert_eq!(sub.related_session_id.as_deref(), Some("sess_spawn_1"));
+    assert_eq!(sub.parent_tool_use_id.as_deref(), Some("call_spawn_1"));
+    assert_eq!(sub.agent_id.as_deref(), Some("agent_inv_42"));
+    assert_eq!(sub.subagent_type.as_deref(), Some("investigator"));
+    assert_eq!(sub.description.as_deref(), Some("find why test_x fails"));
+    assert!(sub.ts.is_some());
+}
+
+#[test]
+fn spawn_function_call_output_carries_agent_id() {
+    let r = parse("with-spawn-agent.jsonl");
+    let spawn = r
+        .tool_result_events
+        .iter()
+        .find(|e| {
+            e.tool_use_id == "call_spawn_1"
+                && matches!(e.event_source, ToolResultEventSource::FunctionCallOutput)
+        })
+        .unwrap();
+    assert_eq!(spawn.agent_id.as_deref(), Some("agent_inv_42"));
+    assert_eq!(spawn.subagent_session_id.as_deref(), Some("agent_inv_42"));
+}
+
+#[test]
+fn subagent_notification_emits_tool_result_event_record() {
+    let r = parse("with-spawn-agent.jsonl");
+    let notif = r
+        .tool_result_events
+        .iter()
+        .find(|e| {
+            matches!(e.event_source, ToolResultEventSource::SubagentNotification)
+                && e.tool_use_id == "call_spawn_1"
+        })
+        .unwrap();
+    assert!(matches!(notif.status, ToolResultStatus::Completed));
+    assert_eq!(notif.agent_id.as_deref(), Some("agent_inv_42"));
+    assert_eq!(notif.subagent_session_id.as_deref(), Some("agent_inv_42"));
+}
+
+#[test]
+fn re_parse_does_not_duplicate_root_relationship() {
+    let a = parse("with-spawn-agent.jsonl");
+    let b = parse("with-spawn-agent.jsonl");
+    let count = |r: &ParseCodexResult| {
+        r.relationships
+            .iter()
+            .filter(|x| matches!(x.relationship_type, RelationshipType::Root))
+            .count()
+    };
+    assert_eq!(count(&a), 1);
+    assert_eq!(count(&b), 1);
+}
+
+#[test]
+fn uncommitted_turn_does_not_emit_relationships_or_events() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(
+        tmp.path(),
+        "uncommitted.jsonl",
+        &[
+            json!({"timestamp":"2026-04-23T00:00:00.000Z","type":"session_meta","payload":{"id":"sess_u","cwd":"/tmp","timestamp":"2026-04-23T00:00:00.000Z"}}),
+            json!({"timestamp":"2026-04-23T00:00:00.050Z","type":"turn_context","payload":{"turn_id":"turn_u","cwd":"/tmp","model":"gpt-5.4"}}),
+            json!({"timestamp":"2026-04-23T00:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_u"}}),
+            json!({"timestamp":"2026-04-23T00:00:00.400Z","type":"response_item","payload":{"type":"function_call","name":"spawn_agent","arguments":"{\"subagent_type\":\"x\"}","call_id":"call_u_1"}}),
+            json!({"timestamp":"2026-04-23T00:00:00.500Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_u_1","output":"{\"agent_id\":\"agent_u\"}"}}),
+        ],
+    );
+    let r = parse_codex_session(&path, &ParseCodexOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), 0);
+    assert_eq!(r.relationships.len(), 0);
+    assert_eq!(r.tool_result_events.len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Incremental dedup
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_duplicate_event_tuples_after_re_parse() {
+    let path = fixture("user-turn-blocks.jsonl");
+    let a =
+        parse_codex_session_incremental(&path, &ParseCodexIncrementalOptions::default()).unwrap();
+    let b =
+        parse_codex_session_incremental(&path, &ParseCodexIncrementalOptions::default()).unwrap();
+    let key =
+        |e: &ToolResultEventRecord| format!("{}|{}|{}", e.session_id, e.tool_use_id, e.event_index);
+    let mut a_keys: Vec<String> = a.tool_result_events.iter().map(key).collect();
+    let mut b_keys: Vec<String> = b.tool_result_events.iter().map(key).collect();
+    a_keys.sort();
+    b_keys.sort();
+    assert_eq!(a_keys, b_keys);
+}
+
+#[test]
+fn does_not_double_emit_relationships_or_events_across_resumes() {
+    let path = fixture("user-turn-blocks.jsonl");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = raw.split('\n').collect();
+    let cut_idx = lines
+        .iter()
+        .position(|l| l.contains("\"task_complete\"") && l.contains("\"turn_utb_2\""))
+        .unwrap();
+    let cutoff: usize = (lines[..=cut_idx].join("\n") + "\n").len();
+
+    let tmp = tempdir().unwrap();
+    let partial_path = tmp.path().join("partial.jsonl");
+    std::fs::write(&partial_path, &raw[..cutoff]).unwrap();
+    let partial =
+        parse_codex_session_incremental(&partial_path, &ParseCodexIncrementalOptions::default())
+            .unwrap();
+    let partial_roots = partial
+        .relationships
+        .iter()
+        .filter(|r| matches!(r.relationship_type, RelationshipType::Root))
+        .count();
+    assert_eq!(partial_roots, 1);
+    let mut partial_event_ids: Vec<&str> = partial
+        .tool_result_events
+        .iter()
+        .map(|e| e.tool_use_id.as_str())
+        .collect();
+    partial_event_ids.sort();
+    assert_eq!(partial_event_ids, vec!["call_b1", "call_b2", "call_p1"]);
+
+    let full_path = tmp.path().join("full.jsonl");
+    std::fs::write(&full_path, &raw).unwrap();
+    let resumed = parse_codex_session_incremental(
+        &full_path,
+        &ParseCodexIncrementalOptions {
+            start_offset: Some(partial.end_offset),
+            resume: Some(partial.resume.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let resumed_roots = resumed
+        .relationships
+        .iter()
+        .filter(|r| matches!(r.relationship_type, RelationshipType::Root))
+        .count();
+    assert_eq!(resumed_roots, 0);
+    let resumed_event_ids: Vec<&str> = resumed
+        .tool_result_events
+        .iter()
+        .map(|e| e.tool_use_id.as_str())
+        .collect();
+    assert_eq!(resumed_event_ids, vec!["call_b3"]);
+
+    let mut indices: Vec<u64> = partial
+        .tool_result_events
+        .iter()
+        .chain(resumed.tool_result_events.iter())
+        .map(|e| e.event_index)
+        .collect();
+    let sorted: Vec<u64> = {
+        let mut s = indices.clone();
+        s.sort();
+        s
+    };
+    assert_eq!(indices, sorted);
+    indices.sort();
+    indices.dedup();
+    assert_eq!(
+        indices.len(),
+        partial.tool_result_events.len() + resumed.tool_result_events.len()
+    );
+}
+
+#[test]
+fn duplicate_session_meta_does_not_re_emit_metadata_edges() {
+    let tmp = tempdir().unwrap();
+    let first_meta = json!({"timestamp":"2026-04-24T00:00:00.000Z","type":"session_meta","payload":{"id":"sess_meta_resume","cwd":"/tmp/project","timestamp":"2026-04-24T00:00:00.000Z","cli_version":"0.130.0","sourceSessionId":"sess_source","forkSessionId":"sess_fork","continuedFromSessionId":"sess_prev"}});
+    let dup_meta = json!({"timestamp":"2026-04-24T00:00:01.000Z","type":"session_meta","payload":{"id":"sess_meta_resume","cwd":"/tmp/project","timestamp":"2026-04-24T00:00:01.000Z","cli_version":"0.130.0","sourceSessionId":"sess_source","forkSessionId":"sess_fork","continuedFromSessionId":"sess_prev"}});
+    let first_lines = vec![
+        first_meta,
+        json!({"timestamp":"2026-04-24T00:00:00.050Z","type":"turn_context","payload":{"turn_id":"turn_meta_a","cwd":"/tmp/project","model":"gpt-5.4"}}),
+        json!({"timestamp":"2026-04-24T00:00:00.100Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_meta_a"}}),
+        json!({"timestamp":"2026-04-24T00:00:00.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10}}}}),
+        json!({"timestamp":"2026-04-24T00:00:00.300Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_meta_a"}}),
+    ];
+    let second_lines = vec![
+        dup_meta,
+        json!({"timestamp":"2026-04-24T00:00:01.050Z","type":"turn_context","payload":{"turn_id":"turn_meta_b","cwd":"/tmp/project","model":"gpt-5.4"}}),
+        json!({"timestamp":"2026-04-24T00:00:01.100Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_meta_b"}}),
+        json!({"timestamp":"2026-04-24T00:00:01.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":150,"cached_input_tokens":0,"output_tokens":20}}}}),
+        json!({"timestamp":"2026-04-24T00:00:01.300Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_meta_b"}}),
+    ];
+    let path = write_jsonl(tmp.path(), "session.jsonl", &first_lines);
+    let first =
+        parse_codex_session_incremental(&path, &ParseCodexIncrementalOptions::default()).unwrap();
+    let fork_first = first
+        .relationships
+        .iter()
+        .filter(|r| matches!(r.relationship_type, RelationshipType::Fork))
+        .count();
+    let cont_first = first
+        .relationships
+        .iter()
+        .filter(|r| matches!(r.relationship_type, RelationshipType::Continuation))
+        .count();
+    assert_eq!(fork_first, 1);
+    assert_eq!(cont_first, 1);
+
+    let mut combined = first_lines.clone();
+    combined.extend(second_lines);
+    let path = write_jsonl(tmp.path(), "session.jsonl", &combined);
+    let second = parse_codex_session_incremental(
+        &path,
+        &ParseCodexIncrementalOptions {
+            start_offset: Some(first.end_offset),
+            resume: Some(first.resume.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let any_meta = second.relationships.iter().any(|r| {
+        matches!(r.relationship_type, RelationshipType::Fork)
+            || matches!(r.relationship_type, RelationshipType::Continuation)
+    });
+    assert!(!any_meta, "duplicate session_meta should not re-emit edges");
+}
+
+// ---------------------------------------------------------------------------
+// Fidelity (issue #84)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fidelity_full_when_token_count_present() {
+    let r = parse("simple-turn.jsonl");
+    let f = r.turns[0].fidelity.as_ref().unwrap();
+    assert!(matches!(f.granularity, UsageGranularity::PerTurn));
+    assert!(f.coverage.has_input_tokens);
+    assert!(f.coverage.has_output_tokens);
+    assert!(f.coverage.has_reasoning_tokens);
+    assert!(f.coverage.has_cache_read_tokens);
+    assert!(!f.coverage.has_cache_create_tokens);
+    assert!(f.coverage.has_tool_calls);
+    assert!(f.coverage.has_tool_result_events);
+    assert!(f.coverage.has_session_relationships);
+    assert!(f.coverage.has_raw_content);
+    assert!(matches!(f.class, FidelityClass::Full));
+}
+
+#[test]
+fn fidelity_partial_when_token_count_absent() {
+    let tmp = tempdir().unwrap();
+    let path = write_jsonl(
+        tmp.path(),
+        "no-tc.jsonl",
+        &[
+            json!({"timestamp":"2026-04-22T00:00:00.000Z","type":"session_meta","payload":{"id":"sess_fid_no_tc","cwd":"/tmp/proj","timestamp":"2026-04-22T00:00:00.000Z"}}),
+            json!({"timestamp":"2026-04-22T00:00:00.050Z","type":"turn_context","payload":{"turn_id":"turn_fid_no_tc","cwd":"/tmp/proj","model":"gpt-5.4"}}),
+            json!({"timestamp":"2026-04-22T00:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn_fid_no_tc"}}),
+            json!({"timestamp":"2026-04-22T00:00:00.300Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}}),
+            json!({"timestamp":"2026-04-22T00:00:00.500Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn_fid_no_tc"}}),
+        ],
+    );
+    let r = parse_codex_session(&path, &ParseCodexOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), 1);
+    let t = &r.turns[0];
+    let f = t.fidelity.as_ref().unwrap();
+    assert!(matches!(f.granularity, UsageGranularity::PerTurn));
+    assert!(matches!(f.class, FidelityClass::Partial));
+    assert!(!f.coverage.has_input_tokens);
+    assert!(!f.coverage.has_output_tokens);
+    assert!(!f.coverage.has_reasoning_tokens);
+    assert!(!f.coverage.has_cache_read_tokens);
+    assert!(f.coverage.has_tool_calls);
+    assert!(f.coverage.has_tool_result_events);
+    assert!(f.coverage.has_raw_content);
+    assert_eq!(t.usage.input, 0);
+    assert_eq!(t.usage.output, 0);
+}
+
+#[test]
+fn every_turn_carries_fidelity() {
+    let r = parse("multi-turn.jsonl");
+    assert!(!r.turns.is_empty());
+    for t in &r.turns {
+        let f = t.fidelity.as_ref().unwrap();
+        assert!(matches!(f.granularity, UsageGranularity::PerTurn));
+    }
+}
+
+#[test]
+fn incremental_populates_fidelity() {
+    let path = fixture("multi-turn.jsonl");
+    let r =
+        parse_codex_session_incremental(&path, &ParseCodexIncrementalOptions::default()).unwrap();
+    assert!(!r.turns.is_empty());
+    for t in &r.turns {
+        let f = t.fidelity.as_ref().unwrap();
+        assert!(matches!(f.granularity, UsageGranularity::PerTurn));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// User-turn dedup
+// ---------------------------------------------------------------------------
+
+#[test]
+fn user_turns_emitted_once_across_resumed_passes() {
+    let path = fixture("user-turn-blocks.jsonl");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = raw.split('\n').collect();
+    let cut_idx = lines
+        .iter()
+        .position(|l| l.contains("\"task_complete\"") && l.contains("\"turn_utb_2\""))
+        .unwrap();
+    let cutoff: usize = (lines[..=cut_idx].join("\n") + "\n").len();
+
+    let tmp = tempdir().unwrap();
+    let partial_path = tmp.path().join("partial.jsonl");
+    std::fs::write(&partial_path, &raw[..cutoff]).unwrap();
+    let partial =
+        parse_codex_session_incremental(&partial_path, &ParseCodexIncrementalOptions::default())
+            .unwrap();
+    assert_eq!(partial.user_turns.len(), 2);
+    assert_eq!(partial.end_offset as usize, cutoff);
+
+    let full_path = tmp.path().join("full.jsonl");
+    std::fs::write(&full_path, &raw).unwrap();
+    let resumed = parse_codex_session_incremental(
+        &full_path,
+        &ParseCodexIncrementalOptions {
+            start_offset: Some(partial.end_offset),
+            resume: Some(partial.resume.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(resumed.user_turns.len(), 1);
+    let between23 = &resumed.user_turns[0];
+    assert_eq!(
+        between23.preceding_message_id.as_deref(),
+        Some("turn_utb_2")
+    );
+    assert_eq!(
+        between23.following_message_id.as_deref(),
+        Some("turn_utb_3")
+    );
+    assert_eq!(between23.blocks.len(), 2);
+    let fail_block = between23
+        .blocks
+        .iter()
+        .find(|b| b.tool_use_id.as_deref() == Some("call_b2"))
+        .unwrap();
+    assert_eq!(fail_block.is_error, Some(true));
+
+    let full_pass = parse_codex_session(&full_path, &ParseCodexOptions::default()).unwrap();
+    let mut combined: Vec<String> = partial
+        .user_turns
+        .iter()
+        .chain(resumed.user_turns.iter())
+        .map(|u| u.user_uuid.clone())
+        .collect();
+    combined.sort();
+    let mut full_ids: Vec<String> = full_pass
+        .user_turns
+        .iter()
+        .map(|u| u.user_uuid.clone())
+        .collect();
+    full_ids.sort();
+    assert_eq!(combined, full_ids);
+    let unique: std::collections::HashSet<_> = combined.iter().collect();
+    assert_eq!(unique.len(), combined.len());
+}

--- a/crates/relayburn-reader/src/lib.rs
+++ b/crates/relayburn-reader/src/lib.rs
@@ -2,9 +2,10 @@
 //!
 //! This crate is a work-in-progress port of the TS reader package. Foundational
 //! modules (`types`, `hash`, `fidelity`, `git`, `classifier`, `user_turn`) are
-//! ported with native conformance tests; the per-harness parsers (`claude`,
-//! `codex`, `opencode`, `opencode_stream`) are scaffolded but not yet
-//! implemented — see #255–#258.
+//! ported with native conformance tests; the `codex` parser is now ported
+//! (#256). The remaining per-harness parsers (`claude`, `opencode`,
+//! `opencode_stream`) are scaffolded but not yet implemented — see #255 / #257
+//! / #258.
 
 pub mod classifier;
 pub mod fidelity;
@@ -17,6 +18,13 @@ pub mod claude;
 pub mod codex;
 pub mod opencode;
 pub mod opencode_stream;
+
+pub use codex::{
+    parse_codex_session, parse_codex_session_incremental, read_codex_session_id_hint,
+    CodexLastCompletedTurn, CodexResumeState, CodexTurnContext, CumulativeUsage,
+    ParseCodexIncrementalOptions, ParseCodexIncrementalResult, ParseCodexOptions,
+    ParseCodexResult, PersistedUserTurnSlot,
+};
 
 pub use classifier::{
     classify_activity, count_retries, normalize_tool_name, parse_bash_command, BashParse,

--- a/crates/relayburn-reader/src/lib.rs
+++ b/crates/relayburn-reader/src/lib.rs
@@ -22,8 +22,8 @@ pub mod opencode_stream;
 pub use codex::{
     parse_codex_session, parse_codex_session_incremental, read_codex_session_id_hint,
     CodexLastCompletedTurn, CodexResumeState, CodexTurnContext, CumulativeUsage,
-    ParseCodexIncrementalOptions, ParseCodexIncrementalResult, ParseCodexOptions,
-    ParseCodexResult, PersistedUserTurnSlot,
+    ParseCodexIncrementalOptions, ParseCodexIncrementalResult, ParseCodexOptions, ParseCodexResult,
+    PersistedUserTurnSlot,
 };
 
 pub use classifier::{


### PR DESCRIPTION
Closes #256.

Ports `packages/reader/src/codex.ts` (~1.5k LoC) to
`crates/relayburn-reader/src/codex.rs` field-for-field, with native Rust
conformance tests against the same `tests/fixtures/codex/*.jsonl` fixtures
the TS suite uses.

## Surface

`pub use`d from `relayburn_reader::codex`:

- `parse_codex_session` / `parse_codex_session_incremental` /
  `read_codex_session_id_hint`
- `ParseCodexOptions`, `ParseCodexIncrementalOptions`,
  `ParseCodexResult`, `ParseCodexIncrementalResult`,
  `CodexResumeState`, `CumulativeUsage`, `CodexTurnContext`,
  `PersistedUserTurnSlot`, `CodexLastCompletedTurn`

## Behavior parity

- Per-turn output is buffered and only committed at `task_complete`
  boundaries — mirrors the TS deferred-emission pattern with
  byte-offset gating on `committedEndOffset`.
- `CodexResumeState` round-trips committed state across passes:
  cumulative usage, session id / cwd, turn contexts, user-turn slot,
  root/session-meta dedup keys, monotonic event index, per-call
  result counters, last-completed-turn anchor.
- Subagent execution graph: `spawn_agent` relationships,
  `function_call_output` agent-id annotation, and
  `subagent_*_complete|_done|_finished|_terminated` notification events.
- Fidelity flags reflect whether `total_token_usage` arrived during
  the turn; capability flags (`hasToolCalls` / `hasToolResultEvents` /
  `hasSessionRelationships` / `hasRawContent`) stay true regardless.
- Codex boilerplate stripping (`<environment_context>`, `<permissions>`,
  `<collaboration_mode>`, `<INSTRUCTIONS>`, `# AGENTS.md`) before
  classifier sees user prompts.

## Tests

42 new tests in `crates/relayburn-reader/src/codex/tests.rs` covering
every non-cl100k scenario in `packages/reader/src/codex.test.ts`:

- `readCodexSessionIdHint` (3)
- `parseCodexSession` (10) — usage deltas, tool calls, files touched,
  compaction anchoring, args hash stability, sessionPath, activity
  classification (incl. failed exec → debugging), boilerplate-stripped
  keyword refinement
- `parseCodexSessionIncremental` (4) — full vs partial, resume snapshot,
  compaction anchoring across resume, no-task_complete tail
- Content capture — off / hash-only / full / drop-on-uncommitted (4)
- User-turn block sizes (3) — slot accumulation, heuristic tokenizer,
  empty session
- Execution graph (10) — root once, fork/continuation, tool result
  events, status from exec_command_end / patch_apply_end, spawn agent
  relationship + output annotation + subagent notification, no-emit
  for uncommitted turns
- Incremental dedup (3) — no duplicate event tuples, no double-emit
  across resume, duplicate session_meta dedup
- Fidelity (4) — full when token_count present, partial when absent,
  every turn carries fidelity, incremental populates fidelity
- User-turn dedup across resume (1)

107/107 tests in the reader crate pass. `cargo clippy --all-targets
-- -D warnings` and `cargo fmt --check` are clean.

## Deferred

The TS parser defaults to a `cl100k` tokenizer for `UserTurnBlock`
sizing. The Rust port uses `HeuristicCounter` (bytes/4) since no
tiktoken-equivalent is on the dep tree yet (see #246). Tests covering
the cl100k ±5% reconciliation are deferred until that lands; the
heuristic-tokenizer test is included.

## Test plan

- [x] `cargo test -p relayburn-reader` (107 tests pass)
- [x] `cargo clippy -p relayburn-reader --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --workspace` (no regressions in other crates)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FmQ3rBSgxtEf3in15PqaPT)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->