### PR TITLE
relayburn-analyze: provider attribution port (closes #267)

### DIFF
--- a/crates/relayburn-analyze/src/lib.rs
+++ b/crates/relayburn-analyze/src/lib.rs
@@ -18,7 +18,8 @@
 pub mod cost;
 pub mod fidelity;
 pub mod pricing;
-mod provider_reattribution;
+pub mod provider;
+pub mod provider_reattribution;
 
 pub use cost::{
     cost_for_turn, cost_for_usage, lookup_model_rate, sum_costs, CostBreakdown, CostForUsageOptions,
@@ -29,4 +30,15 @@ pub use fidelity::{
 };
 pub use pricing::{
     flatten_value, load_builtin_pricing, load_pricing, ModelCost, PricingTable, ReasoningMode,
+};
+pub use provider::{
+    aggregate_by_provider, filter_turns_by_provider, filter_turns_by_provider_with_rules,
+    provider_for, provider_for_model, provider_for_model_with_rules, provider_for_turn,
+    provider_for_with_rules, resolve_turn_provider, AggregateByProviderOptions, AsTurnLike,
+    CoverageField, FieldCoverage, ProviderAggregateRow, ProviderFilter, RowCoverage, TurnProvider,
+    UsageCostAggregateRow,
+};
+pub use provider_reattribution::{
+    default_rules, extend_default_rules, resolve_provider, resolve_provider_with_rules,
+    ProviderPattern, ProviderResolution, ProviderRule,
 };

--- a/crates/relayburn-analyze/src/provider.rs
+++ b/crates/relayburn-analyze/src/provider.rs
@@ -10,8 +10,9 @@
 //! views (`compare`, `summary --by-provider`).
 
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
+use indexmap::IndexMap;
 use relayburn_reader::{Coverage, SourceKind, TurnRecord, Usage};
 
 use crate::cost::{cost_for_turn, CostBreakdown};
@@ -242,10 +243,13 @@ pub fn aggregate_by_provider(
         Some(r) => r,
         None => default_rules(),
     };
-    // Use a HashMap for accumulation, then sort the final vec by descending
-    // total cost to mirror the TS sort. Order of insertion isn't observable
-    // because the sort is stable on cost.
-    let mut by_provider: HashMap<String, ProviderAggregateRow> = HashMap::new();
+    // `IndexMap` (vs `HashMap`) preserves first-seen insertion order so the
+    // final stable sort by descending cost keeps cross-language tie-breaks
+    // matching the TS implementation, where the underlying `Map` already
+    // iterates in insertion order. Without this, two providers tied at the
+    // same `cost.total` (e.g. multiple unpriced providers all at $0) would
+    // surface in arbitrary order from run to run.
+    let mut by_provider: IndexMap<String, ProviderAggregateRow> = IndexMap::new();
     for t in turns {
         let provider = provider_for_with_rules(t, rules).provider;
         let provider = if provider.is_empty() {
@@ -541,6 +545,31 @@ mod tests {
         assert_eq!(rows[0].provider, "openai");
         assert_eq!(rows[1].provider, "synthetic");
         assert!(rows[0].cost.total > rows[1].cost.total);
+    }
+
+    #[test]
+    fn aggregate_preserves_first_seen_order_for_cost_ties() {
+        // Two unpriced providers both end up at $0; the stable sort must
+        // preserve first-seen insertion order so output is deterministic and
+        // matches the TS `Map`-based implementation.
+        let pricing = PricingTable::new();
+        let rows = aggregate_by_provider(
+            &[
+                turn(
+                    "unknown-model-a",
+                    SourceKind::AnthropicApi,
+                    input_only(1_000),
+                ),
+                turn("unknown-model-b", SourceKind::OpenaiApi, input_only(1_000)),
+            ],
+            AggregateByProviderOptions::new(&pricing),
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].cost.total, 0.0);
+        assert_eq!(rows[1].cost.total, 0.0);
+        // First-seen wins on ties: anthropic before openai.
+        assert_eq!(rows[0].provider, "anthropic");
+        assert_eq!(rows[1].provider, "openai");
     }
 
     #[test]

--- a/crates/relayburn-analyze/src/provider.rs
+++ b/crates/relayburn-analyze/src/provider.rs
@@ -1,0 +1,659 @@
+//! Effective-provider helpers + per-provider aggregator. Rust port of
+//! `packages/analyze/src/provider.ts`.
+//!
+//! [`provider_for`] resolves the canonical provider label for a turn,
+//! preferring synthetic-style router prefixes (handled by
+//! [`crate::provider_reattribution`]) before falling back to a raw
+//! `provider/model` model prefix and finally to the collector-implied
+//! provider. [`aggregate_by_provider`] rolls turns up into a
+//! cost-descending list of [`ProviderAggregateRow`]s for the per-provider
+//! views (`compare`, `summary --by-provider`).
+
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap};
+
+use relayburn_reader::{Coverage, SourceKind, TurnRecord, Usage};
+
+use crate::cost::{cost_for_turn, CostBreakdown};
+use crate::pricing::PricingTable;
+use crate::provider_reattribution::{default_rules, resolve_provider_with_rules, ProviderRule};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnProvider {
+    pub provider: String,
+    pub raw_model: String,
+    pub normalized_model: String,
+    pub matched_rule: Option<String>,
+}
+
+/// Lower-cased provider labels used to filter turns. `BTreeSet` (vs the TS
+/// `ReadonlySet`) gives deterministic iteration, which matters for any
+/// future byte-equivalent output.
+pub type ProviderFilter = BTreeSet<String>;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FieldCoverage {
+    pub known: u64,
+    pub missing: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CoverageField {
+    Input,
+    Output,
+    Reasoning,
+    CacheRead,
+    CacheCreate,
+}
+
+pub const COVERAGE_FIELDS: [CoverageField; 5] = [
+    CoverageField::Input,
+    CoverageField::Output,
+    CoverageField::Reasoning,
+    CoverageField::CacheRead,
+    CoverageField::CacheCreate,
+];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RowCoverage {
+    pub input: FieldCoverage,
+    pub output: FieldCoverage,
+    pub reasoning: FieldCoverage,
+    pub cache_read: FieldCoverage,
+    pub cache_create: FieldCoverage,
+}
+
+impl RowCoverage {
+    pub fn field_mut(&mut self, f: CoverageField) -> &mut FieldCoverage {
+        match f {
+            CoverageField::Input => &mut self.input,
+            CoverageField::Output => &mut self.output,
+            CoverageField::Reasoning => &mut self.reasoning,
+            CoverageField::CacheRead => &mut self.cache_read,
+            CoverageField::CacheCreate => &mut self.cache_create,
+        }
+    }
+
+    pub fn field(&self, f: CoverageField) -> &FieldCoverage {
+        match f {
+            CoverageField::Input => &self.input,
+            CoverageField::Output => &self.output,
+            CoverageField::Reasoning => &self.reasoning,
+            CoverageField::CacheRead => &self.cache_read,
+            CoverageField::CacheCreate => &self.cache_create,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageCostAggregateRow {
+    pub label: String,
+    pub turns: u64,
+    pub usage: Usage,
+    pub cost: CostBreakdown,
+    pub coverage: RowCoverage,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderAggregateRow {
+    pub provider: String,
+    pub label: String,
+    pub turns: u64,
+    pub usage: Usage,
+    pub cost: CostBreakdown,
+    pub coverage: RowCoverage,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AggregateByProviderOptions<'a> {
+    pub pricing: &'a PricingTable,
+    /// `None` defers to [`default_rules`].
+    pub rules: Option<&'a [ProviderRule]>,
+}
+
+impl<'a> AggregateByProviderOptions<'a> {
+    pub fn new(pricing: &'a PricingTable) -> Self {
+        Self {
+            pricing,
+            rules: None,
+        }
+    }
+}
+
+/// Resolve the effective provider for a turn.
+///
+/// Synthetic-style router prefixes win first. Otherwise we keep provider
+/// semantics aligned with CLI rendering by using a raw `provider/model`
+/// model prefix when present, then falling back to the collector-implied
+/// provider.
+pub fn provider_for(turn: &TurnRecord) -> TurnProvider {
+    provider_for_with_rules(turn, default_rules())
+}
+
+pub fn provider_for_with_rules(turn: &TurnRecord, rules: &[ProviderRule]) -> TurnProvider {
+    provider_for_model_with_rules(&turn.model, Some(turn.source), rules)
+}
+
+/// Alias of [`provider_for`] — TS exports both `providerFor` and
+/// `providerForTurn` so callers can pick the spelling that reads best.
+pub fn provider_for_turn(turn: &TurnRecord) -> TurnProvider {
+    provider_for(turn)
+}
+
+/// Alias of [`provider_for`].
+pub fn resolve_turn_provider(turn: &TurnRecord) -> TurnProvider {
+    provider_for(turn)
+}
+
+pub fn provider_for_model(model: &str, source: Option<SourceKind>) -> TurnProvider {
+    provider_for_model_with_rules(model, source, default_rules())
+}
+
+pub fn provider_for_model_with_rules(
+    model: &str,
+    source: Option<SourceKind>,
+    rules: &[ProviderRule],
+) -> TurnProvider {
+    let resolved = resolve_provider_with_rules(model, rules);
+    if let Some(provider) = resolved.provider {
+        return TurnProvider {
+            provider,
+            raw_model: model.to_string(),
+            normalized_model: resolved.normalized_model,
+            matched_rule: resolved.matched_rule,
+        };
+    }
+
+    if let Some(prefix) = provider_from_model_prefix(model) {
+        return TurnProvider {
+            provider: prefix,
+            raw_model: model.to_string(),
+            normalized_model: strip_provider_prefix(model).to_string(),
+            matched_rule: None,
+        };
+    }
+
+    TurnProvider {
+        provider: source
+            .map(provider_from_source)
+            .unwrap_or_else(|| "unknown".into()),
+        raw_model: model.to_string(),
+        normalized_model: model.to_string(),
+        matched_rule: None,
+    }
+}
+
+/// Filter turns to those whose effective provider (lower-cased) is in
+/// `filter`. Returns the input slice unchanged when `filter` is `None`.
+pub fn filter_turns_by_provider<'a, T>(
+    turns: &'a [T],
+    filter: Option<&ProviderFilter>,
+) -> Vec<&'a T>
+where
+    T: AsTurnLike,
+{
+    filter_turns_by_provider_with_rules(turns, filter, default_rules())
+}
+
+pub fn filter_turns_by_provider_with_rules<'a, T>(
+    turns: &'a [T],
+    filter: Option<&ProviderFilter>,
+    rules: &[ProviderRule],
+) -> Vec<&'a T>
+where
+    T: AsTurnLike,
+{
+    let Some(filter) = filter else {
+        return turns.iter().collect();
+    };
+    turns
+        .iter()
+        .filter(|t| {
+            let resolved =
+                provider_for_model_with_rules(t.model_str(), Some(t.source_kind()), rules);
+            filter.contains(&resolved.provider.to_lowercase())
+        })
+        .collect()
+}
+
+/// Minimal trait equivalent of TS's structural `Pick<TurnRecord, 'model' |
+/// 'source'>`. Implemented for [`TurnRecord`] out of the box; downstream
+/// callers can implement it for their own row types if they want to share
+/// [`filter_turns_by_provider`].
+pub trait AsTurnLike {
+    fn model_str(&self) -> &str;
+    fn source_kind(&self) -> SourceKind;
+}
+
+impl AsTurnLike for TurnRecord {
+    fn model_str(&self) -> &str {
+        &self.model
+    }
+    fn source_kind(&self) -> SourceKind {
+        self.source
+    }
+}
+
+pub fn aggregate_by_provider(
+    turns: &[TurnRecord],
+    opts: AggregateByProviderOptions<'_>,
+) -> Vec<ProviderAggregateRow> {
+    let rules: &[ProviderRule] = match opts.rules {
+        Some(r) => r,
+        None => default_rules(),
+    };
+    // Use a HashMap for accumulation, then sort the final vec by descending
+    // total cost to mirror the TS sort. Order of insertion isn't observable
+    // because the sort is stable on cost.
+    let mut by_provider: HashMap<String, ProviderAggregateRow> = HashMap::new();
+    for t in turns {
+        let provider = provider_for_with_rules(t, rules).provider;
+        let provider = if provider.is_empty() {
+            "unknown".to_string()
+        } else {
+            provider
+        };
+        let row = by_provider
+            .entry(provider.clone())
+            .or_insert_with(|| empty_provider_row(&provider));
+        row.turns += 1;
+        row.usage.input += t.usage.input;
+        row.usage.output += t.usage.output;
+        row.usage.reasoning += t.usage.reasoning;
+        row.usage.cache_read += t.usage.cache_read;
+        row.usage.cache_create_5m += t.usage.cache_create_5m;
+        row.usage.cache_create_1h += t.usage.cache_create_1h;
+        accumulate_coverage(&mut row.coverage, t.fidelity.as_ref().map(|f| &f.coverage));
+        if let Some(c) = cost_for_turn(t, opts.pricing) {
+            row.cost.total += c.total;
+            row.cost.input += c.input;
+            row.cost.output += c.output;
+            row.cost.reasoning += c.reasoning;
+            row.cost.cache_read += c.cache_read;
+            row.cost.cache_create += c.cache_create;
+        }
+    }
+    let mut rows: Vec<ProviderAggregateRow> = by_provider.into_values().collect();
+    rows.sort_by(|a, b| {
+        b.cost
+            .total
+            .partial_cmp(&a.cost.total)
+            .unwrap_or(Ordering::Equal)
+    });
+    rows
+}
+
+fn empty_provider_row(provider: &str) -> ProviderAggregateRow {
+    ProviderAggregateRow {
+        provider: provider.to_string(),
+        label: provider.to_string(),
+        turns: 0,
+        usage: Usage::default(),
+        cost: CostBreakdown {
+            model: provider.to_string(),
+            total: 0.0,
+            input: 0.0,
+            output: 0.0,
+            reasoning: 0.0,
+            cache_read: 0.0,
+            cache_create: 0.0,
+        },
+        coverage: RowCoverage::default(),
+    }
+}
+
+fn accumulate_coverage(target: &mut RowCoverage, coverage: Option<&Coverage>) {
+    for f in COVERAGE_FIELDS {
+        let known = match coverage {
+            None => true, // mirror TS: missing coverage object → assume known
+            Some(c) => match f {
+                CoverageField::Input => c.has_input_tokens,
+                CoverageField::Output => c.has_output_tokens,
+                CoverageField::Reasoning => c.has_reasoning_tokens,
+                CoverageField::CacheRead => c.has_cache_read_tokens,
+                CoverageField::CacheCreate => c.has_cache_create_tokens,
+            },
+        };
+        let slot = target.field_mut(f);
+        if known {
+            slot.known += 1;
+        } else {
+            slot.missing += 1;
+        }
+    }
+}
+
+fn provider_from_model_prefix(model: &str) -> Option<String> {
+    let i = model.find('/')?;
+    if i == 0 {
+        return None;
+    }
+    Some(model[..i].to_lowercase())
+}
+
+fn strip_provider_prefix(model: &str) -> &str {
+    match model.find('/') {
+        Some(i) => &model[i + 1..],
+        None => model,
+    }
+}
+
+fn provider_from_source(source: SourceKind) -> String {
+    match source {
+        SourceKind::ClaudeCode | SourceKind::AnthropicApi => "anthropic".into(),
+        SourceKind::Codex | SourceKind::OpenaiApi => "openai".into(),
+        SourceKind::GeminiApi => "google".into(),
+        SourceKind::Opencode => "opencode".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pricing::{ModelCost, ReasoningMode};
+    use relayburn_reader::{ToolCall, Usage};
+
+    fn pricing_fixture() -> PricingTable {
+        let mut p = PricingTable::new();
+        p.insert(
+            "deepseek-r1".into(),
+            ModelCost {
+                input: 1.0,
+                output: 2.0,
+                cache_read: 0.1,
+                cache_write: 1.25,
+                reasoning: None,
+                reasoning_mode: ReasoningMode::SameAsOutput,
+            },
+        );
+        p.insert(
+            "gpt-5".into(),
+            ModelCost {
+                input: 3.0,
+                output: 6.0,
+                cache_read: 0.3,
+                cache_write: 3.75,
+                reasoning: None,
+                reasoning_mode: ReasoningMode::SameAsOutput,
+            },
+        );
+        p
+    }
+
+    fn turn(model: &str, source: SourceKind, usage: Usage) -> TurnRecord {
+        TurnRecord {
+            v: 1,
+            source,
+            session_id: "s-provider".into(),
+            session_path: None,
+            message_id: "m-provider".into(),
+            turn_index: 0,
+            ts: "2026-04-20T00:00:00.000Z".into(),
+            model: model.into(),
+            project: None,
+            project_key: None,
+            usage,
+            tool_calls: Vec::<ToolCall>::new(),
+            files_touched: None,
+            subagent: None,
+            stop_reason: None,
+            activity: None,
+            retries: None,
+            has_edits: None,
+            fidelity: None,
+        }
+    }
+
+    fn one_million_in_one_million_out() -> Usage {
+        Usage {
+            input: 1_000_000,
+            output: 1_000_000,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        }
+    }
+
+    fn input_only(input: u64) -> Usage {
+        Usage {
+            input,
+            output: 0,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        }
+    }
+
+    fn output_only(output: u64) -> Usage {
+        Usage {
+            input: 0,
+            output,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        }
+    }
+
+    #[test]
+    fn reattributes_synthetic_routed_models_before_source_fallback() {
+        let p = provider_for(&turn(
+            "hf:deepseek-ai/deepseek-r1",
+            SourceKind::ClaudeCode,
+            one_million_in_one_million_out(),
+        ));
+        assert_eq!(p.provider, "synthetic");
+        assert_eq!(p.normalized_model, "deepseek-r1");
+        assert_eq!(p.matched_rule.as_deref(), Some("synthetic-huggingface"));
+    }
+
+    #[test]
+    fn falls_through_to_collector_implied_providers() {
+        assert_eq!(
+            provider_for(&turn(
+                "gpt-5",
+                SourceKind::Codex,
+                one_million_in_one_million_out()
+            ))
+            .provider,
+            "openai"
+        );
+        assert_eq!(
+            provider_for(&turn(
+                "anthropic/claude-sonnet-4-6",
+                SourceKind::Opencode,
+                one_million_in_one_million_out(),
+            ))
+            .provider,
+            "anthropic"
+        );
+    }
+
+    #[test]
+    fn aggregate_groups_synthetic_turns_regardless_of_routing_prefix() {
+        let pricing = pricing_fixture();
+        let rows = aggregate_by_provider(
+            &[
+                turn(
+                    "hf:deepseek-ai/deepseek-r1",
+                    SourceKind::ClaudeCode,
+                    input_only(1_000_000),
+                ),
+                turn(
+                    "synthetic/deepseek-r1",
+                    SourceKind::ClaudeCode,
+                    output_only(1_000_000),
+                ),
+            ],
+            AggregateByProviderOptions::new(&pricing),
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].provider, "synthetic");
+        assert_eq!(rows[0].turns, 2);
+        assert_eq!(rows[0].usage.input, 1_000_000);
+        assert_eq!(rows[0].usage.output, 1_000_000);
+        assert_eq!(rows[0].cost.total, 3.0);
+    }
+
+    #[test]
+    fn aggregate_falls_through_to_collector_for_non_synthetic_turns() {
+        let pricing = pricing_fixture();
+        let rows = aggregate_by_provider(
+            &[turn(
+                "gpt-5",
+                SourceKind::Codex,
+                one_million_in_one_million_out(),
+            )],
+            AggregateByProviderOptions::new(&pricing),
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].provider, "openai");
+        assert_eq!(rows[0].cost.total, 9.0);
+    }
+
+    #[test]
+    fn aggregate_returns_empty_for_empty_input() {
+        let pricing = pricing_fixture();
+        assert!(aggregate_by_provider(&[], AggregateByProviderOptions::new(&pricing)).is_empty());
+    }
+
+    #[test]
+    fn aggregate_orders_rows_by_descending_total_cost() {
+        let pricing = pricing_fixture();
+        let rows = aggregate_by_provider(
+            &[
+                // openai: 1M in @ $3 + 1M out @ $6 → $9
+                turn("gpt-5", SourceKind::Codex, one_million_in_one_million_out()),
+                // synthetic: 1M in @ $1 → $1
+                turn(
+                    "hf:deepseek-ai/deepseek-r1",
+                    SourceKind::ClaudeCode,
+                    input_only(1_000_000),
+                ),
+            ],
+            AggregateByProviderOptions::new(&pricing),
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].provider, "openai");
+        assert_eq!(rows[1].provider, "synthetic");
+        assert!(rows[0].cost.total > rows[1].cost.total);
+    }
+
+    #[test]
+    fn filter_returns_input_unchanged_when_filter_is_none() {
+        let turns = vec![turn(
+            "claude-sonnet-4-6",
+            SourceKind::ClaudeCode,
+            one_million_in_one_million_out(),
+        )];
+        let filtered = filter_turns_by_provider(&turns, None);
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn filter_keeps_only_matching_providers() {
+        let turns = vec![
+            turn("gpt-5", SourceKind::Codex, one_million_in_one_million_out()),
+            turn(
+                "claude-sonnet-4-6",
+                SourceKind::ClaudeCode,
+                one_million_in_one_million_out(),
+            ),
+        ];
+        let mut want = ProviderFilter::new();
+        want.insert("openai".into());
+        let filtered = filter_turns_by_provider(&turns, Some(&want));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].model, "gpt-5");
+    }
+}
+
+#[cfg(test)]
+mod cost_lookup_via_reattribution_tests {
+    //! Conformance tests ported from the `costForTurn — reattribution-aware
+    //! pricing lookup` describe block in
+    //! `packages/analyze/src/provider-reattribution.test.ts`. They live next
+    //! to the provider tests so the conformance gate in #267 is colocated.
+
+    use super::*;
+    use crate::cost::cost_for_turn;
+    use crate::pricing::load_builtin_pricing;
+    use relayburn_reader::{ToolCall, Usage};
+
+    fn turn(model: &str, usage: Usage) -> TurnRecord {
+        TurnRecord {
+            v: 1,
+            source: SourceKind::ClaudeCode,
+            session_id: "s".into(),
+            session_path: None,
+            message_id: "m".into(),
+            turn_index: 0,
+            ts: "2026-04-20T00:00:00.000Z".into(),
+            model: model.into(),
+            project: None,
+            project_key: None,
+            usage,
+            tool_calls: Vec::<ToolCall>::new(),
+            files_touched: None,
+            subagent: None,
+            stop_reason: None,
+            activity: None,
+            retries: None,
+            has_edits: None,
+            fidelity: None,
+        }
+    }
+
+    fn usage(input: u64, output: u64) -> Usage {
+        Usage {
+            input,
+            output,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        }
+    }
+
+    #[test]
+    fn prices_hf_deepseek_r1_against_deepseek_r1() {
+        let p = load_builtin_pricing();
+        assert!(
+            p.contains_key("deepseek-r1"),
+            "deepseek-r1 expected in builtin pricing"
+        );
+        let t = turn("hf:deepseek-ai/deepseek-r1", usage(1_000_000, 1_000_000));
+        let c = cost_for_turn(&t, &p).expect("non-null cost for synthetic-routed deepseek-r1");
+        let rate = p.get("deepseek-r1").unwrap();
+        assert_eq!(c.input, rate.input);
+        assert_eq!(c.output, rate.output);
+        assert_eq!(c.total, rate.input + rate.output);
+    }
+
+    #[test]
+    fn prices_fireworks_deepseek_r1_against_deepseek_r1() {
+        let p = load_builtin_pricing();
+        let t = turn("accounts/fireworks/models/deepseek-r1", usage(500_000, 0));
+        let c = cost_for_turn(&t, &p).expect("priced");
+        let rate = p.get("deepseek-r1").unwrap();
+        assert_eq!(c.input, rate.input * 0.5);
+    }
+
+    #[test]
+    fn returns_none_for_synthetic_prefixed_unknown_models() {
+        let p = load_builtin_pricing();
+        let c = cost_for_turn(&turn("hf:org/totally-fake-model-xyz", usage(1000, 0)), &p);
+        assert!(c.is_none());
+    }
+
+    #[test]
+    fn does_not_regress_direct_priced_models() {
+        let p = load_builtin_pricing();
+        let c = cost_for_turn(&turn("claude-sonnet-4-6", usage(1_000_000, 0)), &p).expect("priced");
+        assert_eq!(c.input, p.get("claude-sonnet-4-6").unwrap().input);
+    }
+}

--- a/crates/relayburn-analyze/src/provider_reattribution.rs
+++ b/crates/relayburn-analyze/src/provider_reattribution.rs
@@ -9,10 +9,14 @@
 //! store. To attribute that traffic correctly burn applies rule-based
 //! reattribution at query time — never at ledger-write time, so the raw model
 //! string stays revisitable as the rule set evolves.
+//!
+//! This is the extension point for future aggregator detectors (OpenRouter,
+//! etc.). Add a [`ProviderRule`] to a callsite-specific rule set or extend the
+//! defaults via [`extend_default_rules`] and the resolver picks it up.
+
+use std::sync::LazyLock;
 
 use regex::Regex;
-
-use std::sync::OnceLock;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderResolution {
@@ -27,68 +31,131 @@ pub struct ProviderResolution {
     pub matched_rule: Option<String>,
 }
 
-struct ProviderRule {
-    name: &'static str,
-    provider: &'static str,
-    /// Regex with a single capturing group — the first capture is the
-    /// normalized model id.
-    pattern: &'static str,
+/// Pattern used by a [`ProviderRule`]. Mirrors the TS `string | RegExp`
+/// pattern field: literal prefixes use `Prefix` and behave like
+/// `String.prototype.startsWith`; regex patterns must include a single
+/// capturing group whose first capture is the normalized model id.
+#[derive(Debug, Clone)]
+pub enum ProviderPattern {
+    Prefix(String),
+    Regex(Regex),
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderRule {
+    /// Stable identifier; appears in [`ProviderResolution::matched_rule`] and
+    /// is used to dedupe / replace rules when callers extend
+    /// [`default_rules`].
+    pub name: String,
+    /// Provider label to assign when the rule fires.
+    pub provider: String,
+    /// Either a literal prefix (matched via `starts_with`) or a regex with
+    /// at least one capturing group whose first capture is the normalized
+    /// model.
+    pub pattern: ProviderPattern,
+}
+
+impl ProviderRule {
+    /// Build a literal-prefix rule. The rule fires when the model string
+    /// starts with `prefix`; the normalized model is the residual after the
+    /// prefix.
+    pub fn prefix(
+        name: impl Into<String>,
+        provider: impl Into<String>,
+        prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            provider: provider.into(),
+            pattern: ProviderPattern::Prefix(prefix.into()),
+        }
+    }
+
+    /// Build a regex-pattern rule. Returns an error if `pattern` doesn't
+    /// compile.
+    pub fn regex(
+        name: impl Into<String>,
+        provider: impl Into<String>,
+        pattern: &str,
+    ) -> Result<Self, regex::Error> {
+        Ok(Self {
+            name: name.into(),
+            provider: provider.into(),
+            pattern: ProviderPattern::Regex(Regex::new(pattern)?),
+        })
+    }
 }
 
 // Rule order matters: the first match wins. More specific prefixes
 // (`accounts/fireworks/models/`) come before short ones (`hf:`) so a future
 // `hf:accounts/...`-style oddity wouldn't be misattributed.
-const DEFAULT_RULES: &[ProviderRule] = &[
-    ProviderRule {
-        name: "synthetic-fireworks",
-        provider: "synthetic",
-        pattern: r"^accounts/fireworks/models/(.+)$",
-    },
-    ProviderRule {
-        name: "synthetic-explicit",
-        provider: "synthetic",
-        pattern: r"^synthetic/(.+)$",
-    },
-    ProviderRule {
-        name: "synthetic-huggingface",
-        // `hf:deepseek-ai/deepseek-r1-distill` → strip `hf:` and the org
-        // segment so the residual matches the bare model id used by
-        // models.dev pricing.
-        provider: "synthetic",
-        pattern: r"^hf:(?:[^/]+/)?(.+)$",
-    },
-];
+//
+// Mirrors `DEFAULT_RULES` in `packages/analyze/src/provider-reattribution.ts`
+// byte-for-byte (same names, same providers, same patterns, same order).
+static DEFAULT_RULES_INNER: LazyLock<Vec<ProviderRule>> = LazyLock::new(|| {
+    vec![
+        ProviderRule {
+            name: "synthetic-fireworks".into(),
+            provider: "synthetic".into(),
+            pattern: ProviderPattern::Regex(
+                Regex::new(r"^accounts/fireworks/models/(.+)$").expect("default regex compiles"),
+            ),
+        },
+        ProviderRule {
+            name: "synthetic-explicit".into(),
+            provider: "synthetic".into(),
+            pattern: ProviderPattern::Regex(
+                Regex::new(r"^synthetic/(.+)$").expect("default regex compiles"),
+            ),
+        },
+        ProviderRule {
+            name: "synthetic-huggingface".into(),
+            // `hf:deepseek-ai/deepseek-r1-distill` → strip `hf:` and the org
+            // segment so the residual matches the bare model id used by
+            // models.dev pricing.
+            provider: "synthetic".into(),
+            pattern: ProviderPattern::Regex(
+                Regex::new(r"^hf:(?:[^/]+/)?(.+)$").expect("default regex compiles"),
+            ),
+        },
+    ]
+});
 
-fn compiled_regexes() -> &'static [Regex] {
-    static CELL: OnceLock<Vec<Regex>> = OnceLock::new();
-    CELL.get_or_init(|| {
-        DEFAULT_RULES
-            .iter()
-            .map(|rule| Regex::new(rule.pattern).expect("default rule regex must compile"))
-            .collect()
-    })
+/// Default rule set shipped with the analyzer — same prefixes, providers and
+/// ordering as the TS [`DEFAULT_RULES`] export.
+pub fn default_rules() -> &'static [ProviderRule] {
+    DEFAULT_RULES_INNER.as_slice()
 }
 
-/// Resolve a provider + normalized model id from a raw model string. Pure /
-/// deterministic; safe to call per-turn at query time.
+/// Convenience helper: returns a fresh `Vec<ProviderRule>` containing the
+/// defaults followed by `extra`. Mirrors the TS spread idiom
+/// `[...DEFAULT_RULES, customRule]` used by callers extending the rule set.
+pub fn extend_default_rules<I>(extra: I) -> Vec<ProviderRule>
+where
+    I: IntoIterator<Item = ProviderRule>,
+{
+    let mut rules: Vec<ProviderRule> = default_rules().to_vec();
+    rules.extend(extra);
+    rules
+}
+
+/// Resolve a provider + normalized model id from a raw model string against
+/// the default rule set. Pure / deterministic; safe to call per-turn at
+/// query time.
 pub fn resolve_provider(model: &str) -> ProviderResolution {
-    let regexes = compiled_regexes();
-    for (idx, rule) in DEFAULT_RULES.iter().enumerate() {
-        if let Some(caps) = regexes[idx].captures(model) {
-            // First capture group is the normalized model; the default rule
-            // set always provides one, but we fall back to the residual
-            // after the whole match to mirror the TS guard.
-            let normalized = caps
-                .get(1)
-                .map(|m| m.as_str().to_string())
-                .unwrap_or_else(|| {
-                    let whole = caps.get(0).unwrap().as_str();
-                    model[whole.len()..].to_string()
-                });
+    resolve_provider_with_rules(model, default_rules())
+}
+
+/// Like [`resolve_provider`] but uses an explicit rule set — used by the
+/// public analyzer surface to thread `AggregateByProviderOptions::rules`
+/// through, and by tests to exercise extension scenarios.
+pub fn resolve_provider_with_rules(model: &str, rules: &[ProviderRule]) -> ProviderResolution {
+    for rule in rules {
+        if let Some(normalized) = apply_rule(model, rule) {
             return ProviderResolution {
-                provider: Some(rule.provider.to_string()),
+                provider: Some(rule.provider.clone()),
                 normalized_model: normalized,
-                matched_rule: Some(rule.name.to_string()),
+                matched_rule: Some(rule.name.clone()),
             };
         }
     }
@@ -96,6 +163,31 @@ pub fn resolve_provider(model: &str) -> ProviderResolution {
         provider: None,
         normalized_model: model.to_string(),
         matched_rule: None,
+    }
+}
+
+fn apply_rule(model: &str, rule: &ProviderRule) -> Option<String> {
+    match &rule.pattern {
+        ProviderPattern::Prefix(prefix) => {
+            if model.starts_with(prefix.as_str()) {
+                Some(model[prefix.len()..].to_string())
+            } else {
+                None
+            }
+        }
+        ProviderPattern::Regex(re) => {
+            let caps = re.captures(model)?;
+            // First capture group is the normalized model; if a rule omits a
+            // capture group treat the remainder after the match as the
+            // normalized id (mirrors the TS `m[1] ?? model.slice(m[0].length)`
+            // guard).
+            Some(if let Some(cap) = caps.get(1) {
+                cap.as_str().to_string()
+            } else {
+                let whole = caps.get(0).expect("regex match has full text");
+                model[whole.end()..].to_string()
+            })
+        }
     }
 }
 
@@ -128,10 +220,81 @@ mod tests {
     }
 
     #[test]
+    fn hf_with_no_org_segment_routes_to_synthetic() {
+        let r = resolve_provider("hf:llama-3-70b");
+        assert_eq!(r.provider.as_deref(), Some("synthetic"));
+        assert_eq!(r.normalized_model, "llama-3-70b");
+    }
+
+    #[test]
     fn no_match_returns_input_unchanged() {
         let r = resolve_provider("claude-sonnet-4-6");
         assert_eq!(r.provider, None);
         assert_eq!(r.normalized_model, "claude-sonnet-4-6");
         assert_eq!(r.matched_rule, None);
+    }
+
+    #[test]
+    fn anthropic_provider_prefix_is_left_to_cost_fallback() {
+        // The reattribution layer is intentionally narrow: it does not own
+        // the generic `provider/model` strip — that's still cost.rs's job.
+        let r = resolve_provider("anthropic/claude-sonnet-4-6");
+        assert_eq!(r.provider, None);
+        assert_eq!(r.normalized_model, "anthropic/claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn first_matching_rule_wins() {
+        // Sanity check: explicit `synthetic/` should not also accidentally
+        // match `hf:`, and the fireworks rule should win over any later rule
+        // that could swallow it.
+        let r = resolve_provider("accounts/fireworks/models/synthetic/foo");
+        assert_eq!(r.matched_rule.as_deref(), Some("synthetic-fireworks"));
+        assert_eq!(r.normalized_model, "synthetic/foo");
+    }
+
+    #[test]
+    fn accepts_a_custom_rule_set() {
+        let rules = extend_default_rules([ProviderRule::prefix(
+            "openrouter",
+            "openrouter",
+            "openrouter/",
+        )]);
+        let r = resolve_provider_with_rules("openrouter/anthropic/claude-sonnet-4-6", &rules);
+        assert_eq!(r.provider.as_deref(), Some("openrouter"));
+        assert_eq!(r.normalized_model, "anthropic/claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn default_rules_table_matches_ts_one_for_one() {
+        // Regression guard for the conformance gate in #267: every default
+        // rule must resolve to the documented provider for a representative
+        // model id, in the documented order.
+        let rules = default_rules();
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].name, "synthetic-fireworks");
+        assert_eq!(rules[0].provider, "synthetic");
+        assert_eq!(
+            resolve_provider("accounts/fireworks/models/deepseek-r1")
+                .matched_rule
+                .as_deref(),
+            Some("synthetic-fireworks"),
+        );
+        assert_eq!(rules[1].name, "synthetic-explicit");
+        assert_eq!(rules[1].provider, "synthetic");
+        assert_eq!(
+            resolve_provider("synthetic/deepseek-r1-0528")
+                .matched_rule
+                .as_deref(),
+            Some("synthetic-explicit"),
+        );
+        assert_eq!(rules[2].name, "synthetic-huggingface");
+        assert_eq!(rules[2].provider, "synthetic");
+        assert_eq!(
+            resolve_provider("hf:deepseek-ai/deepseek-r1-distill")
+                .matched_rule
+                .as_deref(),
+            Some("synthetic-huggingface"),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Ports `packages/analyze/src/provider.ts` + the public surface of `provider-reattribution.ts` to Rust, completing the #267 conformance gate.

- **`provider_reattribution`** — now `pub`. Adds `ProviderRule`, `ProviderPattern` (literal-prefix or regex), `extend_default_rules`, `resolve_provider_with_rules`, and a `default_rules()` accessor that matches the TS `DEFAULT_RULES` table 1:1 in name, provider, and order.
- **`provider`** (new) — `TurnProvider`, `ProviderFilter` (`BTreeSet<String>` for deterministic iteration), `FieldCoverage`, `CoverageField`, `RowCoverage`, `UsageCostAggregateRow`, `ProviderAggregateRow`, `AggregateByProviderOptions`, plus `provider_for` / `provider_for_model` / `filter_turns_by_provider` / `aggregate_by_provider` (and the `provider_for_turn` / `resolve_turn_provider` aliases mirroring the TS exports).
- Conformance tests ported from `provider.test.ts` (4) and `provider-reattribution.test.ts` (12 incl. the `costForTurn` reattribution-aware lookup tests against the builtin pricing snapshot).

## Acceptance (from #267)

- [x] `cargo test -p relayburn-analyze` green for provider + provider-reattribution (49 tests pass).
- [x] Public surface: `provider_for`, `provider_for_model`, `filter_turns_by_provider`, `aggregate_by_provider`, `resolve_provider`, `default_rules`, plus all listed types.
- [x] `aggregate_by_provider` over a fixture with mixed providers produces rows in the same canonical order as TS (descending total cost; verified by the new ordering test).
- [x] `default_rules()` matches the TS table 1:1 — same prefixes, providers, ordering. Regression test asserts the resolved provider/rule for every entry.

## Test plan

- [x] `cargo test -p relayburn-analyze` (49 passing)
- [x] `cargo test --workspace` (all crates green)
- [x] `cargo build --workspace --all-targets` clean

Closes #267

https://claude.ai/code/session_011fy5FpvU2AqdUbG5j4sknE

---
_Generated by [Claude Code](https://claude.ai/code/session_011fy5FpvU2AqdUbG5j4sknE)_