### PR TITLE
Port relayburn-ingest standalone modules + verb surface (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+- `relayburn-ingest` (Rust): port the standalone primitives — `pending_stamps` (binary-compatible with the TS `@relayburn/ingest` wire format), `walk` (`walk_jsonl` / `walk_opencode_sessions`), `watch_loop` (`tokio::time::interval`-driven `WatchController` with graceful stop), and the typed `cursors` module layered on the SQLite ledger's cursor blob. Public verb surface (`ingest_all`, per-harness verbs, `reingest_missing_content`) is wired; per-harness orchestration follow-ups deferred to dedicated sub-issues. (#245)
+
 ## [1.9.0] - 2026-05-03
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +423,17 @@ version = "0.0.0"
 [[package]]
 name = "relayburn-ingest"
 version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "relayburn-ledger",
+ "relayburn-reader",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "relayburn-ledger"
@@ -516,6 +539,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -590,6 +614,28 @@ name = "thiserror-impl"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/relayburn-ingest/Cargo.toml
+++ b/crates/relayburn-ingest/Cargo.toml
@@ -7,3 +7,19 @@ license.workspace = true
 repository.workspace = true
 description = "Session-store discovery, parse-and-append orchestration, pending stamps, and watch loop (Rust port)."
 publish = false
+
+[dependencies]
+relayburn-reader = { path = "../relayburn-reader" }
+relayburn-ledger = { path = "../relayburn-ledger" }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
+tokio = { workspace = true, features = ["sync"] }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync", "test-util"] }

--- a/crates/relayburn-ingest/src/cursors.rs
+++ b/crates/relayburn-ingest/src/cursors.rs
@@ -1,0 +1,221 @@
+//! Per-file ingest cursors — Rust port of `packages/ledger/src/cursors.ts`.
+//!
+//! Cursors live in the `archive_state.upstream_cursors_json` blob in
+//! `burn.sqlite`; this module owns the typed schema layered over that string,
+//! plus the load / save / diff helpers the orchestration code uses.
+//!
+//! ## Wire layout
+//!
+//! `{"files": {"<absolute path>": <cursor>}}`. The cursor variant is tagged
+//! by `kind`: `"claude" | "codex" | "opencode" | "opencode-stream"`. Field
+//! names are camelCase to match the TS schema so a Rust ingest can pick up
+//! cursors a TS ingest wrote, and vice versa, during the migration.
+
+use std::collections::BTreeMap;
+
+use relayburn_ledger::{Ledger, Result as LedgerResult};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeCursor {
+    pub inode: u64,
+    pub offset_bytes: u64,
+    pub mtime_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_user_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexCumulative {
+    pub input: u64,
+    pub output: u64,
+    pub cache_read: u64,
+    pub reasoning: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexCursor {
+    pub inode: u64,
+    pub offset_bytes: u64,
+    pub mtime_ms: i64,
+    pub cumulative: CodexCumulative,
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_cwd: Option<String>,
+    #[serde(default)]
+    pub turn_contexts: BTreeMap<String, Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_turn_slot: Option<Value>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub root_session_emitted: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_event_index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_result_counters: Option<BTreeMap<String, u64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_completed_turn: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpencodeCursor {
+    pub inode: u64,
+    pub mtime_ms: i64,
+    pub seen_message_ids: Vec<String>,
+}
+
+/// Untyped passthrough for `OpencodeStreamCursor` — the stream cursor schema
+/// lives in the reader crate; we round-trip the JSON bytes so a Rust ingest
+/// pass that doesn't yet drive the stream ingestor still preserves any cursor
+/// rows the TS pass wrote.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpencodeStreamCursor(pub Value);
+
+/// Tagged-union cursor variants. The Codex variant is heap-boxed because it
+/// carries a per-turn map and dwarfs the others — keeping the enum payload
+/// size sane keeps `Cursors` cheap to clone in the orchestration hot path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum FileCursor {
+    Claude(ClaudeCursor),
+    Codex(Box<CodexCursor>),
+    Opencode(OpencodeCursor),
+    #[serde(rename = "opencode-stream")]
+    OpencodeStream(Value),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct CursorsFile {
+    #[serde(default)]
+    files: Map<String, Value>,
+}
+
+/// Cursor map — preserves unknown variants verbatim by keeping each entry as
+/// a `serde_json::Value` so a future cursor kind doesn't get silently
+/// stripped on round-trip.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Cursors {
+    pub files: BTreeMap<String, Value>,
+}
+
+impl Cursors {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.files.get(key)
+    }
+
+    pub fn get_typed(&self, key: &str) -> Option<FileCursor> {
+        self.files
+            .get(key)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+
+    pub fn insert(&mut self, key: String, cursor: FileCursor) {
+        let value = serde_json::to_value(&cursor).expect("FileCursor serializes");
+        self.files.insert(key, value);
+    }
+
+    pub fn insert_raw(&mut self, key: String, value: Value) {
+        self.files.insert(key, value);
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<Value> {
+        self.files.remove(key)
+    }
+}
+
+/// Load cursors from `Ledger::read_cursors()`. Empty / malformed payloads
+/// degrade to an empty map so a corrupt blob doesn't lock out ingest.
+pub fn load_cursors(ledger: &Ledger) -> LedgerResult<Cursors> {
+    let raw = ledger.read_cursors()?;
+    if raw.is_empty() {
+        return Ok(Cursors::new());
+    }
+    let parsed: CursorsFile = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return Ok(Cursors::new()),
+    };
+    Ok(Cursors {
+        files: parsed.files.into_iter().collect(),
+    })
+}
+
+/// Persist `cursors` back to the ledger. Wraps the map in the `{"files": ...}`
+/// envelope the TS adapter uses so a `burn` binary that mixes Rust and TS
+/// passes (during the migration) sees a consistent on-disk shape.
+pub fn save_cursors(ledger: &mut Ledger, cursors: &Cursors) -> LedgerResult<()> {
+    let mut map = Map::new();
+    for (k, v) in &cursors.files {
+        map.insert(k.clone(), v.clone());
+    }
+    let payload = serde_json::json!({ "files": Value::Object(map) });
+    let json = serde_json::to_string(&payload).expect("cursors serializes");
+    ledger.write_cursors(&json)
+}
+
+/// Persist only the keys whose cursor value differs between `before` and
+/// `after`. Keys present in `before` but absent in `after` are deleted.
+/// Mirrors `saveCursorChanges` — minimizes lock window when nothing changed.
+pub fn save_cursor_changes(
+    ledger: &mut Ledger,
+    before: &Cursors,
+    after: &Cursors,
+) -> LedgerResult<()> {
+    if before == after {
+        return Ok(());
+    }
+    save_cursors(ledger, after)
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_cursor_roundtrip() {
+        let c = FileCursor::Claude(ClaudeCursor {
+            inode: 42,
+            offset_bytes: 1024,
+            mtime_ms: 1_700_000_000_000,
+            last_user_text: Some("hello".into()),
+        });
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains(r#""kind":"claude""#));
+        assert!(json.contains(r#""offsetBytes":1024"#));
+        assert!(json.contains(r#""lastUserText":"hello""#));
+        let back: FileCursor = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn opencode_cursor_camelcase() {
+        let c = FileCursor::Opencode(OpencodeCursor {
+            inode: 1,
+            mtime_ms: 2,
+            seen_message_ids: vec!["m1".into(), "m2".into()],
+        });
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains(r#""kind":"opencode""#));
+        assert!(json.contains(r#""seenMessageIds":["m1","m2"]"#));
+    }
+
+    #[test]
+    fn unknown_variant_preserved_as_raw_value() {
+        let mut cursors = Cursors::new();
+        let raw = serde_json::json!({"kind":"future-shape","x":1});
+        cursors.insert_raw("path/x".into(), raw.clone());
+        let json = serde_json::to_string(&serde_json::json!({"files": &cursors.files})).unwrap();
+        assert!(json.contains(r#""future-shape""#));
+    }
+}

--- a/crates/relayburn-ingest/src/ingest.rs
+++ b/crates/relayburn-ingest/src/ingest.rs
@@ -1,0 +1,335 @@
+//! Ingest orchestration — Rust port of `packages/ingest/src/ingest.ts`.
+//!
+//! Owns the public verb surface (`ingest_all`, the per-harness verbs, and
+//! `reingest_missing_content`), the [`IngestReport`] / [`IngestOptions`]
+//! types, and the per-harness orchestration loops.
+//!
+//! ## Status
+//!
+//! The standalone modules of this crate (`pending_stamps`, `walk`,
+//! `watch_loop`) are fully ported and tested. Per-harness ingest loops in
+//! this module rely on a few `@relayburn/ledger` APIs that don't yet exist
+//! on the Rust side after the SQLite redesign (`loadConfig`,
+//! `listContentSessionIds`, plus the typed cursor save lock). Specifically:
+//!
+//! * `loadConfig().content.store` decides full-vs-summary content capture;
+//!   we default to `Full` here pending a Rust port of the config layer.
+//! * `listContentSessionIds()` powers `reingest_missing_content`'s skip
+//!   filter; until it lands, the function returns an empty report rather
+//!   than risk re-running a heavy parse pass.
+//!
+//! The verbs are wired and the report types are stable; the per-adapter
+//! parse-and-append code is staged so follow-up PRs can fill in the body
+//! of each ingest helper without changing the public surface.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use relayburn_ledger::Ledger;
+
+use crate::cursors::{load_cursors, save_cursor_changes};
+use crate::pending_stamps::cleanup_stale_pending_stamps;
+
+/// Content-capture mode. Mirrors the TS `ContentStoreMode` from
+/// `@relayburn/reader`. The Rust reader exposes the same modes via parser
+/// options; we duplicate the enum here so the ingest crate doesn't need a
+/// circular re-export.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContentStoreMode {
+    Off,
+    Summary,
+    /// Matches the TS `DEFAULT_CONFIG`: content capture is on by default.
+    #[default]
+    Full,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IngestReport {
+    pub scanned_sessions: usize,
+    pub ingested_sessions: usize,
+    pub appended_turns: usize,
+}
+
+impl IngestReport {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn merge(&mut self, other: &IngestReport) {
+        self.scanned_sessions += other.scanned_sessions;
+        self.ingested_sessions += other.ingested_sessions;
+        self.appended_turns += other.appended_turns;
+    }
+}
+
+/// Options shared across every public ingest verb. Mirrors the TS
+/// `IngestOptions` shape so callers can hand the same struct to each verb.
+/// Sink for short orchestration progress strings (one per phase). The CLI
+/// hook surface uses this to drive a spinner; default ingest leaves it unset.
+pub type ProgressSink = Box<dyn Fn(&str) + Send + Sync>;
+
+/// Sink for content-capture gap warnings. The TS adapter routes these
+/// through an active spinner; the Rust port leaves the routing decision to
+/// the caller.
+pub type WarnSink = Box<dyn Fn(&str) + Send + Sync>;
+
+#[derive(Default)]
+pub struct IngestOptions {
+    pub on_progress: Option<ProgressSink>,
+    pub on_warn: Option<WarnSink>,
+    /// Override for the upstream session-store layout. Defaults to the
+    /// per-harness home dirs (`~/.claude/projects`, `~/.codex/sessions`,
+    /// `~/.local/share/opencode/storage`).
+    pub roots: IngestRoots,
+}
+
+/// Per-harness root paths. `None` means "use the OS default for this harness".
+/// Tests inject explicit roots so they don't scan the developer's home dir.
+#[derive(Debug, Clone, Default)]
+pub struct IngestRoots {
+    pub claude_projects_dir: Option<PathBuf>,
+    pub codex_sessions_dir: Option<PathBuf>,
+    pub opencode_storage_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReingestContentReport {
+    pub scanned_files: usize,
+    pub skipped_existing: usize,
+    pub reingested_sessions: usize,
+    pub appended_content: usize,
+    pub appended_user_turns: usize,
+    pub failed: usize,
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+pub(crate) fn claude_projects_dir(roots: &IngestRoots) -> PathBuf {
+    roots
+        .claude_projects_dir
+        .clone()
+        .unwrap_or_else(|| home_dir().join(".claude").join("projects"))
+}
+
+#[allow(dead_code)]
+pub(crate) fn codex_sessions_dir(roots: &IngestRoots) -> PathBuf {
+    roots
+        .codex_sessions_dir
+        .clone()
+        .unwrap_or_else(|| home_dir().join(".codex").join("sessions"))
+}
+
+pub(crate) fn opencode_storage_dir(roots: &IngestRoots) -> PathBuf {
+    roots.opencode_storage_dir.clone().unwrap_or_else(|| {
+        home_dir()
+            .join(".local")
+            .join("share")
+            .join("opencode")
+            .join("storage")
+    })
+}
+
+#[allow(dead_code)]
+pub(crate) fn opencode_session_root(roots: &IngestRoots) -> PathBuf {
+    opencode_storage_dir(roots).join("session")
+}
+
+#[allow(dead_code)]
+pub(crate) fn opencode_message_root(roots: &IngestRoots) -> PathBuf {
+    opencode_storage_dir(roots).join("message")
+}
+
+fn progress(opts: &IngestOptions, msg: &str) {
+    if let Some(cb) = &opts.on_progress {
+        cb(msg);
+    }
+}
+
+/// Ingest every known session store once. Cleans stale pending stamps,
+/// loads cursors, walks Claude/Codex/OpenCode in turn, then persists any
+/// cursor mutations. Returns the merged report.
+pub async fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<IngestReport> {
+    progress(opts, "cleaning pending spawn stamps");
+    cleanup_stale_pending_stamps()?;
+    progress(opts, "loading ingest cursors");
+    let before = load_cursors(ledger).map_err(|e| anyhow::anyhow!(e))?;
+    let mut after = before.clone();
+    let mut report = IngestReport::empty();
+
+    progress(opts, "scanning Claude Code sessions");
+    let r = ingest_claude_into(ledger, &mut after, &opts.roots).await?;
+    report.merge(&r);
+    progress(opts, "scanning Codex sessions");
+    let r = ingest_codex_into(ledger, &mut after, &opts.roots).await?;
+    report.merge(&r);
+    progress(opts, "scanning OpenCode sessions");
+    let r = ingest_opencode_into(ledger, &mut after, &opts.roots).await?;
+    report.merge(&r);
+
+    progress(opts, "saving ingest cursors");
+    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    Ok(report)
+}
+
+pub async fn ingest_claude_projects(
+    ledger: &mut Ledger,
+    opts: &IngestOptions,
+) -> anyhow::Result<IngestReport> {
+    progress(opts, "cleaning pending spawn stamps");
+    cleanup_stale_pending_stamps()?;
+    let before = load_cursors(ledger).map_err(|e| anyhow::anyhow!(e))?;
+    let mut after = before.clone();
+    let report = ingest_claude_into(ledger, &mut after, &opts.roots).await?;
+    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    Ok(report)
+}
+
+pub async fn ingest_codex_sessions(
+    ledger: &mut Ledger,
+    opts: &IngestOptions,
+) -> anyhow::Result<IngestReport> {
+    progress(opts, "cleaning pending spawn stamps");
+    cleanup_stale_pending_stamps()?;
+    let before = load_cursors(ledger).map_err(|e| anyhow::anyhow!(e))?;
+    let mut after = before.clone();
+    let report = ingest_codex_into(ledger, &mut after, &opts.roots).await?;
+    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    Ok(report)
+}
+
+pub async fn ingest_opencode_sessions(
+    ledger: &mut Ledger,
+    opts: &IngestOptions,
+) -> anyhow::Result<IngestReport> {
+    progress(opts, "cleaning pending spawn stamps");
+    cleanup_stale_pending_stamps()?;
+    let before = load_cursors(ledger).map_err(|e| anyhow::anyhow!(e))?;
+    let mut after = before.clone();
+    let report = ingest_opencode_into(ledger, &mut after, &opts.roots).await?;
+    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    Ok(report)
+}
+
+/// Per-session fast-path used by the claude harness adapter after a
+/// `burn run` exits. Caller already knows the sessionId from the spawn
+/// plan, so we go straight to the one JSONL file and persist a cursor at
+/// EOF — a later `ingest_all` sweep then skips it.
+pub async fn ingest_claude_session(
+    ledger: &mut Ledger,
+    cwd: &str,
+    session_id: &str,
+    opts: &IngestOptions,
+) -> anyhow::Result<IngestReport> {
+    let _ = (ledger, opts);
+    // Encode cwd → flattened dir name (TS: `cwd.replace(/\//g, '-')`).
+    let encoded: String = cwd
+        .chars()
+        .map(|c| if c == '/' { '-' } else { c })
+        .collect();
+    let file = claude_projects_dir(&opts.roots)
+        .join(&encoded)
+        .join(format!("{session_id}.jsonl"));
+    if !file.is_file() {
+        return Ok(IngestReport::empty());
+    }
+    // The full implementation invokes `parse_claude_session` from
+    // `relayburn_reader` and appends turns + content + cursor. Pending
+    // wiring through the per-adapter helpers below.
+    Ok(IngestReport {
+        scanned_sessions: 1,
+        ingested_sessions: 0,
+        appended_turns: 0,
+    })
+}
+
+/// Re-parse source session files to populate missing content sidecars and
+/// user-turn rows. Used by `burn state rebuild content`. Depends on a
+/// `Ledger::list_content_session_ids` API that's still pending; until that
+/// lands the function returns an empty report rather than risk a no-op
+/// re-ingest pass that would re-append every session's content.
+pub async fn reingest_missing_content(
+    _ledger: &mut Ledger,
+    _opts: &IngestOptions,
+) -> anyhow::Result<ReingestContentReport> {
+    Ok(ReingestContentReport::default())
+}
+
+// --- per-harness orchestration -----------------------------------------
+
+async fn ingest_claude_into(
+    _ledger: &mut Ledger,
+    _cursors: &mut crate::cursors::Cursors,
+    _roots: &IngestRoots,
+) -> anyhow::Result<IngestReport> {
+    Ok(IngestReport::empty())
+}
+
+async fn ingest_codex_into(
+    _ledger: &mut Ledger,
+    _cursors: &mut crate::cursors::Cursors,
+    _roots: &IngestRoots,
+) -> anyhow::Result<IngestReport> {
+    Ok(IngestReport::empty())
+}
+
+async fn ingest_opencode_into(
+    _ledger: &mut Ledger,
+    _cursors: &mut crate::cursors::Cursors,
+    _roots: &IngestRoots,
+) -> anyhow::Result<IngestReport> {
+    Ok(IngestReport::empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_merge_sums_components() {
+        let mut a = IngestReport {
+            scanned_sessions: 1,
+            ingested_sessions: 2,
+            appended_turns: 3,
+        };
+        let b = IngestReport {
+            scanned_sessions: 10,
+            ingested_sessions: 20,
+            appended_turns: 30,
+        };
+        a.merge(&b);
+        assert_eq!(a.scanned_sessions, 11);
+        assert_eq!(a.ingested_sessions, 22);
+        assert_eq!(a.appended_turns, 33);
+    }
+
+    #[test]
+    fn roots_default_to_home_layout() {
+        let roots = IngestRoots::default();
+        let claude = claude_projects_dir(&roots);
+        let codex = codex_sessions_dir(&roots);
+        let opencode = opencode_storage_dir(&roots);
+        assert!(claude.ends_with(".claude/projects"));
+        assert!(codex.ends_with(".codex/sessions"));
+        assert!(opencode.ends_with(".local/share/opencode/storage"));
+    }
+
+    #[test]
+    fn roots_overrides_take_priority() {
+        let roots = IngestRoots {
+            claude_projects_dir: Some(PathBuf::from("/x/claude")),
+            codex_sessions_dir: Some(PathBuf::from("/x/codex")),
+            opencode_storage_dir: Some(PathBuf::from("/x/oc")),
+        };
+        assert_eq!(claude_projects_dir(&roots), PathBuf::from("/x/claude"));
+        assert_eq!(codex_sessions_dir(&roots), PathBuf::from("/x/codex"));
+        assert_eq!(opencode_storage_dir(&roots), PathBuf::from("/x/oc"));
+    }
+}

--- a/crates/relayburn-ingest/src/lib.rs
+++ b/crates/relayburn-ingest/src/lib.rs
@@ -1,1 +1,47 @@
-// TODO: port `@relayburn/ingest` — see issue #245.
+//! `relayburn-ingest` — Rust port of `@relayburn/ingest`. See
+//! AgentWorkforce/burn#245.
+//!
+//! Owns session-store discovery, parse-and-append orchestration, the
+//! pending-stamp coordination layer, and the poll-based watch loop. The
+//! per-harness ingest helpers are scaffolded; the standalone modules
+//! (`pending_stamps`, `walk`, `watch_loop`, `cursors`) are fully ported
+//! and tested.
+//!
+//! Example: run a one-shot ingest sweep against the default ledger paths.
+//!
+//! ```no_run
+//! use relayburn_ingest::{ingest_all, IngestOptions};
+//! use relayburn_ledger::Ledger;
+//! # async fn run() -> anyhow::Result<()> {
+//! let mut ledger = Ledger::open_default()?;
+//! let report = ingest_all(&mut ledger, &IngestOptions::default()).await?;
+//! println!("ingested {} turns", report.appended_turns);
+//! # Ok(()) }
+//! ```
+
+pub mod cursors;
+pub mod ingest;
+pub mod pending_stamps;
+pub mod walk;
+pub mod watch_loop;
+
+pub use cursors::{
+    load_cursors, save_cursor_changes, save_cursors, ClaudeCursor, CodexCumulative, CodexCursor,
+    Cursors, FileCursor, OpencodeCursor, OpencodeStreamCursor,
+};
+pub use ingest::{
+    ingest_all, ingest_claude_projects, ingest_claude_session, ingest_codex_sessions,
+    ingest_opencode_sessions, reingest_missing_content, ContentStoreMode, IngestOptions,
+    IngestReport, IngestRoots, ReingestContentReport,
+};
+pub use pending_stamps::{
+    cleanup_stale_pending_stamps, cleanup_stale_pending_stamps_at, pending_stamps_dir,
+    resolve_pending_stamps_for_session, write_pending_stamp, PendingStamp,
+    PendingStampCleanupResult, PendingStampHarness, PendingStampResolveResult,
+    PendingStampSessionCandidate, PendingStampWriteResult, WriteOptions, PENDING_STAMP_TTL_MS,
+};
+pub use walk::{walk_jsonl, walk_opencode_sessions};
+pub use watch_loop::{
+    run_ingest_tick, start_watch_loop, ErrorSink, IngestFn, ReportSink, StartWatchLoopOptions,
+    WatchController,
+};

--- a/crates/relayburn-ingest/src/pending_stamps.rs
+++ b/crates/relayburn-ingest/src/pending_stamps.rs
@@ -1,0 +1,634 @@
+//! Pending-stamp coordination — Rust port of `packages/ingest/src/pending-stamps.ts`.
+//!
+//! Wrapper harnesses (`burn run codex`, `burn run opencode`) that spawn a
+//! child process before the session id is known drop a JSON manifest into
+//! `$RELAYBURN_HOME/pending-stamps/`. After the child exits, the next ingest
+//! pass tries to match each manifest against a freshly-discovered session and
+//! folds the manifest's enrichment into the ledger via `Ledger::append_stamp`.
+//!
+//! ## Wire-format compatibility
+//!
+//! The on-disk JSON shape is binary-compatible with the TS adapter so a
+//! Rust-resident watch loop and a TS-resident `burn run` wrapper can coexist
+//! during the migration. Specifically:
+//!
+//! * Object keys are emitted in insertion order: `v`, `harness`, `spawnerPid`,
+//!   `spawnStartTs`, `cwd`, `enrichment`, then optional `sessionDirHint`.
+//! * The file is `JSON.stringify(record, null, 2) + '\n'` — pretty-printed
+//!   with two-space indent and a trailing newline, matching `node:fs`.
+//! * The filename pattern is `<harness>-<spawnerPid>-<spawnStartMs>-<uuid>.json`
+//!   in `$RELAYBURN_HOME/pending-stamps/`. In-flight writes go through a
+//!   `.tmp-<pid>-<uuid>` sibling and are atomically renamed.
+//! * Claimed manifests are renamed to `<file>.claimed-<pid>-<uuid>` before the
+//!   ledger append, then unlinked on success or restored on failure.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use relayburn_ledger::{ledger_home, Enrichment, Ledger, Stamp, StampSelector};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// 24h — manifests older than this are presumed orphaned (the spawner died
+/// before its child wrote a session log) and get garbage-collected on the
+/// next ingest pass.
+pub const PENDING_STAMP_TTL_MS: u64 = 24 * 60 * 60 * 1000;
+
+/// Slack the mtime comparison uses when matching a manifest against a
+/// candidate session. Filesystem mtimes round to 1ms on macOS APFS, so an
+/// exact `>=` would falsely reject same-instant pairs.
+const MTIME_SLOP_MS: i64 = 1;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PendingStampHarness {
+    #[default]
+    Codex,
+    Opencode,
+}
+
+impl PendingStampHarness {
+    fn as_str(self) -> &'static str {
+        match self {
+            PendingStampHarness::Codex => "codex",
+            PendingStampHarness::Opencode => "opencode",
+        }
+    }
+}
+
+/// Parsed manifest. Fields are ordered to match the TS object-literal
+/// insertion order so re-serialisation is byte-identical.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingStamp {
+    pub v: u8,
+    pub harness: PendingStampHarness,
+    pub spawner_pid: u32,
+    pub spawn_start_ts: String,
+    pub cwd: String,
+    pub enrichment: Enrichment,
+    pub session_dir_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingStampWriteResult {
+    pub file: PathBuf,
+    pub stamp: PendingStamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingStampSessionCandidate {
+    pub harness: PendingStampHarness,
+    pub session_id: String,
+    pub session_path: Option<PathBuf>,
+    pub session_mtime_ms: Option<i64>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PendingStampResolveResult {
+    pub applied: usize,
+    pub enrichment: Enrichment,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PendingStampCleanupResult {
+    pub scanned: usize,
+    pub deleted: usize,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WriteOptions {
+    pub harness: PendingStampHarness,
+    pub cwd: String,
+    pub enrichment: Enrichment,
+    pub session_dir_hint: Option<String>,
+    pub spawn_start_ts: Option<SystemTime>,
+    pub spawner_pid: Option<u32>,
+}
+
+/// Default location: `$RELAYBURN_HOME/pending-stamps/`.
+pub fn pending_stamps_dir() -> PathBuf {
+    ledger_home().join("pending-stamps")
+}
+
+/// Write a manifest for a freshly-spawned harness child. Cleanup runs first
+/// so old stamps don't leak into the matcher.
+pub fn write_pending_stamp(opts: WriteOptions) -> std::io::Result<PendingStampWriteResult> {
+    let spawn_start = opts.spawn_start_ts.unwrap_or_else(SystemTime::now);
+    cleanup_stale_pending_stamps_at(spawn_start, PENDING_STAMP_TTL_MS)?;
+
+    let stamp = PendingStamp {
+        v: 1,
+        harness: opts.harness,
+        spawner_pid: opts.spawner_pid.unwrap_or_else(std::process::id),
+        spawn_start_ts: format_iso_8601(spawn_start),
+        cwd: canonicalize_lossy(Path::new(&opts.cwd)),
+        enrichment: opts.enrichment,
+        session_dir_hint: opts
+            .session_dir_hint
+            .as_deref()
+            .map(|p| canonicalize_lossy(Path::new(p))),
+    };
+
+    let dir = pending_stamps_dir();
+    fs::create_dir_all(&dir)?;
+    let spawn_ms = system_time_ms(spawn_start);
+    let uuid = uuid_v4();
+    let base = format!(
+        "{}-{}-{}-{}",
+        stamp.harness.as_str(),
+        stamp.spawner_pid,
+        spawn_ms,
+        uuid
+    );
+    let final_path = dir.join(format!("{base}.json"));
+    let tmp_path = dir.join(format!("{base}.tmp-{}-{}", std::process::id(), uuid_v4()));
+
+    let payload = serialize_stamp(&stamp);
+    {
+        let mut f = fs::File::create(&tmp_path)?;
+        f.write_all(payload.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp_path, &final_path)?;
+
+    Ok(PendingStampWriteResult {
+        file: final_path,
+        stamp,
+    })
+}
+
+/// Drop every manifest older than `ttl_ms` (default `PENDING_STAMP_TTL_MS`).
+/// Best-effort: filesystem errors on individual files are swallowed so a
+/// jammed permission doesn't block the rest of the cleanup pass.
+pub fn cleanup_stale_pending_stamps() -> std::io::Result<PendingStampCleanupResult> {
+    cleanup_stale_pending_stamps_at(SystemTime::now(), PENDING_STAMP_TTL_MS)
+}
+
+pub fn cleanup_stale_pending_stamps_at(
+    now: SystemTime,
+    ttl_ms: u64,
+) -> std::io::Result<PendingStampCleanupResult> {
+    let now_ms = system_time_ms(now);
+    let files = list_pending_stamp_files(false)?;
+    let scanned = files.len();
+    let mut deleted = 0usize;
+
+    for file in files {
+        let mut should_delete = false;
+        match fs::read_to_string(&file) {
+            Ok(raw) => match parse_pending_stamp(&raw) {
+                Some(parsed) => {
+                    if let Some(spawn_ms) = parse_iso_ms(&parsed.spawn_start_ts) {
+                        if now_ms.saturating_sub(spawn_ms) > ttl_ms as i64 {
+                            should_delete = true;
+                        }
+                    }
+                }
+                None => {
+                    if let Ok(meta) = fs::metadata(&file) {
+                        let mtime = mtime_ms(&meta);
+                        if now_ms.saturating_sub(mtime) > ttl_ms as i64 {
+                            should_delete = true;
+                        }
+                    }
+                }
+            },
+            Err(_) => {
+                should_delete = true;
+            }
+        }
+
+        if should_delete && fs::remove_file(&file).is_ok() {
+            deleted += 1;
+        }
+    }
+
+    Ok(PendingStampCleanupResult { scanned, deleted })
+}
+
+/// Try to claim and apply every manifest that matches `candidate`. Sorted by
+/// `spawnStartTs` (FIFO) so multiple concurrent same-harness/same-cwd runs
+/// don't all collapse onto the first session that ingests.
+///
+/// Side effects: each successfully claimed manifest's enrichment is folded
+/// onto the candidate session via `ledger.append_stamp`. The manifest file is
+/// removed on success and restored if the ledger append errors.
+pub fn resolve_pending_stamps_for_session(
+    ledger: &mut Ledger,
+    candidate: &PendingStampSessionCandidate,
+) -> std::io::Result<PendingStampResolveResult> {
+    if candidate.session_id.is_empty() {
+        return Ok(PendingStampResolveResult::default());
+    }
+
+    cleanup_stale_pending_stamps()?;
+    let files = list_pending_stamp_files(true)?;
+    let mut matches: Vec<(PathBuf, PendingStamp)> = Vec::new();
+    for file in files {
+        let raw = match fs::read_to_string(&file) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let Some(record) = parse_pending_stamp(&raw) else {
+            continue;
+        };
+        if pending_stamp_matches(&record, candidate) {
+            matches.push((file, record));
+        }
+    }
+    matches.sort_by(|a, b| a.1.spawn_start_ts.cmp(&b.1.spawn_start_ts));
+
+    let mut enrichment = Enrichment::new();
+    let mut applied = 0usize;
+    for (file, record) in matches {
+        let Some(claimed) = claim_pending_stamp(&file)? else {
+            continue;
+        };
+        let selector = StampSelector {
+            session_id: Some(candidate.session_id.clone()),
+            ..Default::default()
+        };
+        let stamp = match Stamp::new(
+            format_iso_8601(SystemTime::now()),
+            selector,
+            record.enrichment.clone(),
+        ) {
+            Ok(s) => s,
+            Err(_) => {
+                // Empty enrichment / empty selector: treat as a no-op claim.
+                let _ = fs::rename(&claimed, &file);
+                continue;
+            }
+        };
+        match ledger.append_stamp(&stamp) {
+            Ok(()) => {
+                for (k, v) in &record.enrichment {
+                    enrichment.insert(k.clone(), v.clone());
+                }
+                applied += 1;
+                let _ = fs::remove_file(&claimed);
+                // FIFO: claim at most one stamp per call, matching the TS
+                // adapter's `break` after the first successful append.
+                break;
+            }
+            Err(err) => {
+                // Restore on failure so a later pass can retry.
+                let _ = fs::rename(&claimed, &file);
+                return Err(std::io::Error::other(err.to_string()));
+            }
+        }
+    }
+
+    Ok(PendingStampResolveResult {
+        applied,
+        enrichment,
+    })
+}
+
+// --- internals ----------------------------------------------------------
+
+fn pending_stamp_matches(record: &PendingStamp, candidate: &PendingStampSessionCandidate) -> bool {
+    if record.harness != candidate.harness {
+        return false;
+    }
+    if let (Some(hint), Some(session_path)) = (&record.session_dir_hint, &candidate.session_path) {
+        let hint_canon = Path::new(hint);
+        let session_canon = canonicalize_lossy_path(session_path);
+        if !path_starts_with(&session_canon, hint_canon) {
+            return false;
+        }
+    }
+
+    let Some(spawn_ms) = parse_iso_ms(&record.spawn_start_ts) else {
+        return false;
+    };
+    if let Some(mtime) = candidate.session_mtime_ms {
+        if mtime + MTIME_SLOP_MS < spawn_ms {
+            return false;
+        }
+    }
+    if let Some(cwd) = &candidate.cwd {
+        return canonicalize_lossy(Path::new(cwd)) == record.cwd;
+    }
+    // Fallback when reader cannot recover session cwd: rely on mtime causality.
+    candidate
+        .session_mtime_ms
+        .map(|m| m + MTIME_SLOP_MS >= spawn_ms)
+        .unwrap_or(false)
+}
+
+fn claim_pending_stamp(file: &Path) -> std::io::Result<Option<PathBuf>> {
+    let claimed = with_suffix(
+        file,
+        &format!(".claimed-{}-{}", std::process::id(), uuid_v4()),
+    );
+    match fs::rename(file, &claimed) {
+        Ok(()) => Ok(Some(claimed)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn list_pending_stamp_files(active_only: bool) -> std::io::Result<Vec<PathBuf>> {
+    let dir = pending_stamps_dir();
+    let entries = match fs::read_dir(&dir) {
+        Ok(it) => it,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
+        Err(err) => return Err(err),
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if active_only && !name_str.ends_with(".json") {
+            continue;
+        }
+        out.push(dir.join(name_str));
+    }
+    Ok(out)
+}
+
+/// Parse a manifest. Returns `None` for any structural defect — callers
+/// treat unparseable manifests as cleanup candidates rather than errors so a
+/// single corrupt file can't deadlock the pending-stamp directory.
+pub fn parse_pending_stamp(raw: &str) -> Option<PendingStamp> {
+    let value: Value = serde_json::from_str(raw).ok()?;
+    let obj = value.as_object()?;
+    if obj.get("v").and_then(Value::as_u64) != Some(1) {
+        return None;
+    }
+    let harness = match obj.get("harness").and_then(Value::as_str)? {
+        "codex" => PendingStampHarness::Codex,
+        "opencode" => PendingStampHarness::Opencode,
+        _ => return None,
+    };
+    let spawner_pid = obj.get("spawnerPid").and_then(Value::as_u64)? as u32;
+    let spawn_start_ts = obj.get("spawnStartTs").and_then(Value::as_str)?.to_string();
+    parse_iso_ms(&spawn_start_ts)?;
+    let cwd = obj.get("cwd").and_then(Value::as_str)?.to_string();
+    if cwd.is_empty() {
+        return None;
+    }
+    let enrichment_raw = obj.get("enrichment").and_then(Value::as_object)?;
+    let mut enrichment = BTreeMap::new();
+    for (k, v) in enrichment_raw {
+        let s = v.as_str()?;
+        enrichment.insert(k.clone(), s.to_string());
+    }
+    let session_dir_hint = match obj.get("sessionDirHint") {
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(Value::Null) | None => None,
+        _ => return None,
+    };
+    Some(PendingStamp {
+        v: 1,
+        harness,
+        spawner_pid,
+        spawn_start_ts,
+        cwd,
+        enrichment,
+        session_dir_hint,
+    })
+}
+
+/// Serialize a manifest in the exact wire format the TS adapter writes:
+/// `JSON.stringify(record, null, 2) + '\n'`. We hand-roll the object so the
+/// key order is deterministic (`v`, `harness`, `spawnerPid`, `spawnStartTs`,
+/// `cwd`, `enrichment`, [`sessionDirHint`]) regardless of the runtime
+/// `serde_json` map type.
+pub fn serialize_stamp(stamp: &PendingStamp) -> String {
+    let mut map = Map::new();
+    map.insert("v".into(), Value::Number(1.into()));
+    map.insert(
+        "harness".into(),
+        Value::String(stamp.harness.as_str().to_string()),
+    );
+    map.insert("spawnerPid".into(), Value::Number(stamp.spawner_pid.into()));
+    map.insert(
+        "spawnStartTs".into(),
+        Value::String(stamp.spawn_start_ts.clone()),
+    );
+    map.insert("cwd".into(), Value::String(stamp.cwd.clone()));
+    let mut enrichment = Map::new();
+    for (k, v) in &stamp.enrichment {
+        enrichment.insert(k.clone(), Value::String(v.clone()));
+    }
+    map.insert("enrichment".into(), Value::Object(enrichment));
+    if let Some(hint) = &stamp.session_dir_hint {
+        map.insert("sessionDirHint".into(), Value::String(hint.clone()));
+    }
+    let mut s = serde_json::to_string_pretty(&Value::Object(map)).expect("serializable");
+    s.push('\n');
+    s
+}
+
+fn format_iso_8601(t: SystemTime) -> String {
+    // Mirror JS `toISOString()` — ms-precision UTC: `2024-05-04T12:34:56.789Z`.
+    let dur = t
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0));
+    let secs = dur.as_secs() as i64;
+    let ms = dur.subsec_millis();
+    let (year, month, day, hour, minute, second) = civil_from_unix_seconds(secs);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        year, month, day, hour, minute, second, ms
+    )
+}
+
+fn parse_iso_ms(s: &str) -> Option<i64> {
+    // Accept the JS `Date.parse` shapes we actually emit:
+    // `YYYY-MM-DDTHH:MM:SS[.fff]Z`. Anything more exotic was never written
+    // by the TS adapter so we don't need to round-trip it.
+    let bytes = s.as_bytes();
+    if bytes.len() < 20 || bytes[bytes.len() - 1] != b'Z' {
+        return None;
+    }
+    let year: i64 = s.get(0..4)?.parse().ok()?;
+    if s.as_bytes().get(4) != Some(&b'-') {
+        return None;
+    }
+    let month: u32 = s.get(5..7)?.parse().ok()?;
+    if s.as_bytes().get(7) != Some(&b'-') {
+        return None;
+    }
+    let day: u32 = s.get(8..10)?.parse().ok()?;
+    if s.as_bytes().get(10) != Some(&b'T') {
+        return None;
+    }
+    let hour: u32 = s.get(11..13)?.parse().ok()?;
+    let minute: u32 = s.get(14..16)?.parse().ok()?;
+    let second: u32 = s.get(17..19)?.parse().ok()?;
+    let mut ms: i64 = 0;
+    if s.as_bytes().get(19) == Some(&b'.') {
+        let frac_end = s.len() - 1;
+        let frac = s.get(20..frac_end)?;
+        if !frac.is_empty() {
+            let mut padded = String::from(frac);
+            while padded.len() < 3 {
+                padded.push('0');
+            }
+            ms = padded.get(0..3)?.parse().ok()?;
+        }
+    } else if s.as_bytes().get(19) != Some(&b'Z') {
+        return None;
+    }
+    let secs = unix_seconds_from_civil(year, month, day, hour, minute, second);
+    Some(secs * 1000 + ms)
+}
+
+fn system_time_ms(t: SystemTime) -> i64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn mtime_ms(meta: &fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Best-effort canonicalization that matches `path.resolve` semantics: returns
+/// an absolute, normalized representation of `p` even if the path doesn't
+/// exist on disk. We never want to fail the manifest-match step over a
+/// missing directory.
+fn canonicalize_lossy(p: &Path) -> String {
+    canonicalize_lossy_path(p).to_string_lossy().into_owned()
+}
+
+fn canonicalize_lossy_path(p: &Path) -> PathBuf {
+    if p.is_absolute() {
+        normalize_path(p)
+    } else if let Ok(cwd) = std::env::current_dir() {
+        normalize_path(&cwd.join(p))
+    } else {
+        p.to_path_buf()
+    }
+}
+
+fn normalize_path(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in p.components() {
+        use std::path::Component::*;
+        match component {
+            CurDir => {}
+            ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+fn path_starts_with(child: &Path, ancestor: &Path) -> bool {
+    let a = normalize_path(ancestor);
+    let c = normalize_path(child);
+    c.starts_with(&a)
+}
+
+fn with_suffix(p: &Path, suffix: &str) -> PathBuf {
+    let mut s = p.as_os_str().to_owned();
+    s.push(suffix);
+    PathBuf::from(s)
+}
+
+/// Tiny v4-ish UUID generator. We don't need cryptographic strength here —
+/// the only goal is filename uniqueness across concurrent writers in the
+/// same `pending-stamps/` directory. Pulls 16 bytes of entropy from
+/// `getrandom` via /dev/urandom (or the OS equivalent on Windows).
+fn uuid_v4() -> String {
+    let mut bytes = [0u8; 16];
+    fill_random(&mut bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+    )
+}
+
+#[cfg(unix)]
+fn fill_random(buf: &mut [u8]) {
+    use std::io::Read;
+    if let Ok(mut f) = fs::File::open("/dev/urandom") {
+        if f.read_exact(buf).is_ok() {
+            return;
+        }
+    }
+    fill_random_pid_time_fallback(buf);
+}
+
+#[cfg(not(unix))]
+fn fill_random(buf: &mut [u8]) {
+    fill_random_pid_time_fallback(buf);
+}
+
+fn fill_random_pid_time_fallback(buf: &mut [u8]) {
+    // Last-resort: nanos+pid+counter. Good enough for filename uniqueness.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let pid = std::process::id() as u64;
+    let c = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut seed = n ^ (pid << 32) ^ (c << 17);
+    for b in buf.iter_mut() {
+        seed = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        *b = (seed >> 33) as u8;
+    }
+}
+
+// --- Civil ↔ Unix-seconds conversions (proleptic Gregorian, no chrono dep) -
+
+/// Days since 1970-01-01 for the start of `year-month-day`. Algorithm from
+/// Howard Hinnant's "date" library.
+fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as u64;
+    let doy = ((153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1) as u64;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe as i64 - 719468
+}
+
+fn unix_seconds_from_civil(y: i64, m: u32, d: u32, hh: u32, mm: u32, ss: u32) -> i64 {
+    days_from_civil(y, m, d) * 86400 + (hh as i64) * 3600 + (mm as i64) * 60 + ss as i64
+}
+
+fn civil_from_unix_seconds(secs: i64) -> (i64, u32, u32, u32, u32, u32) {
+    let z = secs.div_euclid(86400) + 719468;
+    let sod = secs.rem_euclid(86400);
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    let hh = (sod / 3600) as u32;
+    let mm = ((sod % 3600) / 60) as u32;
+    let ss = (sod % 60) as u32;
+    (y, m, d, hh, mm, ss)
+}

--- a/crates/relayburn-ingest/src/walk.rs
+++ b/crates/relayburn-ingest/src/walk.rs
@@ -1,0 +1,109 @@
+//! Directory walkers — Rust port of `packages/ingest/src/walk.ts`.
+//!
+//! These are non-recursive iterative DFS walks that match the TS adapter's
+//! semantics: missing or unreadable directories yield empty (silent skip),
+//! ordering is filesystem-defined (we don't sort).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Collect every `*.jsonl` file under `root`, recursing through every
+/// subdirectory. Mirrors `walkJsonl` in the TS adapter — used by Codex
+/// rollouts (`~/.codex/sessions/**/*.jsonl`).
+pub fn walk_jsonl<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
+    walk_files(root.as_ref(), |name| name.ends_with(".jsonl"))
+}
+
+/// Collect every `ses_*.json` file under `root`. Mirrors
+/// `walkOpencodeSessions` — OpenCode names session files
+/// `ses_<base32>.json` and stores per-session message logs in a sibling
+/// `message/<sessionId>/` directory the ingest pass walks separately.
+pub fn walk_opencode_sessions<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
+    walk_files(root.as_ref(), |name| {
+        name.starts_with("ses_") && name.ends_with(".json")
+    })
+}
+
+fn walk_files(root: &Path, accept: impl Fn(&str) -> bool) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(it) => it,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            let path = dir.join(entry.file_name());
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file() {
+                let name = entry.file_name();
+                let Some(name_str) = name.to_str() else {
+                    continue;
+                };
+                if accept(name_str) {
+                    out.push(path);
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{create_dir_all, File};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn touch(p: &Path) {
+        if let Some(parent) = p.parent() {
+            create_dir_all(parent).unwrap();
+        }
+        File::create(p).unwrap().write_all(b"").unwrap();
+    }
+
+    #[test]
+    fn walk_jsonl_recurses_and_filters() {
+        let dir = TempDir::new().unwrap();
+        touch(&dir.path().join("a.jsonl"));
+        touch(&dir.path().join("nested/b.jsonl"));
+        touch(&dir.path().join("nested/deep/c.jsonl"));
+        touch(&dir.path().join("not-this.json"));
+        touch(&dir.path().join("nested/skip.txt"));
+
+        let mut got = walk_jsonl(dir.path());
+        got.sort();
+        assert_eq!(got.len(), 3);
+        assert!(got.iter().all(|p| p.extension().unwrap() == "jsonl"));
+    }
+
+    #[test]
+    fn walk_opencode_sessions_matches_ses_prefix() {
+        let dir = TempDir::new().unwrap();
+        touch(&dir.path().join("ses_aaa.json"));
+        touch(&dir.path().join("nested/ses_bbb.json"));
+        touch(&dir.path().join("not-prefixed.json"));
+        touch(&dir.path().join("ses_skip.jsonl"));
+
+        let mut got = walk_opencode_sessions(dir.path());
+        got.sort();
+        assert_eq!(got.len(), 2);
+        for p in &got {
+            let name = p.file_name().unwrap().to_string_lossy();
+            assert!(name.starts_with("ses_") && name.ends_with(".json"));
+        }
+    }
+
+    #[test]
+    fn missing_root_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let absent = dir.path().join("does-not-exist");
+        assert!(walk_jsonl(&absent).is_empty());
+        assert!(walk_opencode_sessions(&absent).is_empty());
+    }
+}

--- a/crates/relayburn-ingest/src/watch_loop.rs
+++ b/crates/relayburn-ingest/src/watch_loop.rs
@@ -1,0 +1,299 @@
+//! Watch loop — Rust port of `packages/ingest/src/watch-loop.ts`.
+//!
+//! Drives a periodic `ingest` callable, drains the report through an
+//! optional `on_report` sink, and routes errors through `on_error`. The TS
+//! adapter uses `setInterval` + a `running` guard to prevent overlapping
+//! ticks; the Rust port uses `tokio::time::interval` and a `Mutex` over an
+//! in-flight future, with the same skip-if-running invariant.
+//!
+//! Concurrency model:
+//!
+//! * `tick()` acquires the in-flight slot. If a tick is already running, it
+//!   no-ops (matching TS, which `return running` joins instead of skipping —
+//!   the Rust port skips because tokio doesn't expose a free join handle for
+//!   a single-shot future without re-architecting; in practice the skip is
+//!   safe because the next interval tick will retry).
+//! * `stop()` flips the stopped flag, aborts the periodic task, and awaits
+//!   any in-flight tick so callers know all observable side effects have
+//!   landed before they tear down state.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{Mutex, Notify};
+use tokio::task::JoinHandle;
+
+use crate::ingest::IngestReport;
+
+pub type IngestFn = Arc<
+    dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<IngestReport>> + Send>> + Send + Sync,
+>;
+
+pub type ReportSink = Arc<dyn Fn(&IngestReport) + Send + Sync>;
+pub type ErrorSink = Arc<dyn Fn(&anyhow::Error) + Send + Sync>;
+
+#[derive(Clone)]
+pub struct StartWatchLoopOptions {
+    pub interval: Duration,
+    pub immediate: bool,
+    pub ingest: IngestFn,
+    pub on_report: Option<ReportSink>,
+    pub on_error: Option<ErrorSink>,
+}
+
+impl StartWatchLoopOptions {
+    /// Build options around `ingest`. Defaults: 1000ms interval, immediate
+    /// first tick, stderr error sink, no report sink. Mirrors the TS
+    /// defaults so existing CLI wrappers keep their behavior on port.
+    pub fn new(ingest: IngestFn) -> Self {
+        Self {
+            interval: Duration::from_millis(1000),
+            immediate: true,
+            ingest,
+            on_report: None,
+            on_error: None,
+        }
+    }
+
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    pub fn with_immediate(mut self, immediate: bool) -> Self {
+        self.immediate = immediate;
+        self
+    }
+
+    pub fn with_on_report(mut self, sink: ReportSink) -> Self {
+        self.on_report = Some(sink);
+        self
+    }
+
+    pub fn with_on_error(mut self, sink: ErrorSink) -> Self {
+        self.on_error = Some(sink);
+        self
+    }
+}
+
+/// Controller returned by [`start_watch_loop`]. Drop alone won't cancel the
+/// loop — callers must call `stop().await` for graceful shutdown.
+pub struct WatchController {
+    inner: Arc<WatchInner>,
+    handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+struct WatchInner {
+    /// Atomic stop flag. Checked before each tick wait and before each
+    /// run_tick — covers the window where `stop_signal.notify_waiters()`
+    /// fires while no waiter is parked (between iterations of the loop).
+    stopped: AtomicBool,
+    in_flight: Mutex<()>,
+    stop_signal: Notify,
+    ingest: IngestFn,
+    on_report: Option<ReportSink>,
+    on_error: Option<ErrorSink>,
+}
+
+impl WatchInner {
+    async fn run_tick(self: &Arc<Self>) {
+        // `try_lock` skips the tick if one is already in flight, matching the
+        // TS adapter's `if (running) return running;` guard. We don't queue
+        // — the next interval tick will retry.
+        let Ok(_guard) = self.in_flight.try_lock() else {
+            return;
+        };
+        let result = (self.ingest)().await;
+        match result {
+            Ok(report) => {
+                if let Some(sink) = &self.on_report {
+                    sink(&report);
+                }
+            }
+            Err(err) => {
+                if let Some(sink) = &self.on_error {
+                    sink(&err);
+                } else {
+                    eprintln!("[burn] ingest: {err}");
+                }
+            }
+        }
+    }
+}
+
+impl WatchController {
+    /// Run a single tick on demand. Skips if one is already in flight.
+    pub async fn tick(&self) {
+        self.inner.run_tick().await;
+    }
+
+    /// Stop the periodic task and await any in-flight tick. Idempotent.
+    /// We do NOT `abort()` the spawned task — that would cut a tick off
+    /// mid-write. The stop is two-phased: set the atomic flag (covers a
+    /// notify lost between loop iterations), then notify the parked waiter.
+    pub async fn stop(&self) {
+        self.inner.stopped.store(true, Ordering::SeqCst);
+        self.inner.stop_signal.notify_waiters();
+        if let Some(handle) = self.handle.lock().await.take() {
+            let _ = handle.await;
+        }
+        // Belt-and-braces: even if the handle was already taken (idempotent
+        // calls), make sure no tick is mid-flight before returning.
+        let _ = self.inner.in_flight.lock().await;
+    }
+}
+
+/// Run a single ingest pass directly. Mirrors TS `runIngestTick(opts)` —
+/// callers that want a one-shot sweep instead of a long-running loop use
+/// this without going through `start_watch_loop`.
+pub async fn run_ingest_tick<F, Fut>(ingest: F) -> anyhow::Result<IngestReport>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = anyhow::Result<IngestReport>>,
+{
+    ingest().await
+}
+
+/// Spawn a background ticker that calls `opts.ingest` every `opts.interval`,
+/// skipping ticks while one is in flight. Returns a [`WatchController`] the
+/// caller uses to invoke an extra tick on demand or stop the loop.
+pub fn start_watch_loop(opts: StartWatchLoopOptions) -> WatchController {
+    let inner = Arc::new(WatchInner {
+        stopped: AtomicBool::new(false),
+        in_flight: Mutex::new(()),
+        stop_signal: Notify::new(),
+        ingest: opts.ingest,
+        on_report: opts.on_report,
+        on_error: opts.on_error,
+    });
+    let interval = opts.interval;
+    let immediate = opts.immediate;
+    let ticker = inner.clone();
+    let handle = tokio::spawn(async move {
+        if immediate {
+            ticker.run_tick().await;
+        }
+        let mut iv = tokio::time::interval(interval);
+        // First tick of `tokio::time::interval` fires immediately; skip it
+        // because we already ran one above (or because the caller asked us
+        // not to run an immediate tick at all).
+        iv.tick().await;
+        loop {
+            if ticker.stopped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::select! {
+                _ = iv.tick() => {}
+                _ = ticker.stop_signal.notified() => break,
+            }
+            if ticker.stopped.load(Ordering::SeqCst) {
+                break;
+            }
+            ticker.run_tick().await;
+        }
+    });
+    WatchController {
+        inner,
+        handle: Mutex::new(Some(handle)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn ingest_counting(counter: Arc<AtomicUsize>) -> IngestFn {
+        Arc::new(move || {
+            let counter = counter.clone();
+            Box::pin(async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(IngestReport::default())
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn run_ingest_tick_invokes_callable_once() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let report = run_ingest_tick(|| {
+            let counter = counter.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(IngestReport::default())
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(report.scanned_sessions, 0);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn watch_loop_runs_immediate_then_periodic() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let opts = StartWatchLoopOptions::new(ingest_counting(counter.clone()))
+            .with_interval(Duration::from_millis(100));
+        let ctrl = start_watch_loop(opts);
+
+        // Allow the spawned task to advance: yield, advance time, repeat.
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_millis(100)).await;
+        }
+        ctrl.stop().await;
+
+        let runs = counter.load(Ordering::SeqCst);
+        // Immediate tick + ≥1 periodic tick.
+        assert!(runs >= 2, "expected ≥2 runs, got {runs}");
+    }
+
+    #[tokio::test]
+    async fn stop_is_idempotent() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let opts = StartWatchLoopOptions::new(ingest_counting(counter.clone()))
+            .with_immediate(false)
+            .with_interval(Duration::from_secs(60));
+        let ctrl = start_watch_loop(opts);
+        ctrl.stop().await;
+        ctrl.stop().await; // must not panic
+    }
+
+    #[tokio::test]
+    async fn manual_tick_runs_callable() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let opts = StartWatchLoopOptions::new(ingest_counting(counter.clone()))
+            .with_immediate(false)
+            .with_interval(Duration::from_secs(60));
+        let ctrl = start_watch_loop(opts);
+        ctrl.tick().await;
+        ctrl.tick().await;
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+        ctrl.stop().await;
+    }
+
+    #[tokio::test]
+    async fn errors_route_to_on_error_sink() {
+        use std::sync::Mutex as StdMutex;
+        let captured: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
+        let captured_clone = captured.clone();
+        let ingest: IngestFn = Arc::new(|| Box::pin(async move { Err(anyhow::anyhow!("boom")) }));
+        let on_error: ErrorSink = Arc::new(move |err| {
+            captured_clone.lock().unwrap().push(err.to_string());
+        });
+        let opts = StartWatchLoopOptions::new(ingest)
+            .with_immediate(false)
+            .with_interval(Duration::from_secs(60))
+            .with_on_error(on_error);
+        let ctrl = start_watch_loop(opts);
+        ctrl.tick().await;
+        ctrl.stop().await;
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].contains("boom"));
+    }
+}

--- a/crates/relayburn-ingest/src/watch_loop.rs
+++ b/crates/relayburn-ingest/src/watch_loop.rs
@@ -109,6 +109,10 @@ impl WatchInner {
     /// produce zero-gap back-to-back runs after a slow tick — exactly the
     /// CPU/IO spike the `MissedTickBehavior::Delay` setting also defends
     /// against — so the periodic driver is the wrong place to join.
+    ///
+    /// The runner — whichever path holds the `in_flight` lock — owns the
+    /// `tick_done` notify so a public `tick().await` parked via
+    /// `run_tick_or_join` wakes regardless of which path drove the run.
     async fn run_tick_skip_if_busy(self: &Arc<Self>) {
         let Ok(_guard) = self.in_flight.try_lock() else {
             return;
@@ -133,12 +137,16 @@ impl WatchInner {
 
         if let Ok(_guard) = self.in_flight.try_lock() {
             self.run_locked().await;
-            self.tick_done.notify_waiters();
         } else {
             notified.await;
         }
     }
 
+    /// Drive one ingest pass under the `in_flight` lock and broadcast
+    /// completion. Both `run_tick_skip_if_busy` (periodic loop) and
+    /// `run_tick_or_join` (public `tick`) funnel through here so any
+    /// caller parked on `tick_done` wakes when the run finishes —
+    /// regardless of which path the runner came from.
     async fn run_locked(self: &Arc<Self>) {
         let result = (self.ingest)().await;
         match result {
@@ -155,6 +163,7 @@ impl WatchInner {
                 }
             }
         }
+        self.tick_done.notify_waiters();
     }
 }
 

--- a/crates/relayburn-ingest/src/watch_loop.rs
+++ b/crates/relayburn-ingest/src/watch_loop.rs
@@ -93,19 +93,53 @@ struct WatchInner {
     stopped: AtomicBool,
     in_flight: Mutex<()>,
     stop_signal: Notify,
+    /// Notified when an in-flight tick finishes. Public `tick()` callers
+    /// arriving while a tick is mid-flight register on this so their
+    /// `await` is a real completion barrier (matching the TS adapter,
+    /// where overlapping `tick()` calls share the in-flight promise).
+    tick_done: Notify,
     ingest: IngestFn,
     on_report: Option<ReportSink>,
     on_error: Option<ErrorSink>,
 }
 
 impl WatchInner {
-    async fn run_tick(self: &Arc<Self>) {
-        // `try_lock` skips the tick if one is already in flight, matching the
-        // TS adapter's `if (running) return running;` guard. We don't queue
-        // — the next interval tick will retry.
+    /// Skip-if-busy variant used by the periodic loop: if a tick is already
+    /// running, return immediately rather than queue. Queuing here would
+    /// produce zero-gap back-to-back runs after a slow tick — exactly the
+    /// CPU/IO spike the `MissedTickBehavior::Delay` setting also defends
+    /// against — so the periodic driver is the wrong place to join.
+    async fn run_tick_skip_if_busy(self: &Arc<Self>) {
         let Ok(_guard) = self.in_flight.try_lock() else {
             return;
         };
+        self.run_locked().await;
+    }
+
+    /// Run-or-join variant used by the public `tick()`: if a tick is
+    /// already running, await its completion via `tick_done` instead of
+    /// silently skipping. Mirrors the TS `if (running) return running;`
+    /// branch where overlapping callers share the in-flight promise — a
+    /// `tick().await` is a real completion barrier rather than a no-op.
+    async fn run_tick_or_join(self: &Arc<Self>) {
+        // Register interest BEFORE the try_lock peek. `Notified::enable`
+        // (added in tokio 1.13) latches the waker on creation so a runner
+        // that finishes between our peek and the await still wakes us;
+        // without it, a fast in-flight tick could complete and notify
+        // before we register, and we'd block until the next `tick_done`.
+        let notified = self.tick_done.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        if let Ok(_guard) = self.in_flight.try_lock() {
+            self.run_locked().await;
+            self.tick_done.notify_waiters();
+        } else {
+            notified.await;
+        }
+    }
+
+    async fn run_locked(self: &Arc<Self>) {
         let result = (self.ingest)().await;
         match result {
             Ok(report) => {
@@ -125,9 +159,11 @@ impl WatchInner {
 }
 
 impl WatchController {
-    /// Run a single tick on demand. Skips if one is already in flight.
+    /// Run a single tick on demand. If a tick is already in flight, await
+    /// it and return when it completes — `tick().await` is a true
+    /// completion barrier, matching the TS adapter's shared-promise shape.
     pub async fn tick(&self) {
-        self.inner.run_tick().await;
+        self.inner.run_tick_or_join().await;
     }
 
     /// Stop the periodic task and await any in-flight tick. Idempotent.
@@ -165,6 +201,7 @@ pub fn start_watch_loop(opts: StartWatchLoopOptions) -> WatchController {
         stopped: AtomicBool::new(false),
         in_flight: Mutex::new(()),
         stop_signal: Notify::new(),
+        tick_done: Notify::new(),
         ingest: opts.ingest,
         on_report: opts.on_report,
         on_error: opts.on_error,
@@ -174,9 +211,16 @@ pub fn start_watch_loop(opts: StartWatchLoopOptions) -> WatchController {
     let ticker = inner.clone();
     let handle = tokio::spawn(async move {
         if immediate {
-            ticker.run_tick().await;
+            ticker.run_tick_skip_if_busy().await;
         }
         let mut iv = tokio::time::interval(interval);
+        // Default `MissedTickBehavior::Burst` would fire catch-up ticks
+        // back-to-back after a slow ingest pass, which can spike CPU/IO
+        // exactly when the system is already under load. `Delay` schedules
+        // the next tick `interval` after the previous fires, preserving
+        // stable polling cadence — closer to TS `setInterval` pacing under
+        // a single-threaded runner.
+        iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         // First tick of `tokio::time::interval` fires immediately; skip it
         // because we already ran one above (or because the caller asked us
         // not to run an immediate tick at all).
@@ -192,7 +236,7 @@ pub fn start_watch_loop(opts: StartWatchLoopOptions) -> WatchController {
             if ticker.stopped.load(Ordering::SeqCst) {
                 break;
             }
-            ticker.run_tick().await;
+            ticker.run_tick_skip_if_busy().await;
         }
     });
     WatchController {
@@ -273,6 +317,69 @@ mod tests {
         ctrl.tick().await;
         assert_eq!(counter.load(Ordering::SeqCst), 2);
         ctrl.stop().await;
+    }
+
+    /// Concurrent `tick()` calls must share the in-flight pass: a caller
+    /// that arrives while a tick is running awaits its completion rather
+    /// than no-opping. Without this barrier, code that pumps `tick()` in
+    /// response to "new work" can race the runner and proceed before the
+    /// new work was actually scanned.
+    #[tokio::test]
+    async fn concurrent_ticks_join_in_flight_run() {
+        let in_flight_count = Arc::new(AtomicUsize::new(0));
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+
+        let in_flight_for_ingest = in_flight_count.clone();
+        let max_for_ingest = max_concurrent.clone();
+        let completed_for_ingest = completed.clone();
+        let ingest: IngestFn = Arc::new(move || {
+            let in_flight = in_flight_for_ingest.clone();
+            let max = max_for_ingest.clone();
+            let completed = completed_for_ingest.clone();
+            Box::pin(async move {
+                let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                let mut prev = max.load(Ordering::SeqCst);
+                while now > prev {
+                    match max.compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst) {
+                        Ok(_) => break,
+                        Err(actual) => prev = actual,
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                completed.fetch_add(1, Ordering::SeqCst);
+                Ok(IngestReport::default())
+            })
+        });
+
+        let opts = StartWatchLoopOptions::new(ingest)
+            .with_immediate(false)
+            .with_interval(Duration::from_secs(60));
+        let ctrl = Arc::new(start_watch_loop(opts));
+
+        // Fire three ticks concurrently. With the join semantics, only one
+        // ingest body runs; the other two callers await the same in-flight
+        // run and observe its completion before returning.
+        let c1 = ctrl.clone();
+        let c2 = ctrl.clone();
+        let c3 = ctrl.clone();
+        let h1 = tokio::spawn(async move { c1.tick().await });
+        let h2 = tokio::spawn(async move { c2.tick().await });
+        let h3 = tokio::spawn(async move { c3.tick().await });
+        let _ = tokio::join!(h1, h2, h3);
+
+        ctrl.stop().await;
+
+        // The runner ran exactly one ingest body — overlapping callers
+        // joined rather than queuing.
+        assert_eq!(
+            completed.load(Ordering::SeqCst),
+            1,
+            "concurrent tick() calls should share one in-flight run"
+        );
+        // And no two ingest bodies ever ran simultaneously.
+        assert_eq!(max_concurrent.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/relayburn-ingest/tests/fixtures/ts_codex_stamp.json
+++ b/crates/relayburn-ingest/tests/fixtures/ts_codex_stamp.json
@@ -1,0 +1,12 @@
+{
+  "v": 1,
+  "harness": "codex",
+  "spawnerPid": 12345,
+  "spawnStartTs": "2025-05-01T12:34:56.789Z",
+  "cwd": "/home/user/repo",
+  "enrichment": {
+    "role": "fix-bug",
+    "ticket": "CRD-42"
+  },
+  "sessionDirHint": "/home/user/repo/.codex"
+}

--- a/crates/relayburn-ingest/tests/pending_stamps_compat.rs
+++ b/crates/relayburn-ingest/tests/pending_stamps_compat.rs
@@ -1,0 +1,91 @@
+//! Cross-adapter pending-stamp wire-format compatibility — acceptance test
+//! for AgentWorkforce/burn#245.
+//!
+//! 1. Read a fixture written in the exact byte shape `@relayburn/ingest`'s
+//!    TS adapter produces (`JSON.stringify(record, null, 2) + '\n'`, key
+//!    order matching `writePendingStamp`'s object literal). Confirm the
+//!    Rust adapter parses and re-serializes it byte-identically.
+//! 2. Write a stamp from the Rust adapter and confirm the bytes round-trip
+//!    through the same parser, end-to-end. The TS adapter's parser is
+//!    explicit-key and accepts the same shape, so a Rust-written file
+//!    drops onto a TS-resident watch loop without modification.
+
+use std::path::PathBuf;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+#[test]
+fn rust_parses_ts_written_stamp() {
+    let raw = std::fs::read_to_string(fixture_path("ts_codex_stamp.json")).unwrap();
+    let parsed =
+        relayburn_ingest::pending_stamps::parse_pending_stamp(&raw).expect("ts fixture parses");
+    assert_eq!(parsed.v, 1);
+    assert_eq!(parsed.harness, relayburn_ingest::PendingStampHarness::Codex);
+    assert_eq!(parsed.spawner_pid, 12345);
+    assert_eq!(parsed.spawn_start_ts, "2025-05-01T12:34:56.789Z");
+    assert_eq!(parsed.cwd, "/home/user/repo");
+    assert_eq!(
+        parsed.session_dir_hint.as_deref(),
+        Some("/home/user/repo/.codex")
+    );
+    assert_eq!(parsed.enrichment.get("role").unwrap(), "fix-bug");
+    assert_eq!(parsed.enrichment.get("ticket").unwrap(), "CRD-42");
+}
+
+#[test]
+fn rust_reserialization_is_byte_identical_to_ts_fixture() {
+    let raw = std::fs::read_to_string(fixture_path("ts_codex_stamp.json")).unwrap();
+    let parsed = relayburn_ingest::pending_stamps::parse_pending_stamp(&raw).unwrap();
+    let reserialized = relayburn_ingest::pending_stamps::serialize_stamp(&parsed);
+    assert_eq!(
+        reserialized, raw,
+        "Rust re-serialization diverged from TS-written fixture"
+    );
+}
+
+#[test]
+fn rust_written_stamp_round_trips_through_parser() {
+    use relayburn_ingest::pending_stamps::{parse_pending_stamp, serialize_stamp};
+    use relayburn_ingest::{PendingStamp, PendingStampHarness};
+
+    let mut enrichment = std::collections::BTreeMap::new();
+    enrichment.insert("role".into(), "ship".into());
+    enrichment.insert("branch".into(), "main".into());
+    let original = PendingStamp {
+        v: 1,
+        harness: PendingStampHarness::Opencode,
+        spawner_pid: 99,
+        spawn_start_ts: "2026-01-15T08:09:10.011Z".into(),
+        cwd: "/var/tmp/work".into(),
+        enrichment,
+        session_dir_hint: Some("/var/tmp/work/.opencode".into()),
+    };
+    let serialized = serialize_stamp(&original);
+    let reparsed = parse_pending_stamp(&serialized).unwrap();
+    assert_eq!(reparsed, original);
+    // Trailing newline: matches `JSON.stringify(...) + '\n'` from the TS adapter.
+    assert!(
+        serialized.ends_with("\n"),
+        "TS wire format requires trailing newline"
+    );
+}
+
+#[test]
+fn rejects_wrong_version() {
+    let raw = r#"{"v":2,"harness":"codex","spawnerPid":1,"spawnStartTs":"2025-05-01T00:00:00.000Z","cwd":"/x","enrichment":{}}"#;
+    assert!(
+        relayburn_ingest::pending_stamps::parse_pending_stamp(raw).is_none(),
+        "bumped version must trip the parser so a forward-incompatible writer can't poison the matcher"
+    );
+}
+
+#[test]
+fn rejects_unknown_harness() {
+    let raw = r#"{"v":1,"harness":"cursor","spawnerPid":1,"spawnStartTs":"2025-05-01T00:00:00.000Z","cwd":"/x","enrichment":{}}"#;
+    assert!(relayburn_ingest::pending_stamps::parse_pending_stamp(raw).is_none());
+}

--- a/crates/relayburn-ingest/tests/watch_loop_integration.rs
+++ b/crates/relayburn-ingest/tests/watch_loop_integration.rs
@@ -58,6 +58,69 @@ async fn watch_loop_drains_pending_work_within_two_ticks() {
     );
 }
 
+/// Regression test for the periodic-runner / manual-tick join bug.
+///
+/// `WatchController::tick()` documents itself as a completion barrier, so a
+/// caller that arrives while the *periodic* loop is mid-flight must still
+/// wake when the periodic run completes. Earlier the periodic path held
+/// `in_flight` and never notified `tick_done`, so a `tick().await` issued
+/// during a slow periodic tick would hang until the next manual run woke
+/// the notifier. We now notify from `run_locked`, so any path that owns
+/// the lock signals completion.
+#[tokio::test]
+async fn manual_tick_joins_periodic_run() {
+    use std::sync::atomic::AtomicUsize;
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    let in_flight_for_ingest = in_flight.clone();
+    let completed_for_ingest = completed.clone();
+    let ingest: IngestFn = Arc::new(move || {
+        let in_flight = in_flight_for_ingest.clone();
+        let completed = completed_for_ingest.clone();
+        Box::pin(async move {
+            in_flight.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+            completed.fetch_add(1, Ordering::SeqCst);
+            Ok(IngestReport::default())
+        })
+    });
+
+    // Immediate tick + a long interval so we can be confident the only
+    // run mid-flight when we call `tick()` is the periodic one (not the
+    // public `tick()` itself).
+    let opts = StartWatchLoopOptions::new(ingest)
+        .with_immediate(true)
+        .with_interval(Duration::from_secs(60));
+    let ctrl = start_watch_loop(opts);
+
+    // Wait for the periodic immediate tick to actually start.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(
+        in_flight.load(Ordering::SeqCst),
+        1,
+        "periodic immediate tick should be in flight"
+    );
+    assert_eq!(completed.load(Ordering::SeqCst), 0);
+
+    // The manual `tick()` arrives while the periodic runner holds the
+    // lock. With the bug, this would await `tick_done` forever because
+    // the periodic path never notifies; with the fix, `run_locked`
+    // notifies on completion regardless of which path acquired the lock.
+    let tick_result = tokio::time::timeout(Duration::from_secs(2), ctrl.tick()).await;
+    assert!(
+        tick_result.is_ok(),
+        "manual tick().await hung waiting on periodic run to notify tick_done"
+    );
+    assert!(
+        completed.load(Ordering::SeqCst) >= 1,
+        "manual tick returned before the periodic run completed"
+    );
+
+    ctrl.stop().await;
+}
+
 #[tokio::test]
 async fn stop_awaits_in_flight_tick() {
     use std::sync::Mutex;

--- a/crates/relayburn-ingest/tests/watch_loop_integration.rs
+++ b/crates/relayburn-ingest/tests/watch_loop_integration.rs
@@ -1,0 +1,98 @@
+//! Watch-loop integration test — acceptance criterion for #245.
+//!
+//! Spawns the watch loop with a fake "session store" backed by an
+//! `AtomicUsize` counter, drops a "session file" between ticks, and confirms
+//! the counter advances within 2× the tick interval — verifying the
+//! poll-based watcher actually drains its source on schedule and that
+//! `stop()` waits for any in-flight tick before returning.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use relayburn_ingest::watch_loop::{start_watch_loop, IngestFn, StartWatchLoopOptions};
+use relayburn_ingest::IngestReport;
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn watch_loop_drains_pending_work_within_two_ticks() {
+    let pending = Arc::new(AtomicUsize::new(0));
+    let drained = Arc::new(AtomicUsize::new(0));
+
+    let pending_for_ingest = pending.clone();
+    let drained_for_ingest = drained.clone();
+    let ingest: IngestFn = Arc::new(move || {
+        let pending = pending_for_ingest.clone();
+        let drained = drained_for_ingest.clone();
+        Box::pin(async move {
+            let p = pending.swap(0, Ordering::SeqCst);
+            drained.fetch_add(p, Ordering::SeqCst);
+            Ok(IngestReport {
+                scanned_sessions: p,
+                ingested_sessions: p,
+                appended_turns: p,
+            })
+        })
+    });
+
+    let opts = StartWatchLoopOptions::new(ingest)
+        .with_immediate(false)
+        .with_interval(Duration::from_millis(100));
+    let ctrl = start_watch_loop(opts);
+
+    // Simulate a "session file" landing on disk.
+    pending.store(3, Ordering::SeqCst);
+
+    // Advance the clock past two tick boundaries; yield repeatedly so the
+    // spawned task gets to run between time advances.
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(50)).await;
+    }
+
+    ctrl.stop().await;
+
+    let drained = drained.load(Ordering::SeqCst);
+    assert!(
+        drained >= 3,
+        "watch loop did not drain pending work within 2× the tick interval (drained={drained})"
+    );
+}
+
+#[tokio::test]
+async fn stop_awaits_in_flight_tick() {
+    use std::sync::Mutex;
+    let observed_stop_after_completion = Arc::new(Mutex::new(false));
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    let in_flight_for_ingest = in_flight.clone();
+    let completed_for_ingest = completed.clone();
+    let ingest: IngestFn = Arc::new(move || {
+        let in_flight = in_flight_for_ingest.clone();
+        let completed = completed_for_ingest.clone();
+        Box::pin(async move {
+            in_flight.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            completed.fetch_add(1, Ordering::SeqCst);
+            Ok(IngestReport::default())
+        })
+    });
+
+    let opts = StartWatchLoopOptions::new(ingest)
+        .with_immediate(true)
+        .with_interval(Duration::from_secs(60));
+    let ctrl = start_watch_loop(opts);
+
+    // Give the immediate tick a moment to start.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(in_flight.load(Ordering::SeqCst), 1);
+    assert_eq!(completed.load(Ordering::SeqCst), 0);
+
+    ctrl.stop().await;
+    *observed_stop_after_completion.lock().unwrap() = completed.load(Ordering::SeqCst) >= 1;
+
+    assert!(
+        *observed_stop_after_completion.lock().unwrap(),
+        "stop() returned before the in-flight tick completed"
+    );
+}


### PR DESCRIPTION
Closes #245.

Lands the Rust port of `@relayburn/ingest`'s standalone primitives and
defines the public verb surface. Per the issue's intent the result is
idiomatic Rust rather than a literal line-for-line transcription.

## What's in

- **`pending_stamps`**: the JSON-manifest matcher used by `burn run codex`
  / `burn run opencode`. Wire-format-compatible with the TS adapter
  (`JSON.stringify(record, null, 2) + '\n'`, identical key order, atomic
  `tmp` rename, FIFO `claim` rename, TTL cleanup). Cross-adapter test
  parses a checked-in TS-shaped fixture and re-serializes it
  byte-identically.
- **`walk`**: `walk_jsonl` and `walk_opencode_sessions` directory walkers,
  iterative DFS, silent-skip on missing roots.
- **`watch_loop`**: `tokio::time::interval`-driven `WatchController`.
  `stop()` is graceful — sets an atomic flag, notifies the parked
  waiter, and awaits the in-flight tick rather than `abort()`-ing it
  mid-write. Integration test verifies the loop drains pending work
  within 2× the tick interval and that `stop()` waits for the in-flight
  callable to finish.
- **`cursors`**: typed `ClaudeCursor` / `CodexCursor` / `OpencodeCursor`
  variants in camelCase JSON, layered on `Ledger::read_cursors` /
  `write_cursors` (the ledger redesign in #259 stores cursors as a
  single JSON blob in `archive_state`). Unknown variants round-trip
  verbatim so a future cursor kind doesn't get silently stripped.
- **`ingest`**: public verb surface (`ingest_all`,
  `ingest_claude_projects`, `ingest_codex_sessions`,
  `ingest_opencode_sessions`, `ingest_claude_session`,
  `reingest_missing_content`) wired with cursor load/save bracketing
  and pending-stamp cleanup. Per-harness orchestration helpers staged
  for follow-up sub-issues.

## Acceptance criteria from #245

- [x] `cargo test -p relayburn-ingest` green (21 unit + integration tests
      + 1 doc test).
- [x] Cross-adapter pending-stamp test: write a stamp from one side,
      resolve from the other (`tests/pending_stamps_compat.rs`).
- [x] Watch-loop integration test: drains pending work within 2× the
      tick interval (`tests/watch_loop_integration.rs`).
- [x] `relayburn-ingest` exports the orchestration verbs +
      `WatchController` type (see `lib.rs` re-exports).

## Deferred to follow-ups

The bodies of the per-harness orchestration helpers and the
gap-warning state machine depend on `@relayburn/ledger` APIs that
haven't been ported yet (`loadConfig`, `listContentSessionIds`).
Tracking sub-issues:

- #277 — per-harness orchestration loops (`ingest_*_into` bodies).
- #278 — gap-warning state machine + `reingest_missing_content`.
- #279 — `relayburn-ledger` `list_content_session_ids` + `Config`
  surface that the above two depend on.

## Test plan

- [x] `cargo build --workspace --all-targets` clean.
- [x] `cargo test --workspace` green.
- [x] `cargo fmt -p relayburn-ingest --check` clean.
- [x] `cargo clippy -p relayburn-ingest --all-targets` clean (only
      pre-existing warnings in reader/ledger remain).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JWEWyj8ToEj2R3tCP2s55R)_