### PR TITLE
relayburn-analyze: foundation (pricing + cost + fidelity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "relayburn-analyze"
 version = "0.0.0"
 dependencies = [
+ "indexmap",
  "regex",
  "relayburn-reader",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "relayburn-analyze"
 version = "0.0.0"
+dependencies = [
+ "regex",
+ "relayburn-reader",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "relayburn-cli"

--- a/crates/relayburn-analyze/Cargo.toml
+++ b/crates/relayburn-analyze/Cargo.toml
@@ -11,5 +11,10 @@ publish = false
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+# `IndexMap` preserves JSON insertion order so duplicate model IDs in
+# `models.dev.json` (e.g. `claude-sonnet-4-6` under both `anthropic` and
+# `nano-gpt`) resolve deterministically — last entry in file order wins,
+# matching the TS `Object.values` / `Object.entries` iteration semantics.
+indexmap = { version = "2", features = ["serde"] }
 regex = "1"
 relayburn-reader = { path = "../relayburn-reader" }

--- a/crates/relayburn-analyze/Cargo.toml
+++ b/crates/relayburn-analyze/Cargo.toml
@@ -7,3 +7,9 @@ license.workspace = true
 repository.workspace = true
 description = "Pricing, cost derivation, hotspots, and overhead computation (Rust port)."
 publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+regex = "1"
+relayburn-reader = { path = "../relayburn-reader" }

--- a/crates/relayburn-analyze/src/cost.rs
+++ b/crates/relayburn-analyze/src/cost.rs
@@ -1,0 +1,480 @@
+//! Per-record cost derivation — Rust port of `packages/analyze/src/cost.ts`.
+//!
+//! The math (per-token rate × token count, with cache-read / cache-create /
+//! reasoning splits) is the precision-sensitive core of analyze. We use `f64`
+//! to mirror the TS `number` type and keep accumulation order identical so
+//! drift stays bounded by the documented 1e-9 USD precision contract that the
+//! later overhead sub-issue depends on.
+
+use relayburn_reader::{SourceKind, TurnRecord, Usage};
+
+use crate::pricing::{ModelCost, PricingTable, ReasoningMode};
+use crate::provider_reattribution::resolve_provider;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CostBreakdown {
+    pub model: String,
+    pub total: f64,
+    pub input: f64,
+    pub output: f64,
+    pub reasoning: f64,
+    pub cache_read: f64,
+    pub cache_create: f64,
+}
+
+/// Override the reasoning-billing semantics for a `cost_for_usage` call. When
+/// `reasoning_mode` is `None`, the mode is taken from the resolved
+/// `ModelCost`; when `Some`, it wins — used by `cost_for_turn` to force
+/// `IncludedInOutput` for sources whose transcripts already fold reasoning
+/// into `output_tokens` (Codex).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CostForUsageOptions {
+    pub reasoning_mode: Option<ReasoningMode>,
+}
+
+const PER_MILLION: f64 = 1_000_000.0;
+
+pub fn cost_for_usage(
+    usage: &Usage,
+    model: &str,
+    pricing: &PricingTable,
+    options: CostForUsageOptions,
+) -> Option<CostBreakdown> {
+    let rate = lookup_model_rate(model, pricing)?;
+    let mode = options.reasoning_mode.unwrap_or(rate.reasoning_mode);
+    let input = (usage.input as f64 / PER_MILLION) * rate.input;
+    let output = (usage.output as f64 / PER_MILLION) * rate.output;
+    let reasoning = reasoning_cost(usage.reasoning, rate, mode);
+    let cache_read = (usage.cache_read as f64 / PER_MILLION) * rate.cache_read;
+    let cache_create = ((usage.cache_create_5m as f64 + usage.cache_create_1h as f64)
+        / PER_MILLION)
+        * rate.cache_write;
+    Some(CostBreakdown {
+        model: model.to_string(),
+        total: input + output + reasoning + cache_read + cache_create,
+        input,
+        output,
+        reasoning,
+        cache_read,
+        cache_create,
+    })
+}
+
+pub fn cost_for_turn(turn: &TurnRecord, pricing: &PricingTable) -> Option<CostBreakdown> {
+    let opts = CostForUsageOptions {
+        reasoning_mode: reasoning_mode_for_source(turn.source),
+    };
+    cost_for_usage(&turn.usage, &turn.model, pricing, opts)
+}
+
+fn reasoning_cost(reasoning_tokens: u64, rate: &ModelCost, mode: ReasoningMode) -> f64 {
+    match mode {
+        // Already billed inside `usage.output` — informational only.
+        ReasoningMode::IncludedInOutput => 0.0,
+        // Use the model's distinct reasoning tariff. If the override forced
+        // this mode but the model has no `rate.reasoning`, fall back to the
+        // output rate so we never silently drop reasoning tokens.
+        ReasoningMode::Separate => {
+            (reasoning_tokens as f64 / PER_MILLION) * rate.reasoning.unwrap_or(rate.output)
+        }
+        ReasoningMode::SameAsOutput => (reasoning_tokens as f64 / PER_MILLION) * rate.output,
+    }
+}
+
+/// Per-source reasoning-billing semantics override. Returning `None` means
+/// "defer to the model's `reasoning_mode`".
+///
+/// - Codex: `output_tokens` already includes reasoning; never bill it on top.
+/// - Everyone else: defer to the model.
+fn reasoning_mode_for_source(source: SourceKind) -> Option<ReasoningMode> {
+    match source {
+        SourceKind::Codex => Some(ReasoningMode::IncludedInOutput),
+        _ => None,
+    }
+}
+
+/// Shared lookup: direct match → synthetic reattribution → generic
+/// `provider/model` strip. Used by `cost_for_usage` and (later) by the
+/// hotspots / claude-md attribution paths so synthetic-routed turns price
+/// consistently across views.
+pub fn lookup_model_rate<'a>(model: &str, pricing: &'a PricingTable) -> Option<&'a ModelCost> {
+    if let Some(direct) = pricing.get(model) {
+        return Some(direct);
+    }
+    let reattributed = resolve_provider(model);
+    if reattributed.normalized_model != model {
+        if let Some(via) = pricing.get(&reattributed.normalized_model) {
+            return Some(via);
+        }
+    }
+    let stripped = strip_provider_prefix(model);
+    if stripped != model {
+        if let Some(via) = pricing.get(stripped) {
+            return Some(via);
+        }
+    }
+    None
+}
+
+fn strip_provider_prefix(model: &str) -> &str {
+    match model.find('/') {
+        Some(i) => &model[i + 1..],
+        None => model,
+    }
+}
+
+pub fn sum_costs<I, B>(costs: I) -> CostBreakdown
+where
+    I: IntoIterator<Item = B>,
+    B: std::borrow::Borrow<CostBreakdown>,
+{
+    let mut acc = CostBreakdown {
+        model: "aggregate".to_string(),
+        total: 0.0,
+        input: 0.0,
+        output: 0.0,
+        reasoning: 0.0,
+        cache_read: 0.0,
+        cache_create: 0.0,
+    };
+    for c in costs {
+        let c = c.borrow();
+        acc.total += c.total;
+        acc.input += c.input;
+        acc.output += c.output;
+        acc.reasoning += c.reasoning;
+        acc.cache_read += c.cache_read;
+        acc.cache_create += c.cache_create;
+    }
+    acc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pricing::{load_builtin_pricing, ModelCost, ReasoningMode};
+    use relayburn_reader::{SourceKind, ToolCall, TurnRecord, Usage};
+
+    fn turn(model: &str, usage: Usage, source: SourceKind) -> TurnRecord {
+        TurnRecord {
+            v: 1,
+            source,
+            session_id: "s".into(),
+            session_path: None,
+            message_id: "m".into(),
+            turn_index: 0,
+            ts: "2026-04-20T00:00:00.000Z".into(),
+            model: model.into(),
+            project: None,
+            project_key: None,
+            usage,
+            tool_calls: Vec::<ToolCall>::new(),
+            files_touched: None,
+            subagent: None,
+            stop_reason: None,
+            activity: None,
+            retries: None,
+            has_edits: None,
+            fidelity: None,
+        }
+    }
+
+    fn usage_with(input: u64, output: u64, reasoning: u64) -> Usage {
+        Usage {
+            input,
+            output,
+            reasoning,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        }
+    }
+
+    #[test]
+    fn loads_builtin_pricing_and_finds_claude_models() {
+        let p = load_builtin_pricing();
+        assert!(p.contains_key("claude-opus-4-7"), "opus-4-7 present");
+        assert!(p.contains_key("claude-sonnet-4-6"), "sonnet-4-6 present");
+        assert!(p.contains_key("claude-haiku-4-5"), "haiku-4-5 present");
+    }
+
+    #[test]
+    fn computes_dollars_for_a_simple_sonnet_turn() {
+        let p = load_builtin_pricing();
+        let c = cost_for_turn(
+            &turn(
+                "claude-sonnet-4-6",
+                usage_with(1_000_000, 1_000_000, 0),
+                SourceKind::ClaudeCode,
+            ),
+            &p,
+        )
+        .expect("priced");
+        let rate = p.get("claude-sonnet-4-6").unwrap();
+        assert_eq!(c.input, rate.input);
+        assert_eq!(c.output, rate.output);
+        assert_eq!(c.total, rate.input + rate.output);
+    }
+
+    #[test]
+    fn applies_cache_write_rate_to_both_5m_and_1h_cache_creation() {
+        let p = load_builtin_pricing();
+        let c = cost_for_usage(
+            &Usage {
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache_read: 0,
+                cache_create_5m: 500_000,
+                cache_create_1h: 500_000,
+            },
+            "claude-opus-4-7",
+            &p,
+            CostForUsageOptions::default(),
+        )
+        .expect("priced");
+        assert_eq!(
+            c.cache_create,
+            p.get("claude-opus-4-7").unwrap().cache_write
+        );
+    }
+
+    #[test]
+    fn bills_reasoning_at_output_rate_for_claude_same_as_output() {
+        let p = load_builtin_pricing();
+        let c = cost_for_turn(
+            &turn(
+                "claude-sonnet-4-6",
+                usage_with(0, 1_000_000, 1_000_000),
+                SourceKind::ClaudeCode,
+            ),
+            &p,
+        )
+        .expect("priced");
+        let rate = p.get("claude-sonnet-4-6").unwrap();
+        assert_eq!(rate.reasoning_mode, ReasoningMode::SameAsOutput);
+        assert_eq!(c.output, rate.output);
+        assert_eq!(c.reasoning, rate.output);
+        assert_eq!(c.total, rate.output * 2.0);
+    }
+
+    #[test]
+    fn does_not_double_bill_reasoning_for_codex_turns() {
+        // Acceptance criterion from issue #32: a Codex turn with
+        //   input = 1_000_000, output = 500_000, reasoning = 200_000
+        // and a model priced input=2.5/output=15 should bill 10.0, not 13.0.
+        let mut p = PricingTable::new();
+        p.insert(
+            "gpt-5-codex".into(),
+            ModelCost {
+                input: 2.5,
+                output: 15.0,
+                cache_read: 0.0,
+                cache_write: 2.5,
+                reasoning: None,
+                reasoning_mode: ReasoningMode::SameAsOutput,
+            },
+        );
+        let c = cost_for_turn(
+            &turn(
+                "gpt-5-codex",
+                usage_with(1_000_000, 500_000, 200_000),
+                SourceKind::Codex,
+            ),
+            &p,
+        )
+        .expect("priced");
+        assert_eq!(c.input, 2.5);
+        assert_eq!(c.output, 7.5);
+        assert_eq!(
+            c.reasoning, 0.0,
+            "reasoning is informational for Codex, not billed",
+        );
+        assert_eq!(c.total, 10.0);
+    }
+
+    #[test]
+    fn codex_regression_11_3_percent_overstatement_scenario() {
+        // 10 Codex turns aggregated: input 660_698, output 52_676,
+        // reasoning 29_070, cacheRead 5_618_688. The issue documents
+        // $4.282607 (current/wrong) vs $3.846557 (corrected) at gpt-5-codex
+        // pricing (input=1.25, output=10, cacheRead=0.125). We assert the
+        // corrected number to within 1e-9.
+        let mut p = PricingTable::new();
+        p.insert(
+            "gpt-5-codex".into(),
+            ModelCost {
+                input: 1.25,
+                output: 10.0,
+                cache_read: 0.125,
+                cache_write: 1.25,
+                reasoning: None,
+                reasoning_mode: ReasoningMode::SameAsOutput,
+            },
+        );
+        let c = cost_for_turn(
+            &turn(
+                "gpt-5-codex",
+                Usage {
+                    input: 660_698,
+                    output: 52_676,
+                    reasoning: 29_070,
+                    cache_read: 5_618_688,
+                    cache_create_5m: 0,
+                    cache_create_1h: 0,
+                },
+                SourceKind::Codex,
+            ),
+            &p,
+        )
+        .expect("priced");
+
+        let expected = (660_698.0_f64 / 1_000_000.0) * 1.25
+            + (52_676.0_f64 / 1_000_000.0) * 10.0
+            + (5_618_688.0_f64 / 1_000_000.0) * 0.125;
+        assert!(
+            (c.total - expected).abs() < 1e-9,
+            "expected {expected}, got {}",
+            c.total
+        );
+        assert_eq!(c.reasoning, 0.0);
+    }
+
+    #[test]
+    fn honors_a_separate_reasoning_tariff_when_models_dev_provides_one() {
+        // Acceptance criterion from issue #32: a model with input=1, output=4,
+        // reasoning=8 and 1M tokens of each should bill 13.
+        let mut p = PricingTable::new();
+        p.insert(
+            "synthetic-reasoner".into(),
+            ModelCost {
+                input: 1.0,
+                output: 4.0,
+                cache_read: 0.0,
+                cache_write: 1.0,
+                reasoning: Some(8.0),
+                reasoning_mode: ReasoningMode::Separate,
+            },
+        );
+        let c = cost_for_usage(
+            &usage_with(1_000_000, 1_000_000, 1_000_000),
+            "synthetic-reasoner",
+            &p,
+            CostForUsageOptions::default(),
+        )
+        .expect("priced");
+        assert_eq!(c.input, 1.0);
+        assert_eq!(c.output, 4.0);
+        assert_eq!(c.reasoning, 8.0);
+        assert_eq!(c.total, 13.0);
+    }
+
+    #[test]
+    fn explicit_reasoning_mode_option_overrides_the_model_default() {
+        let mut p = PricingTable::new();
+        p.insert(
+            "override-test".into(),
+            ModelCost {
+                input: 1.0,
+                output: 10.0,
+                cache_read: 0.0,
+                cache_write: 1.0,
+                reasoning: None,
+                reasoning_mode: ReasoningMode::SameAsOutput,
+            },
+        );
+        let usage = usage_with(0, 0, 1_000_000);
+        let billed = cost_for_usage(&usage, "override-test", &p, CostForUsageOptions::default())
+            .expect("billed priced");
+        let skipped = cost_for_usage(
+            &usage,
+            "override-test",
+            &p,
+            CostForUsageOptions {
+                reasoning_mode: Some(ReasoningMode::IncludedInOutput),
+            },
+        )
+        .expect("skipped priced");
+        assert_eq!(billed.reasoning, 10.0);
+        assert_eq!(skipped.reasoning, 0.0);
+    }
+
+    #[test]
+    fn returns_none_for_unknown_model() {
+        let p = load_builtin_pricing();
+        let c = cost_for_turn(
+            &turn(
+                "definitely-not-a-model",
+                usage_with(100, 0, 0),
+                SourceKind::ClaudeCode,
+            ),
+            &p,
+        );
+        assert!(c.is_none());
+    }
+
+    #[test]
+    fn cache_read_is_much_cheaper_than_input() {
+        let p = load_builtin_pricing();
+        let rate = p.get("claude-opus-4-7").unwrap();
+        assert!(rate.cache_read < rate.input);
+    }
+
+    #[test]
+    fn lookup_model_rate_falls_back_to_synthetic_normalization() {
+        // If the bundled snapshot lists e.g. `qwen3-coder` but a session logs
+        // `synthetic/qwen3-coder`, the synthetic normalization branch should
+        // route the lookup to the bare id without forcing callers to
+        // pre-strip.
+        let mut p = PricingTable::new();
+        p.insert(
+            "qwen3-coder".into(),
+            ModelCost {
+                input: 1.0,
+                output: 2.0,
+                cache_read: 0.0,
+                cache_write: 1.0,
+                reasoning: None,
+                reasoning_mode: ReasoningMode::SameAsOutput,
+            },
+        );
+        let rate = lookup_model_rate("synthetic/qwen3-coder", &p).expect("synthetic prefix routes");
+        assert_eq!(rate.input, 1.0);
+        assert_eq!(rate.output, 2.0);
+    }
+
+    #[test]
+    fn sum_costs_aggregates_each_field_and_labels_aggregate() {
+        let a = CostBreakdown {
+            model: "x".into(),
+            total: 1.0,
+            input: 0.5,
+            output: 0.5,
+            reasoning: 0.0,
+            cache_read: 0.0,
+            cache_create: 0.0,
+        };
+        let b = CostBreakdown {
+            model: "y".into(),
+            total: 2.0,
+            input: 1.0,
+            output: 1.0,
+            reasoning: 0.0,
+            cache_read: 0.0,
+            cache_create: 0.0,
+        };
+        let s = sum_costs([&a, &b]);
+        assert_eq!(s.model, "aggregate");
+        assert_eq!(s.total, 3.0);
+        assert_eq!(s.input, 1.5);
+        assert_eq!(s.output, 1.5);
+    }
+
+    #[test]
+    fn sum_costs_on_empty_input_returns_zero_aggregate() {
+        let empty: Vec<CostBreakdown> = vec![];
+        let s = sum_costs(empty.iter());
+        assert_eq!(s.model, "aggregate");
+        assert_eq!(s.total, 0.0);
+    }
+}

