### PR TITLE
relayburn-analyze: port findings + quality (#268)

### DIFF
--- a/crates/relayburn-analyze/src/findings.rs
+++ b/crates/relayburn-analyze/src/findings.rs
@@ -1,0 +1,1070 @@
+//! Structured envelope for waste-detector output. Rust port of
+//! `packages/analyze/src/findings.ts`.
+//!
+//! Each per-detector struct (`RetryLoop`, `FailureRun`, `CompactionLoss`,
+//! `EditRevertCycle`, `EditHeavySession`, `SkillRecallDup`,
+//! `SkillPruningProtection`, `SystemPromptTax`) keeps its narrow shape for
+//! downstream consumers that want it. This module wraps each one in a common
+//! `WasteFinding` shape so the CLI can render every detector through one
+//! table renderer, severity-rank a heterogeneous list, and (eventually) drive
+//! a confirmation-gated `burn hotspots --apply` pipeline against typed
+//! `WasteAction`s instead of scraping strings.
+//!
+//! The pattern struct types referenced by the `*ToFinding` adapters live in
+//! this module so the future `patterns.rs` port can depend on it without a
+//! circular dependency. See AgentWorkforce/burn#268.
+
+use relayburn_reader::{SourceKind, ToolResultEventSource};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Pattern struct types — concrete shapes consumed by the adapters below.
+// These mirror the TS interfaces in `packages/analyze/src/patterns.ts`. The
+// upcoming `patterns.rs` port re-exports / re-uses them so detector code and
+// finding adapters share one set of shapes.
+// ---------------------------------------------------------------------------
+
+/// Either a real `ToolResultEventSource` (passed through verbatim) or
+/// `Mixed`, used when a finding spans event records of differing sources.
+/// Serializes to the same kebab/snake-case strings as the TS union.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatternEventSource {
+    ToolResult,
+    SubagentNotification,
+    QueueEvent,
+    ProgressEvent,
+    FunctionCallOutput,
+    Mixed,
+}
+
+impl From<ToolResultEventSource> for PatternEventSource {
+    fn from(src: ToolResultEventSource) -> Self {
+        match src {
+            ToolResultEventSource::ToolResult => PatternEventSource::ToolResult,
+            ToolResultEventSource::SubagentNotification => PatternEventSource::SubagentNotification,
+            ToolResultEventSource::QueueEvent => PatternEventSource::QueueEvent,
+            ToolResultEventSource::ProgressEvent => PatternEventSource::ProgressEvent,
+            ToolResultEventSource::FunctionCallOutput => PatternEventSource::FunctionCallOutput,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetryLoop {
+    pub session_id: String,
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    pub args_hash: String,
+    pub attempts: u64,
+    pub start_turn_index: u64,
+    pub end_turn_index: u64,
+    pub cost: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_source: Option<PatternEventSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailureRunErrorSignature {
+    pub tool: String,
+    pub first_line: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailureRun {
+    pub session_id: String,
+    pub length: u64,
+    pub start_turn_index: u64,
+    pub end_turn_index: u64,
+    pub tools_involved: Vec<String>,
+    pub cost: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_signatures: Option<Vec<FailureRunErrorSignature>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_source: Option<PatternEventSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancellationRun {
+    pub session_id: String,
+    pub length: u64,
+    pub start_turn_index: u64,
+    pub end_turn_index: u64,
+    pub tools_involved: Vec<String>,
+    pub cost: f64,
+    pub event_source: PatternEventSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompactionLostWork {
+    pub files: Vec<String>,
+    pub bash_count: u64,
+    pub edit_count: u64,
+    pub read_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompactionLoss {
+    pub session_id: String,
+    pub ts: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preceding_message_id: Option<String>,
+    pub tokens_before_compact: u64,
+    pub cache_lost_cost: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lost_work: Option<CompactionLostWork>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditPreview {
+    pub old: String,
+    pub new: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditRevertSamplePreview {
+    pub first_edit: EditPreview,
+    pub revert: EditPreview,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditRevertCycle {
+    pub session_id: String,
+    pub file_path: String,
+    pub first_edit_turn_index: u64,
+    pub revert_turn_index: u64,
+    pub span_turns: u64,
+    pub cost: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_preview: Option<EditRevertSamplePreview>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillRecallDup {
+    pub session_id: String,
+    pub skill_name: String,
+    pub call_count: u64,
+    pub first_turn_index: u64,
+    pub last_turn_index: u64,
+    pub cost: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillPruningProtection {
+    pub session_id: String,
+    pub skill_name: String,
+    pub invoked_turn_index: u64,
+    pub riding_turns: u64,
+    pub last_cached_turn_index: u64,
+    pub cost: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemPromptTax {
+    pub session_id: String,
+    pub first_turn_cache_create: u64,
+    pub first_user_message_tokens: u64,
+    pub estimated_system_prompt_tokens: u64,
+    pub riding_turns: u64,
+    pub total_cost: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditHeavySession {
+    pub source: SourceKind,
+    pub session_id: String,
+    pub read_count: u64,
+    pub edit_count: u64,
+    /// `editCount / readCount`; `f64::INFINITY` when reads === 0.
+    pub ratio: f64,
+    pub likely_retries: u64,
+    pub cost: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionPatternSummary {
+    pub session_id: String,
+    pub retry_loop_count: u64,
+    pub failure_run_count: u64,
+    pub cancellation_run_count: u64,
+    pub consecutive_failure_max: u64,
+    pub compaction_count: u64,
+    pub edit_revert_count: u64,
+    pub skill_recall_dup_count: u64,
+    pub skill_pruning_protection_count: u64,
+    pub system_prompt_tax_count: u64,
+    pub edit_heavy_count: u64,
+    pub total_retries: u64,
+    pub total_pattern_cost: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PatternsResult {
+    pub retry_loops: Vec<RetryLoop>,
+    pub failure_runs: Vec<FailureRun>,
+    pub cancelled_runs: Vec<CancellationRun>,
+    pub compactions: Vec<CompactionLoss>,
+    pub edit_reverts: Vec<EditRevertCycle>,
+    pub skill_recall_dups: Vec<SkillRecallDup>,
+    pub skill_pruning_protection: Vec<SkillPruningProtection>,
+    pub system_prompt_taxes: Vec<SystemPromptTax>,
+    pub edit_heavy_sessions: Vec<EditHeavySession>,
+    pub session_summaries: Vec<SessionPatternSummary>,
+}
+
+// ---------------------------------------------------------------------------
+// Finding types
+// ---------------------------------------------------------------------------
+
+/// A typed action a finding suggests the user (or `burn hotspots --apply`)
+/// take. `Paste` is text the user copies somewhere; `Command` is a shell
+/// command; `FileContent` is a full file body to write to disk. Keeping the
+/// union closed lets `--apply` decide what is safe to execute automatically
+/// vs. what needs explicit user action.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum WasteAction {
+    Paste {
+        label: String,
+        text: String,
+    },
+    Command {
+        label: String,
+        text: String,
+    },
+    FileContent {
+        label: String,
+        path: String,
+        content: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WasteSeverity {
+    Info,
+    Warn,
+    High,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EstimatedSavings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_per_session: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usd_per_session: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usd_per_month: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WasteFinding {
+    pub kind: String,
+    pub severity: WasteSeverity,
+    pub session_id: String,
+    pub title: String,
+    pub detail: String,
+    pub estimated_savings: EstimatedSavings,
+    pub actions: Vec<WasteAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_source: Option<PatternEventSource>,
+}
+
+// ---------------------------------------------------------------------------
+// Adapters
+// ---------------------------------------------------------------------------
+
+const SEVERITY_HIGH_USD: f64 = 0.5;
+const SEVERITY_WARN_USD: f64 = 0.05;
+
+fn severity_from_usd(usd: f64) -> WasteSeverity {
+    if usd >= SEVERITY_HIGH_USD {
+        WasteSeverity::High
+    } else if usd >= SEVERITY_WARN_USD {
+        WasteSeverity::Warn
+    } else {
+        WasteSeverity::Info
+    }
+}
+
+fn hotspots_action(session_id: &str) -> WasteAction {
+    WasteAction::Command {
+        label: "Inspect this session".to_string(),
+        text: format!("burn hotspots --session {session_id}"),
+    }
+}
+
+fn fmt_usd(n: f64) -> String {
+    format!("${:.4}", n)
+}
+
+/// Format an integer with thousands separators, matching the JS
+/// `Number.prototype.toLocaleString()` output for plain en-US locale.
+fn format_with_commas(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut result = String::with_capacity(len + len / 3);
+    for (i, &b) in bytes.iter().enumerate() {
+        if i > 0 && (len - i).is_multiple_of(3) {
+            result.push(',');
+        }
+        result.push(b as char);
+    }
+    result
+}
+
+pub fn retry_loop_to_finding(loop_: &RetryLoop) -> WasteFinding {
+    let target = match &loop_.target {
+        Some(t) => format!(" {t}"),
+        None => String::new(),
+    };
+    let title_suffix = match &loop_.error_signature {
+        Some(sig) => format!(": '{sig}'"),
+        None => String::new(),
+    };
+    WasteFinding {
+        kind: "retry-loop".to_string(),
+        severity: severity_from_usd(loop_.cost),
+        session_id: loop_.session_id.clone(),
+        title: format!(
+            "Retry loop: {tool}{target} failed {attempts}× in a row{title_suffix}",
+            tool = loop_.tool,
+            target = target,
+            attempts = loop_.attempts,
+            title_suffix = title_suffix,
+        ),
+        detail: format!(
+            "Turns {start}-{end} are {attempts} consecutive errored {tool} calls with the same arguments. \
+Cumulative turn cost {cost} — the agent kept retrying without changing inputs.",
+            start = loop_.start_turn_index,
+            end = loop_.end_turn_index,
+            attempts = loop_.attempts,
+            tool = loop_.tool,
+            cost = fmt_usd(loop_.cost),
+        ),
+        estimated_savings: EstimatedSavings {
+            usd_per_session: Some(loop_.cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&loop_.session_id)],
+        event_source: loop_.event_source,
+    }
+}
+
+pub fn failure_run_to_finding(run: &FailureRun) -> WasteFinding {
+    let sig_detail = match &run.error_signatures {
+        Some(sigs) if !sigs.is_empty() => {
+            let parts: Vec<String> = sigs
+                .iter()
+                .map(|s| format!("{}='{}'", s.tool, s.first_line))
+                .collect();
+            format!(" Errors: {}.", parts.join("; "))
+        }
+        _ => String::new(),
+    };
+    WasteFinding {
+        kind: "failure-run".to_string(),
+        severity: severity_from_usd(run.cost),
+        session_id: run.session_id.clone(),
+        title: format!(
+            "Failure run: {len} consecutive failed tool calls",
+            len = run.length
+        ),
+        detail: format!(
+            "Turns {start}-{end} failed across {n_tools} distinct tool(s) ({tools}). \
+Cumulative turn cost {cost} — agent likely stuck without recovering or asking for help.{sig}",
+            start = run.start_turn_index,
+            end = run.end_turn_index,
+            n_tools = run.tools_involved.len(),
+            tools = run.tools_involved.join(", "),
+            cost = fmt_usd(run.cost),
+            sig = sig_detail,
+        ),
+        estimated_savings: EstimatedSavings {
+            usd_per_session: Some(run.cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&run.session_id)],
+        event_source: run.event_source,
+    }
+}
+
+pub fn cancellation_run_to_finding(run: &CancellationRun) -> WasteFinding {
+    let tool_list = run.tools_involved.join(", ");
+    let plural = if run.length == 1 { "" } else { "s" };
+    WasteFinding {
+        kind: "cancellation-run".to_string(),
+        severity: severity_from_usd(run.cost),
+        session_id: run.session_id.clone(),
+        title: format!(
+            "Cancellation run: {len} cancelled tool call{plural}",
+            len = run.length,
+            plural = plural,
+        ),
+        detail: format!(
+            "Turns {start}-{end} ended with cancelled tool/subagent status ({tools}). \
+Cumulative turn cost {cost}.",
+            start = run.start_turn_index,
+            end = run.end_turn_index,
+            tools = tool_list,
+            cost = fmt_usd(run.cost),
+        ),
+        estimated_savings: EstimatedSavings {
+            usd_per_session: Some(run.cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&run.session_id)],
+        event_source: Some(run.event_source),
+    }
+}
+
+pub fn compaction_loss_to_finding(loss: &CompactionLoss) -> WasteFinding {
+    let mut savings = EstimatedSavings {
+        usd_per_session: Some(loss.cache_lost_cost),
+        ..Default::default()
+    };
+    if loss.tokens_before_compact > 0 {
+        savings.tokens_per_session = Some(loss.tokens_before_compact);
+    }
+    let lost_work_detail = match &loss.lost_work {
+        Some(work) => {
+            let mut s = format!(
+                " Compacted window: {edit} edit(s), {bash} bash, {read} read(s)",
+                edit = work.edit_count,
+                bash = work.bash_count,
+                read = work.read_count,
+            );
+            if !work.files.is_empty() {
+                if work.files.len() <= 3 {
+                    s.push_str(" on ");
+                    s.push_str(&work.files.join(", "));
+                } else {
+                    s.push_str(" on ");
+                    s.push_str(&work.files[..3].join(", "));
+                    s.push_str(&format!(" +{} more", work.files.len() - 3));
+                }
+            }
+            s.push('.');
+            s
+        }
+        None => String::new(),
+    };
+    WasteFinding {
+        kind: "compaction-loss".to_string(),
+        severity: severity_from_usd(loss.cache_lost_cost),
+        session_id: loss.session_id.clone(),
+        title: format!(
+            "Compaction lost {tokens} cached tokens",
+            tokens = format_with_commas(loss.tokens_before_compact)
+        ),
+        detail: format!(
+            "A compaction at {ts} discarded {tokens} tokens of cache. \
+Pre-compact cacheRead cost {cost} — that cache won't be reused on subsequent turns.{lost}",
+            ts = loss.ts,
+            tokens = format_with_commas(loss.tokens_before_compact),
+            cost = fmt_usd(loss.cache_lost_cost),
+            lost = lost_work_detail,
+        ),
+        estimated_savings: savings,
+        actions: vec![hotspots_action(&loss.session_id)],
+        event_source: None,
+    }
+}
+
+pub fn edit_revert_to_finding(cycle: &EditRevertCycle) -> WasteFinding {
+    let preview_detail = match &cycle.sample_preview {
+        Some(p) => format!(
+            " First edit: '{fe_old}' → '{fe_new}'. Revert: '{r_old}' → '{r_new}'.",
+            fe_old = p.first_edit.old,
+            fe_new = p.first_edit.new,
+            r_old = p.revert.old,
+            r_new = p.revert.new,
+        ),
+        None => String::new(),
+    };
+    WasteFinding {
+        kind: "edit-revert".to_string(),
+        severity: severity_from_usd(cycle.cost),
+        session_id: cycle.session_id.clone(),
+        title: format!("Edit revert on {path}", path = cycle.file_path),
+        detail: format!(
+            "Turn {first} edited {path}; turn {revert} restored a prior file state {span} turns later. \
+Cumulative anchor-turn cost {cost} — the intermediate work was erased.{preview}",
+            first = cycle.first_edit_turn_index,
+            path = cycle.file_path,
+            revert = cycle.revert_turn_index,
+            span = cycle.span_turns,
+            cost = fmt_usd(cycle.cost),
+            preview = preview_detail,
+        ),
+        estimated_savings: EstimatedSavings {
+            usd_per_session: Some(cycle.cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&cycle.session_id)],
+        event_source: None,
+    }
+}
+
+pub fn edit_heavy_to_finding(session: &EditHeavySession) -> WasteFinding {
+    let ratio_str = if session.ratio.is_finite() {
+        format!("{:.1}", session.ratio)
+    } else {
+        "∞".to_string()
+    };
+    let raw_severity = severity_from_usd(session.cost);
+    let severity = if raw_severity == WasteSeverity::High {
+        WasteSeverity::Warn
+    } else {
+        raw_severity
+    };
+    // SourceKind serializes via serde to kebab-case; render its discriminant
+    // through serde_json so the detail string matches TS's `${session.source}`
+    // (which uses the same string set).
+    let source_str = match serde_json::to_value(session.source) {
+        Ok(serde_json::Value::String(s)) => s,
+        _ => String::new(),
+    };
+    WasteFinding {
+        kind: "edit-heavy".to_string(),
+        severity,
+        session_id: session.session_id.clone(),
+        title: format!(
+            "Edit-heavy session: {edits} edits / {reads} reads (ratio {ratio})",
+            edits = session.edit_count,
+            reads = session.read_count,
+            ratio = ratio_str,
+        ),
+        detail: format!(
+            "{source} session has {edits} edit-tool calls against only {reads} read-tool calls \
+(ratio {ratio}, threshold 4×). {retries} edit→bash→edit retry pattern(s) observed. \
+Edit-bearing turn cost {cost} — careless editing without first reading surrounding context.",
+            source = source_str,
+            edits = session.edit_count,
+            reads = session.read_count,
+            ratio = ratio_str,
+            retries = session.likely_retries,
+            cost = fmt_usd(session.cost),
+        ),
+        estimated_savings: EstimatedSavings {
+            usd_per_session: Some(session.cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&session.session_id)],
+        event_source: None,
+    }
+}
+
+pub fn skill_recall_dup_to_finding(dup: &SkillRecallDup) -> WasteFinding {
+    WasteFinding {
+        kind: "skill-recall-dup".to_string(),
+        severity: severity_from_usd(dup.cost),
+        session_id: dup.session_id.clone(),
+        title: format!(
+            "OpenCode skill \"{name}\" called {count}× without dedup",
+            name = dup.skill_name,
+            count = dup.call_count,
+        ),
+        detail: format!(
+            "OpenCode does not deduplicate skill tool results, so each of the {count} calls \
+(turns {first}-{last}) re-injects the full SKILL.md content into context. \
+Cumulative turn cost {cost}.",
+            count = dup.call_count,
+            first = dup.first_turn_index,
+            last = dup.last_turn_index,
+            cost = fmt_usd(dup.cost),
+        ),
+        estimated_savings: EstimatedSavings {
+            usd_per_session: Some(dup.cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&dup.session_id)],
+        event_source: None,
+    }
+}
+
+pub fn skill_pruning_protection_to_finding(prot: &SkillPruningProtection) -> WasteFinding {
+    WasteFinding {
+        kind: "skill-pruning-protection".to_string(),
+        severity: severity_from_usd(prot.cost),
+        session_id: prot.session_id.clone(),
+        title: format!(
+            "OpenCode skill \"{name}\" rode in cache {turns} turn(s)",
+            name = prot.skill_name,
+            turns = prot.riding_turns,
+        ),
+        detail: format!(
+            "Skill tool results are listed in OpenCode's PRUNE_PROTECTED_TOOLS and never evict during compaction. \
+Invoked at turn {invoked}; still in cacheRead at turn {last}. \
+Invoke + riding-turn cost {cost}.",
+            invoked = prot.invoked_turn_index,
+            last = prot.last_cached_turn_index,
+            cost = fmt_usd(prot.cost),
+        ),
+        estimated_savings: EstimatedSavings {
+            usd_per_session: Some(prot.cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&prot.session_id)],
+        event_source: None,
+    }
+}
+
+pub fn system_prompt_tax_to_finding(tax: &SystemPromptTax) -> WasteFinding {
+    let riding_tokens = tax
+        .estimated_system_prompt_tokens
+        .saturating_mul(tax.riding_turns);
+    WasteFinding {
+        kind: "system-prompt-tax".to_string(),
+        severity: severity_from_usd(tax.total_cost),
+        session_id: tax.session_id.clone(),
+        title: format!(
+            "OpenCode system prompt tax: ~{tokens} tokens × {turns} turn(s)",
+            tokens = format_with_commas(tax.estimated_system_prompt_tokens),
+            turns = tax.riding_turns,
+        ),
+        detail: format!(
+            "First-turn cacheCreate of {first} tokens minus the first user message ({user}) \
+leaves ~{est} tokens of system prompt + skill catalog riding cacheRead across {turns} subsequent turn(s). \
+Total cost {cost}.",
+            first = format_with_commas(tax.first_turn_cache_create),
+            user = format_with_commas(tax.first_user_message_tokens),
+            est = format_with_commas(tax.estimated_system_prompt_tokens),
+            turns = tax.riding_turns,
+            cost = fmt_usd(tax.total_cost),
+        ),
+        estimated_savings: EstimatedSavings {
+            tokens_per_session: Some(riding_tokens),
+            usd_per_session: Some(tax.total_cost),
+            ..Default::default()
+        },
+        actions: vec![hotspots_action(&tax.session_id)],
+        event_source: None,
+    }
+}
+
+/// Roll the full PatternsResult into a single severity-ranked list. Within
+/// the same severity tier, sort by `usdPerSession` descending so the most
+/// expensive findings surface first.
+pub fn findings_from_patterns(result: &PatternsResult) -> Vec<WasteFinding> {
+    let mut findings: Vec<WasteFinding> = Vec::new();
+    for r in &result.retry_loops {
+        findings.push(retry_loop_to_finding(r));
+    }
+    for f in &result.failure_runs {
+        findings.push(failure_run_to_finding(f));
+    }
+    for c in &result.cancelled_runs {
+        findings.push(cancellation_run_to_finding(c));
+    }
+    for c in &result.compactions {
+        findings.push(compaction_loss_to_finding(c));
+    }
+    for e in &result.edit_reverts {
+        findings.push(edit_revert_to_finding(e));
+    }
+    for e in &result.edit_heavy_sessions {
+        findings.push(edit_heavy_to_finding(e));
+    }
+    for d in &result.skill_recall_dups {
+        findings.push(skill_recall_dup_to_finding(d));
+    }
+    for p in &result.skill_pruning_protection {
+        findings.push(skill_pruning_protection_to_finding(p));
+    }
+    for s in &result.system_prompt_taxes {
+        findings.push(system_prompt_tax_to_finding(s));
+    }
+    sort_findings(&mut findings);
+    findings
+}
+
+fn severity_order(s: WasteSeverity) -> u8 {
+    match s {
+        WasteSeverity::High => 0,
+        WasteSeverity::Warn => 1,
+        WasteSeverity::Info => 2,
+    }
+}
+
+/// Sort in place: severity descending (high → warn → info), then by
+/// `usdPerSession` descending. Stable, mirroring the TS `Array.prototype.sort`
+/// guarantee.
+pub fn sort_findings(findings: &mut [WasteFinding]) {
+    findings.sort_by(|a, b| {
+        let sev = severity_order(a.severity).cmp(&severity_order(b.severity));
+        if sev != std::cmp::Ordering::Equal {
+            return sev;
+        }
+        let a_usd = a.estimated_savings.usd_per_session.unwrap_or(0.0);
+        let b_usd = b.estimated_savings.usd_per_session.unwrap_or(0.0);
+        // Descending: larger first.
+        b_usd
+            .partial_cmp(&a_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SESSION: &str = "11111111-2222-3333-4444-555555555555";
+
+    fn base_retry_loop() -> RetryLoop {
+        RetryLoop {
+            session_id: SESSION.to_string(),
+            tool: "Bash".to_string(),
+            target: Some("pnpm test".to_string()),
+            args_hash: "abc123".to_string(),
+            attempts: 4,
+            start_turn_index: 0,
+            end_turn_index: 3,
+            cost: 0.6,
+            error_signature: None,
+            event_source: None,
+        }
+    }
+
+    #[test]
+    fn retry_loop_to_finding_basic() {
+        let f = retry_loop_to_finding(&base_retry_loop());
+        assert_eq!(f.kind, "retry-loop");
+        assert_eq!(f.session_id, SESSION);
+        assert_eq!(f.severity, WasteSeverity::High);
+        assert!(
+            f.title.contains("Bash pnpm test failed 4× in a row"),
+            "title: {}",
+            f.title
+        );
+        assert!(f.detail.contains("Turns 0-3"), "detail: {}", f.detail);
+        assert_eq!(f.estimated_savings.usd_per_session, Some(0.6));
+        assert_eq!(f.actions.len(), 1);
+        match &f.actions[0] {
+            WasteAction::Command { text, .. } => {
+                assert!(text.contains("burn hotspots --session"), "text: {text}");
+            }
+            other => panic!("expected Command action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retry_loop_severity_thresholds() {
+        let mut r = base_retry_loop();
+        r.cost = 0.0001;
+        assert_eq!(retry_loop_to_finding(&r).severity, WasteSeverity::Info);
+        r.cost = 0.1;
+        assert_eq!(retry_loop_to_finding(&r).severity, WasteSeverity::Warn);
+        r.cost = 1.0;
+        assert_eq!(retry_loop_to_finding(&r).severity, WasteSeverity::High);
+    }
+
+    #[test]
+    fn failure_run_to_finding_lists_tools() {
+        let fr = FailureRun {
+            session_id: SESSION.to_string(),
+            length: 3,
+            start_turn_index: 5,
+            end_turn_index: 7,
+            tools_involved: vec!["Bash".into(), "Read".into(), "Edit".into()],
+            cost: 0.08,
+            error_signatures: None,
+            event_source: None,
+        };
+        let f = failure_run_to_finding(&fr);
+        assert_eq!(f.kind, "failure-run");
+        assert_eq!(f.severity, WasteSeverity::Warn);
+        assert!(
+            f.detail.contains("Bash, Read, Edit"),
+            "detail: {}",
+            f.detail
+        );
+    }
+
+    #[test]
+    fn compaction_loss_exposes_tokens() {
+        let c = CompactionLoss {
+            session_id: SESSION.to_string(),
+            ts: "2026-04-20T00:00:00.000Z".to_string(),
+            preceding_message_id: Some("msg-1".to_string()),
+            tokens_before_compact: 9000,
+            cache_lost_cost: 0.04,
+            lost_work: None,
+        };
+        let f = compaction_loss_to_finding(&c);
+        assert_eq!(f.kind, "compaction-loss");
+        assert_eq!(f.estimated_savings.tokens_per_session, Some(9000));
+        assert_eq!(f.estimated_savings.usd_per_session, Some(0.04));
+        assert_eq!(f.severity, WasteSeverity::Info);
+    }
+
+    #[test]
+    fn compaction_loss_omits_tokens_when_zero() {
+        let c = CompactionLoss {
+            session_id: SESSION.to_string(),
+            ts: "2026-04-20T00:00:00.000Z".to_string(),
+            preceding_message_id: None,
+            tokens_before_compact: 0,
+            cache_lost_cost: 0.0,
+            lost_work: None,
+        };
+        let f = compaction_loss_to_finding(&c);
+        assert_eq!(f.estimated_savings.tokens_per_session, None);
+    }
+
+    #[test]
+    fn edit_revert_to_finding_basic() {
+        let e = EditRevertCycle {
+            session_id: SESSION.to_string(),
+            file_path: "src/foo.ts".to_string(),
+            first_edit_turn_index: 2,
+            revert_turn_index: 8,
+            span_turns: 6,
+            cost: 0.72,
+            sample_preview: None,
+        };
+        let f = edit_revert_to_finding(&e);
+        assert_eq!(f.kind, "edit-revert");
+        assert_eq!(f.severity, WasteSeverity::High);
+        assert!(f.detail.contains("6 turns later"), "detail: {}", f.detail);
+        assert!(f.title.contains("src/foo.ts"), "title: {}", f.title);
+    }
+
+    #[test]
+    fn edit_heavy_caps_severity_at_warn() {
+        let s = EditHeavySession {
+            source: SourceKind::ClaudeCode,
+            session_id: SESSION.to_string(),
+            read_count: 1,
+            edit_count: 12,
+            ratio: 12.0,
+            likely_retries: 3,
+            cost: 5.0,
+        };
+        let f = edit_heavy_to_finding(&s);
+        assert_eq!(f.kind, "edit-heavy");
+        assert_eq!(f.severity, WasteSeverity::Warn);
+        assert!(f.title.contains("12 edits / 1 reads"), "title: {}", f.title);
+    }
+
+    #[test]
+    fn edit_heavy_renders_infinity_ratio() {
+        let s = EditHeavySession {
+            source: SourceKind::Codex,
+            session_id: SESSION.to_string(),
+            read_count: 0,
+            edit_count: 6,
+            ratio: f64::INFINITY,
+            likely_retries: 0,
+            cost: 0.01,
+        };
+        let f = edit_heavy_to_finding(&s);
+        assert!(f.title.contains("ratio ∞"), "title: {}", f.title);
+    }
+
+    #[test]
+    fn skill_recall_dup_basic() {
+        let d = SkillRecallDup {
+            session_id: SESSION.to_string(),
+            skill_name: "init".to_string(),
+            call_count: 3,
+            first_turn_index: 1,
+            last_turn_index: 11,
+            cost: 0.2,
+        };
+        let f = skill_recall_dup_to_finding(&d);
+        assert_eq!(f.kind, "skill-recall-dup");
+        assert!(
+            f.title.contains("init") && f.title.contains("3×"),
+            "title: {}",
+            f.title
+        );
+    }
+
+    #[test]
+    fn skill_pruning_protection_basic() {
+        let p = SkillPruningProtection {
+            session_id: SESSION.to_string(),
+            skill_name: "init".to_string(),
+            invoked_turn_index: 0,
+            riding_turns: 7,
+            last_cached_turn_index: 7,
+            cost: 0.55,
+        };
+        let f = skill_pruning_protection_to_finding(&p);
+        assert_eq!(f.kind, "skill-pruning-protection");
+        assert_eq!(f.severity, WasteSeverity::High);
+    }
+
+    #[test]
+    fn system_prompt_tax_riding_tokens_estimate() {
+        let t = SystemPromptTax {
+            session_id: SESSION.to_string(),
+            first_turn_cache_create: 4500,
+            first_user_message_tokens: 500,
+            estimated_system_prompt_tokens: 4000,
+            riding_turns: 6,
+            total_cost: 0.07,
+        };
+        let f = system_prompt_tax_to_finding(&t);
+        assert_eq!(f.kind, "system-prompt-tax");
+        assert_eq!(f.estimated_savings.tokens_per_session, Some(4000 * 6));
+        assert_eq!(f.estimated_savings.usd_per_session, Some(0.07));
+    }
+
+    fn finding_with(kind: &str, sev: WasteSeverity, session: &str, usd: f64) -> WasteFinding {
+        WasteFinding {
+            kind: kind.to_string(),
+            severity: sev,
+            session_id: session.to_string(),
+            title: kind.to_string(),
+            detail: String::new(),
+            estimated_savings: EstimatedSavings {
+                usd_per_session: Some(usd),
+                ..Default::default()
+            },
+            actions: vec![],
+            event_source: None,
+        }
+    }
+
+    #[test]
+    fn sort_findings_orders_high_warn_info_then_usd() {
+        let mut findings = vec![
+            finding_with("a", WasteSeverity::Info, "s1", 0.001),
+            finding_with("b", WasteSeverity::High, "s2", 0.6),
+            finding_with("c", WasteSeverity::High, "s3", 1.2),
+            finding_with("d", WasteSeverity::Warn, "s4", 0.3),
+        ];
+        sort_findings(&mut findings);
+        let kinds: Vec<&str> = findings.iter().map(|f| f.kind.as_str()).collect();
+        assert_eq!(kinds, vec!["c", "b", "d", "a"]);
+    }
+
+    #[test]
+    fn findings_from_patterns_rolls_up_across_kinds() {
+        let summary = SessionPatternSummary {
+            session_id: SESSION.to_string(),
+            retry_loop_count: 1,
+            failure_run_count: 1,
+            cancellation_run_count: 0,
+            consecutive_failure_max: 3,
+            compaction_count: 1,
+            edit_revert_count: 1,
+            skill_recall_dup_count: 0,
+            skill_pruning_protection_count: 0,
+            system_prompt_tax_count: 0,
+            edit_heavy_count: 0,
+            total_retries: 4,
+            total_pattern_cost: 1.5,
+        };
+        let result = PatternsResult {
+            retry_loops: vec![base_retry_loop()],
+            failure_runs: vec![FailureRun {
+                session_id: SESSION.to_string(),
+                length: 3,
+                start_turn_index: 0,
+                end_turn_index: 2,
+                tools_involved: vec!["Bash".into(), "Edit".into()],
+                cost: 0.05,
+                error_signatures: None,
+                event_source: None,
+            }],
+            cancelled_runs: vec![],
+            compactions: vec![CompactionLoss {
+                session_id: SESSION.to_string(),
+                ts: "2026-04-20T00:00:00.000Z".to_string(),
+                preceding_message_id: Some("m".to_string()),
+                tokens_before_compact: 9000,
+                cache_lost_cost: 0.04,
+                lost_work: None,
+            }],
+            edit_reverts: vec![EditRevertCycle {
+                session_id: SESSION.to_string(),
+                file_path: "src/foo.ts".to_string(),
+                first_edit_turn_index: 1,
+                revert_turn_index: 4,
+                span_turns: 3,
+                cost: 0.2,
+                sample_preview: None,
+            }],
+            edit_heavy_sessions: vec![],
+            skill_recall_dups: vec![],
+            skill_pruning_protection: vec![],
+            system_prompt_taxes: vec![],
+            session_summaries: vec![summary],
+        };
+        let findings = findings_from_patterns(&result);
+        assert_eq!(findings.len(), 4);
+        let kinds: std::collections::HashSet<&str> =
+            findings.iter().map(|f| f.kind.as_str()).collect();
+        assert!(kinds.contains("retry-loop"));
+        assert!(kinds.contains("failure-run"));
+        assert!(kinds.contains("compaction-loss"));
+        assert!(kinds.contains("edit-revert"));
+        assert_eq!(findings[0].kind, "retry-loop");
+    }
+
+    #[test]
+    fn waste_severity_serializes_to_lowercase_strings() {
+        assert_eq!(
+            serde_json::to_string(&WasteSeverity::High).unwrap(),
+            "\"high\""
+        );
+        assert_eq!(
+            serde_json::to_string(&WasteSeverity::Warn).unwrap(),
+            "\"warn\""
+        );
+        assert_eq!(
+            serde_json::to_string(&WasteSeverity::Info).unwrap(),
+            "\"info\""
+        );
+    }
+
+    #[test]
+    fn waste_action_tag_round_trip() {
+        let cmd = WasteAction::Command {
+            label: "run".to_string(),
+            text: "echo hi".to_string(),
+        };
+        let s = serde_json::to_string(&cmd).unwrap();
+        assert!(s.contains("\"type\":\"command\""), "json: {s}");
+        let fc = WasteAction::FileContent {
+            label: "write".to_string(),
+            path: "a.txt".to_string(),
+            content: "x".to_string(),
+        };
+        let s = serde_json::to_string(&fc).unwrap();
+        assert!(s.contains("\"type\":\"file-content\""), "json: {s}");
+    }
+
+    #[test]
+    fn format_with_commas_basic() {
+        assert_eq!(format_with_commas(0), "0");
+        assert_eq!(format_with_commas(100), "100");
+        assert_eq!(format_with_commas(1000), "1,000");
+        assert_eq!(format_with_commas(1234567), "1,234,567");
+        assert_eq!(format_with_commas(9000), "9,000");
+    }
+}

--- a/crates/relayburn-analyze/src/lib.rs
+++ b/crates/relayburn-analyze/src/lib.rs
@@ -17,8 +17,10 @@
 
 pub mod cost;
 pub mod fidelity;
+pub mod findings;
 pub mod pricing;
 mod provider_reattribution;
+pub mod quality;
 
 pub use cost::{
     cost_for_turn, cost_for_usage, lookup_model_rate, sum_costs, CostBreakdown, CostForUsageOptions,
@@ -27,6 +29,20 @@ pub use fidelity::{
     empty_fidelity_summary, has_minimum_fidelity, summarize_fidelity, summarize_fidelity_from_iter,
     FidelitySummary, COVERAGE_FIELDS,
 };
+pub use findings::{
+    cancellation_run_to_finding, compaction_loss_to_finding, edit_heavy_to_finding,
+    edit_revert_to_finding, failure_run_to_finding, findings_from_patterns, retry_loop_to_finding,
+    skill_pruning_protection_to_finding, skill_recall_dup_to_finding, sort_findings,
+    system_prompt_tax_to_finding, CancellationRun, CompactionLoss, CompactionLostWork,
+    EditHeavySession, EditPreview, EditRevertCycle, EditRevertSamplePreview, EstimatedSavings,
+    FailureRun, FailureRunErrorSignature, PatternEventSource, PatternsResult, RetryLoop,
+    SessionPatternSummary, SkillPruningProtection, SkillRecallDup, SystemPromptTax, WasteAction,
+    WasteFinding, WasteSeverity,
+};
 pub use pricing::{
     flatten_value, load_builtin_pricing, load_pricing, ModelCost, PricingTable, ReasoningMode,
+};
+pub use quality::{
+    compute_one_shot_rate, compute_quality, infer_outcome, ComputeQualityOptions, OneShotMetrics,
+    OutcomeConfidence, OutcomeLabel, OutcomeReason, QualityResult, SessionOutcome,
 };

--- a/crates/relayburn-analyze/src/quality.rs
+++ b/crates/relayburn-analyze/src/quality.rs
@@ -1,0 +1,1015 @@
+//! Quality signals for the "was this work good enough that a cheaper model
+//! could have done it" question. Rust port of `packages/analyze/src/quality.ts`.
+//!
+//! Two orthogonal detectors: outcome inference (agentsview) + one-shot rate
+//! (codeburn).
+//!
+//! Design choices (preserved from TS):
+//! - No prompt storage required — both signals work from session metadata and
+//!   tool-call patterns alone. Content (last assistant text) is used *only*
+//!   to downgrade confidence; never required.
+//! - Computed lazily at query time, not persisted in the ledger. Upgrading
+//!   the rules later doesn't require a rebuild.
+//! - Confidence is explicit on every classification so downstream consumers
+//!   can filter out low-confidence signals rather than treat them as noise.
+
+use std::collections::HashMap;
+
+use relayburn_reader::{ContentKind, ContentRecord, ContentRole, TurnRecord};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutcomeLabel {
+    Completed,
+    Abandoned,
+    Errored,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutcomeConfidence {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OutcomeReason {
+    Automated,
+    SingleExchange,
+    TooShort,
+    Recent,
+    UserEnded,
+    UserEndedLong,
+    FailureStreak,
+    GiveUp,
+    AssistantEnded,
+    UnknownEnding,
+    Empty,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionOutcome {
+    pub session_id: String,
+    pub outcome: OutcomeLabel,
+    pub confidence: OutcomeConfidence,
+    pub is_recent: bool,
+    pub reason: OutcomeReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OneShotMetrics {
+    pub session_id: String,
+    pub edit_turns: u64,
+    pub one_shot_turns: u64,
+    /// `oneShotTurns / editTurns` when editTurns > 0, else `None`. Callers
+    /// decide what to display for zero-edit sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub one_shot_rate: Option<f64>,
+    /// Total retries across all turns in the session.
+    pub total_retries: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QualityResult {
+    pub outcomes: Vec<SessionOutcome>,
+    pub one_shot: Vec<OneShotMetrics>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ComputeQualityOptions<'a> {
+    /// Optional content sidecar records. When provided, give-up phrase
+    /// matching on the last assistant text downgrades assistant-ended
+    /// sessions from `completed/medium` to `completed/low`. Without content,
+    /// the give-up downgrade is skipped — the classifier still runs.
+    pub content_by_session: Option<&'a HashMap<String, Vec<ContentRecord>>>,
+    /// Clock override for tests, in milliseconds since the Unix epoch.
+    /// Defaults to system clock when `None`.
+    pub now_ms: Option<i64>,
+}
+
+const GIVE_UP_PATTERNS: &[&str] = &[
+    "i'm unable to",
+    "i am unable to",
+    "i can't proceed",
+    "i cannot proceed",
+    "i don't have access",
+    "i cannot access",
+    "unable to verify",
+    "doesn't appear to exist",
+];
+
+const RECENT_WINDOW_MS: i64 = 10 * 60 * 1000;
+const SHORT_CONVERSATION_THRESHOLD: usize = 3;
+const LONG_CONVERSATION_THRESHOLD: usize = 10;
+const FAILURE_STREAK_THRESHOLD: u64 = 3;
+
+pub fn compute_quality(turns: &[TurnRecord], opts: &ComputeQualityOptions) -> QualityResult {
+    // Preserve TS Map iteration order: insertion-order across sessionIds.
+    let mut by_session: Vec<(String, Vec<TurnRecord>)> = Vec::new();
+    let mut idx: HashMap<String, usize> = HashMap::new();
+    for t in turns {
+        if let Some(&i) = idx.get(&t.session_id) {
+            by_session[i].1.push(t.clone());
+        } else {
+            idx.insert(t.session_id.clone(), by_session.len());
+            by_session.push((t.session_id.clone(), vec![t.clone()]));
+        }
+    }
+
+    let now = opts.now_ms.unwrap_or_else(now_ms_system);
+
+    let mut outcomes = Vec::with_capacity(by_session.len());
+    let mut one_shot = Vec::with_capacity(by_session.len());
+    for (session_id, mut session_turns) in by_session {
+        session_turns.sort_by_key(|t| t.turn_index);
+        outcomes.push(infer_outcome(
+            &session_id,
+            &session_turns,
+            opts.content_by_session,
+            now,
+        ));
+        one_shot.push(compute_one_shot_rate(&session_id, &session_turns));
+    }
+
+    QualityResult { outcomes, one_shot }
+}
+
+pub fn infer_outcome(
+    session_id: &str,
+    turns: &[TurnRecord],
+    content_by_session: Option<&HashMap<String, Vec<ContentRecord>>>,
+    now_ms: i64,
+) -> SessionOutcome {
+    if turns.is_empty() {
+        return SessionOutcome {
+            session_id: session_id.to_string(),
+            outcome: OutcomeLabel::Unknown,
+            confidence: OutcomeConfidence::Low,
+            is_recent: false,
+            reason: OutcomeReason::Empty,
+        };
+    }
+
+    let last = turns.last().unwrap();
+    let last_ms = parse_iso8601_ms(&last.ts);
+    let is_recent = match last_ms {
+        Some(ms) => now_ms - ms < RECENT_WINDOW_MS,
+        None => false,
+    };
+
+    let message_count = turns.len();
+    let ended_role = ending_role(turns);
+    let failure_streak = trailing_failure_streak(turns);
+
+    // A single assistant turn that reached end_turn is almost always an
+    // intentional one-shot exchange. TurnRecord counts assistant turns only,
+    // so messageCount <= 2 covers both shapes.
+    if message_count <= 2 && ended_role == EndingRole::Assistant {
+        return SessionOutcome {
+            session_id: session_id.to_string(),
+            outcome: OutcomeLabel::Completed,
+            confidence: OutcomeConfidence::Medium,
+            is_recent,
+            reason: OutcomeReason::SingleExchange,
+        };
+    }
+    if message_count < SHORT_CONVERSATION_THRESHOLD {
+        return SessionOutcome {
+            session_id: session_id.to_string(),
+            outcome: OutcomeLabel::Unknown,
+            confidence: OutcomeConfidence::Low,
+            is_recent,
+            reason: OutcomeReason::TooShort,
+        };
+    }
+    if is_recent {
+        return SessionOutcome {
+            session_id: session_id.to_string(),
+            outcome: OutcomeLabel::Unknown,
+            confidence: OutcomeConfidence::Low,
+            is_recent: true,
+            reason: OutcomeReason::Recent,
+        };
+    }
+
+    if ended_role == EndingRole::User {
+        let high = message_count >= LONG_CONVERSATION_THRESHOLD;
+        return SessionOutcome {
+            session_id: session_id.to_string(),
+            outcome: OutcomeLabel::Abandoned,
+            confidence: if high {
+                OutcomeConfidence::High
+            } else {
+                OutcomeConfidence::Medium
+            },
+            is_recent: false,
+            reason: if high {
+                OutcomeReason::UserEndedLong
+            } else {
+                OutcomeReason::UserEnded
+            },
+        };
+    }
+
+    if failure_streak >= FAILURE_STREAK_THRESHOLD {
+        return SessionOutcome {
+            session_id: session_id.to_string(),
+            outcome: OutcomeLabel::Errored,
+            confidence: OutcomeConfidence::Medium,
+            is_recent: false,
+            reason: OutcomeReason::FailureStreak,
+        };
+    }
+
+    if ended_role == EndingRole::Unknown {
+        return SessionOutcome {
+            session_id: session_id.to_string(),
+            outcome: OutcomeLabel::Completed,
+            confidence: OutcomeConfidence::Low,
+            is_recent: false,
+            reason: OutcomeReason::UnknownEnding,
+        };
+    }
+
+    let gave_up = match content_by_session {
+        Some(map) => detect_give_up(map.get(session_id)),
+        None => false,
+    };
+    SessionOutcome {
+        session_id: session_id.to_string(),
+        outcome: OutcomeLabel::Completed,
+        confidence: if gave_up {
+            OutcomeConfidence::Low
+        } else {
+            OutcomeConfidence::Medium
+        },
+        is_recent: false,
+        reason: if gave_up {
+            OutcomeReason::GiveUp
+        } else {
+            OutcomeReason::AssistantEnded
+        },
+    }
+}
+
+pub fn compute_one_shot_rate(session_id: &str, turns: &[TurnRecord]) -> OneShotMetrics {
+    let mut edit_turns: u64 = 0;
+    let mut one_shot_turns: u64 = 0;
+    let mut total_retries: u64 = 0;
+    for t in turns {
+        if let Some(s) = &t.subagent {
+            if s.is_sidechain {
+                continue;
+            }
+        }
+        if !t.has_edits.unwrap_or(false) {
+            continue;
+        }
+        edit_turns += 1;
+        let r = t.retries.unwrap_or(0);
+        total_retries += r;
+        if r == 0 {
+            one_shot_turns += 1;
+        }
+    }
+    OneShotMetrics {
+        session_id: session_id.to_string(),
+        edit_turns,
+        one_shot_turns,
+        one_shot_rate: if edit_turns > 0 {
+            Some(one_shot_turns as f64 / edit_turns as f64)
+        } else {
+            None
+        },
+        total_retries,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndingRole {
+    User,
+    Assistant,
+    Unknown,
+}
+
+fn ending_role(turns: &[TurnRecord]) -> EndingRole {
+    // TurnRecord represents assistant turns; "ended-with-assistant" means the
+    // final turn reached a natural stop (`end_turn`). A non-`end_turn` stop
+    // reason means user-ended (session died after a tool_use). When the
+    // source doesn't record stopReason at all (e.g. Codex), return Unknown.
+    let last = turns.last().expect("turns non-empty");
+    match &last.stop_reason {
+        None => EndingRole::Unknown,
+        Some(s) if s == "end_turn" => EndingRole::Assistant,
+        Some(_) => EndingRole::User,
+    }
+}
+
+fn trailing_failure_streak(turns: &[TurnRecord]) -> u64 {
+    let mut streak: u64 = 0;
+    for t in turns.iter().rev() {
+        let calls = &t.tool_calls;
+        if calls.is_empty() {
+            break;
+        }
+        let all_errored = calls.iter().all(|c| c.is_error == Some(true));
+        if !all_errored {
+            break;
+        }
+        streak += calls.len() as u64;
+    }
+    streak
+}
+
+fn detect_give_up(records: Option<&Vec<ContentRecord>>) -> bool {
+    let records = match records {
+        Some(r) if !r.is_empty() => r,
+        _ => return false,
+    };
+    for r in records.iter().rev() {
+        if r.role == ContentRole::Assistant && r.kind == ContentKind::Text {
+            if let Some(text) = &r.text {
+                let haystack = text.to_lowercase();
+                return GIVE_UP_PATTERNS.iter().any(|p| haystack.contains(p));
+            }
+        }
+    }
+    false
+}
+
+fn now_ms_system() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Parse a subset of ISO 8601 sufficient for the timestamps produced by the
+/// readers and the test fixtures: `YYYY-MM-DDTHH:MM:SS(.fff)?(Z|±HH:MM)`.
+/// Returns milliseconds since the Unix epoch, or `None` when the input fails
+/// to match — mirroring `Number.isFinite(Date.parse(...))` in TS.
+fn parse_iso8601_ms(s: &str) -> Option<i64> {
+    let bytes = s.as_bytes();
+    if bytes.len() < 19 {
+        return None;
+    }
+    let year: i32 = std::str::from_utf8(&bytes[0..4]).ok()?.parse().ok()?;
+    if bytes[4] != b'-' {
+        return None;
+    }
+    let month: u32 = std::str::from_utf8(&bytes[5..7]).ok()?.parse().ok()?;
+    if bytes[7] != b'-' {
+        return None;
+    }
+    let day: u32 = std::str::from_utf8(&bytes[8..10]).ok()?.parse().ok()?;
+    if bytes[10] != b'T' && bytes[10] != b' ' {
+        return None;
+    }
+    let hour: u32 = std::str::from_utf8(&bytes[11..13]).ok()?.parse().ok()?;
+    if bytes[13] != b':' {
+        return None;
+    }
+    let minute: u32 = std::str::from_utf8(&bytes[14..16]).ok()?.parse().ok()?;
+    if bytes[16] != b':' {
+        return None;
+    }
+    let second: u32 = std::str::from_utf8(&bytes[17..19]).ok()?.parse().ok()?;
+
+    let mut idx = 19;
+    let mut millis: u32 = 0;
+    if idx < bytes.len() && bytes[idx] == b'.' {
+        idx += 1;
+        let frac_start = idx;
+        while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+            idx += 1;
+        }
+        let frac = std::str::from_utf8(&bytes[frac_start..idx]).ok()?;
+        // Pad/truncate to 3 digits to get milliseconds.
+        let mut buf = String::with_capacity(3);
+        for c in frac.chars().take(3) {
+            buf.push(c);
+        }
+        while buf.len() < 3 {
+            buf.push('0');
+        }
+        millis = buf.parse().ok()?;
+    }
+
+    let mut tz_offset_minutes: i64 = 0;
+    if idx < bytes.len() {
+        match bytes[idx] {
+            b'Z' | b'z' => {
+                idx += 1;
+            }
+            b'+' | b'-' => {
+                let sign: i64 = if bytes[idx] == b'-' { -1 } else { 1 };
+                idx += 1;
+                if idx + 5 > bytes.len() || bytes[idx + 2] != b':' {
+                    return None;
+                }
+                let oh: i64 = std::str::from_utf8(&bytes[idx..idx + 2])
+                    .ok()?
+                    .parse()
+                    .ok()?;
+                let om: i64 = std::str::from_utf8(&bytes[idx + 3..idx + 5])
+                    .ok()?
+                    .parse()
+                    .ok()?;
+                tz_offset_minutes = sign * (oh * 60 + om);
+                idx += 5;
+            }
+            _ => return None,
+        }
+    }
+    if idx != bytes.len() {
+        return None;
+    }
+
+    let days = days_from_civil(year, month, day);
+    let utc_secs = days * 86400 + (hour as i64) * 3600 + (minute as i64) * 60 + second as i64;
+    let secs = utc_secs - tz_offset_minutes * 60;
+    secs.checked_mul(1000)?.checked_add(millis as i64)
+}
+
+/// Howard Hinnant's `days_from_civil`: signed days from 1970-01-01 to the
+/// given proleptic-Gregorian date.
+fn days_from_civil(y: i32, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era: i64 = if y >= 0 {
+        (y / 400) as i64
+    } else {
+        ((y - 399) / 400) as i64
+    };
+    let yoe: i64 = (y as i64) - era * 400;
+    let m_adj: i64 = if m > 2 {
+        (m as i64) - 3
+    } else {
+        (m as i64) + 9
+    };
+    let doy: i64 = (153 * m_adj + 2) / 5 + (d as i64) - 1;
+    let doe: i64 = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use relayburn_reader::{
+        ContentKind, ContentRecord, ContentRole, SourceKind, Subagent, ToolCall, Usage,
+    };
+
+    fn fixed_now() -> i64 {
+        // `Date.parse('2026-04-21T00:00:00.000Z')`
+        parse_iso8601_ms("2026-04-21T00:00:00.000Z").expect("parse fixed_now")
+    }
+
+    fn tc(id: &str, name: &str, is_error: Option<bool>) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            target: None,
+            args_hash: format!("{name}:{id}"),
+            is_error,
+            edit_pre_hash: None,
+            edit_post_hash: None,
+            skill_name: None,
+            replaced_tools: None,
+            collapsed_calls: None,
+        }
+    }
+
+    #[derive(Default, Clone)]
+    struct TurnOverrides {
+        message_id: String,
+        turn_index: u64,
+        ts: Option<String>,
+        session_id: Option<String>,
+        source: Option<SourceKind>,
+        stop_reason: Option<Option<String>>,
+        tool_calls: Option<Vec<ToolCall>>,
+        retries: Option<Option<u64>>,
+        has_edits: Option<bool>,
+        subagent: Option<Subagent>,
+    }
+
+    fn turn(o: TurnOverrides) -> TurnRecord {
+        TurnRecord {
+            v: 1,
+            source: o.source.unwrap_or(SourceKind::ClaudeCode),
+            session_id: o.session_id.unwrap_or_else(|| "s".to_string()),
+            session_path: None,
+            message_id: o.message_id,
+            turn_index: o.turn_index,
+            ts: o
+                .ts
+                .unwrap_or_else(|| "2026-04-20T00:00:00.000Z".to_string()),
+            model: "claude-sonnet-4-6".to_string(),
+            project: None,
+            project_key: None,
+            usage: Usage {
+                input: 10,
+                output: 5,
+                reasoning: 0,
+                cache_read: 0,
+                cache_create_5m: 0,
+                cache_create_1h: 0,
+            },
+            tool_calls: o.tool_calls.unwrap_or_default(),
+            files_touched: None,
+            subagent: o.subagent,
+            stop_reason: o.stop_reason.unwrap_or_default(),
+            activity: None,
+            retries: match o.retries {
+                Some(v) => v,
+                None => Some(0),
+            },
+            has_edits: Some(o.has_edits.unwrap_or(false)),
+            fidelity: None,
+        }
+    }
+
+    #[test]
+    fn empty_session_is_unknown_low() {
+        let o = infer_outcome("s", &[], None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Unknown);
+        assert_eq!(o.confidence, OutcomeConfidence::Low);
+        assert_eq!(o.reason, OutcomeReason::Empty);
+    }
+
+    #[test]
+    fn single_exchange_assistant_ended_is_completed_medium() {
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "m1".into(),
+                turn_index: 0,
+                stop_reason: Some(Some("tool_use".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m2".into(),
+                turn_index: 1,
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+        ];
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Completed);
+        assert_eq!(o.confidence, OutcomeConfidence::Medium);
+        assert_eq!(o.reason, OutcomeReason::SingleExchange);
+    }
+
+    #[test]
+    fn one_turn_assistant_ended_is_single_exchange() {
+        let turns = vec![turn(TurnOverrides {
+            message_id: "m1".into(),
+            turn_index: 0,
+            stop_reason: Some(Some("end_turn".into())),
+            ..Default::default()
+        })];
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Completed);
+        assert_eq!(o.confidence, OutcomeConfidence::Medium);
+        assert_eq!(o.reason, OutcomeReason::SingleExchange);
+    }
+
+    #[test]
+    fn very_short_session_is_unknown_too_short() {
+        let turns = vec![turn(TurnOverrides {
+            message_id: "m1".into(),
+            turn_index: 0,
+            stop_reason: Some(Some("tool_use".into())),
+            ..Default::default()
+        })];
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Unknown);
+        assert_eq!(o.reason, OutcomeReason::TooShort);
+    }
+
+    #[test]
+    fn recent_session_is_unknown_recent() {
+        let now = parse_iso8601_ms("2026-04-20T00:05:00.000Z").unwrap();
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "m1".into(),
+                turn_index: 0,
+                ts: Some("2026-04-20T00:00:00.000Z".into()),
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m2".into(),
+                turn_index: 1,
+                ts: Some("2026-04-20T00:01:00.000Z".into()),
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m3".into(),
+                turn_index: 2,
+                ts: Some("2026-04-20T00:02:00.000Z".into()),
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+        ];
+        let o = infer_outcome("s", &turns, None, now);
+        assert_eq!(o.outcome, OutcomeLabel::Unknown);
+        assert!(o.is_recent);
+        assert_eq!(o.reason, OutcomeReason::Recent);
+    }
+
+    #[test]
+    fn user_ended_long_is_abandoned_high() {
+        let turns: Vec<TurnRecord> = (0..10)
+            .map(|i| {
+                turn(TurnOverrides {
+                    message_id: format!("m{i}"),
+                    turn_index: i as u64,
+                    stop_reason: Some(Some(
+                        if i == 9 { "tool_use" } else { "end_turn" }.to_string(),
+                    )),
+                    ..Default::default()
+                })
+            })
+            .collect();
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Abandoned);
+        assert_eq!(o.confidence, OutcomeConfidence::High);
+        assert_eq!(o.reason, OutcomeReason::UserEndedLong);
+    }
+
+    #[test]
+    fn user_ended_short_medium_is_abandoned_medium() {
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "m1".into(),
+                turn_index: 0,
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m2".into(),
+                turn_index: 1,
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m3".into(),
+                turn_index: 2,
+                stop_reason: Some(Some("tool_use".into())),
+                ..Default::default()
+            }),
+        ];
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Abandoned);
+        assert_eq!(o.confidence, OutcomeConfidence::Medium);
+        assert_eq!(o.reason, OutcomeReason::UserEnded);
+    }
+
+    #[test]
+    fn trailing_failure_streak_is_errored_medium() {
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "m1".into(),
+                turn_index: 0,
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m2".into(),
+                turn_index: 1,
+                stop_reason: Some(Some("end_turn".into())),
+                tool_calls: Some(vec![tc("u1", "Bash", Some(true))]),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m3".into(),
+                turn_index: 2,
+                stop_reason: Some(Some("end_turn".into())),
+                tool_calls: Some(vec![tc("u2", "Bash", Some(true))]),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m4".into(),
+                turn_index: 3,
+                stop_reason: Some(Some("end_turn".into())),
+                tool_calls: Some(vec![tc("u3", "Bash", Some(true))]),
+                ..Default::default()
+            }),
+        ];
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Errored);
+        assert_eq!(o.reason, OutcomeReason::FailureStreak);
+    }
+
+    #[test]
+    fn assistant_ended_is_completed_medium_default() {
+        let turns: Vec<TurnRecord> = (0..3)
+            .map(|i| {
+                turn(TurnOverrides {
+                    message_id: format!("m{}", i + 1),
+                    turn_index: i,
+                    stop_reason: Some(Some("end_turn".into())),
+                    ..Default::default()
+                })
+            })
+            .collect();
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Completed);
+        assert_eq!(o.confidence, OutcomeConfidence::Medium);
+        assert_eq!(o.reason, OutcomeReason::AssistantEnded);
+    }
+
+    #[test]
+    fn no_stop_reason_is_completed_low_unknown_ending() {
+        let turns: Vec<TurnRecord> = (0..3)
+            .map(|i| {
+                turn(TurnOverrides {
+                    message_id: format!("m{}", i + 1),
+                    turn_index: i,
+                    source: Some(SourceKind::Codex),
+                    stop_reason: Some(None),
+                    ..Default::default()
+                })
+            })
+            .collect();
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Completed);
+        assert_eq!(o.confidence, OutcomeConfidence::Low);
+        assert_eq!(o.reason, OutcomeReason::UnknownEnding);
+    }
+
+    #[test]
+    fn no_stop_reason_still_detects_failure_streak() {
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "m1".into(),
+                turn_index: 0,
+                source: Some(SourceKind::Codex),
+                stop_reason: Some(None),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m2".into(),
+                turn_index: 1,
+                source: Some(SourceKind::Codex),
+                stop_reason: Some(None),
+                tool_calls: Some(vec![tc("u1", "Bash", Some(true))]),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m3".into(),
+                turn_index: 2,
+                source: Some(SourceKind::Codex),
+                stop_reason: Some(None),
+                tool_calls: Some(vec![tc("u2", "Bash", Some(true))]),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m4".into(),
+                turn_index: 3,
+                source: Some(SourceKind::Codex),
+                stop_reason: Some(None),
+                tool_calls: Some(vec![tc("u3", "Bash", Some(true))]),
+                ..Default::default()
+            }),
+        ];
+        let o = infer_outcome("s", &turns, None, fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Errored);
+        assert_eq!(o.reason, OutcomeReason::FailureStreak);
+    }
+
+    #[test]
+    fn give_up_phrase_downgrades_assistant_ended() {
+        let turns: Vec<TurnRecord> = (0..3)
+            .map(|i| {
+                turn(TurnOverrides {
+                    message_id: format!("m{}", i + 1),
+                    turn_index: i,
+                    stop_reason: Some(Some("end_turn".into())),
+                    ..Default::default()
+                })
+            })
+            .collect();
+        let content = vec![ContentRecord {
+            v: 1,
+            source: SourceKind::ClaudeCode,
+            session_id: "s".into(),
+            message_id: "m3".into(),
+            ts: "2026-04-20T00:00:00.000Z".into(),
+            role: ContentRole::Assistant,
+            kind: ContentKind::Text,
+            text: Some("I'm unable to access the file, so I will stop here.".into()),
+            tool_use: None,
+            tool_result: None,
+        }];
+        let mut map: HashMap<String, Vec<ContentRecord>> = HashMap::new();
+        map.insert("s".to_string(), content);
+        let o = infer_outcome("s", &turns, Some(&map), fixed_now());
+        assert_eq!(o.outcome, OutcomeLabel::Completed);
+        assert_eq!(o.confidence, OutcomeConfidence::Low);
+        assert_eq!(o.reason, OutcomeReason::GiveUp);
+    }
+
+    #[test]
+    fn one_shot_rate_counts_zero_retries_as_one_shot() {
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "m1".into(),
+                turn_index: 0,
+                has_edits: Some(true),
+                retries: Some(Some(0)),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m2".into(),
+                turn_index: 1,
+                has_edits: Some(true),
+                retries: Some(Some(2)),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m3".into(),
+                turn_index: 2,
+                has_edits: Some(true),
+                retries: Some(Some(0)),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m4".into(),
+                turn_index: 3,
+                has_edits: Some(false),
+                retries: Some(Some(5)),
+                ..Default::default()
+            }),
+        ];
+        let m = compute_one_shot_rate("s", &turns);
+        assert_eq!(m.edit_turns, 3);
+        assert_eq!(m.one_shot_turns, 2);
+        assert_eq!(m.one_shot_rate, Some(2.0 / 3.0));
+        assert_eq!(m.total_retries, 2);
+    }
+
+    #[test]
+    fn one_shot_rate_undefined_with_no_edit_turns() {
+        let turns = vec![turn(TurnOverrides {
+            message_id: "m1".into(),
+            turn_index: 0,
+            has_edits: Some(false),
+            ..Default::default()
+        })];
+        let m = compute_one_shot_rate("s", &turns);
+        assert_eq!(m.edit_turns, 0);
+        assert_eq!(m.one_shot_rate, None);
+    }
+
+    #[test]
+    fn one_shot_rate_excludes_sidechain_turns() {
+        let sidechain = Subagent {
+            is_sidechain: true,
+            parent_tool_use_id: None,
+            agent_id: None,
+            parent_agent_id: None,
+            subagent_type: None,
+            description: None,
+        };
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "m1".into(),
+                turn_index: 0,
+                has_edits: Some(true),
+                retries: Some(Some(0)),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "m2".into(),
+                turn_index: 1,
+                has_edits: Some(true),
+                retries: Some(Some(5)),
+                subagent: Some(sidechain),
+                ..Default::default()
+            }),
+        ];
+        let m = compute_one_shot_rate("s", &turns);
+        assert_eq!(m.edit_turns, 1);
+        assert_eq!(m.one_shot_rate, Some(1.0));
+    }
+
+    #[test]
+    fn compute_quality_pairs_outcome_and_one_shot_per_session() {
+        let turns = vec![
+            turn(TurnOverrides {
+                message_id: "a1".into(),
+                turn_index: 0,
+                session_id: Some("A".into()),
+                has_edits: Some(true),
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "a2".into(),
+                turn_index: 1,
+                session_id: Some("A".into()),
+                has_edits: Some(true),
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "a3".into(),
+                turn_index: 2,
+                session_id: Some("A".into()),
+                stop_reason: Some(Some("end_turn".into())),
+                ..Default::default()
+            }),
+            turn(TurnOverrides {
+                message_id: "b1".into(),
+                turn_index: 0,
+                session_id: Some("B".into()),
+                stop_reason: Some(Some("tool_use".into())),
+                ..Default::default()
+            }),
+        ];
+        let q = compute_quality(
+            &turns,
+            &ComputeQualityOptions {
+                content_by_session: None,
+                now_ms: Some(fixed_now()),
+            },
+        );
+        let a_out = q.outcomes.iter().find(|o| o.session_id == "A").unwrap();
+        let b_out = q.outcomes.iter().find(|o| o.session_id == "B").unwrap();
+        assert_eq!(a_out.outcome, OutcomeLabel::Completed);
+        assert_eq!(b_out.outcome, OutcomeLabel::Unknown);
+        assert_eq!(
+            q.one_shot
+                .iter()
+                .find(|m| m.session_id == "A")
+                .unwrap()
+                .edit_turns,
+            2
+        );
+        assert_eq!(
+            q.one_shot
+                .iter()
+                .find(|m| m.session_id == "B")
+                .unwrap()
+                .edit_turns,
+            0
+        );
+    }
+
+    #[test]
+    fn outcome_labels_serialize_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&OutcomeLabel::Completed).unwrap(),
+            "\"completed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeLabel::Abandoned).unwrap(),
+            "\"abandoned\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeLabel::Errored).unwrap(),
+            "\"errored\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeLabel::Unknown).unwrap(),
+            "\"unknown\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeConfidence::High).unwrap(),
+            "\"high\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeReason::SingleExchange).unwrap(),
+            "\"single-exchange\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeReason::UserEndedLong).unwrap(),
+            "\"user-ended-long\""
+        );
+    }
+
+    #[test]
+    fn parse_iso_round_trip_to_known_epoch_ms() {
+        // 2026-04-20T00:00:00.000Z
+        let ms = parse_iso8601_ms("2026-04-20T00:00:00.000Z").unwrap();
+        // (2026-1970)*365.25 days approximation; but we want exact equality
+        // with chrono if available. Validate against another known anchor:
+        let later = parse_iso8601_ms("2026-04-20T00:00:01.000Z").unwrap();
+        assert_eq!(later - ms, 1000);
+        let plus_minute = parse_iso8601_ms("2026-04-20T00:01:00.000Z").unwrap();
+        assert_eq!(plus_minute - ms, 60_000);
+        let plus_hour = parse_iso8601_ms("2026-04-20T01:00:00.000Z").unwrap();
+        assert_eq!(plus_hour - ms, 3_600_000);
+        let plus_day = parse_iso8601_ms("2026-04-21T00:00:00.000Z").unwrap();
+        assert_eq!(plus_day - ms, 86_400_000);
+    }
+}

--- a/crates/relayburn-analyze/src/quality.rs
+++ b/crates/relayburn-analyze/src/quality.rs
@@ -383,6 +383,19 @@ fn parse_iso8601_ms(s: &str) -> Option<i64> {
     }
     let second: u32 = std::str::from_utf8(&bytes[17..19]).ok()?.parse().ok()?;
 
+    // Reject out-of-range components — `Date.parse` returns NaN for these in
+    // the TS reference implementation. Day-of-month bounds are validated
+    // loosely (1..=31) here; the proleptic-Gregorian conversion below would
+    // otherwise silently roll an invalid date forward.
+    if !(1..=12).contains(&month)
+        || !(1..=31).contains(&day)
+        || hour > 23
+        || minute > 59
+        || second > 59
+    {
+        return None;
+    }
+
     let mut idx = 19;
     let mut millis: u32 = 0;
     if idx < bytes.len() && bytes[idx] == b'.' {
@@ -1011,5 +1024,18 @@ mod tests {
         assert_eq!(plus_hour - ms, 3_600_000);
         let plus_day = parse_iso8601_ms("2026-04-21T00:00:00.000Z").unwrap();
         assert_eq!(plus_day - ms, 86_400_000);
+    }
+
+    #[test]
+    fn parse_iso_rejects_out_of_range_components() {
+        // Mirror `Date.parse` behavior: out-of-range minute / second / hour /
+        // month / day all return NaN in JS, so the parser returns None here.
+        assert!(parse_iso8601_ms("2026-04-20T23:60:00Z").is_none());
+        assert!(parse_iso8601_ms("2026-04-20T23:59:60Z").is_none());
+        assert!(parse_iso8601_ms("2026-04-20T24:00:00Z").is_none());
+        assert!(parse_iso8601_ms("2026-13-20T00:00:00Z").is_none());
+        assert!(parse_iso8601_ms("2026-04-32T00:00:00Z").is_none());
+        assert!(parse_iso8601_ms("2026-00-20T00:00:00Z").is_none());
+        assert!(parse_iso8601_ms("2026-04-00T00:00:00Z").is_none());
     }
 }


### PR DESCRIPTION
Closes #268.

Ports the two leaf modules that the upcoming detector PRs (#TODO ghost-surface, #TODO tool-call-patterns, #TODO patterns) depend on:

## `findings.rs`

- `WasteFinding`, `WasteSeverity`, `WasteAction` (closed tagged enum), `EstimatedSavings`.
- The nine `*ToFinding` adapters: `retry_loop_to_finding`, `failure_run_to_finding`, `cancellation_run_to_finding`, `compaction_loss_to_finding`, `edit_revert_to_finding`, `edit_heavy_to_finding`, `skill_recall_dup_to_finding`, `skill_pruning_protection_to_finding`, `system_prompt_tax_to_finding`.
- `findings_from_patterns` (rolls a `PatternsResult` into a sorted finding list) and `sort_findings`.
- The pattern struct types (`RetryLoop`, `FailureRun`, `CancellationRun`, `CompactionLoss`, `EditRevertCycle`, `EditHeavySession`, `SkillRecallDup`, `SkillPruningProtection`, `SystemPromptTax`, plus `PatternsResult` and `SessionPatternSummary`) live in this module so the upcoming `patterns.rs` port depends on it without a circular reference. Per the issue: either layout is acceptable as long as `findings` doesn't depend on `patterns`.

Severity emits `"high"|"warn"|"info"` and action discriminants emit `"paste"|"command"|"file-content"` byte-identical to TS.

## `quality.rs`

- `OutcomeLabel`, `OutcomeConfidence`, `OutcomeReason`, `SessionOutcome`, `OneShotMetrics`, `QualityResult`, `ComputeQualityOptions`.
- `infer_outcome`, `compute_one_shot_rate`, `compute_quality`.
- A small ISO 8601 parser (no `chrono` dep) sufficient for recency-window math against the timestamps emitted by every reader.

Outcome labels and reasons serialize to the same lowercase / kebab-case strings as TS.

## Conformance

`cargo test -p relayburn-analyze` is green: **66 tests pass** (including 16 findings tests + 17 quality tests). Tests mirror the TS suites turn-for-turn — severity tiers, every outcome reason, the give-up downgrade, sidechain exclusion, and the `sort_findings` ordering contract.

Crate is `cargo fmt` and `cargo clippy --tests -- -D warnings` clean.

## Acceptance checklist

- [x] `cargo test -p relayburn-analyze` green for findings + quality.
- [x] Public surface: `WasteFinding`, `WasteSeverity`, `WasteAction`, `EstimatedSavings`, all `*ToFinding` adapters, `findings_from_patterns`, `sort_findings`, `OutcomeLabel`, `OutcomeConfidence`, `SessionOutcome`, `OneShotMetrics`, `QualityResult`, `ComputeQualityOptions`, `infer_outcome`, `compute_one_shot_rate`, `compute_quality`.
- [x] `sort_findings` ordering matches TS (severity desc, savings desc), with a fixture-driven test.
- [x] Pattern struct definitions placed so the `patterns` sub-issue can import without a circular dep.

https://claude.ai/code/session_01NwRmLTJEXPpA5zaiHzTV2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwRmLTJEXPpA5zaiHzTV2c)_