### PR TITLE
relayburn-reader: port OpenCode parser to Rust

### DIFF
--- a/crates/relayburn-reader/src/lib.rs
+++ b/crates/relayburn-reader/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! This crate is a work-in-progress port of the TS reader package. Foundational
 //! modules (`types`, `hash`, `fidelity`, `git`, `classifier`, `user_turn`) are
-//! ported with native conformance tests; the `codex` parser is now ported
-//! (#256). The remaining per-harness parsers (`claude`, `opencode`,
-//! `opencode_stream`) are scaffolded but not yet implemented — see #255 / #257
-//! / #258.
+//! ported with native conformance tests; the `codex` (#256) and `opencode`
+//! (#257) parsers are now ported. The remaining per-harness parsers (`claude`,
+//! `opencode_stream`) are scaffolded but not yet implemented — see #255 /
+//! #258.
 
 pub mod classifier;
 pub mod fidelity;
@@ -25,6 +25,10 @@ pub use codex::{
     ParseCodexIncrementalOptions, ParseCodexIncrementalResult, ParseCodexOptions, ParseCodexResult,
     PersistedUserTurnSlot,
 };
+pub use opencode::{
+    parse_opencode_session, parse_opencode_session_incremental, ParseOpencodeIncrementalOptions,
+    ParseOpencodeIncrementalResult, ParseOpencodeOptions, ParseOpencodeResult,
+};
 
 pub use classifier::{
     classify_activity, count_retries, normalize_tool_name, parse_bash_command, BashParse,
@@ -40,7 +44,7 @@ pub use types::{
     ContentToolResult, ContentToolUse, Coverage, Fidelity, FidelityClass, Harness,
     RelationshipSourceKind, RelationshipType, SessionRelationshipRecord, SourceKind, Subagent,
     ToolCall, ToolResultEventRecord, ToolResultEventSource, ToolResultStatus, TurnRecord, Usage,
-    UsageGranularity, UserTurnBlock, UserTurnRecord,
+    UsageAttribution, UsageGranularity, UserTurnBlock, UserTurnRecord,
 };
 pub use user_turn::{
     bytes_to_approx_tokens, measure_content_bytes, stringify_measured_content, HeuristicCounter,

--- a/crates/relayburn-reader/src/opencode.rs
+++ b/crates/relayburn-reader/src/opencode.rs
@@ -725,16 +725,13 @@ fn collect_opencode_tool_result_events(
         .filter_map(as_tool_part)
         .filter(is_terminal_tool)
         .collect();
-    let usage_share = if !terminals.is_empty() {
-        Some(divide_usage(turn_usage, terminals.len() as u64))
-    } else {
-        None
-    };
+    let n = terminals.len() as u64;
     let usage_attribution = match terminals.len() {
         1 => Some(UsageAttribution::SingleToolTurn),
-        n if n > 1 => Some(UsageAttribution::EvenSplitTurn),
+        x if x > 1 => Some(UsageAttribution::EvenSplitTurn),
         _ => None,
     };
+    let mut terminal_idx: u64 = 0;
     for p in parts {
         let Some(tp) = as_tool_part(p) else { continue };
         if !is_terminal_tool(&tp) {
@@ -772,29 +769,46 @@ fn collect_opencode_tool_result_events(
             collapsed_calls: None,
         };
         next_index += 1;
-        if let Some(share) = usage_share.as_ref() {
-            record.usage = Some(share.clone());
+        if n >= 1 {
+            record.usage = Some(per_tool_usage_share(turn_usage, n, terminal_idx));
             record.usage_attribution = usage_attribution;
         }
         out.push(record);
+        terminal_idx += 1;
     }
     next_index
 }
 
-fn divide_usage(usage: &Usage, divisor: u64) -> Usage {
-    if divisor <= 1 {
-        return usage.clone();
-    }
-    // Note: TS uses floating-point division here. Rust's `Usage` is u64, so
-    // fractional shares get truncated. Sums across an even-split turn will be
-    // ≤ the original total when the divisor doesn't evenly divide each field.
+/// Per-tool slice of an even-split usage. The TS port uses floating-point
+/// division, which preserves the sum at the cost of fractional usage values;
+/// `Usage` is `u64` here, so we instead distribute the integer remainder one
+/// extra unit at a time to the first `total % n` tools. The sum of shares
+/// across the turn equals the original total exactly, which keeps downstream
+/// aggregations (cost, summary) honest when the totals don't divide evenly.
+fn per_tool_usage_share(total: &Usage, n: u64, idx: u64) -> Usage {
     Usage {
-        input: usage.input / divisor,
-        output: usage.output / divisor,
-        reasoning: usage.reasoning / divisor,
-        cache_read: usage.cache_read / divisor,
-        cache_create_5m: usage.cache_create_5m / divisor,
-        cache_create_1h: usage.cache_create_1h / divisor,
+        input: split_field(total.input, n, idx),
+        output: split_field(total.output, n, idx),
+        reasoning: split_field(total.reasoning, n, idx),
+        cache_read: split_field(total.cache_read, n, idx),
+        cache_create_5m: split_field(total.cache_create_5m, n, idx),
+        cache_create_1h: split_field(total.cache_create_1h, n, idx),
+    }
+}
+
+fn split_field(total: u64, n: u64, idx: u64) -> u64 {
+    if n == 0 {
+        return 0;
+    }
+    if n == 1 {
+        return total;
+    }
+    let base = total / n;
+    let remainder = total % n;
+    if idx < remainder {
+        base + 1
+    } else {
+        base
     }
 }
 

--- a/crates/relayburn-reader/src/opencode.rs
+++ b/crates/relayburn-reader/src/opencode.rs
@@ -1,3 +1,1298 @@
-//! OpenCode session parser — Rust port stub.
+//! OpenCode session parser — Rust port of `packages/reader/src/opencode.ts`.
 //!
-//! TODO(#242): port `packages/reader/src/opencode.ts`.
+//! OpenCode lays sessions out as a directory tree under a storage root:
+//!
+//! ```text
+//! storage/session/<scope>/<sessionId>.json
+//! storage/message/<sessionId>/<messageId>.json
+//! storage/part/<messageId>/<partId>.json
+//! ```
+//!
+//! The parser reads the session payload, enumerates messages for that session,
+//! sorts them chronologically, and walks the assistant messages to emit
+//! [`TurnRecord`]s. Tool calls and tool-result events come from the per-message
+//! `part/<messageId>/*.json` files; [`UserTurnRecord`]s bridge consecutive
+//! assistant turns by combining the previous turn's tool outputs with any user
+//! message text preceding the next assistant.
+//!
+//! Note: the TS parser defaults to a `cl100k` tokenizer for `UserTurnBlock`
+//! sizing. The Rust port uses [`HeuristicCounter`] (bytes/4) — see #246 for
+//! the cl100k hookup.
+
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::classifier::{classify_activity, ClassificationInput};
+use crate::fidelity::classify_fidelity;
+use crate::git::ProjectResolver;
+use crate::hash::{args_hash, content_hash};
+use crate::types::{
+    CompactionEvent, ContentKind, ContentRecord, ContentRole, ContentStoreMode, ContentToolResult,
+    ContentToolUse, Coverage, Fidelity, RelationshipSourceKind, RelationshipType,
+    SessionRelationshipRecord, SourceKind, Subagent, ToolCall, ToolResultEventRecord,
+    ToolResultEventSource, ToolResultStatus, TurnRecord, Usage, UsageAttribution, UsageGranularity,
+    UserTurnBlock, UserTurnRecord,
+};
+use crate::user_turn::{HeuristicCounter, TokenCounter, UserTurnTokenizer};
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseOpencodeOptions {
+    pub session_path: Option<String>,
+    pub content_mode: Option<ContentStoreMode>,
+    pub tokenizer: Option<UserTurnTokenizer>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseOpencodeIncrementalOptions {
+    pub session_path: Option<String>,
+    pub content_mode: Option<ContentStoreMode>,
+    pub tokenizer: Option<UserTurnTokenizer>,
+    pub seen_message_ids: Option<BTreeSet<String>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseOpencodeResult {
+    pub turns: Vec<TurnRecord>,
+    pub content: Vec<ContentRecord>,
+    pub events: Vec<CompactionEvent>,
+    pub user_turns: Vec<UserTurnRecord>,
+    pub relationships: Vec<SessionRelationshipRecord>,
+    pub tool_result_events: Vec<ToolResultEventRecord>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParseOpencodeIncrementalResult {
+    pub turns: Vec<TurnRecord>,
+    pub content: Vec<ContentRecord>,
+    pub events: Vec<CompactionEvent>,
+    pub user_turns: Vec<UserTurnRecord>,
+    pub relationships: Vec<SessionRelationshipRecord>,
+    pub tool_result_events: Vec<ToolResultEventRecord>,
+    pub seen_message_ids: BTreeSet<String>,
+}
+
+pub fn parse_opencode_session(
+    session_file_path: impl AsRef<Path>,
+    options: &ParseOpencodeOptions,
+) -> std::io::Result<ParseOpencodeResult> {
+    let inc_opts = ParseOpencodeIncrementalOptions {
+        session_path: options.session_path.clone(),
+        content_mode: options.content_mode,
+        tokenizer: options.tokenizer,
+        seen_message_ids: None,
+    };
+    let r = parse_opencode_session_incremental(session_file_path, &inc_opts)?;
+    Ok(ParseOpencodeResult {
+        turns: r.turns,
+        content: r.content,
+        events: r.events,
+        user_turns: r.user_turns,
+        relationships: r.relationships,
+        tool_result_events: r.tool_result_events,
+    })
+}
+
+pub fn parse_opencode_session_incremental(
+    session_file_path: impl AsRef<Path>,
+    options: &ParseOpencodeIncrementalOptions,
+) -> std::io::Result<ParseOpencodeIncrementalResult> {
+    resolve_token_counter(options.tokenizer)?;
+
+    let session_path_ref = session_file_path.as_ref();
+    let session = match read_session(session_path_ref) {
+        Some(s) => s,
+        None => {
+            return Ok(ParseOpencodeIncrementalResult {
+                turns: vec![],
+                content: vec![],
+                events: vec![],
+                user_turns: vec![],
+                relationships: vec![],
+                tool_result_events: vec![],
+                seen_message_ids: options.seen_message_ids.clone().unwrap_or_default(),
+            });
+        }
+    };
+
+    let storage_root = derive_storage_root(session_path_ref);
+
+    let messages = read_messages(&storage_root, &session.id);
+    let mut assistants: Vec<AssistantMessage> = messages
+        .iter()
+        .filter_map(parse_complete_assistant)
+        .collect();
+    let mut users: Vec<UserMessage> = messages.iter().filter_map(parse_complete_user).collect();
+    assistants.sort_by_key(|a| a.time_created);
+    users.sort_by_key(|u| u.time_created);
+
+    let capture_content = matches!(options.content_mode, Some(ContentStoreMode::Full));
+    let counter = HeuristicCounter;
+    let is_sidechain = session
+        .parent_id
+        .as_ref()
+        .map(|p| !p.is_empty())
+        .unwrap_or(false);
+
+    let mut seen: BTreeSet<String> = options.seen_message_ids.clone().unwrap_or_default();
+    let mut turns: Vec<TurnRecord> = Vec::new();
+    let mut content_out: Vec<ContentRecord> = Vec::new();
+    let mut events: Vec<CompactionEvent> = Vec::new();
+    let mut user_turns: Vec<UserTurnRecord> = Vec::new();
+    let mut tool_result_events: Vec<ToolResultEventRecord> = Vec::new();
+    let mut call_index_counters: HashMap<String, u64> = HashMap::new();
+    let mut next_event_index: u64 = 0;
+
+    let project_resolver = ProjectResolver::new();
+
+    for i in 0..assistants.len() {
+        let m_id = assistants[i].id.clone();
+        if seen.contains(&m_id) {
+            continue;
+        }
+        let prev_idx = if i > 0 { Some(i - 1) } else { None };
+        let m_time = assistants[i].time_created;
+        let user_msg = find_preceding_user(&users, m_time);
+
+        let prev_time = prev_idx.map(|pi| assistants[pi].time_created);
+        let user_msg_for_gap = match (&user_msg, prev_time) {
+            (Some(um), Some(pt)) if um.time_created <= pt => None,
+            (Some(um), _) => Some(um.clone()),
+            _ => None,
+        };
+
+        let prev_for_build = prev_idx.map(|pi| assistants[pi].clone());
+        let user_turn = build_opencode_user_turn_record(
+            &storage_root,
+            &session.id,
+            prev_for_build.as_ref(),
+            &assistants[i],
+            user_msg_for_gap.as_ref(),
+            &counter,
+        );
+        if let Some(ut) = user_turn {
+            user_turns.push(ut);
+        }
+
+        let parts = read_parts(&storage_root, &m_id);
+        let extracted = extract_tools_and_files(&parts);
+        let stop_reason = last_step_finish_reason(&parts);
+
+        let m = &assistants[i];
+        let model = build_model(m.provider_id.as_deref(), m.model_id.as_deref());
+        let project = m.path_cwd.clone().or_else(|| session.directory.clone());
+
+        let usage = to_usage(m.tokens.as_ref());
+        let mut usage_coverage = coverage_from_tokens(m.tokens.as_ref());
+        for sf in step_finish_tokens(&parts) {
+            usage_coverage =
+                merge_usage_coverage(&usage_coverage, &coverage_from_tokens(Some(&sf)));
+        }
+
+        let ts = ms_to_iso(m.time_created);
+        let mut record = TurnRecord {
+            v: 1,
+            source: SourceKind::Opencode,
+            session_id: m.session_id.clone(),
+            session_path: options.session_path.clone(),
+            message_id: m.id.clone(),
+            turn_index: i as u64,
+            ts: ts.clone(),
+            model,
+            project: None,
+            project_key: None,
+            usage: usage.clone(),
+            tool_calls: extracted.tool_calls.clone(),
+            files_touched: if extracted.files_touched.is_empty() {
+                None
+            } else {
+                Some(extracted.files_touched.clone())
+            },
+            subagent: None,
+            stop_reason: stop_reason.clone(),
+            activity: None,
+            retries: None,
+            has_edits: None,
+            fidelity: Some(build_opencode_fidelity(&usage_coverage)),
+        };
+        if let Some(p) = project.as_ref() {
+            let resolved = project_resolver.resolve(p);
+            record.project = Some(resolved.project);
+            record.project_key = resolved.project_key;
+        }
+        if is_sidechain {
+            record.subagent = Some(Subagent {
+                is_sidechain: true,
+                parent_tool_use_id: None,
+                agent_id: None,
+                parent_agent_id: None,
+                subagent_type: None,
+                description: None,
+            });
+        }
+
+        let user_text = match &user_msg {
+            Some(u) => read_user_text(&storage_root, &u.id),
+            None => String::new(),
+        };
+        let assistant_text = extract_assistant_text(&parts);
+        let combined_text = join_nonempty(&[user_text.as_str(), assistant_text.as_str()], "\n");
+        let has_failed_tool = extracted
+            .tool_calls
+            .iter()
+            .any(|tc| extracted.errored_call_ids.contains(&tc.id));
+        let classified = classify_activity(ClassificationInput {
+            tool_calls: &extracted.tool_calls,
+            text: &combined_text,
+            has_failed_tool,
+            reasoning_tokens: usage.reasoning,
+        });
+        record.activity = Some(classified.activity);
+        record.retries = Some(classified.retries);
+        record.has_edits = Some(classified.has_edits);
+
+        turns.push(record);
+        seen.insert(m_id.clone());
+
+        next_event_index = collect_opencode_tool_result_events(
+            &parts,
+            &m.session_id,
+            &m.id,
+            &ts,
+            &usage,
+            &mut tool_result_events,
+            &mut call_index_counters,
+            next_event_index,
+        );
+
+        if capture_content {
+            let assistant_ts = ts.clone();
+            if let Some(um) = user_msg.as_ref() {
+                let user_ts = ms_to_iso(um.time_created);
+                for t in read_user_text_parts(&storage_root, &um.id) {
+                    content_out.push(ContentRecord {
+                        v: 1,
+                        source: SourceKind::Opencode,
+                        session_id: m.session_id.clone(),
+                        message_id: um.id.clone(),
+                        ts: user_ts.clone(),
+                        role: ContentRole::User,
+                        kind: ContentKind::Text,
+                        text: Some(t),
+                        tool_use: None,
+                        tool_result: None,
+                    });
+                }
+            }
+            for rec in extract_assistant_content(&parts, &m.session_id, &m.id, &assistant_ts) {
+                content_out.push(rec);
+            }
+        }
+    }
+
+    // Compaction events.
+    for u in &users {
+        if seen.contains(&u.id) {
+            continue;
+        }
+        let user_parts = read_parts(&storage_root, &u.id);
+        if !user_parts.iter().any(|p| p.kind == "compaction") {
+            continue;
+        }
+        let preceding = find_preceding_assistant_by_time(&assistants, u.time_created);
+        let mut ev = CompactionEvent {
+            v: 1,
+            source: SourceKind::Opencode,
+            session_id: session.id.clone(),
+            ts: ms_to_iso(u.time_created),
+            preceding_message_id: None,
+            tokens_before_compact: None,
+        };
+        if let Some(p) = preceding {
+            ev.preceding_message_id = Some(p.id.clone());
+            ev.tokens_before_compact = Some(to_usage(p.tokens.as_ref()).cache_read);
+        }
+        events.push(ev);
+        seen.insert(u.id.clone());
+    }
+
+    let relationships = build_opencode_relationships(&session, &assistants);
+
+    Ok(ParseOpencodeIncrementalResult {
+        turns,
+        content: content_out,
+        events,
+        user_turns,
+        relationships,
+        tool_result_events,
+        seen_message_ids: seen,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct SessionInfo {
+    id: String,
+    parent_id: Option<String>,
+    directory: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct MessageTokens {
+    input: Option<u64>,
+    output: Option<u64>,
+    reasoning: Option<u64>,
+    cache_read: Option<u64>,
+    cache_write: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct AssistantMessage {
+    id: String,
+    session_id: String,
+    time_created: i64,
+    provider_id: Option<String>,
+    model_id: Option<String>,
+    path_cwd: Option<String>,
+    tokens: Option<MessageTokens>,
+}
+
+#[derive(Debug, Clone)]
+struct UserMessage {
+    id: String,
+    #[allow(dead_code)]
+    session_id: String,
+    time_created: i64,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedPart {
+    id: Option<String>,
+    kind: String,
+    raw: Map<String, Value>,
+}
+
+impl ParsedPart {
+    fn get(&self, k: &str) -> Option<&Value> {
+        self.raw.get(k)
+    }
+}
+
+struct ToolPart<'a> {
+    call_id: &'a str,
+    tool: Option<&'a str>,
+    state: Option<&'a Map<String, Value>>,
+}
+
+fn as_tool_part(p: &ParsedPart) -> Option<ToolPart<'_>> {
+    if p.kind != "tool" {
+        return None;
+    }
+    let call_id = p.get("callID")?.as_str()?;
+    if call_id.is_empty() {
+        return None;
+    }
+    let tool = p.get("tool").and_then(|v| v.as_str());
+    let state = p.get("state").and_then(|v| v.as_object());
+    Some(ToolPart {
+        call_id,
+        tool,
+        state,
+    })
+}
+
+fn is_terminal_tool(p: &ToolPart<'_>) -> bool {
+    match p.state {
+        Some(s) => s.contains_key("output"),
+        None => false,
+    }
+}
+
+struct Extracted {
+    tool_calls: Vec<ToolCall>,
+    files_touched: Vec<String>,
+    errored_call_ids: BTreeSet<String>,
+}
+
+fn extract_tools_and_files(parts: &[ParsedPart]) -> Extracted {
+    let mut tool_calls = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut files = BTreeSet::new();
+    let mut errored = BTreeSet::new();
+    for p in parts {
+        let Some(tp) = as_tool_part(p) else { continue };
+        let tool = match tp.tool {
+            Some(t) => t,
+            None => continue,
+        };
+        if seen.contains(tp.call_id) {
+            continue;
+        }
+        seen.insert(tp.call_id.to_string());
+        let input_val = tp
+            .state
+            .and_then(|s| s.get("input"))
+            .cloned()
+            .unwrap_or(Value::Object(Map::new()));
+        let input_obj = match &input_val {
+            Value::Object(_) => input_val.clone(),
+            _ => Value::Object(Map::new()),
+        };
+        let mut call = ToolCall {
+            id: tp.call_id.to_string(),
+            name: tool.to_string(),
+            target: pick_target(tool, &input_obj),
+            args_hash: args_hash(&input_obj),
+            is_error: None,
+            edit_pre_hash: None,
+            edit_post_hash: None,
+            skill_name: None,
+            replaced_tools: None,
+            collapsed_calls: None,
+        };
+        if tool == "skill" {
+            if let Value::Object(input_map) = &input_obj {
+                for k in ["skill", "name", "skill_name"] {
+                    if let Some(v) = input_map.get(k).and_then(|x| x.as_str()) {
+                        call.skill_name = Some(v.to_string());
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(target) = call.target.clone() {
+            if is_file_tool(tool) {
+                files.insert(target);
+            }
+        }
+        if is_failed_tool(tp.state) {
+            errored.insert(tp.call_id.to_string());
+        }
+        tool_calls.push(call);
+    }
+    Extracted {
+        tool_calls,
+        files_touched: files.into_iter().collect(),
+        errored_call_ids: errored,
+    }
+}
+
+fn pick_target(name: &str, input: &Value) -> Option<String> {
+    let obj = input.as_object()?;
+    let s =
+        |k: &str| -> Option<String> { obj.get(k).and_then(|v| v.as_str()).map(|x| x.to_string()) };
+    match name {
+        "read" | "write" | "edit" => s("filePath")
+            .or_else(|| s("file_path"))
+            .or_else(|| s("path")),
+        "bash" => s("command"),
+        "grep" => s("pattern"),
+        "glob" => s("pattern"),
+        "webfetch" => s("url"),
+        "task" => s("subagent_type")
+            .or_else(|| s("description"))
+            .or_else(|| s("prompt")),
+        _ => s("filePath")
+            .or_else(|| s("file_path"))
+            .or_else(|| s("path"))
+            .or_else(|| s("url"))
+            .or_else(|| s("command")),
+    }
+}
+
+fn is_file_tool(name: &str) -> bool {
+    matches!(name, "read" | "write" | "edit")
+}
+
+fn is_failed_tool(state: Option<&Map<String, Value>>) -> bool {
+    let Some(s) = state else {
+        return false;
+    };
+    if s.get("status").and_then(|v| v.as_str()) == Some("error") {
+        return true;
+    }
+    let exit = s
+        .get("metadata")
+        .and_then(|m| m.as_object())
+        .and_then(|m| m.get("exit"))
+        .and_then(|v| v.as_i64());
+    matches!(exit, Some(e) if e != 0)
+}
+
+fn last_step_finish_reason(parts: &[ParsedPart]) -> Option<String> {
+    for p in parts.iter().rev() {
+        if p.kind == "step-finish" {
+            if let Some(r) = p.get("reason").and_then(|v| v.as_str()) {
+                return Some(r.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn step_finish_tokens(parts: &[ParsedPart]) -> Vec<MessageTokens> {
+    let mut out = Vec::new();
+    for p in parts {
+        if p.kind != "step-finish" {
+            continue;
+        }
+        if let Some(tokens_val) = p.get("tokens") {
+            out.push(parse_tokens(Some(tokens_val)));
+        }
+    }
+    out
+}
+
+fn extract_assistant_text(parts: &[ParsedPart]) -> String {
+    let mut chunks = Vec::new();
+    for p in parts {
+        if p.kind != "text" {
+            continue;
+        }
+        if p.get("synthetic").and_then(|v| v.as_bool()) == Some(true) {
+            continue;
+        }
+        if let Some(t) = p.get("text").and_then(|v| v.as_str()) {
+            if !t.is_empty() {
+                chunks.push(t.to_string());
+            }
+        }
+    }
+    chunks.join("\n")
+}
+
+fn read_user_text(storage_root: &Path, user_message_id: &str) -> String {
+    let parts = read_parts(storage_root, user_message_id);
+    let mut chunks = Vec::new();
+    for p in parts {
+        if p.kind != "text" {
+            continue;
+        }
+        if p.get("synthetic").and_then(|v| v.as_bool()) == Some(true) {
+            continue;
+        }
+        if let Some(t) = p.get("text").and_then(|v| v.as_str()) {
+            if !t.is_empty() {
+                chunks.push(t.to_string());
+            }
+        }
+    }
+    chunks.join("\n")
+}
+
+fn read_user_text_parts(storage_root: &Path, user_message_id: &str) -> Vec<String> {
+    let parts = read_parts(storage_root, user_message_id);
+    let mut out = Vec::new();
+    for p in parts {
+        if p.kind != "text" {
+            continue;
+        }
+        if p.get("synthetic").and_then(|v| v.as_bool()) == Some(true) {
+            continue;
+        }
+        if let Some(t) = p.get("text").and_then(|v| v.as_str()) {
+            if !t.is_empty() {
+                out.push(t.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn extract_assistant_content(
+    parts: &[ParsedPart],
+    session_id: &str,
+    message_id: &str,
+    ts: &str,
+) -> Vec<ContentRecord> {
+    let mut out = Vec::new();
+    for p in parts {
+        if p.kind == "text" {
+            if p.get("synthetic").and_then(|v| v.as_bool()) == Some(true) {
+                continue;
+            }
+            if let Some(t) = p.get("text").and_then(|v| v.as_str()) {
+                if !t.is_empty() {
+                    out.push(ContentRecord {
+                        v: 1,
+                        source: SourceKind::Opencode,
+                        session_id: session_id.to_string(),
+                        message_id: message_id.to_string(),
+                        ts: ts.to_string(),
+                        role: ContentRole::Assistant,
+                        kind: ContentKind::Text,
+                        text: Some(t.to_string()),
+                        tool_use: None,
+                        tool_result: None,
+                    });
+                }
+            }
+            continue;
+        }
+        if p.kind == "tool" {
+            let Some(tp) = as_tool_part(p) else { continue };
+            let Some(tool) = tp.tool else { continue };
+            let input_val = tp
+                .state
+                .and_then(|s| s.get("input"))
+                .cloned()
+                .unwrap_or(Value::Object(Map::new()));
+            let input_map = match input_val {
+                Value::Object(m) => m.into_iter().collect(),
+                _ => Default::default(),
+            };
+            out.push(ContentRecord {
+                v: 1,
+                source: SourceKind::Opencode,
+                session_id: session_id.to_string(),
+                message_id: message_id.to_string(),
+                ts: ts.to_string(),
+                role: ContentRole::Assistant,
+                kind: ContentKind::ToolUse,
+                text: None,
+                tool_use: Some(ContentToolUse {
+                    id: tp.call_id.to_string(),
+                    name: tool.to_string(),
+                    input: input_map,
+                }),
+                tool_result: None,
+            });
+            if let Some(state) = tp.state {
+                if state.contains_key("output") {
+                    let output = state
+                        .get("output")
+                        .cloned()
+                        .unwrap_or(Value::String(String::new()));
+                    let mut is_error = None;
+                    if state.get("status").and_then(|v| v.as_str()) == Some("error") {
+                        is_error = Some(true);
+                    } else {
+                        let exit = state
+                            .get("metadata")
+                            .and_then(|m| m.as_object())
+                            .and_then(|m| m.get("exit"))
+                            .and_then(|v| v.as_i64());
+                        if matches!(exit, Some(e) if e != 0) {
+                            is_error = Some(true);
+                        }
+                    }
+                    out.push(ContentRecord {
+                        v: 1,
+                        source: SourceKind::Opencode,
+                        session_id: session_id.to_string(),
+                        message_id: message_id.to_string(),
+                        ts: ts.to_string(),
+                        role: ContentRole::ToolResult,
+                        kind: ContentKind::ToolResult,
+                        text: None,
+                        tool_use: None,
+                        tool_result: Some(ContentToolResult {
+                            tool_use_id: tp.call_id.to_string(),
+                            content: output,
+                            is_error,
+                        }),
+                    });
+                }
+            }
+        }
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_opencode_tool_result_events(
+    parts: &[ParsedPart],
+    session_id: &str,
+    message_id: &str,
+    ts: &str,
+    turn_usage: &Usage,
+    out: &mut Vec<ToolResultEventRecord>,
+    call_index_counters: &mut HashMap<String, u64>,
+    start_event_index: u64,
+) -> u64 {
+    let mut next_index = start_event_index;
+    let terminals: Vec<ToolPart<'_>> = parts
+        .iter()
+        .filter_map(as_tool_part)
+        .filter(is_terminal_tool)
+        .collect();
+    let usage_share = if !terminals.is_empty() {
+        Some(divide_usage(turn_usage, terminals.len() as u64))
+    } else {
+        None
+    };
+    let usage_attribution = match terminals.len() {
+        1 => Some(UsageAttribution::SingleToolTurn),
+        n if n > 1 => Some(UsageAttribution::EvenSplitTurn),
+        _ => None,
+    };
+    for p in parts {
+        let Some(tp) = as_tool_part(p) else { continue };
+        if !is_terminal_tool(&tp) {
+            continue;
+        }
+        let state = tp.state.unwrap();
+        let is_error = is_failed_tool(Some(state));
+        let call_id = tp.call_id.to_string();
+        let call_index = *call_index_counters.get(&call_id).unwrap_or(&0);
+        call_index_counters.insert(call_id.clone(), call_index + 1);
+        let measured = measure_opencode_tool_output(state.get("output"));
+        let mut record = ToolResultEventRecord {
+            v: 1,
+            source: SourceKind::Opencode,
+            session_id: session_id.to_string(),
+            message_id: Some(message_id.to_string()),
+            tool_use_id: call_id,
+            call_index: Some(call_index),
+            event_index: next_index,
+            ts: Some(ts.to_string()),
+            status: if is_error {
+                ToolResultStatus::Errored
+            } else {
+                ToolResultStatus::Completed
+            },
+            event_source: ToolResultEventSource::ToolResult,
+            content_length: measured.length,
+            content_hash: measured.hash,
+            is_error: if is_error { Some(true) } else { None },
+            usage: None,
+            usage_attribution: None,
+            subagent_session_id: None,
+            agent_id: None,
+            replaced_tools: None,
+            collapsed_calls: None,
+        };
+        next_index += 1;
+        if let Some(share) = usage_share.as_ref() {
+            record.usage = Some(share.clone());
+            record.usage_attribution = usage_attribution;
+        }
+        out.push(record);
+    }
+    next_index
+}
+
+fn divide_usage(usage: &Usage, divisor: u64) -> Usage {
+    if divisor <= 1 {
+        return usage.clone();
+    }
+    // Note: TS uses floating-point division here. Rust's `Usage` is u64, so
+    // fractional shares get truncated. Sums across an even-split turn will be
+    // ≤ the original total when the divisor doesn't evenly divide each field.
+    Usage {
+        input: usage.input / divisor,
+        output: usage.output / divisor,
+        reasoning: usage.reasoning / divisor,
+        cache_read: usage.cache_read / divisor,
+        cache_create_5m: usage.cache_create_5m / divisor,
+        cache_create_1h: usage.cache_create_1h / divisor,
+    }
+}
+
+#[derive(Default)]
+struct Measured {
+    length: Option<u64>,
+    hash: Option<String>,
+}
+
+fn measure_opencode_tool_output(output: Option<&Value>) -> Measured {
+    match output {
+        None | Some(Value::Null) => Measured::default(),
+        Some(Value::String(s)) => Measured {
+            length: Some(s.len() as u64),
+            hash: Some(content_hash(s)),
+        },
+        Some(other) => match serde_json::to_string(other) {
+            Ok(serialized) => Measured {
+                length: Some(serialized.len() as u64),
+                hash: Some(content_hash(&serialized)),
+            },
+            Err(_) => Measured::default(),
+        },
+    }
+}
+
+fn build_opencode_relationships(
+    session: &SessionInfo,
+    assistants: &[AssistantMessage],
+) -> Vec<SessionRelationshipRecord> {
+    let mut out = Vec::new();
+    let first_ts = assistants.first().map(|a| ms_to_iso(a.time_created));
+    let mut root = SessionRelationshipRecord {
+        v: 1,
+        source: RelationshipSourceKind::Opencode,
+        session_id: session.id.clone(),
+        related_session_id: None,
+        relationship_type: RelationshipType::Root,
+        ts: None,
+        source_session_id: None,
+        source_version: None,
+        parent_tool_use_id: None,
+        agent_id: None,
+        subagent_type: None,
+        description: None,
+    };
+    if let Some(t) = first_ts.clone() {
+        root.ts = Some(t);
+    }
+    out.push(root);
+    if let Some(parent) = session.parent_id.as_ref() {
+        if !parent.is_empty() {
+            let mut sub = SessionRelationshipRecord {
+                v: 1,
+                source: RelationshipSourceKind::NativeOpencode,
+                session_id: session.id.clone(),
+                related_session_id: Some(parent.clone()),
+                relationship_type: RelationshipType::Subagent,
+                ts: None,
+                source_session_id: None,
+                source_version: None,
+                parent_tool_use_id: None,
+                agent_id: None,
+                subagent_type: None,
+                description: None,
+            };
+            if let Some(t) = first_ts {
+                sub.ts = Some(t);
+            }
+            out.push(sub);
+        }
+    }
+    out
+}
+
+fn build_opencode_user_turn_record<C: TokenCounter + ?Sized>(
+    storage_root: &Path,
+    session_id: &str,
+    prev: Option<&AssistantMessage>,
+    next: &AssistantMessage,
+    user_msg: Option<&UserMessage>,
+    counter: &C,
+) -> Option<UserTurnRecord> {
+    let mut blocks: Vec<UserTurnBlock> = Vec::new();
+
+    if let Some(prev) = prev {
+        let prev_parts = read_parts(storage_root, &prev.id);
+        for p in &prev_parts {
+            let Some(tp) = as_tool_part(p) else { continue };
+            let Some(state) = tp.state else { continue };
+            if !state.contains_key("output") {
+                continue;
+            }
+            let is_error = is_failed_tool(Some(state));
+            let output = state
+                .get("output")
+                .cloned()
+                .unwrap_or(Value::String(String::new()));
+            blocks.push(UserTurnBlock::tool_result(
+                tp.call_id.to_string(),
+                &output,
+                if is_error { Some(true) } else { None },
+                counter,
+            ));
+        }
+    }
+
+    let mut ts = user_msg
+        .map(|u| ms_to_iso(u.time_created))
+        .unwrap_or_default();
+    if let Some(um) = user_msg {
+        let user_parts = read_parts(storage_root, &um.id);
+        for p in &user_parts {
+            if p.kind != "text" {
+                continue;
+            }
+            if let Some(t) = p.get("text").and_then(|v| v.as_str()) {
+                if !t.is_empty() {
+                    blocks.push(UserTurnBlock::text(t, counter));
+                }
+            }
+        }
+    }
+
+    if blocks.is_empty() {
+        return None;
+    }
+    if ts.is_empty() {
+        ts = ms_to_iso(next.time_created);
+    }
+    let user_uuid = match user_msg {
+        Some(um) => um.id.clone(),
+        None => format!(
+            "{}:{}->{}",
+            session_id,
+            prev.map(|p| p.id.as_str()).unwrap_or("start"),
+            next.id
+        ),
+    };
+    let mut record = UserTurnRecord {
+        v: 1,
+        source: SourceKind::Opencode,
+        session_id: session_id.to_string(),
+        user_uuid,
+        ts,
+        preceding_message_id: None,
+        following_message_id: Some(next.id.clone()),
+        blocks,
+    };
+    if let Some(prev) = prev {
+        record.preceding_message_id = Some(prev.id.clone());
+    }
+    Some(record)
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O helpers
+// ---------------------------------------------------------------------------
+
+fn derive_storage_root(session_file_path: &Path) -> PathBuf {
+    let mut p = session_file_path.to_path_buf();
+    for _ in 0..3 {
+        if !p.pop() {
+            break;
+        }
+    }
+    p
+}
+
+fn read_session(session_file_path: &Path) -> Option<SessionInfo> {
+    let raw = fs::read_to_string(session_file_path).ok()?;
+    let parsed: Value = serde_json::from_str(&raw).ok()?;
+    let obj = parsed.as_object()?;
+    let id = obj.get("id")?.as_str()?.to_string();
+    Some(SessionInfo {
+        id,
+        parent_id: obj
+            .get("parentID")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        directory: obj
+            .get("directory")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+    })
+}
+
+fn read_messages(storage_root: &Path, session_id: &str) -> Vec<Map<String, Value>> {
+    let dir = storage_root.join("message").join(session_id);
+    let entries = match fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+    let mut names: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    names.sort();
+    let mut out = Vec::new();
+    for path in names {
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(parsed) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        if let Value::Object(obj) = parsed {
+            let has_role = obj.get("role").and_then(|v| v.as_str()).is_some();
+            let has_id = obj.get("id").and_then(|v| v.as_str()).is_some();
+            if has_role && has_id {
+                out.push(obj);
+            }
+        }
+    }
+    out
+}
+
+fn read_parts(storage_root: &Path, message_id: &str) -> Vec<ParsedPart> {
+    let dir = storage_root.join("part").join(message_id);
+    let entries = match fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    let mut parts: Vec<ParsedPart> = Vec::new();
+    for path in paths {
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(parsed) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        if let Value::Object(obj) = parsed {
+            let kind = obj
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let id = obj.get("id").and_then(|v| v.as_str()).map(str::to_string);
+            parts.push(ParsedPart { id, kind, raw: obj });
+        }
+    }
+    parts.sort_by(|a, b| {
+        a.id.as_deref()
+            .unwrap_or("")
+            .cmp(b.id.as_deref().unwrap_or(""))
+    });
+    parts
+}
+
+// ---------------------------------------------------------------------------
+// Message parsing
+// ---------------------------------------------------------------------------
+
+fn parse_complete_assistant(m: &Map<String, Value>) -> Option<AssistantMessage> {
+    if m.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+        return None;
+    }
+    let id = m.get("id")?.as_str()?.to_string();
+    let session_id = m.get("sessionID")?.as_str()?.to_string();
+    let time_created = m
+        .get("time")
+        .and_then(|v| v.as_object())
+        .and_then(|t| t.get("created"))
+        .and_then(|v| v.as_i64())?;
+    let provider_id = m
+        .get("providerID")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let model_id = m
+        .get("modelID")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let path_cwd = m
+        .get("path")
+        .and_then(|v| v.as_object())
+        .and_then(|p| p.get("cwd"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let tokens = m.get("tokens").map(|t| parse_tokens(Some(t)));
+    Some(AssistantMessage {
+        id,
+        session_id,
+        time_created,
+        provider_id,
+        model_id,
+        path_cwd,
+        tokens,
+    })
+}
+
+fn parse_complete_user(m: &Map<String, Value>) -> Option<UserMessage> {
+    if m.get("role").and_then(|v| v.as_str()) != Some("user") {
+        return None;
+    }
+    let id = m.get("id")?.as_str()?.to_string();
+    let session_id = m.get("sessionID")?.as_str()?.to_string();
+    let time_created = m
+        .get("time")
+        .and_then(|v| v.as_object())
+        .and_then(|t| t.get("created"))
+        .and_then(|v| v.as_i64())?;
+    Some(UserMessage {
+        id,
+        session_id,
+        time_created,
+    })
+}
+
+fn parse_tokens(v: Option<&Value>) -> MessageTokens {
+    let Some(v) = v.and_then(|x| x.as_object()) else {
+        return MessageTokens {
+            input: None,
+            output: None,
+            reasoning: None,
+            cache_read: None,
+            cache_write: None,
+        };
+    };
+    let cache = v.get("cache").and_then(|x| x.as_object());
+    MessageTokens {
+        input: v.get("input").and_then(|x| x.as_u64()),
+        output: v.get("output").and_then(|x| x.as_u64()),
+        reasoning: v.get("reasoning").and_then(|x| x.as_u64()),
+        cache_read: cache.and_then(|c| c.get("read")).and_then(|x| x.as_u64()),
+        cache_write: cache.and_then(|c| c.get("write")).and_then(|x| x.as_u64()),
+    }
+}
+
+fn to_usage(t: Option<&MessageTokens>) -> Usage {
+    let input = t.and_then(|t| t.input).unwrap_or(0);
+    let output = t.and_then(|t| t.output).unwrap_or(0);
+    let reasoning = t.and_then(|t| t.reasoning).unwrap_or(0);
+    let cache_read = t.and_then(|t| t.cache_read).unwrap_or(0);
+    let cache_write = t.and_then(|t| t.cache_write).unwrap_or(0);
+    Usage {
+        input,
+        output,
+        reasoning,
+        cache_read,
+        cache_create_5m: cache_write,
+        cache_create_1h: 0,
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct OpencodeUsageCoverage {
+    has_input_tokens: bool,
+    has_output_tokens: bool,
+    has_reasoning_tokens: bool,
+    has_cache_read_tokens: bool,
+    has_cache_create_tokens: bool,
+}
+
+fn coverage_from_tokens(t: Option<&MessageTokens>) -> OpencodeUsageCoverage {
+    let Some(t) = t else {
+        return OpencodeUsageCoverage::default();
+    };
+    OpencodeUsageCoverage {
+        has_input_tokens: t.input.is_some(),
+        has_output_tokens: t.output.is_some(),
+        has_reasoning_tokens: t.reasoning.is_some(),
+        has_cache_read_tokens: t.cache_read.is_some(),
+        has_cache_create_tokens: t.cache_write.is_some(),
+    }
+}
+
+fn merge_usage_coverage(
+    a: &OpencodeUsageCoverage,
+    b: &OpencodeUsageCoverage,
+) -> OpencodeUsageCoverage {
+    OpencodeUsageCoverage {
+        has_input_tokens: a.has_input_tokens || b.has_input_tokens,
+        has_output_tokens: a.has_output_tokens || b.has_output_tokens,
+        has_reasoning_tokens: a.has_reasoning_tokens || b.has_reasoning_tokens,
+        has_cache_read_tokens: a.has_cache_read_tokens || b.has_cache_read_tokens,
+        has_cache_create_tokens: a.has_cache_create_tokens || b.has_cache_create_tokens,
+    }
+}
+
+fn build_opencode_fidelity(usage_coverage: &OpencodeUsageCoverage) -> Fidelity {
+    let coverage = Coverage {
+        has_input_tokens: usage_coverage.has_input_tokens,
+        has_output_tokens: usage_coverage.has_output_tokens,
+        has_reasoning_tokens: usage_coverage.has_reasoning_tokens,
+        has_cache_read_tokens: usage_coverage.has_cache_read_tokens,
+        has_cache_create_tokens: usage_coverage.has_cache_create_tokens,
+        has_tool_calls: true,
+        has_tool_result_events: true,
+        has_session_relationships: true,
+        has_raw_content: true,
+    };
+    let class = classify_fidelity(UsageGranularity::PerTurn, &coverage);
+    Fidelity {
+        granularity: UsageGranularity::PerTurn,
+        coverage,
+        class,
+    }
+}
+
+fn build_model(provider_id: Option<&str>, model_id: Option<&str>) -> String {
+    match (provider_id, model_id) {
+        (Some(p), Some(m)) if !p.is_empty() && !m.is_empty() => format!("{}/{}", p, m),
+        (_, Some(m)) => m.to_string(),
+        (Some(p), _) => p.to_string(),
+        _ => String::new(),
+    }
+}
+
+fn find_preceding_user(users: &[UserMessage], ts_created: i64) -> Option<UserMessage> {
+    let mut best: Option<UserMessage> = None;
+    for u in users {
+        if u.time_created <= ts_created {
+            best = Some(u.clone());
+        } else {
+            break;
+        }
+    }
+    best
+}
+
+fn find_preceding_assistant_by_time(
+    assistants: &[AssistantMessage],
+    ts: i64,
+) -> Option<&AssistantMessage> {
+    let mut best: Option<&AssistantMessage> = None;
+    for a in assistants {
+        if a.time_created < ts {
+            best = Some(a);
+        } else {
+            break;
+        }
+    }
+    best
+}
+
+fn join_nonempty(parts: &[&str], sep: &str) -> String {
+    let mut out: Vec<&str> = Vec::with_capacity(parts.len());
+    for p in parts {
+        if !p.is_empty() {
+            out.push(p);
+        }
+    }
+    out.join(sep)
+}
+
+fn ms_to_iso(ms: i64) -> String {
+    // `new Date(ms).toISOString()` — UTC with millisecond precision.
+    const MS_PER_DAY: i64 = 86_400_000;
+    let total_days_since_epoch = ms.div_euclid(MS_PER_DAY);
+    let ms_in_day = ms.rem_euclid(MS_PER_DAY);
+    let (y, mo, d) = days_to_ymd(total_days_since_epoch);
+    let h = ms_in_day / 3_600_000;
+    let m = (ms_in_day / 60_000) % 60;
+    let s = (ms_in_day / 1_000) % 60;
+    let frac = ms_in_day % 1_000;
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        y, mo, d, h, m, s, frac
+    )
+}
+
+fn days_to_ymd(days_since_epoch: i64) -> (i32, u32, u32) {
+    // Hinnant's days-from-civil inverse.
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 {
+        z / 146_097
+    } else {
+        (z - 146_096) / 146_097
+    };
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
+}
+
+fn resolve_token_counter(
+    tokenizer: Option<UserTurnTokenizer>,
+) -> std::io::Result<HeuristicCounter> {
+    match tokenizer {
+        None | Some(UserTurnTokenizer::Heuristic) => Ok(HeuristicCounter),
+        Some(UserTurnTokenizer::Cl100k) => Err(std::io::Error::other(
+            "cl100k tokenizer is not yet available in the Rust port; \
+             omit `tokenizer` or pass `Some(Heuristic)` (see AgentWorkforce/burn#246)",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/relayburn-reader/src/opencode/tests.rs
+++ b/crates/relayburn-reader/src/opencode/tests.rs
@@ -839,8 +839,16 @@ fn tool_result_events_per_resolved_part_with_size_and_hash() {
         ok.usage_attribution,
         Some(UsageAttribution::EvenSplitTurn)
     ));
-    // Three terminal tools, input usage = 5 → 5 / 3 = 1 (truncated to u64).
-    assert_eq!(ok.usage.as_ref().unwrap().input, 1);
+    // Three terminal tools, input usage = 5. Floor share = 1; the first
+    // `5 % 3 = 2` tools get one extra so per-tool slices sum back to 5
+    // (`call_read` is the first terminal in part-id order: 2 + 2 + 1 = 5).
+    assert_eq!(ok.usage.as_ref().unwrap().input, 2);
+    let input_sum: u64 = r
+        .tool_result_events
+        .iter()
+        .filter_map(|e| e.usage.as_ref().map(|u| u.input))
+        .sum();
+    assert_eq!(input_sum, 5, "per-tool usage shares sum to the turn total");
 
     let err_status = r
         .tool_result_events

--- a/crates/relayburn-reader/src/opencode/tests.rs
+++ b/crates/relayburn-reader/src/opencode/tests.rs
@@ -1,0 +1,931 @@
+//! OpenCode parser conformance tests. The bundled fixtures live at the repo
+//! root (`tests/fixtures/opencode/*`) and are shared with the TS test suite —
+//! mirroring the expectations in `packages/reader/src/opencode.test.ts`.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+
+use super::*;
+use crate::types::{
+    ContentKind, ContentRole, FidelityClass, RelationshipType, SourceKind, ToolResultEventSource,
+    ToolResultStatus, UsageAttribution, UsageGranularity, UserTurnBlockKind,
+};
+
+fn fixtures_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/relayburn-reader/ -> repo root
+    p.pop();
+    p.pop();
+    p.push("tests/fixtures/opencode");
+    p
+}
+
+fn session_file(fixture: &str, session_id: &str) -> PathBuf {
+    let mut p = fixtures_root();
+    p.push(fixture);
+    p.push("storage/session/global");
+    p.push(format!("{}.json", session_id));
+    p
+}
+
+fn parse(fixture: &str, session_id: &str) -> ParseOpencodeResult {
+    parse_opencode_session(
+        session_file(fixture, session_id),
+        &ParseOpencodeOptions::default(),
+    )
+    .unwrap()
+}
+
+fn parse_with(fixture: &str, session_id: &str, opts: ParseOpencodeOptions) -> ParseOpencodeResult {
+    parse_opencode_session(session_file(fixture, session_id), &opts).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// parseOpencodeSession — basic shapes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parses_simple_one_turn_session() {
+    let r = parse("simple", "ses_simple");
+    assert_eq!(r.turns.len(), 1);
+    let t = &r.turns[0];
+    assert_eq!(t.v, 1);
+    assert!(matches!(t.source, SourceKind::Opencode));
+    assert_eq!(t.session_id, "ses_simple");
+    assert_eq!(t.message_id, "msg_simple_asst");
+    assert_eq!(t.turn_index, 0);
+    assert_eq!(t.model, "anthropic/claude-sonnet-4-5");
+    assert_eq!(t.project.as_deref(), Some("/tmp/project"));
+    assert_eq!(t.ts, "2026-04-24T00:00:02.000Z");
+    assert_eq!(t.stop_reason.as_deref(), Some("end_turn"));
+    assert_eq!(
+        t.usage,
+        Usage {
+            input: 10,
+            output: 5,
+            reasoning: 0,
+            cache_read: 500,
+            cache_create_5m: 80,
+            cache_create_1h: 0,
+        },
+    );
+    assert_eq!(t.tool_calls.len(), 0);
+    assert!(t.files_touched.is_none());
+    assert!(t.subagent.is_none());
+}
+
+#[test]
+fn extracts_tool_calls_and_files_touched_for_file_tools() {
+    let r = parse("with-tool", "ses_tool");
+    assert_eq!(r.turns.len(), 1);
+    let t = &r.turns[0];
+    assert_eq!(t.tool_calls.len(), 3);
+    let read = &t.tool_calls[0];
+    let edit = &t.tool_calls[1];
+    let bash = &t.tool_calls[2];
+    assert_eq!(read.name, "read");
+    assert_eq!(read.target.as_deref(), Some("/src/a.ts"));
+    assert_eq!(edit.name, "edit");
+    assert_eq!(edit.target.as_deref(), Some("/src/b.ts"));
+    assert_eq!(bash.name, "bash");
+    assert_eq!(bash.target.as_deref(), Some("ls -la"));
+    let mut files = t.files_touched.clone().unwrap();
+    files.sort();
+    assert_eq!(
+        files,
+        vec!["/src/a.ts".to_string(), "/src/b.ts".to_string()]
+    );
+    assert_eq!(t.stop_reason.as_deref(), Some("tool-calls"));
+}
+
+#[test]
+fn emits_per_turn_usage_across_multiple_turns() {
+    let r = parse("multi-turn", "ses_multi");
+    assert_eq!(r.turns.len(), 2);
+    let t1 = &r.turns[0];
+    let t2 = &r.turns[1];
+    assert_eq!(t1.message_id, "msg_multi_a1");
+    assert_eq!(t1.turn_index, 0);
+    assert_eq!(t1.model, "anthropic/claude-sonnet-4-5");
+    assert_eq!(
+        t1.usage,
+        Usage {
+            input: 5,
+            output: 100,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 15000,
+            cache_create_1h: 0,
+        },
+    );
+    assert!(t1.subagent.is_none());
+
+    assert_eq!(t2.message_id, "msg_multi_a2");
+    assert_eq!(t2.turn_index, 1);
+    assert_eq!(t2.model, "anthropic/claude-opus-4-5");
+    assert_eq!(
+        t2.usage,
+        Usage {
+            input: 5,
+            output: 200,
+            reasoning: 50,
+            cache_read: 15000,
+            cache_create_5m: 3000,
+            cache_create_1h: 0,
+        },
+    );
+    assert_eq!(t2.tool_calls.len(), 1);
+    assert_eq!(t2.tool_calls[0].name, "bash");
+    assert_eq!(t2.tool_calls[0].target.as_deref(), Some("git status"));
+}
+
+#[test]
+fn marks_sidechain_for_session_with_parent_id() {
+    let r = parse("multi-turn", "ses_child");
+    assert_eq!(r.turns.len(), 1);
+    let t = &r.turns[0];
+    let sub = t.subagent.as_ref().expect("subagent populated");
+    assert!(sub.is_sidechain);
+    assert_eq!(t.model, "anthropic/claude-haiku-4-5");
+}
+
+#[test]
+fn produces_stable_args_hash_for_identical_inputs() {
+    let a = parse("with-tool", "ses_tool");
+    let b = parse("with-tool", "ses_tool");
+    assert_eq!(
+        a.turns[0].tool_calls[0].args_hash,
+        b.turns[0].tool_calls[0].args_hash
+    );
+    assert_ne!(
+        a.turns[0].tool_calls[0].args_hash,
+        a.turns[0].tool_calls[1].args_hash
+    );
+}
+
+#[test]
+fn respects_session_path_option() {
+    let path = session_file("simple", "ses_simple");
+    let path_str = path.to_string_lossy().to_string();
+    let r = parse_with(
+        "simple",
+        "ses_simple",
+        ParseOpencodeOptions {
+            session_path: Some(path_str.clone()),
+            ..ParseOpencodeOptions::default()
+        },
+    );
+    assert_eq!(r.turns[0].session_path.as_deref(), Some(path_str.as_str()));
+}
+
+#[test]
+fn classifies_activity_via_aliased_tool_names() {
+    let r = parse("with-tool", "ses_tool");
+    let t = &r.turns[0];
+    assert_eq!(t.has_edits, Some(true));
+    assert_eq!(t.activity.unwrap(), crate::types::ActivityCategory::Coding);
+}
+
+// ---------------------------------------------------------------------------
+// parseOpencodeSessionIncremental
+// ---------------------------------------------------------------------------
+
+#[test]
+fn incremental_returns_all_turns_when_seen_empty() {
+    let path = session_file("multi-turn", "ses_multi");
+    let r = parse_opencode_session_incremental(&path, &ParseOpencodeIncrementalOptions::default())
+        .unwrap();
+    assert_eq!(r.turns.len(), 2);
+    assert!(r.seen_message_ids.contains("msg_multi_a1"));
+    assert!(r.seen_message_ids.contains("msg_multi_a2"));
+}
+
+#[test]
+fn incremental_filters_already_seen_message_ids() {
+    let path = session_file("multi-turn", "ses_multi");
+    let mut seen = BTreeSet::new();
+    seen.insert("msg_multi_a1".to_string());
+    let r = parse_opencode_session_incremental(
+        &path,
+        &ParseOpencodeIncrementalOptions {
+            seen_message_ids: Some(seen),
+            ..ParseOpencodeIncrementalOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(r.turns.len(), 1);
+    assert_eq!(r.turns[0].message_id, "msg_multi_a2");
+    assert!(r.seen_message_ids.contains("msg_multi_a1"));
+    assert!(r.seen_message_ids.contains("msg_multi_a2"));
+}
+
+#[test]
+fn incremental_yields_zero_turns_when_all_seen() {
+    let path = session_file("multi-turn", "ses_multi");
+    let mut seen = BTreeSet::new();
+    seen.insert("msg_multi_a1".to_string());
+    seen.insert("msg_multi_a2".to_string());
+    let r = parse_opencode_session_incremental(
+        &path,
+        &ParseOpencodeIncrementalOptions {
+            seen_message_ids: Some(seen),
+            ..ParseOpencodeIncrementalOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(r.turns.len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Errored tool call ⇒ debugging
+// ---------------------------------------------------------------------------
+
+fn write_json(p: &Path, body: &str) {
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(p, body).unwrap();
+}
+
+#[test]
+fn errored_tool_part_marks_turn_as_debugging() {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    let msg_dir = storage.join("message/ses_fail");
+    let part_asst = storage.join("part/msg_fail_asst");
+    let part_user = storage.join("part/msg_fail_user");
+
+    write_json(
+        &session_dir.join("ses_fail.json"),
+        r#"{"id":"ses_fail","directory":"/tmp/proj"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_fail_user.json"),
+        r#"{"id":"msg_fail_user","sessionID":"ses_fail","role":"user","time":{"created":1776988000000}}"#,
+    );
+    write_json(
+        &part_user.join("prt_fail_user_1.json"),
+        r#"{"id":"prt_fail_user_1","sessionID":"ses_fail","messageID":"msg_fail_user","type":"text","text":"please check why the build is broken"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_fail_asst.json"),
+        r#"{"id":"msg_fail_asst","sessionID":"ses_fail","role":"assistant","providerID":"anthropic","modelID":"claude-haiku-4-5","time":{"created":1776988001000},"path":{"cwd":"/tmp/proj"},"tokens":{"input":10,"output":20,"cache":{"read":0,"write":0}}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_fail_asst_1.json"),
+        r#"{"id":"prt_fail_asst_1","sessionID":"ses_fail","messageID":"msg_fail_asst","type":"tool","callID":"call_fail_bash","tool":"bash","state":{"status":"completed","input":{"command":"npm run build"},"output":"command not found: foo","metadata":{"exit":1}}}"#,
+    );
+
+    let file = session_dir.join("ses_fail.json");
+    let r = parse_opencode_session(&file, &ParseOpencodeOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), 1);
+    let t = &r.turns[0];
+    assert_eq!(
+        t.activity.unwrap(),
+        crate::types::ActivityCategory::Debugging
+    );
+    assert_eq!(t.has_edits, Some(false));
+}
+
+// ---------------------------------------------------------------------------
+// Compaction events
+// ---------------------------------------------------------------------------
+
+#[test]
+fn emits_compaction_event_anchored_to_preceding_turn() {
+    let r = parse("with-compaction", "ses_compact");
+    assert_eq!(r.turns.len(), 3);
+    assert_eq!(r.events.len(), 1);
+    let ev = &r.events[0];
+    assert_eq!(ev.v, 1);
+    assert!(matches!(ev.source, SourceKind::Opencode));
+    assert_eq!(ev.session_id, "ses_compact");
+    assert_eq!(ev.ts, "2026-04-24T02:50:03.000Z");
+    assert_eq!(ev.preceding_message_id.as_deref(), Some("msg_compact_a1"));
+    let preceding = r
+        .turns
+        .iter()
+        .find(|t| t.message_id == "msg_compact_a1")
+        .unwrap();
+    assert_eq!(ev.tokens_before_compact, Some(preceding.usage.cache_read));
+    assert_eq!(ev.tokens_before_compact, Some(12000));
+}
+
+#[test]
+fn does_not_re_emit_compaction_when_user_id_seen() {
+    let path = session_file("with-compaction", "ses_compact");
+    let mut seen = BTreeSet::new();
+    seen.insert("msg_compact_a1".to_string());
+    seen.insert("msg_compact_summary".to_string());
+    seen.insert("msg_compact_uc".to_string());
+    let r = parse_opencode_session_incremental(
+        &path,
+        &ParseOpencodeIncrementalOptions {
+            seen_message_ids: Some(seen),
+            ..ParseOpencodeIncrementalOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(r.events.len(), 0);
+    assert_eq!(r.turns.len(), 1);
+    assert_eq!(r.turns[0].message_id, "msg_compact_a2");
+}
+
+// ---------------------------------------------------------------------------
+// Content capture
+// ---------------------------------------------------------------------------
+
+fn with_content_fixture<F: FnOnce(&Path)>(body: F) {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    let msg_dir = storage.join("message/ses_content");
+    let part_asst = storage.join("part/msg_content_asst");
+    let part_user = storage.join("part/msg_content_user");
+
+    write_json(
+        &session_dir.join("ses_content.json"),
+        r#"{"id":"ses_content","directory":"/tmp/proj"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_content_user.json"),
+        r#"{"id":"msg_content_user","sessionID":"ses_content","role":"user","time":{"created":1776988000000}}"#,
+    );
+    write_json(
+        &part_user.join("prt_user_a.json"),
+        r#"{"id":"prt_user_a","sessionID":"ses_content","messageID":"msg_content_user","type":"text","text":"run tests"}"#,
+    );
+    write_json(
+        &part_user.join("prt_user_b.json"),
+        r#"{"id":"prt_user_b","sessionID":"ses_content","messageID":"msg_content_user","type":"text","text":"<synthetic nudge>","synthetic":true}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_content_asst.json"),
+        r#"{"id":"msg_content_asst","sessionID":"ses_content","role":"assistant","providerID":"anthropic","modelID":"claude-sonnet-4-6","time":{"created":1776988001000},"path":{"cwd":"/tmp/proj"},"tokens":{"input":100,"output":20,"cache":{"read":0,"write":0}}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_asst_a.json"),
+        r#"{"id":"prt_asst_a","sessionID":"ses_content","messageID":"msg_content_asst","type":"text","text":"running now."}"#,
+    );
+    write_json(
+        &part_asst.join("prt_asst_b.json"),
+        r#"{"id":"prt_asst_b","sessionID":"ses_content","messageID":"msg_content_asst","type":"tool","callID":"call_oc_bash","tool":"bash","state":{"status":"completed","input":{"command":"npm test"},"output":"10 passed","metadata":{"exit":0}}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_asst_c.json"),
+        r#"{"id":"prt_asst_c","sessionID":"ses_content","messageID":"msg_content_asst","type":"tool","callID":"call_oc_fail","tool":"bash","state":{"status":"completed","input":{"command":"lint"},"output":"ERR","metadata":{"exit":2}}}"#,
+    );
+    body(&session_dir.join("ses_content.json"));
+}
+
+#[test]
+fn content_default_off() {
+    with_content_fixture(|file| {
+        let r = parse_opencode_session(file, &ParseOpencodeOptions::default()).unwrap();
+        assert!(r.content.is_empty());
+    });
+}
+
+#[test]
+fn content_hash_only_returns_empty() {
+    with_content_fixture(|file| {
+        let r = parse_opencode_session(
+            file,
+            &ParseOpencodeOptions {
+                content_mode: Some(ContentStoreMode::HashOnly),
+                ..ParseOpencodeOptions::default()
+            },
+        )
+        .unwrap();
+        assert!(r.content.is_empty());
+    });
+}
+
+#[test]
+fn content_full_emits_tool_results_keyed_by_call_id() {
+    with_content_fixture(|file| {
+        let r = parse_opencode_session(
+            file,
+            &ParseOpencodeOptions {
+                content_mode: Some(ContentStoreMode::Full),
+                ..ParseOpencodeOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(r.turns.len(), 1);
+        let tool_results: Vec<_> = r
+            .content
+            .iter()
+            .filter(|c| matches!(c.kind, ContentKind::ToolResult))
+            .collect();
+        assert_eq!(tool_results.len(), 2);
+        let bash = tool_results
+            .iter()
+            .find(|c| c.tool_result.as_ref().unwrap().tool_use_id == "call_oc_bash")
+            .unwrap();
+        assert_eq!(
+            bash.tool_result.as_ref().unwrap().content.as_str(),
+            Some("10 passed"),
+        );
+        assert_eq!(bash.tool_result.as_ref().unwrap().is_error, None);
+        let fail = tool_results
+            .iter()
+            .find(|c| c.tool_result.as_ref().unwrap().tool_use_id == "call_oc_fail")
+            .unwrap();
+        assert_eq!(
+            fail.tool_result.as_ref().unwrap().content.as_str(),
+            Some("ERR"),
+        );
+        assert_eq!(fail.tool_result.as_ref().unwrap().is_error, Some(true));
+        let turn_tool_ids: BTreeSet<_> = r.turns[0]
+            .tool_calls
+            .iter()
+            .map(|tc| tc.id.clone())
+            .collect();
+        assert!(turn_tool_ids.contains("call_oc_bash"));
+        assert!(turn_tool_ids.contains("call_oc_fail"));
+    });
+}
+
+#[test]
+fn content_full_captures_user_text_skipping_synthetic() {
+    with_content_fixture(|file| {
+        let r = parse_opencode_session(
+            file,
+            &ParseOpencodeOptions {
+                content_mode: Some(ContentStoreMode::Full),
+                ..ParseOpencodeOptions::default()
+            },
+        )
+        .unwrap();
+        let user_texts: Vec<_> = r
+            .content
+            .iter()
+            .filter(|c| matches!(c.role, ContentRole::User) && matches!(c.kind, ContentKind::Text))
+            .map(|c| c.text.clone().unwrap_or_default())
+            .collect();
+        assert_eq!(user_texts, vec!["run tests".to_string()]);
+        let asst_text = r
+            .content
+            .iter()
+            .find(|c| {
+                matches!(c.role, ContentRole::Assistant) && matches!(c.kind, ContentKind::Text)
+            })
+            .unwrap();
+        assert_eq!(asst_text.text.as_deref(), Some("running now."));
+        let tool_uses = r
+            .content
+            .iter()
+            .filter(|c| matches!(c.kind, ContentKind::ToolUse))
+            .count();
+        assert_eq!(tool_uses, 2);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Fidelity (issue #89)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fidelity_full_when_tokens_fully_populated() {
+    let r = parse("simple", "ses_simple");
+    let t = &r.turns[0];
+    let f = t.fidelity.as_ref().unwrap();
+    assert!(matches!(f.granularity, UsageGranularity::PerTurn));
+    assert!(matches!(f.class, FidelityClass::Full));
+    assert!(f.coverage.has_input_tokens);
+    assert!(f.coverage.has_output_tokens);
+    assert!(f.coverage.has_reasoning_tokens);
+    assert!(f.coverage.has_cache_read_tokens);
+    assert!(f.coverage.has_cache_create_tokens);
+    assert!(f.coverage.has_tool_calls);
+    assert!(f.coverage.has_tool_result_events);
+    assert!(f.coverage.has_session_relationships);
+    assert!(f.coverage.has_raw_content);
+}
+
+#[test]
+fn fidelity_partial_when_no_tokens_block() {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    let msg_dir = storage.join("message/ses_no_tokens");
+    fs::create_dir_all(&session_dir).unwrap();
+    fs::create_dir_all(&msg_dir).unwrap();
+    fs::create_dir_all(storage.join("part/msg_no_tokens_asst")).unwrap();
+    write_json(
+        &session_dir.join("ses_no_tokens.json"),
+        r#"{"id":"ses_no_tokens","directory":"/tmp/proj"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_no_tokens_asst.json"),
+        r#"{"id":"msg_no_tokens_asst","sessionID":"ses_no_tokens","role":"assistant","providerID":"anthropic","modelID":"claude-haiku-4-5","time":{"created":1776988001000},"path":{"cwd":"/tmp/proj"}}"#,
+    );
+    let file = session_dir.join("ses_no_tokens.json");
+    let r = parse_opencode_session(&file, &ParseOpencodeOptions::default()).unwrap();
+    assert_eq!(r.turns.len(), 1);
+    let f = r.turns[0].fidelity.as_ref().unwrap();
+    assert!(matches!(f.granularity, UsageGranularity::PerTurn));
+    assert!(matches!(f.class, FidelityClass::Partial));
+    assert!(!f.coverage.has_input_tokens);
+    assert!(!f.coverage.has_output_tokens);
+    assert!(!f.coverage.has_reasoning_tokens);
+    assert!(!f.coverage.has_cache_read_tokens);
+    assert!(!f.coverage.has_cache_create_tokens);
+    assert!(f.coverage.has_tool_calls);
+    assert!(f.coverage.has_tool_result_events);
+    assert!(f.coverage.has_session_relationships);
+    assert!(f.coverage.has_raw_content);
+}
+
+#[test]
+fn fidelity_flips_cache_flags_when_present() {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    let msg_dir = storage.join("message/ses_cache");
+    fs::create_dir_all(&session_dir).unwrap();
+    fs::create_dir_all(&msg_dir).unwrap();
+    fs::create_dir_all(storage.join("part/msg_cache_asst")).unwrap();
+    write_json(
+        &session_dir.join("ses_cache.json"),
+        r#"{"id":"ses_cache","directory":"/tmp/proj"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_cache_asst.json"),
+        r#"{"id":"msg_cache_asst","sessionID":"ses_cache","role":"assistant","providerID":"anthropic","modelID":"claude-sonnet-4-5","time":{"created":1776988001000},"path":{"cwd":"/tmp/proj"},"tokens":{"input":100,"output":50,"cache":{"read":12000,"write":800}}}"#,
+    );
+    let r = parse_opencode_session(
+        session_dir.join("ses_cache.json"),
+        &ParseOpencodeOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(r.turns.len(), 1);
+    let f = r.turns[0].fidelity.as_ref().unwrap();
+    assert!(f.coverage.has_cache_read_tokens);
+    assert!(f.coverage.has_cache_create_tokens);
+    assert!(!f.coverage.has_reasoning_tokens);
+    assert_eq!(r.turns[0].usage.reasoning, 0);
+    assert!(matches!(f.class, FidelityClass::Full));
+}
+
+#[test]
+fn every_emitted_turn_carries_fidelity() {
+    let r = parse("multi-turn", "ses_multi");
+    assert!(!r.turns.is_empty());
+    let unknown = r.turns.iter().filter(|t| t.fidelity.is_none()).count();
+    assert_eq!(unknown, 0);
+    for t in &r.turns {
+        assert!(matches!(
+            t.fidelity.as_ref().unwrap().granularity,
+            UsageGranularity::PerTurn,
+        ));
+    }
+}
+
+#[test]
+fn fidelity_rolls_up_step_finish_coverage() {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    let msg_dir = storage.join("message/ses_sf");
+    let part_asst = storage.join("part/msg_sf_asst");
+    fs::create_dir_all(&session_dir).unwrap();
+    fs::create_dir_all(&msg_dir).unwrap();
+    fs::create_dir_all(&part_asst).unwrap();
+    write_json(
+        &session_dir.join("ses_sf.json"),
+        r#"{"id":"ses_sf","directory":"/tmp/proj"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_sf_asst.json"),
+        r#"{"id":"msg_sf_asst","sessionID":"ses_sf","role":"assistant","providerID":"anthropic","modelID":"claude-sonnet-4-5","time":{"created":1776988001000},"path":{"cwd":"/tmp/proj"},"tokens":{"input":5,"output":3}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_sf_1.json"),
+        r#"{"id":"prt_sf_1","sessionID":"ses_sf","messageID":"msg_sf_asst","type":"step-finish","reason":"end_turn","tokens":{"input":5,"output":3,"cache":{"read":1000,"write":200}}}"#,
+    );
+    let r = parse_opencode_session(
+        session_dir.join("ses_sf.json"),
+        &ParseOpencodeOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(r.turns.len(), 1);
+    let f = r.turns[0].fidelity.as_ref().unwrap();
+    assert!(f.coverage.has_cache_read_tokens);
+    assert!(f.coverage.has_cache_create_tokens);
+}
+
+// ---------------------------------------------------------------------------
+// User-turn block sizes (issue #86)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn user_turn_blocks_one_per_gap() {
+    let r = parse("user-turn-blocks", "ses_utb");
+    assert_eq!(r.turns.len(), 2);
+    assert_eq!(r.user_turns.len(), 2);
+
+    for u in &r.user_turns {
+        assert_eq!(u.v, 1);
+        assert!(matches!(u.source, SourceKind::Opencode));
+        assert_eq!(u.session_id, "ses_utb");
+        assert!(!u.user_uuid.is_empty());
+        assert!(!u.ts.is_empty());
+        assert!(!u.blocks.is_empty());
+    }
+
+    let pre = &r.user_turns[0];
+    let between = &r.user_turns[1];
+
+    assert!(pre.preceding_message_id.is_none());
+    assert_eq!(pre.following_message_id.as_deref(), Some("msg_utb_a1"));
+    assert_eq!(pre.user_uuid, "msg_utb_u1");
+    assert_eq!(pre.blocks.len(), 1);
+    assert!(matches!(pre.blocks[0].kind, UserTurnBlockKind::Text));
+    assert_eq!(pre.blocks[0].byte_len, "fix the build".len() as u64);
+    // Heuristic counter (bytes/4 ceil): ceil(13/4) = 4. Note: the TS test uses
+    // cl100k which yields 3 here; the Rust port currently only ships heuristic.
+    assert_eq!(pre.blocks[0].approx_tokens, 4);
+
+    assert_eq!(between.preceding_message_id.as_deref(), Some("msg_utb_a1"));
+    assert_eq!(between.following_message_id.as_deref(), Some("msg_utb_a2"));
+    assert_eq!(between.user_uuid, "msg_utb_u2");
+    assert_eq!(between.blocks.len(), 3);
+
+    let ok_block = between
+        .blocks
+        .iter()
+        .find(|b| b.tool_use_id.as_deref() == Some("call_b1"))
+        .unwrap();
+    assert!(matches!(ok_block.kind, UserTurnBlockKind::ToolResult));
+    assert_eq!(ok_block.byte_len, "ok\n".len() as u64);
+    assert_eq!(ok_block.is_error, None);
+
+    let fail_block = between
+        .blocks
+        .iter()
+        .find(|b| b.tool_use_id.as_deref() == Some("call_fail"))
+        .unwrap();
+    assert!(matches!(fail_block.kind, UserTurnBlockKind::ToolResult));
+    assert_eq!(fail_block.byte_len, "ERROR: tests failed".len() as u64);
+    assert_eq!(fail_block.is_error, Some(true));
+
+    let txt = between
+        .blocks
+        .iter()
+        .find(|b| matches!(b.kind, UserTurnBlockKind::Text))
+        .unwrap();
+    assert_eq!(txt.byte_len, "now run tests".len() as u64);
+}
+
+#[test]
+fn empty_user_turns_when_no_measurable_blocks() {
+    let r = parse("multi-turn", "ses_multi");
+    assert!(r.user_turns.is_empty());
+}
+
+#[test]
+fn no_double_emit_user_turns_across_resumed_passes() {
+    let path = session_file("user-turn-blocks", "ses_utb");
+    let first =
+        parse_opencode_session_incremental(&path, &ParseOpencodeIncrementalOptions::default())
+            .unwrap();
+    assert_eq!(first.user_turns.len(), 2);
+
+    let mut seen = BTreeSet::new();
+    seen.insert("msg_utb_a1".to_string());
+    let resumed = parse_opencode_session_incremental(
+        &path,
+        &ParseOpencodeIncrementalOptions {
+            seen_message_ids: Some(seen),
+            ..ParseOpencodeIncrementalOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(resumed.turns.len(), 1);
+    assert_eq!(resumed.turns[0].message_id, "msg_utb_a2");
+    assert_eq!(resumed.user_turns.len(), 1);
+    let u = &resumed.user_turns[0];
+    assert_eq!(u.preceding_message_id.as_deref(), Some("msg_utb_a1"));
+    assert_eq!(u.following_message_id.as_deref(), Some("msg_utb_a2"));
+    assert_eq!(u.blocks.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Execution graph (#42 / #93)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn relationships_one_root_for_non_subagent_session() {
+    let r = parse("multi-turn", "ses_multi");
+    assert_eq!(r.relationships.len(), 1);
+    let root = &r.relationships[0];
+    assert_eq!(root.v, 1);
+    assert!(matches!(root.source, RelationshipSourceKind::Opencode));
+    assert_eq!(root.session_id, "ses_multi");
+    assert!(matches!(root.relationship_type, RelationshipType::Root));
+    assert!(root.related_session_id.is_none());
+    assert!(root.ts.is_some());
+}
+
+#[test]
+fn relationships_subagent_when_parent_id_set() {
+    let r = parse("multi-turn", "ses_child");
+    assert_eq!(r.relationships.len(), 2);
+    let sub = r
+        .relationships
+        .iter()
+        .find(|x| matches!(x.relationship_type, RelationshipType::Subagent))
+        .unwrap();
+    assert!(matches!(sub.source, RelationshipSourceKind::NativeOpencode));
+    assert_eq!(sub.session_id, "ses_child");
+    assert_eq!(sub.related_session_id.as_deref(), Some("ses_multi"));
+    let root = r
+        .relationships
+        .iter()
+        .find(|x| matches!(x.relationship_type, RelationshipType::Root))
+        .unwrap();
+    assert_eq!(root.session_id, "ses_child");
+}
+
+#[test]
+fn relationships_emitted_for_empty_subagent_session() {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    fs::create_dir_all(&session_dir).unwrap();
+    write_json(
+        &session_dir.join("ses_empty_child.json"),
+        r#"{"id":"ses_empty_child","parentID":"ses_parent"}"#,
+    );
+    let r = parse_opencode_session(
+        session_dir.join("ses_empty_child.json"),
+        &ParseOpencodeOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(r.turns.len(), 0);
+    assert_eq!(r.relationships.len(), 2);
+    let sub = r
+        .relationships
+        .iter()
+        .find(|x| matches!(x.relationship_type, RelationshipType::Subagent))
+        .unwrap();
+    assert_eq!(sub.related_session_id.as_deref(), Some("ses_parent"));
+    assert!(sub.ts.is_none());
+}
+
+#[test]
+fn tool_result_events_per_resolved_part_with_size_and_hash() {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    let msg_dir = storage.join("message/ses_tre");
+    let part_asst = storage.join("part/msg_tre_asst");
+    fs::create_dir_all(&session_dir).unwrap();
+    fs::create_dir_all(&msg_dir).unwrap();
+    fs::create_dir_all(&part_asst).unwrap();
+    write_json(
+        &session_dir.join("ses_tre.json"),
+        r#"{"id":"ses_tre","directory":"/tmp/proj"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_tre_asst.json"),
+        r#"{"id":"msg_tre_asst","sessionID":"ses_tre","role":"assistant","providerID":"anthropic","modelID":"claude-sonnet-4-5","time":{"created":1777000000000},"tokens":{"input":5,"output":5,"cache":{"read":0,"write":0}}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_tre_a.json"),
+        r#"{"id":"prt_tre_a","sessionID":"ses_tre","messageID":"msg_tre_asst","type":"tool","callID":"call_read","tool":"read","state":{"status":"completed","input":{"filePath":"/x.ts"},"output":"hello world","metadata":{}}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_tre_b.json"),
+        r#"{"id":"prt_tre_b","sessionID":"ses_tre","messageID":"msg_tre_asst","type":"tool","callID":"call_err_status","tool":"webfetch","state":{"status":"error","input":{"url":"https://x"},"output":"fetch failed","metadata":{}}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_tre_c.json"),
+        r#"{"id":"prt_tre_c","sessionID":"ses_tre","messageID":"msg_tre_asst","type":"tool","callID":"call_bash_exit","tool":"bash","state":{"status":"completed","input":{"command":"false"},"output":"oops","metadata":{"exit":1}}}"#,
+    );
+    let r = parse_opencode_session(
+        session_dir.join("ses_tre.json"),
+        &ParseOpencodeOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(r.tool_result_events.len(), 3);
+
+    let ok = r
+        .tool_result_events
+        .iter()
+        .find(|e| e.tool_use_id == "call_read")
+        .unwrap();
+    assert_eq!(ok.v, 1);
+    assert!(matches!(ok.source, SourceKind::Opencode));
+    assert_eq!(ok.session_id, "ses_tre");
+    assert_eq!(ok.message_id.as_deref(), Some("msg_tre_asst"));
+    assert!(matches!(ok.event_source, ToolResultEventSource::ToolResult));
+    assert!(matches!(ok.status, ToolResultStatus::Completed));
+    assert_eq!(ok.is_error, None);
+    assert_eq!(ok.content_length, Some("hello world".len() as u64));
+    assert!(ok
+        .content_hash
+        .as_ref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false));
+    assert_eq!(ok.call_index, Some(0));
+    assert_eq!(ok.event_index, 0);
+    assert_eq!(ok.ts.as_deref(), Some("2026-04-24T03:06:40.000Z"));
+    assert!(matches!(
+        ok.usage_attribution,
+        Some(UsageAttribution::EvenSplitTurn)
+    ));
+    // Three terminal tools, input usage = 5 → 5 / 3 = 1 (truncated to u64).
+    assert_eq!(ok.usage.as_ref().unwrap().input, 1);
+
+    let err_status = r
+        .tool_result_events
+        .iter()
+        .find(|e| e.tool_use_id == "call_err_status")
+        .unwrap();
+    assert!(matches!(err_status.status, ToolResultStatus::Errored));
+    assert_eq!(err_status.is_error, Some(true));
+    assert_eq!(err_status.content_length, Some("fetch failed".len() as u64));
+
+    let err_exit = r
+        .tool_result_events
+        .iter()
+        .find(|e| e.tool_use_id == "call_bash_exit")
+        .unwrap();
+    assert!(matches!(err_exit.status, ToolResultStatus::Errored));
+    assert_eq!(err_exit.is_error, Some(true));
+    assert_eq!(err_exit.content_length, Some("oops".len() as u64));
+
+    let mut indices: Vec<u64> = r.tool_result_events.iter().map(|e| e.event_index).collect();
+    let sorted = {
+        let mut s = indices.clone();
+        s.sort();
+        s
+    };
+    assert_eq!(indices, sorted);
+    indices.dedup();
+    assert_eq!(indices.len(), r.tool_result_events.len());
+}
+
+#[test]
+fn tool_result_event_hashes_structured_output() {
+    let tmp = tempdir().unwrap();
+    let storage = tmp.path().join("storage");
+    let session_dir = storage.join("session/global");
+    let msg_dir = storage.join("message/ses_struct");
+    let part_asst = storage.join("part/msg_struct_asst");
+    fs::create_dir_all(&session_dir).unwrap();
+    fs::create_dir_all(&msg_dir).unwrap();
+    fs::create_dir_all(&part_asst).unwrap();
+    write_json(
+        &session_dir.join("ses_struct.json"),
+        r#"{"id":"ses_struct","directory":"/tmp/proj"}"#,
+    );
+    write_json(
+        &msg_dir.join("msg_struct_asst.json"),
+        r#"{"id":"msg_struct_asst","sessionID":"ses_struct","role":"assistant","modelID":"claude-sonnet-4-5","time":{"created":1777000001000},"tokens":{"input":5,"output":5,"cache":{"read":0,"write":0}}}"#,
+    );
+    write_json(
+        &part_asst.join("prt_struct.json"),
+        r#"{"id":"prt_struct","sessionID":"ses_struct","messageID":"msg_struct_asst","type":"tool","callID":"call_struct","tool":"read","state":{"status":"completed","input":{"filePath":"/x.ts"},"output":{"kind":"image","size":12},"metadata":{}}}"#,
+    );
+    let r = parse_opencode_session(
+        session_dir.join("ses_struct.json"),
+        &ParseOpencodeOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(r.tool_result_events.len(), 1);
+    let ev = &r.tool_result_events[0];
+    let expected = serde_json::to_string(&serde_json::json!({"kind":"image","size":12})).unwrap();
+    assert_eq!(ev.content_length, Some(expected.len() as u64));
+    assert!(ev
+        .content_hash
+        .as_ref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false));
+}
+
+#[test]
+fn tool_result_events_no_duplicates_across_resumed_passes() {
+    let path = session_file("multi-turn", "ses_multi");
+    let first =
+        parse_opencode_session_incremental(&path, &ParseOpencodeIncrementalOptions::default())
+            .unwrap();
+    let second = parse_opencode_session_incremental(
+        &path,
+        &ParseOpencodeIncrementalOptions {
+            seen_message_ids: Some(first.seen_message_ids.clone()),
+            ..ParseOpencodeIncrementalOptions::default()
+        },
+    )
+    .unwrap();
+    assert!(!first.tool_result_events.is_empty());
+    assert_eq!(second.tool_result_events.len(), 0);
+    assert_eq!(second.turns.len(), 0);
+    assert_eq!(first.relationships.len(), 1);
+    assert_eq!(second.relationships.len(), 1);
+}


### PR DESCRIPTION
Ports `packages/reader/src/opencode.ts` to `crates/relayburn-reader/src/opencode.rs` field-for-field.

## Surface

- `parse_opencode_session` / `parse_opencode_session_incremental` mirror the TS surface, returning the same set of records (`turns`, `content`, `events`, `user_turns`, `relationships`, `tool_result_events`) plus `seen_message_ids` for resumed-pass dedup.

## Behaviour ported

- Walks the `storage/{session,message,part}/...` tree on disk, sorting assistants and users by `time.created`, anchoring `UserTurnRecord`s to the gap between consecutive assistants (prior-turn tool outputs + intervening user text), with the same `userUuid` fallback when the gap has only tool outputs.
- Tool-call extraction includes target-field heuristics for `read`/`write`/`edit`/`bash`/`grep`/`glob`/`webfetch`/`task`, the skill-name detector for OpenCode's `skill` tool, and the bash-family failure rule (`state.status='error'` OR non-zero `metadata.exit`).
- Tool-result events get monotonic `eventIndex`, per-`callID` `callIndex`, even-split usage attribution across terminal tools in the turn, and `contentHash`/`contentLength` derived from the (possibly structured) output.
- Compaction events anchor to the assistant chronologically preceding the synthetic user message carrying `type: "compaction"`, reporting the preceding turn's `cache.read` as `tokensBeforeCompact`.
- Relationships always emit a `root` row plus a `subagent` row when `session.parentID` is set; emitted on every pass and deduped by hash in the writer.
- Fidelity flags reflect coverage from `m.tokens` and any `step-finish` parts so a turn whose assistant message lacks `cache.read` but whose step-finish part includes it still flips `hasCacheReadTokens`.

## Tests

Native Rust conformance tests in `opencode/tests.rs` cover all `packages/reader/src/opencode.test.ts` scenarios that don't depend on the cl100k tokenizer (deferred — the Rust port uses `HeuristicCounter`, see #246). The fixtures at `tests/fixtures/opencode/*` are shared verbatim between the TS and Rust suites.

139 reader-crate tests pass; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

Closes #257

## Test plan

- [x] `cargo test -p relayburn-reader`
- [x] `cargo clippy -p relayburn-reader --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --workspace --all-targets`


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTTDVQ8k62JCtFj1jWe1J5)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/burn/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->