--- a/crates/relayburn-analyze/src/fidelity.rs
+++ b/crates/relayburn-analyze/src/fidelity.rs
@@ -1,0 +1,310 @@
+//! Fidelity summary aggregation — Rust port of
+//! `packages/analyze/src/fidelity.ts`.
+//!
+//! Higher-level aggregators (compare, hotspots) use this to refuse stats on
+//! undersized fixtures, so it lands before them.
+
+use std::collections::HashMap;
+
+use relayburn_reader::{
+    classify_fidelity, Coverage, Fidelity, FidelityClass, TurnRecord, UsageGranularity,
+};
+
+/// Names of the boolean fields on [`Coverage`]. Mirrors the TS `keyof Coverage`
+/// iteration order so the resulting map keys match the JSON shape callers
+/// already serialize.
+pub const COVERAGE_FIELDS: &[&str] = &[
+    "hasInputTokens",
+    "hasOutputTokens",
+    "hasReasoningTokens",
+    "hasCacheReadTokens",
+    "hasCacheCreateTokens",
+    "hasToolCalls",
+    "hasToolResultEvents",
+    "hasSessionRelationships",
+    "hasRawContent",
+];
+
+fn coverage_get(c: &Coverage, field: &str) -> bool {
+    match field {
+        "hasInputTokens" => c.has_input_tokens,
+        "hasOutputTokens" => c.has_output_tokens,
+        "hasReasoningTokens" => c.has_reasoning_tokens,
+        "hasCacheReadTokens" => c.has_cache_read_tokens,
+        "hasCacheCreateTokens" => c.has_cache_create_tokens,
+        "hasToolCalls" => c.has_tool_calls,
+        "hasToolResultEvents" => c.has_tool_result_events,
+        "hasSessionRelationships" => c.has_session_relationships,
+        "hasRawContent" => c.has_raw_content,
+        _ => unreachable!("unknown coverage field: {field}"),
+    }
+}
+
+/// What every command needs to honestly describe a slice of turns:
+///   - how many turns landed in each [`FidelityClass`]
+///   - how many turns are missing each individual coverage field
+///
+/// The `unknown` bucket counts records that pre-date the fidelity field on
+/// `TurnRecord` (older ledger writers, foreign sources). Treat them as
+/// best-effort full fidelity for backward compatibility, but expose the count
+/// so callers can show the gap if they care.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FidelitySummary {
+    pub total: u64,
+    pub by_class: HashMap<FidelityClass, u64>,
+    pub by_granularity: HashMap<UsageGranularity, u64>,
+    pub missing_coverage: HashMap<&'static str, u64>,
+    /// Records with no `fidelity` field at all — emitted by older ledger
+    /// writers. Counted separately so we don't pretend they're "full".
+    pub unknown: u64,
+}
+
+pub fn empty_fidelity_summary() -> FidelitySummary {
+    let mut by_class = HashMap::new();
+    by_class.insert(FidelityClass::Full, 0);
+    by_class.insert(FidelityClass::UsageOnly, 0);
+    by_class.insert(FidelityClass::AggregateOnly, 0);
+    by_class.insert(FidelityClass::CostOnly, 0);
+    by_class.insert(FidelityClass::Partial, 0);
+
+    let mut by_granularity = HashMap::new();
+    by_granularity.insert(UsageGranularity::PerTurn, 0);
+    by_granularity.insert(UsageGranularity::PerMessage, 0);
+    by_granularity.insert(UsageGranularity::PerSessionAggregate, 0);
+    by_granularity.insert(UsageGranularity::CostOnly, 0);
+
+    let mut missing_coverage: HashMap<&'static str, u64> = HashMap::new();
+    for field in COVERAGE_FIELDS {
+        missing_coverage.insert(*field, 0);
+    }
+
+    FidelitySummary {
+        total: 0,
+        by_class,
+        by_granularity,
+        missing_coverage,
+        unknown: 0,
+    }
+}
+
+/// Walk a slice of turn records and emit a [`FidelitySummary`]. Pure
+/// aggregation — no I/O, no caching, safe to call repeatedly. The input
+/// iterator yields `Option<&Fidelity>` so callers can pass either real
+/// `TurnRecord`s (via [`summarize_fidelity`]) or projected pairs.
+pub fn summarize_fidelity_from_iter<'a, I>(fidelities: I) -> FidelitySummary
+where
+    I: IntoIterator<Item = Option<&'a Fidelity>>,
+{
+    let mut out = empty_fidelity_summary();
+    for f in fidelities {
+        out.total += 1;
+        let Some(f) = f else {
+            out.unknown += 1;
+            continue;
+        };
+        // Trust whatever `class` was written, but re-derive when granularity
+        // + coverage say something different — the older serializer might be
+        // lying. (In Rust the field is non-optional so `class` is always
+        // present; we re-derive defensively to match the TS semantic.)
+        let cls = classify_fidelity(f.granularity, &f.coverage);
+        // Prefer the recorded class if it matches the re-derivation; if they
+        // diverge, use the recorded one (TS uses `f.class ?? classify(...)`,
+        // i.e. recorded wins). Either way we increment exactly once.
+        let cls = if f.class == cls { cls } else { f.class };
+        *out.by_class.entry(cls).or_insert(0) += 1;
+        *out.by_granularity.entry(f.granularity).or_insert(0) += 1;
+        // Count records *missing* each field (so a non-zero number always
+        // means "this many turns lack X").
+        for field in COVERAGE_FIELDS {
+            if !coverage_get(&f.coverage, field) {
+                *out.missing_coverage.entry(*field).or_insert(0) += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Convenience wrapper over [`summarize_fidelity_from_iter`] that takes a
+/// slice of [`TurnRecord`]s.
+pub fn summarize_fidelity(turns: &[TurnRecord]) -> FidelitySummary {
+    summarize_fidelity_from_iter(turns.iter().map(|t| t.fidelity.as_ref()))
+}
+
+const FIDELITY_ORDER: &[FidelityClass] = &[
+    FidelityClass::CostOnly,
+    FidelityClass::AggregateOnly,
+    FidelityClass::Partial,
+    FidelityClass::UsageOnly,
+    FidelityClass::Full,
+];
+
+fn rank(class: FidelityClass) -> usize {
+    FIDELITY_ORDER
+        .iter()
+        .position(|c| *c == class)
+        .expect("FidelityClass must be ranked")
+}
+
+/// Convenience predicate for the "default exclude aggregate-only / cost-only"
+/// filtering pattern used by `burn compare` and friends. Records without
+/// fidelity are treated as best-effort full (older ledger writers) — a strict
+/// mode that drops unknown is a separate decision the caller can layer on top.
+pub fn has_minimum_fidelity(fidelity: Option<&Fidelity>, minimum: FidelityClass) -> bool {
+    let Some(f) = fidelity else {
+        return true;
+    };
+    rank(f.class) >= rank(minimum)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use relayburn_reader::{
+        parse_opencode_session, Coverage, Fidelity, FidelityClass, ParseOpencodeOptions,
+        UsageGranularity,
+    };
+    use std::path::PathBuf;
+
+    fn full_fidelity() -> Fidelity {
+        Fidelity::new(
+            UsageGranularity::PerTurn,
+            Coverage {
+                has_input_tokens: true,
+                has_output_tokens: true,
+                has_cache_read_tokens: true,
+                has_tool_calls: true,
+                has_tool_result_events: true,
+                has_session_relationships: true,
+                ..Coverage::EMPTY
+            },
+        )
+    }
+
+    fn partial_fidelity() -> Fidelity {
+        // missing output / cache-read / tool-result events → "partial"
+        Fidelity::new(
+            UsageGranularity::PerTurn,
+            Coverage {
+                has_input_tokens: true,
+                ..Coverage::EMPTY
+            },
+        )
+    }
+
+    fn aggregate_fidelity() -> Fidelity {
+        Fidelity::new(
+            UsageGranularity::PerSessionAggregate,
+            Coverage {
+                has_input_tokens: true,
+                has_output_tokens: true,
+                ..Coverage::EMPTY
+            },
+        )
+    }
+
+    #[test]
+    fn returns_empty_summary_for_empty_turn_list() {
+        let s = summarize_fidelity_from_iter(std::iter::empty::<Option<&Fidelity>>());
+        assert_eq!(s, empty_fidelity_summary());
+    }
+
+    #[test]
+    fn counts_each_turn_into_by_class_and_by_granularity() {
+        let full = full_fidelity();
+        let partial = partial_fidelity();
+        let agg = aggregate_fidelity();
+        let s = summarize_fidelity_from_iter(vec![
+            Some(&full),
+            Some(&full),
+            Some(&partial),
+            Some(&agg),
+        ]);
+        assert_eq!(s.total, 4);
+        assert_eq!(s.by_class[&FidelityClass::Full], 2);
+        assert_eq!(s.by_class[&FidelityClass::Partial], 1);
+        assert_eq!(s.by_class[&FidelityClass::AggregateOnly], 1);
+        assert_eq!(s.by_granularity[&UsageGranularity::PerTurn], 3);
+        assert_eq!(s.by_granularity[&UsageGranularity::PerSessionAggregate], 1);
+        assert_eq!(s.unknown, 0);
+    }
+
+    #[test]
+    fn reports_records_without_fidelity_in_unknown_bucket() {
+        let full = full_fidelity();
+        let s = summarize_fidelity_from_iter(vec![None, Some(&full), None]);
+        assert_eq!(s.total, 3);
+        assert_eq!(s.unknown, 2);
+        assert_eq!(s.by_class[&FidelityClass::Full], 1);
+        // Unknown records do not get classified or counted as missing —
+        // they're an explicit "we don't know" rather than "we know it's
+        // incomplete".
+        assert_eq!(s.missing_coverage["hasOutputTokens"], 0);
+    }
+
+    #[test]
+    fn counts_missing_fields_correctly_across_mixed_fidelity() {
+        let full = full_fidelity();
+        let partial = partial_fidelity();
+        let s = summarize_fidelity_from_iter(vec![Some(&full), Some(&partial)]);
+        // FULL has input+output+cacheRead+toolCalls+toolResultEvents+
+        // sessionRelationships; PARTIAL has only input. So:
+        //   hasOutputTokens missing on 1 turn (PARTIAL)
+        //   hasCacheReadTokens missing on 1 turn (PARTIAL)
+        //   hasToolResultEvents missing on 1 turn (PARTIAL)
+        //   hasSessionRelationships missing on 1 turn (PARTIAL)
+        assert_eq!(s.missing_coverage["hasInputTokens"], 0);
+        assert_eq!(s.missing_coverage["hasOutputTokens"], 1);
+        assert_eq!(s.missing_coverage["hasCacheReadTokens"], 1);
+        assert_eq!(s.missing_coverage["hasToolResultEvents"], 1);
+        assert_eq!(s.missing_coverage["hasSessionRelationships"], 1);
+        // hasReasoningTokens missing on both (no source surfaces it in
+        // these synthetic fixtures).
+        assert_eq!(s.missing_coverage["hasReasoningTokens"], 2);
+    }
+
+    #[test]
+    fn over_an_opencode_session_unknown_is_zero() {
+        // Conformance with `fidelity.test.ts`'s OpenCode regression: every
+        // turn produced by the parser carries fidelity, so `unknown` is 0.
+        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.pop();
+        p.pop();
+        p.push("tests/fixtures/opencode/multi-turn/storage/session/global/ses_multi.json");
+        let result = parse_opencode_session(&p, &ParseOpencodeOptions::default())
+            .expect("opencode fixture parses");
+        assert!(!result.turns.is_empty());
+        let summary = summarize_fidelity(&result.turns);
+        assert_eq!(summary.unknown, 0);
+        assert_eq!(summary.total as usize, result.turns.len());
+        // Every OpenCode turn carries per-turn granularity.
+        assert_eq!(
+            summary.by_granularity[&UsageGranularity::PerTurn] as usize,
+            result.turns.len(),
+        );
+    }
+
+    #[test]
+    fn has_minimum_fidelity_treats_undefined_as_passing() {
+        assert!(has_minimum_fidelity(None, FidelityClass::Full));
+        assert!(has_minimum_fidelity(None, FidelityClass::UsageOnly));
+    }
+
+    #[test]
+    fn has_minimum_fidelity_orders_classes_from_cost_only_up_to_full() {
+        let full = full_fidelity();
+        let partial = partial_fidelity();
+        let agg = aggregate_fidelity();
+        assert!(has_minimum_fidelity(Some(&full), FidelityClass::UsageOnly));
+        assert!(has_minimum_fidelity(Some(&full), FidelityClass::Full));
+        assert!(!has_minimum_fidelity(
+            Some(&partial),
+            FidelityClass::UsageOnly
+        ));
+        assert!(!has_minimum_fidelity(Some(&partial), FidelityClass::Full));
+        assert!(has_minimum_fidelity(
+            Some(&agg),
+            FidelityClass::AggregateOnly
+        ));
+        assert!(!has_minimum_fidelity(Some(&agg), FidelityClass::UsageOnly));
+    }
+}

--- a/crates/relayburn-analyze/src/lib.rs
+++ b/crates/relayburn-analyze/src/lib.rs
@@ -1,1 +1,32 @@
-// TODO: port `@relayburn/analyze` — see issue #244.
+//! Rust port of `@relayburn/analyze`. See AgentWorkforce/burn#244.
+//!
+//! This crate is a work-in-progress port of the TS analyze package. The
+//! foundation modules (`pricing`, `cost`, `fidelity`) land first because
+//! nearly every higher-level analyzer (compare, hotspots, overhead, ghost
+//! surface) consumes them. Follow-up sub-issues fill in the remaining
+//! modules.
+//!
+//! # Numeric precision
+//!
+//! USD costs are represented as `f64` to match the TS `number` type used in
+//! `@relayburn/analyze`. The per-record math in `cost::cost_for_usage`
+//! preserves the same accumulation order as the TS implementation so output
+//! stays bit-for-bit equivalent on the cost-test fixture corpus, with the
+//! 1e-9 USD precision contract that the future `overhead` sub-issue gates
+//! against.
+
+pub mod cost;
+pub mod fidelity;
+pub mod pricing;
+mod provider_reattribution;
+
+pub use cost::{
+    cost_for_turn, cost_for_usage, lookup_model_rate, sum_costs, CostBreakdown, CostForUsageOptions,
+};
+pub use fidelity::{
+    empty_fidelity_summary, has_minimum_fidelity, summarize_fidelity, summarize_fidelity_from_iter,
+    FidelitySummary, COVERAGE_FIELDS,
+};
+pub use pricing::{
+    flatten_value, load_builtin_pricing, load_pricing, ModelCost, PricingTable, ReasoningMode,
+};

--- a/crates/relayburn-analyze/src/pricing.rs
+++ b/crates/relayburn-analyze/src/pricing.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// How a model's reasoning tokens should be priced.
@@ -69,11 +70,17 @@ struct ModelsDevCost {
 
 #[derive(Debug, Default, Deserialize)]
 struct ModelsDevProvider {
+    // `IndexMap` preserves JSON insertion order so iteration over the model
+    // map matches the TS `Object.entries` walk; this is what makes
+    // duplicate-id resolution deterministic (last entry in file order wins).
     #[serde(default)]
-    models: Option<HashMap<String, ModelsDevModel>>,
+    models: Option<IndexMap<String, ModelsDevModel>>,
 }
 
-type ModelsDevRoot = HashMap<String, ModelsDevProvider>;
+// Same reason as `ModelsDevProvider::models`: providers iterate in file
+// order so a duplicate model id encountered under a later provider block
+// overwrites the earlier one, matching the TS `Object.values(root)` walk.
+type ModelsDevRoot = IndexMap<String, ModelsDevProvider>;
 
 /// Bundled `models.dev.json` snapshot. Refreshed via `pnpm run pricing:update`.
 const BUILTIN_PRICING_JSON: &str =
@@ -221,6 +228,27 @@ mod tests {
         assert_eq!(entry.reasoning, None);
         // cache_write falls back to input when omitted.
         assert_eq!(entry.cache_write, 1.0);
+    }
+
+    #[test]
+    fn flatten_resolves_duplicate_model_ids_with_last_wins_file_order() {
+        // `models.dev.json` lists ~1900 model IDs that appear under multiple
+        // providers (e.g. `claude-sonnet-4-6` under both `anthropic` and
+        // `nano-gpt`). The TS path iterates `Object.values(root)` /
+        // `Object.entries(models)` in insertion order and lets the last
+        // assignment to `out[id]` win. We must do the same so duplicate-id
+        // pricing is deterministic across runs.
+        let raw = r#"{
+            "first":  { "models": { "shared": { "cost": { "input": 1, "output": 2 } } } },
+            "second": { "models": { "shared": { "cost": { "input": 9, "output": 8 } } } }
+        }"#;
+        // Run repeatedly; each run must surface the second-provider entry.
+        for _ in 0..10 {
+            let table = parse_pricing(raw).unwrap();
+            let entry = table.get("shared").unwrap();
+            assert_eq!(entry.input, 9.0);
+            assert_eq!(entry.output, 8.0);
+        }
     }
 
     #[test]

--- a/crates/relayburn-analyze/src/pricing.rs
+++ b/crates/relayburn-analyze/src/pricing.rs
@@ -1,0 +1,289 @@
+//! Per-million-token pricing tables — Rust port of
+//! `packages/analyze/src/pricing.ts`.
+//!
+//! The bundled `models.dev.json` snapshot ships embedded via `include_str!` so
+//! the binary stays self-contained and `load_builtin_pricing` performs no I/O.
+//! `load_pricing` accepts an optional override path that, when present,
+//! shallow-merges over the builtin (override entries win on collision).
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// How a model's reasoning tokens should be priced.
+///
+/// - `IncludedInOutput`: the harness/source already counts reasoning tokens
+///   inside `usage.output`, so `usage.reasoning` is informational only and
+///   must NOT be billed on top. Codex transcripts behave this way.
+/// - `Separate`: the model has a distinct reasoning tariff (`cost.reasoning`
+///   in the `models.dev` snapshot). Bill `usage.reasoning` at that tariff.
+/// - `SameAsOutput`: `usage.output` and `usage.reasoning` are non-overlapping
+///   token buckets and there is no distinct reasoning tariff. Bill
+///   `usage.reasoning` at the output rate. Anthropic Claude transcripts are
+///   the canonical example.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningMode {
+    IncludedInOutput,
+    Separate,
+    SameAsOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelCost {
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: f64,
+    pub cache_write: f64,
+    /// Per-million reasoning-token tariff. Set iff `reasoning_mode == Separate`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<f64>,
+    pub reasoning_mode: ReasoningMode,
+}
+
+pub type PricingTable = HashMap<String, ModelCost>;
+
+#[derive(Debug, Default, Deserialize)]
+struct ModelsDevModel {
+    #[serde(default)]
+    cost: Option<ModelsDevCost>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ModelsDevCost {
+    #[serde(default)]
+    input: Option<f64>,
+    #[serde(default)]
+    output: Option<f64>,
+    #[serde(default)]
+    cache_read: Option<f64>,
+    #[serde(default)]
+    cache_write: Option<f64>,
+    #[serde(default)]
+    reasoning: Option<f64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ModelsDevProvider {
+    #[serde(default)]
+    models: Option<HashMap<String, ModelsDevModel>>,
+}
+
+type ModelsDevRoot = HashMap<String, ModelsDevProvider>;
+
+/// Bundled `models.dev.json` snapshot. Refreshed via `pnpm run pricing:update`.
+const BUILTIN_PRICING_JSON: &str =
+    include_str!("../../../packages/analyze/pricing/models.dev.json");
+
+/// Load the bundled `models.dev` snapshot. No I/O — the JSON is embedded at
+/// compile time via `include_str!`.
+pub fn load_builtin_pricing() -> PricingTable {
+    parse_pricing(BUILTIN_PRICING_JSON).expect("bundled models.dev.json must parse")
+}
+
+/// Load pricing, optionally merging an override file over the builtin. When
+/// `override_path` is `Some` and the file exists + parses, its entries shadow
+/// builtin entries on key collision (TS `{ ...builtin, ...user }` semantics).
+/// Any read or parse error on the override silently falls back to the builtin
+/// — matches the TS `try/catch` in `loadPricing`.
+pub fn load_pricing(override_path: Option<&Path>) -> PricingTable {
+    let mut table = load_builtin_pricing();
+    if let Some(path) = override_path {
+        if let Ok(user) = load_from_file(path) {
+            for (k, v) in user {
+                table.insert(k, v);
+            }
+        }
+    }
+    table
+}
+
+fn load_from_file(path: &Path) -> io::Result<PricingTable> {
+    let raw = fs::read_to_string(path)?;
+    parse_pricing(&raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+fn parse_pricing(raw: &str) -> serde_json::Result<PricingTable> {
+    let parsed: ModelsDevRoot = serde_json::from_str(raw)?;
+    Ok(flatten(&parsed))
+}
+
+/// Flatten a nested `provider → model → cost` map into the flat
+/// `model_id → ModelCost` table burn uses for lookup. Skips entries that lack
+/// either `input` or `output` — matches the TS guard so we don't surface
+/// half-priced models.
+fn flatten(root: &ModelsDevRoot) -> PricingTable {
+    let mut out = PricingTable::new();
+    for provider in root.values() {
+        let Some(models) = provider.models.as_ref() else {
+            continue;
+        };
+        for (id, model) in models {
+            let Some(cost) = model.cost.as_ref() else {
+                continue;
+            };
+            let (Some(input), Some(output)) = (cost.input, cost.output) else {
+                continue;
+            };
+            let has_reasoning = cost.reasoning.is_some();
+            let entry = ModelCost {
+                input,
+                output,
+                cache_read: cost.cache_read.unwrap_or(0.0),
+                // Mirrors the TS `cost.cache_write ?? cost.input` fallback so
+                // models that don't publish a cache-write rate get billed at
+                // the input rate for cache creation.
+                cache_write: cost.cache_write.unwrap_or(input),
+                reasoning: cost.reasoning,
+                reasoning_mode: if has_reasoning {
+                    ReasoningMode::Separate
+                } else {
+                    ReasoningMode::SameAsOutput
+                },
+            };
+            out.insert(id.clone(), entry);
+        }
+    }
+    out
+}
+
+/// Public flatten helper, useful for callers that already hold a parsed
+/// `models.dev`-shaped JSON value.
+pub fn flatten_value(value: &serde_json::Value) -> serde_json::Result<PricingTable> {
+    let root: ModelsDevRoot = serde_json::from_value(value.clone())?;
+    Ok(flatten(&root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_snapshot_parses_and_has_anthropic_models() {
+        let table = load_builtin_pricing();
+        assert!(table.contains_key("claude-opus-4-7"), "opus-4-7 present");
+        assert!(
+            table.contains_key("claude-sonnet-4-6"),
+            "sonnet-4-6 present"
+        );
+        assert!(table.contains_key("claude-haiku-4-5"), "haiku-4-5 present");
+    }
+
+    #[test]
+    fn flatten_preserves_separate_reasoning_tariff() {
+        let raw = r#"{
+            "acme": {
+                "id": "acme",
+                "models": {
+                    "reasoner-v1": {
+                        "id": "reasoner-v1",
+                        "cost": {
+                            "input": 0.7,
+                            "output": 2.8,
+                            "reasoning": 8.4,
+                            "cache_read": 0.07,
+                            "cache_write": 0.7
+                        }
+                    }
+                }
+            }
+        }"#;
+        let table = parse_pricing(raw).unwrap();
+        let entry = table.get("reasoner-v1").expect("flattened entry");
+        assert_eq!(entry.input, 0.7);
+        assert_eq!(entry.output, 2.8);
+        assert_eq!(entry.reasoning, Some(8.4));
+        assert_eq!(entry.cache_read, 0.07);
+        assert_eq!(entry.cache_write, 0.7);
+        assert_eq!(entry.reasoning_mode, ReasoningMode::Separate);
+    }
+
+    #[test]
+    fn flatten_defaults_reasoning_mode_to_same_as_output() {
+        let raw = r#"{
+            "acme": {
+                "id": "acme",
+                "models": {
+                    "plain-v1": {
+                        "id": "plain-v1",
+                        "cost": { "input": 1, "output": 2 }
+                    }
+                }
+            }
+        }"#;
+        let table = parse_pricing(raw).unwrap();
+        let entry = table.get("plain-v1").unwrap();
+        assert_eq!(entry.reasoning_mode, ReasoningMode::SameAsOutput);
+        assert_eq!(entry.reasoning, None);
+        // cache_write falls back to input when omitted.
+        assert_eq!(entry.cache_write, 1.0);
+    }
+
+    #[test]
+    fn flatten_skips_models_without_input_or_output() {
+        let raw = r#"{
+            "acme": {
+                "models": {
+                    "broken": { "cost": { "input": 1 } },
+                    "ok":     { "cost": { "input": 1, "output": 2 } }
+                }
+            }
+        }"#;
+        let table = parse_pricing(raw).unwrap();
+        assert!(!table.contains_key("broken"));
+        assert!(table.contains_key("ok"));
+    }
+
+    #[test]
+    fn builtin_snapshot_keeps_at_least_one_separate_tariff_model() {
+        let table = load_builtin_pricing();
+        let separate: Vec<_> = table
+            .values()
+            .filter(|m| m.reasoning_mode == ReasoningMode::Separate)
+            .collect();
+        assert!(
+            !separate.is_empty(),
+            "expected at least one separate-tariff model in the bundled snapshot",
+        );
+        for m in separate {
+            assert!(m.reasoning.is_some());
+        }
+    }
+
+    #[test]
+    fn load_pricing_falls_back_to_builtin_on_missing_override() {
+        let table = load_pricing(Some(Path::new("/nonexistent/path/models.json")));
+        assert!(table.contains_key("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn load_pricing_merges_override_over_builtin() {
+        let dir = std::env::temp_dir();
+        let override_path = dir.join(format!(
+            "relayburn-analyze-test-{}.json",
+            std::process::id()
+        ));
+        // Override `claude-opus-4-7` with synthetic numbers; assert the
+        // override wins on key collision and a fresh key is added.
+        let raw = r#"{
+            "test": {
+                "models": {
+                    "claude-opus-4-7": { "cost": { "input": 999, "output": 999 } },
+                    "fresh-model":     { "cost": { "input": 1,   "output": 2   } }
+                }
+            }
+        }"#;
+        fs::write(&override_path, raw).unwrap();
+        let table = load_pricing(Some(&override_path));
+        let _ = fs::remove_file(&override_path);
+
+        assert_eq!(table.get("claude-opus-4-7").unwrap().input, 999.0);
+        assert!(table.contains_key("fresh-model"));
+        // Other builtin entries are still present.
+        assert!(table.contains_key("claude-sonnet-4-6"));
+    }
+}

--- a/crates/relayburn-analyze/src/provider_reattribution.rs
+++ b/crates/relayburn-analyze/src/provider_reattribution.rs
@@ -1,0 +1,137 @@
+//! Synthetic-provider detection / cross-collector reattribution. Rust port of
+//! `packages/analyze/src/provider-reattribution.ts`.
+//!
+//! Synthetic.new is a router that lets users invoke models from various
+//! underlying providers via prefixed model IDs (e.g. `hf:deepseek-ai/...`,
+//! `accounts/fireworks/models/...`). When a Claude Code or OpenCode session
+//! uses a Synthetic-routed model, the model ID in the session log carries a
+//! Synthetic-style prefix but the session data lives in the harness's normal
+//! store. To attribute that traffic correctly burn applies rule-based
+//! reattribution at query time — never at ledger-write time, so the raw model
+//! string stays revisitable as the rule set evolves.
+
+use regex::Regex;
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderResolution {
+    /// Resolved provider label (e.g. `"synthetic"`). `None` when no rule
+    /// matched — callers fall back to whatever provider their data source
+    /// already implies.
+    pub provider: Option<String>,
+    /// Model identifier with the routing prefix stripped, suitable for
+    /// pricing lookup. Equal to the input string when no rule matched.
+    pub normalized_model: String,
+    /// Name of the rule that fired, or `None` if none did.
+    pub matched_rule: Option<String>,
+}
+
+struct ProviderRule {
+    name: &'static str,
+    provider: &'static str,
+    /// Regex with a single capturing group — the first capture is the
+    /// normalized model id.
+    pattern: &'static str,
+}
+
+// Rule order matters: the first match wins. More specific prefixes
+// (`accounts/fireworks/models/`) come before short ones (`hf:`) so a future
+// `hf:accounts/...`-style oddity wouldn't be misattributed.
+const DEFAULT_RULES: &[ProviderRule] = &[
+    ProviderRule {
+        name: "synthetic-fireworks",
+        provider: "synthetic",
+        pattern: r"^accounts/fireworks/models/(.+)$",
+    },
+    ProviderRule {
+        name: "synthetic-explicit",
+        provider: "synthetic",
+        pattern: r"^synthetic/(.+)$",
+    },
+    ProviderRule {
+        name: "synthetic-huggingface",
+        // `hf:deepseek-ai/deepseek-r1-distill` → strip `hf:` and the org
+        // segment so the residual matches the bare model id used by
+        // models.dev pricing.
+        provider: "synthetic",
+        pattern: r"^hf:(?:[^/]+/)?(.+)$",
+    },
+];
+
+fn compiled_regexes() -> &'static [Regex] {
+    static CELL: OnceLock<Vec<Regex>> = OnceLock::new();
+    CELL.get_or_init(|| {
+        DEFAULT_RULES
+            .iter()
+            .map(|rule| Regex::new(rule.pattern).expect("default rule regex must compile"))
+            .collect()
+    })
+}
+
+/// Resolve a provider + normalized model id from a raw model string. Pure /
+/// deterministic; safe to call per-turn at query time.
+pub fn resolve_provider(model: &str) -> ProviderResolution {
+    let regexes = compiled_regexes();
+    for (idx, rule) in DEFAULT_RULES.iter().enumerate() {
+        if let Some(caps) = regexes[idx].captures(model) {
+            // First capture group is the normalized model; the default rule
+            // set always provides one, but we fall back to the residual
+            // after the whole match to mirror the TS guard.
+            let normalized = caps
+                .get(1)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_else(|| {
+                    let whole = caps.get(0).unwrap().as_str();
+                    model[whole.len()..].to_string()
+                });
+            return ProviderResolution {
+                provider: Some(rule.provider.to_string()),
+                normalized_model: normalized,
+                matched_rule: Some(rule.name.to_string()),
+            };
+        }
+    }
+    ProviderResolution {
+        provider: None,
+        normalized_model: model.to_string(),
+        matched_rule: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fireworks_prefix_strips_to_bare_model() {
+        let r = resolve_provider("accounts/fireworks/models/llama-3.1-405b");
+        assert_eq!(r.provider.as_deref(), Some("synthetic"));
+        assert_eq!(r.normalized_model, "llama-3.1-405b");
+        assert_eq!(r.matched_rule.as_deref(), Some("synthetic-fireworks"));
+    }
+
+    #[test]
+    fn synthetic_explicit_prefix_strips() {
+        let r = resolve_provider("synthetic/qwen3-coder");
+        assert_eq!(r.provider.as_deref(), Some("synthetic"));
+        assert_eq!(r.normalized_model, "qwen3-coder");
+        assert_eq!(r.matched_rule.as_deref(), Some("synthetic-explicit"));
+    }
+
+    #[test]
+    fn hf_prefix_strips_org_segment() {
+        let r = resolve_provider("hf:deepseek-ai/deepseek-r1-distill");
+        assert_eq!(r.provider.as_deref(), Some("synthetic"));
+        assert_eq!(r.normalized_model, "deepseek-r1-distill");
+        assert_eq!(r.matched_rule.as_deref(), Some("synthetic-huggingface"));
+    }
+
+    #[test]
+    fn no_match_returns_input_unchanged() {
+        let r = resolve_provider("claude-sonnet-4-6");
+        assert_eq!(r.provider, None);
+        assert_eq!(r.normalized_model, "claude-sonnet-4-6");
+        assert_eq!(r.matched_rule, None);
+    }
+}


### PR DESCRIPTION
Closes #266.

## Summary

Bootstraps the `relayburn-analyze` crate with the three foundational modules every higher-level analyzer consumes: pricing tables, per-record cost derivation, and the fidelity summary used to gate aggregations on input quality.

- **`pricing.rs`** — `ReasoningMode` / `ModelCost` / `PricingTable`, `flatten`, `load_builtin_pricing`, `load_pricing(override)`. The bundled `models.dev.json` snapshot ships embedded via `include_str!` so the binary stays self-contained and the loader performs no I/O.
- **`cost.rs`** — `cost_for_usage` / `cost_for_turn` / `lookup_model_rate` / `sum_costs` with the Codex `included_in_output` override and per-million `f64` math matching the TS path. Honors separate-tariff reasoning models and the synthetic-routing lookup fallback.
- **`fidelity.rs`** — `FidelitySummary`, `empty_fidelity_summary` / `summarize_fidelity` / `summarize_fidelity_from_iter`, `has_minimum_fidelity`. Same class-rank ordering as the TS path.
- **`provider_reattribution.rs`** — private helper porting the synthetic reattribution rules (`accounts/fireworks/...`, `synthetic/...`, `hf:...`) that `lookup_model_rate` consults.

`f64` is the canonical USD type; the per-record arithmetic preserves the TS accumulation order so the documented 1e-9 USD precision contract for the future overhead sub-issue is honored.

## Conformance

Ports the TS test fixtures with native equivalents:
- `cost.test.ts` → 12 tests (Claude / Codex / synthetic-reasoner pricing, cache-write rate, override semantics, the Codex 11.3% overstatement regression at <1e-9 USD).
- `fidelity.test.ts` → 7 tests including the OpenCode-fixture `unknown == 0` regression that loads `tests/fixtures/opencode/multi-turn/...` through `parse_opencode_session`.
- Plus pricing + provider-reattribution unit coverage.

`cargo test -p relayburn-analyze` → **31 passed**.
`cargo test --workspace` → green.

## Test plan

- [x] `cargo build -p relayburn-analyze`
- [x] `cargo test -p relayburn-analyze`
- [x] `cargo test --workspace`
- [x] Bundled `models.dev.json` parses and exposes `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5`
- [x] Codex regression matches TS to within 1e-9 USD

https://claude.ai/code/session_01BejN8WdZoaNHTzaopffsQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BejN8WdZoaNHTzaopffsQz)_