### PR TITLE
relayburn-analyze: port compare aggregator (compare + compare-archive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 ## [Unreleased]
 
 - `relayburn-ingest` (Rust): port the standalone primitives — `pending_stamps` (binary-compatible with the TS `@relayburn/ingest` wire format), `walk` (`walk_jsonl` / `walk_opencode_sessions`), `watch_loop` (`tokio::time::interval`-driven `WatchController` with graceful stop), and the typed `cursors` module layered on the SQLite ledger's cursor blob. Public verb surface (`ingest_all`, per-harness verbs, `reingest_missing_content`) is wired; per-harness orchestration follow-ups deferred to dedicated sub-issues. (#245)
+- `relayburn-analyze` (Rust): port the `compare` aggregator — `build_compare_table` for the in-memory `(model, activity)` rollup with per-cell turn / edit / one-shot / priced / cost / cache-hit / median-retries metrics, plus `compare_from_archive` sourced from the SQLite ledger via `Ledger::query_turns`. Public surface: `CompareCell`, `CompareTable`, `CompareTotals`, `CompareOptions`, `CompareCategory`, `DEFAULT_MIN_SAMPLE`, `compare_from_archive`, `CompareFromArchiveResult`. (#269)
 
 ## [1.9.0] - 2026-05-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,11 @@ version = "0.0.0"
 dependencies = [
  "indexmap",
  "regex",
+ "relayburn-ledger",
  "relayburn-reader",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/relayburn-analyze/Cargo.toml
+++ b/crates/relayburn-analyze/Cargo.toml
@@ -18,3 +18,7 @@ serde_json = { workspace = true }
 indexmap = { version = "2", features = ["serde"] }
 regex = "1"
 relayburn-reader = { path = "../relayburn-reader" }
+relayburn-ledger = { path = "../relayburn-ledger" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/relayburn-analyze/src/compare.rs
+++ b/crates/relayburn-analyze/src/compare.rs
@@ -1,0 +1,718 @@
+//! Per-`(model, activity)` cost rollup — Rust port of
+//! `packages/analyze/src/compare.ts`.
+//!
+//! `build_compare_table` aggregates a slice of [`EnrichedTurn`]s into a
+//! deterministic [`CompareTable`] keyed by `(model, category)`. Cells carry
+//! the same metrics the TS path emits: turn / edit-turn / one-shot counts,
+//! priced-turn count, total cost, mean cost, one-shot rate, cache-hit rate,
+//! median retries, plus the mutually exclusive `no_data` / `insufficient_sample`
+//! flags so JSON consumers can tell "we never saw this combination" apart
+//! from "we have data but the sample is small."
+
+use std::collections::BTreeMap;
+
+use relayburn_ledger::EnrichedTurn;
+use relayburn_reader::ActivityCategory;
+
+use crate::cost::cost_for_turn;
+use crate::pricing::PricingTable;
+
+/// Activity category label, or `"unclassified"` for turns the classifier
+/// couldn't bucket. Mirrors the TS `ActivityCategory | "unclassified"`
+/// union. Exposed as a [`String`] because callers consume it as a key into
+/// [`CompareTable::cells`].
+pub type CompareCategory = String;
+
+/// Default minimum sample count below which a non-empty cell is flagged as
+/// `insufficient_sample`. Matches the TS `DEFAULT_MIN_SAMPLE`.
+pub const DEFAULT_MIN_SAMPLE: u64 = 5;
+
+const UNCLASSIFIED: &str = "unclassified";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompareCell {
+    pub turns: u64,
+    pub edit_turns: u64,
+    pub one_shot_turns: u64,
+    /// Number of turns whose model had pricing in the active table. When
+    /// this is less than `turns`, `total_cost` / `cost_per_turn`
+    /// under-count what the cell actually consumed.
+    pub priced_turns: u64,
+    pub total_cost: f64,
+    /// `None` when no priced turns; cells with unpriced models render as
+    /// "—", never as "$0.00".
+    pub cost_per_turn: Option<f64>,
+    /// `None` for categories with no edits and for empty cells.
+    pub one_shot_rate: Option<f64>,
+    pub cache_hit_rate: Option<f64>,
+    pub median_retries: Option<f64>,
+    /// True when the cell has zero turns. Distinct from `insufficient_sample`
+    /// so JSON consumers can tell "we never saw this combination" apart
+    /// from "we have data but the sample is small." Only one of `no_data` /
+    /// `insufficient_sample` is ever true at a time.
+    pub no_data: bool,
+    /// True when `0 < turns < min_sample`. A cell with `no_data == true`
+    /// always has `insufficient_sample == false`.
+    pub insufficient_sample: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CompareTotals {
+    pub turns: u64,
+    pub total_cost: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompareTable {
+    pub models: Vec<String>,
+    pub categories: Vec<String>,
+    pub cells: BTreeMap<String, BTreeMap<String, CompareCell>>,
+    pub totals: BTreeMap<String, CompareTotals>,
+    pub min_sample: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompareOptions<'a> {
+    pub pricing: &'a PricingTable,
+    /// Optional explicit model allow-list. When set, turns whose model is
+    /// not in this list are dropped, and any listed model that produced
+    /// zero matching turns is still rendered as an all-empty column.
+    pub models: Option<Vec<String>>,
+    pub min_sample: Option<u64>,
+}
+
+impl<'a> CompareOptions<'a> {
+    pub fn new(pricing: &'a PricingTable) -> Self {
+        Self {
+            pricing,
+            models: None,
+            min_sample: None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Accum {
+    turns: u64,
+    edit_turns: u64,
+    one_shot_turns: u64,
+    priced_turns: u64,
+    total_cost: f64,
+    retries_samples: Vec<u64>,
+    cache_read: u64,
+    token_denominator: u64,
+}
+
+pub fn build_compare_table(turns: &[EnrichedTurn], opts: &CompareOptions<'_>) -> CompareTable {
+    let min_sample = opts.min_sample.unwrap_or(DEFAULT_MIN_SAMPLE);
+    let model_filter: Option<Vec<String>> = opts.models.as_ref().filter(|v| !v.is_empty()).cloned();
+
+    let mut by_model_category: BTreeMap<String, BTreeMap<String, Accum>> = BTreeMap::new();
+    let mut model_totals: BTreeMap<String, CompareTotals> = BTreeMap::new();
+    let mut model_set: BTreeMap<String, ()> = BTreeMap::new();
+    let mut category_set: BTreeMap<String, ()> = BTreeMap::new();
+
+    // Pre-seed model_set from the model filter so a model the user
+    // explicitly asked about stays visible (as an all-empty column with
+    // coverage notes) even if zero turns matched. Without this, the "no
+    // <model> data" coverage signal silently disappears for filtered-but-
+    // absent models.
+    if let Some(ref filter) = model_filter {
+        for m in filter {
+            model_set.insert(m.clone(), ());
+            model_totals.insert(m.clone(), CompareTotals::default());
+        }
+    }
+
+    for et in turns {
+        let t = &et.turn;
+        let model = if t.model.is_empty() {
+            "unknown".to_string()
+        } else {
+            t.model.clone()
+        };
+        if let Some(ref filter) = model_filter {
+            if !filter.iter().any(|m| m == &model) {
+                continue;
+            }
+        }
+        let cat = activity_label(t.activity);
+        model_set.insert(model.clone(), ());
+        category_set.insert(cat.clone(), ());
+
+        let by_cat = by_model_category.entry(model.clone()).or_default();
+        let acc = by_cat.entry(cat).or_default();
+
+        acc.turns += 1;
+        let mt = model_totals.entry(model.clone()).or_default();
+        mt.turns += 1;
+        if let Some(c) = cost_for_turn(t, opts.pricing) {
+            acc.priced_turns += 1;
+            acc.total_cost += c.total;
+            mt.total_cost += c.total;
+        }
+        if t.has_edits.unwrap_or(false) {
+            acc.edit_turns += 1;
+            let r = t.retries.unwrap_or(0);
+            acc.retries_samples.push(r);
+            if r == 0 {
+                acc.one_shot_turns += 1;
+            }
+        }
+        acc.cache_read += t.usage.cache_read;
+        acc.token_denominator +=
+            t.usage.input + t.usage.cache_read + t.usage.cache_create_5m + t.usage.cache_create_1h;
+    }
+
+    // Sort models by total cost DESC, then ASCII-lex on the id. The TS path
+    // uses `localeCompare` here; for the model-id corpus that is in practice
+    // ASCII alphanumeric+`-`/`/`, the two orderings agree.
+    let mut models: Vec<String> = model_set.keys().cloned().collect();
+    models.sort_by(|a, b| {
+        let ca = model_totals.get(a).map(|v| v.total_cost).unwrap_or(0.0);
+        let cb = model_totals.get(b).map(|v| v.total_cost).unwrap_or(0.0);
+        match cb.partial_cmp(&ca).unwrap_or(std::cmp::Ordering::Equal) {
+            std::cmp::Ordering::Equal => a.cmp(b),
+            other => other,
+        }
+    });
+
+    // Sort categories by total turns across all (already-sorted) models DESC,
+    // then by label ASC. Mirrors the TS path so the on-the-wire row ordering
+    // is byte-identical for the same fixture.
+    let mut categories: Vec<String> = category_set.keys().cloned().collect();
+    categories.sort_by(|a, b| {
+        let ta: u64 = models
+            .iter()
+            .map(|m| {
+                by_model_category
+                    .get(m)
+                    .and_then(|by_cat| by_cat.get(a))
+                    .map(|acc| acc.turns)
+                    .unwrap_or(0)
+            })
+            .sum();
+        let tb: u64 = models
+            .iter()
+            .map(|m| {
+                by_model_category
+                    .get(m)
+                    .and_then(|by_cat| by_cat.get(b))
+                    .map(|acc| acc.turns)
+                    .unwrap_or(0)
+            })
+            .sum();
+        match tb.cmp(&ta) {
+            std::cmp::Ordering::Equal => a.cmp(b),
+            other => other,
+        }
+    });
+
+    let mut cells: BTreeMap<String, BTreeMap<String, CompareCell>> = BTreeMap::new();
+    for m in &models {
+        let mut row: BTreeMap<String, CompareCell> = BTreeMap::new();
+        for cat in &categories {
+            let acc = by_model_category.get(m).and_then(|by_cat| by_cat.get(cat));
+            row.insert(cat.clone(), to_cell(acc, min_sample));
+        }
+        cells.insert(m.clone(), row);
+    }
+
+    CompareTable {
+        models,
+        categories,
+        cells,
+        totals: model_totals,
+        min_sample,
+    }
+}
+
+fn to_cell(acc: Option<&Accum>, min_sample: u64) -> CompareCell {
+    let Some(acc) = acc else {
+        return empty_cell();
+    };
+    if acc.turns == 0 {
+        return empty_cell();
+    }
+    CompareCell {
+        turns: acc.turns,
+        edit_turns: acc.edit_turns,
+        one_shot_turns: acc.one_shot_turns,
+        priced_turns: acc.priced_turns,
+        total_cost: acc.total_cost,
+        // `cost_per_turn` is `None` when none of the turns in this cell
+        // have pricing — emitting 0 would silently misrepresent unknown
+        // cost as free.
+        cost_per_turn: if acc.priced_turns > 0 {
+            Some(acc.total_cost / acc.priced_turns as f64)
+        } else {
+            None
+        },
+        one_shot_rate: if acc.edit_turns > 0 {
+            Some(acc.one_shot_turns as f64 / acc.edit_turns as f64)
+        } else {
+            None
+        },
+        cache_hit_rate: if acc.token_denominator > 0 {
+            Some(acc.cache_read as f64 / acc.token_denominator as f64)
+        } else {
+            None
+        },
+        median_retries: if acc.edit_turns > 0 {
+            Some(median(&acc.retries_samples))
+        } else {
+            None
+        },
+        no_data: false,
+        insufficient_sample: acc.turns < min_sample,
+    }
+}
+
+fn empty_cell() -> CompareCell {
+    CompareCell {
+        turns: 0,
+        edit_turns: 0,
+        one_shot_turns: 0,
+        priced_turns: 0,
+        total_cost: 0.0,
+        cost_per_turn: None,
+        one_shot_rate: None,
+        cache_hit_rate: None,
+        median_retries: None,
+        no_data: true,
+        insufficient_sample: false,
+    }
+}
+
+fn median(xs: &[u64]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let mut s: Vec<u64> = xs.to_vec();
+    s.sort_unstable();
+    let mid = s.len() / 2;
+    if s.len().is_multiple_of(2) {
+        (s[mid - 1] as f64 + s[mid] as f64) / 2.0
+    } else {
+        s[mid] as f64
+    }
+}
+
+fn activity_label(activity: Option<ActivityCategory>) -> String {
+    match activity {
+        Some(a) => match serde_json::to_value(a) {
+            Ok(serde_json::Value::String(s)) => s,
+            _ => UNCLASSIFIED.to_string(),
+        },
+        None => UNCLASSIFIED.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pricing::load_builtin_pricing;
+    use relayburn_ledger::EnrichedTurn;
+    use relayburn_reader::{ActivityCategory, SourceKind, ToolCall, TurnRecord, Usage};
+    use std::collections::BTreeMap;
+
+    fn turn(
+        model: &str,
+        activity: Option<ActivityCategory>,
+        usage: Usage,
+        has_edits: Option<bool>,
+        retries: Option<u64>,
+    ) -> EnrichedTurn {
+        let id = format!("m-{}", rand_suffix());
+        EnrichedTurn {
+            turn: TurnRecord {
+                v: 1,
+                source: SourceKind::ClaudeCode,
+                session_id: "s".into(),
+                session_path: None,
+                message_id: id,
+                turn_index: 0,
+                ts: "2026-04-20T00:00:00.000Z".into(),
+                model: model.into(),
+                project: None,
+                project_key: None,
+                usage,
+                tool_calls: Vec::<ToolCall>::new(),
+                files_touched: None,
+                subagent: None,
+                stop_reason: None,
+                activity,
+                retries,
+                has_edits,
+                fidelity: None,
+            },
+            enrichment: BTreeMap::new(),
+        }
+    }
+
+    fn rand_suffix() -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        COUNTER.fetch_add(1, Ordering::Relaxed).to_string()
+    }
+
+    fn default_usage() -> Usage {
+        Usage {
+            input: 1000,
+            output: 500,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        }
+    }
+
+    #[test]
+    fn buckets_turns_by_model_and_activity_with_per_cell_metrics() {
+        let pricing = load_builtin_pricing();
+        let mut turns: Vec<EnrichedTurn> = Vec::new();
+        // 6 Sonnet coding turns, 4 one-shot.
+        for _ in 0..4 {
+            turns.push(turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Coding),
+                default_usage(),
+                Some(true),
+                Some(0),
+            ));
+        }
+        turns.push(turn(
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Coding),
+            default_usage(),
+            Some(true),
+            Some(2),
+        ));
+        turns.push(turn(
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Coding),
+            default_usage(),
+            Some(true),
+            Some(1),
+        ));
+        // 5 Haiku coding turns, 2 one-shot.
+        for r in [0u64, 0, 1, 2, 1] {
+            turns.push(turn(
+                "claude-haiku-4-5",
+                Some(ActivityCategory::Coding),
+                default_usage(),
+                Some(true),
+                Some(r),
+            ));
+        }
+        // Sonnet exploration, no edits — Haiku exploration cell stays no-data.
+        turns.push(turn(
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Exploration),
+            default_usage(),
+            Some(false),
+            None,
+        ));
+        turns.push(turn(
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Exploration),
+            default_usage(),
+            Some(false),
+            None,
+        ));
+
+        let opts = CompareOptions::new(&pricing);
+        let t = build_compare_table(&turns, &opts);
+        let mut sorted = t.models.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["claude-haiku-4-5", "claude-sonnet-4-6"]);
+        assert!(t.categories.iter().any(|c| c == "coding"));
+        assert!(t.categories.iter().any(|c| c == "exploration"));
+
+        let sonnet_coding = &t.cells["claude-sonnet-4-6"]["coding"];
+        assert_eq!(sonnet_coding.turns, 6);
+        assert_eq!(sonnet_coding.edit_turns, 6);
+        assert_eq!(sonnet_coding.one_shot_turns, 4);
+        assert_eq!(sonnet_coding.one_shot_rate, Some(4.0 / 6.0));
+
+        let haiku_coding = &t.cells["claude-haiku-4-5"]["coding"];
+        assert_eq!(haiku_coding.turns, 5);
+        assert_eq!(haiku_coding.one_shot_rate, Some(2.0 / 5.0));
+
+        let haiku_exploration = &t.cells["claude-haiku-4-5"]["exploration"];
+        assert_eq!(haiku_exploration.turns, 0);
+        assert!(haiku_exploration.no_data);
+        assert!(!haiku_exploration.insufficient_sample);
+        assert_eq!(haiku_exploration.cost_per_turn, None);
+        assert_eq!(haiku_exploration.one_shot_rate, None);
+    }
+
+    #[test]
+    fn returns_none_one_shot_rate_for_categories_with_no_edit_turns() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Exploration),
+                default_usage(),
+                Some(false),
+                None,
+            ),
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Exploration),
+                default_usage(),
+                Some(false),
+                None,
+            ),
+        ];
+        let t = build_compare_table(&turns, &CompareOptions::new(&pricing));
+        let cell = &t.cells["claude-sonnet-4-6"]["exploration"];
+        assert_eq!(cell.turns, 2);
+        assert_eq!(cell.edit_turns, 0);
+        assert_eq!(cell.one_shot_rate, None);
+        assert_eq!(cell.median_retries, None);
+    }
+
+    #[test]
+    fn flags_low_sample_cells_as_insufficient_not_no_data() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Refactoring),
+                default_usage(),
+                Some(true),
+                Some(0),
+            ),
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Refactoring),
+                default_usage(),
+                Some(true),
+                Some(0),
+            ),
+        ];
+        let opts = CompareOptions {
+            pricing: &pricing,
+            models: None,
+            min_sample: Some(5),
+        };
+        let t = build_compare_table(&turns, &opts);
+        let cell = &t.cells["claude-sonnet-4-6"]["refactoring"];
+        assert!(cell.insufficient_sample);
+        assert!(!cell.no_data);
+        assert_eq!(cell.turns, 2);
+    }
+
+    #[test]
+    fn applies_models_filter() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Coding),
+                default_usage(),
+                Some(true),
+                Some(0),
+            ),
+            turn(
+                "claude-haiku-4-5",
+                Some(ActivityCategory::Coding),
+                default_usage(),
+                Some(true),
+                Some(0),
+            ),
+            turn(
+                "claude-opus-4-7",
+                Some(ActivityCategory::Coding),
+                default_usage(),
+                Some(true),
+                Some(0),
+            ),
+        ];
+        let opts = CompareOptions {
+            pricing: &pricing,
+            models: Some(vec!["claude-sonnet-4-6".into(), "claude-haiku-4-5".into()]),
+            min_sample: None,
+        };
+        let t = build_compare_table(&turns, &opts);
+        let mut sorted = t.models.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["claude-haiku-4-5", "claude-sonnet-4-6"]);
+    }
+
+    #[test]
+    fn keeps_explicitly_requested_models_visible_with_zero_turns() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![turn(
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Coding),
+            default_usage(),
+            Some(true),
+            Some(0),
+        )];
+        let opts = CompareOptions {
+            pricing: &pricing,
+            models: Some(vec!["claude-sonnet-4-6".into(), "claude-haiku-4-5".into()]),
+            min_sample: None,
+        };
+        let t = build_compare_table(&turns, &opts);
+        assert!(
+            t.models.iter().any(|m| m == "claude-haiku-4-5"),
+            "requested model must remain in the table"
+        );
+        let haiku_cell = &t.cells["claude-haiku-4-5"]["coding"];
+        assert!(haiku_cell.no_data);
+        assert_eq!(haiku_cell.turns, 0);
+        assert_eq!(t.totals["claude-haiku-4-5"].turns, 0);
+    }
+
+    #[test]
+    fn renders_cost_per_turn_as_none_when_no_priced_turn() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![
+            turn(
+                "definitely-not-a-model",
+                Some(ActivityCategory::Coding),
+                default_usage(),
+                Some(true),
+                Some(0),
+            ),
+            turn(
+                "definitely-not-a-model",
+                Some(ActivityCategory::Coding),
+                default_usage(),
+                Some(true),
+                Some(1),
+            ),
+        ];
+        let t = build_compare_table(&turns, &CompareOptions::new(&pricing));
+        let cell = &t.cells["definitely-not-a-model"]["coding"];
+        assert_eq!(cell.turns, 2);
+        assert_eq!(cell.priced_turns, 0);
+        assert_eq!(cell.total_cost, 0.0);
+        assert_eq!(cell.cost_per_turn, None);
+    }
+
+    #[test]
+    fn uses_priced_turns_as_cost_per_turn_denominator() {
+        let pricing = load_builtin_pricing();
+        let usage = Usage {
+            input: 1_000_000,
+            output: 0,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        };
+        let turns = vec![
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Coding),
+                usage.clone(),
+                Some(true),
+                Some(0),
+            ),
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Coding),
+                usage,
+                Some(true),
+                Some(0),
+            ),
+        ];
+        let t = build_compare_table(&turns, &CompareOptions::new(&pricing));
+        let cell = &t.cells["claude-sonnet-4-6"]["coding"];
+        assert_eq!(cell.priced_turns, 2);
+        assert_eq!(cell.turns, 2);
+        let cpt = cell.cost_per_turn.expect("priced");
+        assert!((cpt - cell.total_cost / 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn groups_unclassified_turns_under_unclassified() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![
+            turn(
+                "claude-sonnet-4-6",
+                None,
+                default_usage(),
+                Some(false),
+                None,
+            ),
+            turn(
+                "claude-sonnet-4-6",
+                None,
+                default_usage(),
+                Some(false),
+                None,
+            ),
+        ];
+        let t = build_compare_table(&turns, &CompareOptions::new(&pricing));
+        assert!(t.categories.iter().any(|c| c == "unclassified"));
+        assert_eq!(t.cells["claude-sonnet-4-6"]["unclassified"].turns, 2);
+    }
+
+    #[test]
+    fn total_cost_per_model_matches_sum_of_its_cells() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Coding),
+                Usage {
+                    input: 500_000,
+                    output: 100_000,
+                    reasoning: 0,
+                    cache_read: 0,
+                    cache_create_5m: 0,
+                    cache_create_1h: 0,
+                },
+                Some(true),
+                Some(0),
+            ),
+            turn(
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Debugging),
+                Usage {
+                    input: 1_000_000,
+                    output: 100_000,
+                    reasoning: 0,
+                    cache_read: 0,
+                    cache_create_5m: 0,
+                    cache_create_1h: 0,
+                },
+                Some(true),
+                Some(1),
+            ),
+        ];
+        let t = build_compare_table(&turns, &CompareOptions::new(&pricing));
+        let sum = t.cells["claude-sonnet-4-6"]["coding"].total_cost
+            + t.cells["claude-sonnet-4-6"]["debugging"].total_cost;
+        assert!((sum - t.totals["claude-sonnet-4-6"].total_cost).abs() < 1e-9);
+    }
+
+    #[test]
+    fn computes_cache_hit_rate_across_input_and_cache_buckets() {
+        let pricing = load_builtin_pricing();
+        let turns = vec![turn(
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Coding),
+            Usage {
+                input: 1000,
+                output: 200,
+                reasoning: 0,
+                cache_read: 3000,
+                cache_create_5m: 0,
+                cache_create_1h: 0,
+            },
+            Some(true),
+            Some(0),
+        )];
+        let t = build_compare_table(&turns, &CompareOptions::new(&pricing));
+        let cell = &t.cells["claude-sonnet-4-6"]["coding"];
+        let rate = cell.cache_hit_rate.expect("rate");
+        assert!((rate - 3000.0 / 4000.0).abs() < 1e-9);
+    }
+}

--- a/crates/relayburn-analyze/src/compare_archive.rs
+++ b/crates/relayburn-analyze/src/compare_archive.rs
@@ -1,0 +1,753 @@
+//! `compare` from the SQLite-backed ledger — Rust port of
+//! `packages/analyze/src/compare-archive.ts`.
+//!
+//! Per #259's redesign, the Rust ledger is already SQLite-only, so this
+//! port is a thin shell over [`Ledger::query_turns`] + [`build_compare_table`].
+//! The TS path's bespoke per-column SQL aggregation existed because the
+//! 1.x JSONL ledger had no typed columns; the 2.x port does, so we get
+//! the same per-cell parity for free by reusing the in-memory primitive.
+//!
+//! `analyzed_turns` is the pre-`models`-filter count — matches the TS
+//! semantics that derive it from `queryAll(q).length` rather than from the
+//! post-filter table.
+
+use relayburn_ledger::{Ledger, Query, Result as LedgerResult};
+
+use crate::compare::{build_compare_table, CompareOptions, CompareTable};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompareFromArchiveResult {
+    pub table: CompareTable,
+    /// Total turn count (pre-`models` filter) matching `q`. Mirrors the TS
+    /// path's `analyzedTurns`, which is sourced from `queryAll(q).length`.
+    pub analyzed_turns: usize,
+}
+
+/// Build a [`CompareTable`] sourced from the SQLite ledger. The filter
+/// pipeline (since / until / project / session_id / source) is applied
+/// inside [`Ledger::query_turns`]; the model allow-list lives in `opts`
+/// and is honored by [`build_compare_table`].
+pub fn compare_from_archive(
+    ledger: &Ledger,
+    q: &Query,
+    opts: &CompareOptions<'_>,
+) -> LedgerResult<CompareFromArchiveResult> {
+    let turns = ledger.query_turns(q)?;
+    let analyzed_turns = turns.len();
+    let table = build_compare_table(&turns, opts);
+    Ok(CompareFromArchiveResult {
+        table,
+        analyzed_turns,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compare::CompareOptions;
+    use crate::pricing::load_builtin_pricing;
+    use relayburn_ledger::{Ledger, LedgerLayout, Query};
+    use relayburn_reader::{ActivityCategory, SourceKind, ToolCall, TurnRecord, Usage};
+    use tempfile::TempDir;
+
+    fn open_in(tmp: &TempDir) -> Ledger {
+        let layout = LedgerLayout::under(tmp.path());
+        Ledger::open(&layout.burn, &layout.content).unwrap()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn fake_turn(
+        session: &str,
+        message: &str,
+        ts: &str,
+        model: &str,
+        activity: Option<ActivityCategory>,
+        has_edits: Option<bool>,
+        retries: Option<u64>,
+        usage: Usage,
+        source: SourceKind,
+        project: Option<&str>,
+        project_key: Option<&str>,
+    ) -> TurnRecord {
+        TurnRecord {
+            v: 1,
+            source,
+            session_id: session.into(),
+            session_path: None,
+            message_id: message.into(),
+            turn_index: 0,
+            ts: ts.into(),
+            model: model.into(),
+            project: project.map(str::to_string),
+            project_key: project_key.map(str::to_string),
+            usage,
+            tool_calls: Vec::<ToolCall>::new(),
+            files_touched: None,
+            subagent: None,
+            stop_reason: None,
+            activity,
+            retries,
+            has_edits,
+            fidelity: None,
+        }
+    }
+
+    fn default_usage(input: u64) -> Usage {
+        Usage {
+            input,
+            output: 500,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        }
+    }
+
+    fn assert_num_near(a: Option<f64>, b: Option<f64>, msg: &str) {
+        match (a, b) {
+            (None, None) => {}
+            (Some(x), Some(y)) => {
+                assert!((x - y).abs() < 1e-9, "{msg}: {x} != {y}");
+            }
+            other => panic!("{msg}: mismatched optionals: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parity_matches_in_memory_build_compare_table_for_a_mixed_fixture() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        let mut turns: Vec<TurnRecord> = Vec::new();
+        let mut mid = 0u64;
+        let mut next_id = || {
+            mid += 1;
+            format!("m-{mid}")
+        };
+
+        // 6 Sonnet coding turns, 4 one-shot.
+        for i in 0..4 {
+            turns.push(fake_turn(
+                "s-sonnet",
+                &next_id(),
+                &format!("2026-04-20T00:00:{:02}.000Z", i),
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Coding),
+                Some(true),
+                Some(0),
+                Usage {
+                    input: 5000,
+                    output: 800,
+                    reasoning: 0,
+                    cache_read: 12000,
+                    cache_create_5m: 0,
+                    cache_create_1h: 0,
+                },
+                SourceKind::ClaudeCode,
+                Some("/tmp/project"),
+                None,
+            ));
+        }
+        turns.push(fake_turn(
+            "s-sonnet",
+            &next_id(),
+            "2026-04-20T00:00:04.000Z",
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Coding),
+            Some(true),
+            Some(2),
+            default_usage(1000),
+            SourceKind::ClaudeCode,
+            Some("/tmp/project"),
+            None,
+        ));
+        turns.push(fake_turn(
+            "s-sonnet",
+            &next_id(),
+            "2026-04-20T00:00:05.000Z",
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Coding),
+            Some(true),
+            Some(1),
+            default_usage(1100),
+            SourceKind::ClaudeCode,
+            Some("/tmp/project"),
+            None,
+        ));
+
+        // 5 Haiku coding turns.
+        for i in 0..5u64 {
+            turns.push(fake_turn(
+                "s-haiku",
+                &next_id(),
+                &format!("2026-04-20T01:00:{:02}.000Z", i),
+                "claude-haiku-4-5",
+                Some(ActivityCategory::Coding),
+                Some(true),
+                Some(if i < 2 { 0 } else { i }),
+                Usage {
+                    input: 2000,
+                    output: 400,
+                    reasoning: 0,
+                    cache_read: if i % 2 == 0 { 6000 } else { 0 },
+                    cache_create_5m: 0,
+                    cache_create_1h: 0,
+                },
+                SourceKind::ClaudeCode,
+                Some("/tmp/project"),
+                None,
+            ));
+        }
+
+        // Sonnet exploration (no edits).
+        turns.push(fake_turn(
+            "s-expl",
+            &next_id(),
+            "2026-04-20T02:00:00.000Z",
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Exploration),
+            Some(false),
+            None,
+            default_usage(1200),
+            SourceKind::ClaudeCode,
+            Some("/tmp/project"),
+            None,
+        ));
+        turns.push(fake_turn(
+            "s-expl",
+            &next_id(),
+            "2026-04-20T02:00:01.000Z",
+            "claude-sonnet-4-6",
+            Some(ActivityCategory::Exploration),
+            Some(false),
+            None,
+            default_usage(1300),
+            SourceKind::ClaudeCode,
+            Some("/tmp/project"),
+            None,
+        ));
+
+        // Unpriced model.
+        turns.push(fake_turn(
+            "s-unpriced",
+            &next_id(),
+            "2026-04-20T03:00:00.000Z",
+            "definitely-not-a-model",
+            Some(ActivityCategory::Coding),
+            Some(true),
+            Some(1),
+            default_usage(1400),
+            SourceKind::ClaudeCode,
+            Some("/tmp/project"),
+            None,
+        ));
+
+        // Codex source — exercises the source-aware reasoning override
+        // baked into `cost_for_turn`.
+        turns.push(fake_turn(
+            "s-codex",
+            &next_id(),
+            "2026-04-20T04:00:00.000Z",
+            "gpt-5-codex",
+            Some(ActivityCategory::Coding),
+            Some(true),
+            Some(0),
+            Usage {
+                input: 10000,
+                output: 2000,
+                reasoning: 800,
+                cache_read: 0,
+                cache_create_5m: 0,
+                cache_create_1h: 0,
+            },
+            SourceKind::Codex,
+            Some("/tmp/project"),
+            None,
+        ));
+
+        ledger.append_turns(&turns).unwrap();
+
+        let opts = CompareOptions {
+            pricing: &pricing,
+            models: None,
+            min_sample: Some(5),
+        };
+        let in_memory_turns = ledger.query_turns(&Query::default()).unwrap();
+        let in_memory = crate::compare::build_compare_table(&in_memory_turns, &opts);
+        let from_archive = compare_from_archive(&ledger, &Query::default(), &opts).unwrap();
+
+        assert_eq!(from_archive.table.models, in_memory.models, "models order");
+        assert_eq!(
+            from_archive.table.categories, in_memory.categories,
+            "categories order"
+        );
+        assert_eq!(from_archive.table.min_sample, in_memory.min_sample);
+        assert_eq!(
+            from_archive.analyzed_turns,
+            in_memory_turns.len(),
+            "analyzed_turns"
+        );
+
+        for m in &in_memory.models {
+            for cat in &in_memory.categories {
+                let a = &from_archive.table.cells[m][cat];
+                let b = &in_memory.cells[m][cat];
+                assert_eq!(a.turns, b.turns, "{m}/{cat} turns");
+                assert_eq!(a.edit_turns, b.edit_turns, "{m}/{cat} edit_turns");
+                assert_eq!(
+                    a.one_shot_turns, b.one_shot_turns,
+                    "{m}/{cat} one_shot_turns"
+                );
+                assert_eq!(a.priced_turns, b.priced_turns, "{m}/{cat} priced_turns");
+                assert_num_near(
+                    Some(a.total_cost),
+                    Some(b.total_cost),
+                    &format!("{m}/{cat} total_cost"),
+                );
+                assert_num_near(
+                    a.cost_per_turn,
+                    b.cost_per_turn,
+                    &format!("{m}/{cat} cost_per_turn"),
+                );
+                assert_num_near(
+                    a.one_shot_rate,
+                    b.one_shot_rate,
+                    &format!("{m}/{cat} one_shot_rate"),
+                );
+                assert_num_near(
+                    a.cache_hit_rate,
+                    b.cache_hit_rate,
+                    &format!("{m}/{cat} cache_hit_rate"),
+                );
+                assert_eq!(
+                    a.median_retries, b.median_retries,
+                    "{m}/{cat} median_retries"
+                );
+                assert_eq!(a.no_data, b.no_data, "{m}/{cat} no_data");
+                assert_eq!(
+                    a.insufficient_sample, b.insufficient_sample,
+                    "{m}/{cat} insufficient_sample"
+                );
+            }
+        }
+
+        for m in &in_memory.models {
+            let a = &from_archive.table.totals[m];
+            let b = &in_memory.totals[m];
+            assert_eq!(a.turns, b.turns, "{m} totals.turns");
+            assert_num_near(
+                Some(a.total_cost),
+                Some(b.total_cost),
+                &format!("{m} totals.total_cost"),
+            );
+        }
+    }
+
+    #[test]
+    fn honors_models_filter_and_pre_seeds_requested_but_absent_models() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[
+                fake_turn(
+                    "s-1",
+                    "m-1",
+                    "2026-04-20T00:00:00.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    Some(0),
+                    default_usage(1000),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+                fake_turn(
+                    "s-2",
+                    "m-2",
+                    "2026-04-20T00:00:01.000Z",
+                    "claude-opus-4-7",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    Some(0),
+                    default_usage(1100),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+            ])
+            .unwrap();
+
+        let opts = CompareOptions {
+            pricing: &pricing,
+            models: Some(vec!["claude-sonnet-4-6".into(), "claude-haiku-4-5".into()]),
+            min_sample: None,
+        };
+        let result = compare_from_archive(&ledger, &Query::default(), &opts).unwrap();
+
+        let mut sorted = result.table.models.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["claude-haiku-4-5", "claude-sonnet-4-6"]);
+        assert!(result.table.cells["claude-haiku-4-5"]["coding"].no_data);
+        assert_eq!(result.table.totals["claude-haiku-4-5"].turns, 0);
+        // analyzed_turns is the pre-`models` count and must include both
+        // ledger turns.
+        assert_eq!(result.analyzed_turns, 2);
+    }
+
+    #[test]
+    fn honors_since_filter() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[
+                fake_turn(
+                    "s-1",
+                    "m-old",
+                    "2026-04-19T00:00:00.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    Some(0),
+                    default_usage(1000),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+                fake_turn(
+                    "s-2",
+                    "m-new",
+                    "2026-04-21T00:00:00.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    Some(0),
+                    default_usage(1100),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+            ])
+            .unwrap();
+
+        let q = Query {
+            since: Some("2026-04-20T00:00:00.000Z".into()),
+            ..Query::default()
+        };
+        let opts = CompareOptions::new(&pricing);
+        let result = compare_from_archive(&ledger, &q, &opts).unwrap();
+        assert_eq!(result.analyzed_turns, 1);
+        assert_eq!(result.table.cells["claude-sonnet-4-6"]["coding"].turns, 1);
+    }
+
+    #[test]
+    fn honors_project_filter_against_either_path_or_key() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[
+                fake_turn(
+                    "s-1",
+                    "m-a",
+                    "2026-04-20T00:00:00.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    None,
+                    default_usage(1000),
+                    SourceKind::ClaudeCode,
+                    Some("/tmp/proj-a"),
+                    Some("github.com/me/a"),
+                ),
+                fake_turn(
+                    "s-2",
+                    "m-b",
+                    "2026-04-20T00:00:01.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    None,
+                    default_usage(1100),
+                    SourceKind::ClaudeCode,
+                    Some("/tmp/proj-b"),
+                    Some("github.com/me/b"),
+                ),
+            ])
+            .unwrap();
+
+        let opts = CompareOptions::new(&pricing);
+        let by_path = compare_from_archive(
+            &ledger,
+            &Query {
+                project: Some("/tmp/proj-a".into()),
+                ..Query::default()
+            },
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(by_path.analyzed_turns, 1);
+
+        let by_key = compare_from_archive(
+            &ledger,
+            &Query {
+                project: Some("github.com/me/b".into()),
+                ..Query::default()
+            },
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(by_key.analyzed_turns, 1);
+    }
+
+    #[test]
+    fn honors_session_filter() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[
+                fake_turn(
+                    "s-X",
+                    "m-x",
+                    "2026-04-20T00:00:00.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    None,
+                    default_usage(1000),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+                fake_turn(
+                    "s-Y",
+                    "m-y",
+                    "2026-04-20T00:00:01.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Coding),
+                    Some(true),
+                    None,
+                    default_usage(1100),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+            ])
+            .unwrap();
+
+        let opts = CompareOptions::new(&pricing);
+        let result = compare_from_archive(&ledger, &Query::for_session("s-X"), &opts).unwrap();
+        assert_eq!(result.analyzed_turns, 1);
+    }
+
+    #[test]
+    fn honors_min_sample_flagging() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[
+                fake_turn(
+                    "s-1",
+                    "m-1",
+                    "2026-04-20T00:00:00.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Refactoring),
+                    Some(true),
+                    None,
+                    default_usage(1000),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+                fake_turn(
+                    "s-2",
+                    "m-2",
+                    "2026-04-20T00:00:01.000Z",
+                    "claude-sonnet-4-6",
+                    Some(ActivityCategory::Refactoring),
+                    Some(true),
+                    None,
+                    default_usage(1100),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+            ])
+            .unwrap();
+
+        let opts = CompareOptions {
+            pricing: &pricing,
+            models: None,
+            min_sample: Some(5),
+        };
+        let result = compare_from_archive(&ledger, &Query::default(), &opts).unwrap();
+        let cell = &result.table.cells["claude-sonnet-4-6"]["refactoring"];
+        assert_eq!(cell.turns, 2);
+        assert!(cell.insufficient_sample);
+        assert!(!cell.no_data);
+    }
+
+    #[test]
+    fn empty_archive_yields_empty_table() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        let result =
+            compare_from_archive(&ledger, &Query::default(), &CompareOptions::new(&pricing))
+                .unwrap();
+        assert_eq!(result.analyzed_turns, 0);
+        assert!(result.table.models.is_empty());
+        assert!(result.table.categories.is_empty());
+        assert!(result.table.totals.is_empty());
+    }
+
+    #[test]
+    fn single_cell_archive_populates_exactly_one_cell() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[fake_turn(
+                "s-only",
+                "m-only",
+                "2026-04-20T00:00:00.000Z",
+                "claude-sonnet-4-6",
+                Some(ActivityCategory::Coding),
+                Some(true),
+                Some(0),
+                default_usage(1000),
+                SourceKind::ClaudeCode,
+                None,
+                None,
+            )])
+            .unwrap();
+
+        let result =
+            compare_from_archive(&ledger, &Query::default(), &CompareOptions::new(&pricing))
+                .unwrap();
+        assert_eq!(result.table.models, vec!["claude-sonnet-4-6"]);
+        assert_eq!(result.table.categories, vec!["coding"]);
+        let cell = &result.table.cells["claude-sonnet-4-6"]["coding"];
+        assert_eq!(cell.turns, 1);
+        assert_eq!(cell.edit_turns, 1);
+        assert_eq!(cell.one_shot_turns, 1);
+        assert_eq!(cell.median_retries, Some(0.0));
+        assert!(!cell.no_data);
+        // Default min_sample (5) makes this insufficient — documented
+        // behavior; the cell still reports its metrics, just flagged.
+        assert!(cell.insufficient_sample);
+    }
+
+    #[test]
+    fn groups_unclassified_turns_under_unclassified() {
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[
+                fake_turn(
+                    "s-1",
+                    "m-u1",
+                    "2026-04-20T00:00:00.000Z",
+                    "claude-sonnet-4-6",
+                    None,
+                    None,
+                    None,
+                    default_usage(1000),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+                fake_turn(
+                    "s-2",
+                    "m-u2",
+                    "2026-04-20T00:00:01.000Z",
+                    "claude-sonnet-4-6",
+                    None,
+                    None,
+                    None,
+                    default_usage(1100),
+                    SourceKind::ClaudeCode,
+                    None,
+                    None,
+                ),
+            ])
+            .unwrap();
+
+        let result =
+            compare_from_archive(&ledger, &Query::default(), &CompareOptions::new(&pricing))
+                .unwrap();
+        assert!(result.table.categories.iter().any(|c| c == "unclassified"));
+        assert_eq!(
+            result.table.cells["claude-sonnet-4-6"]["unclassified"].turns,
+            2
+        );
+    }
+
+    #[test]
+    fn codex_turns_bill_reasoning_as_included_in_output() {
+        // Regression guard: Codex's `output_tokens` already includes
+        // reasoning, so a Codex turn with reasoning_tokens > 0 must NOT
+        // pay reasoning on top. The archive path delegates costing to
+        // `cost_for_turn`, which honors the per-source override.
+        let tmp = TempDir::new().unwrap();
+        let mut ledger = open_in(&tmp);
+        let pricing = load_builtin_pricing();
+
+        ledger
+            .append_turns(&[fake_turn(
+                "s-cx",
+                "m-cx",
+                "2026-04-20T00:00:00.000Z",
+                "gpt-5-codex",
+                Some(ActivityCategory::Coding),
+                Some(true),
+                Some(0),
+                Usage {
+                    input: 10000,
+                    output: 2000,
+                    reasoning: 800,
+                    cache_read: 0,
+                    cache_create_5m: 0,
+                    cache_create_1h: 0,
+                },
+                SourceKind::Codex,
+                None,
+                None,
+            )])
+            .unwrap();
+
+        let opts = CompareOptions::new(&pricing);
+        let in_memory_turns = ledger.query_turns(&Query::default()).unwrap();
+        let in_memory = crate::compare::build_compare_table(&in_memory_turns, &opts);
+        let from_archive = compare_from_archive(&ledger, &Query::default(), &opts).unwrap();
+
+        let expected = in_memory
+            .cells
+            .get("gpt-5-codex")
+            .and_then(|by_cat| by_cat.get("coding"))
+            .map(|c| c.total_cost)
+            .unwrap_or(0.0);
+        let got = from_archive
+            .table
+            .cells
+            .get("gpt-5-codex")
+            .and_then(|by_cat| by_cat.get("coding"))
+            .map(|c| c.total_cost)
+            .unwrap_or(0.0);
+        assert_num_near(Some(got), Some(expected), "Codex reasoning-mode parity");
+    }
+}

--- a/crates/relayburn-analyze/src/lib.rs
+++ b/crates/relayburn-analyze/src/lib.rs
@@ -15,6 +15,8 @@
 //! 1e-9 USD precision contract that the future `overhead` sub-issue gates
 //! against.
 
+pub mod compare;
+pub mod compare_archive;
 pub mod cost;
 pub mod fidelity;
 pub mod findings;
@@ -23,6 +25,11 @@ pub mod provider;
 pub mod provider_reattribution;
 pub mod quality;
 
+pub use compare::{
+    build_compare_table, CompareCategory, CompareCell, CompareOptions, CompareTable, CompareTotals,
+    DEFAULT_MIN_SAMPLE,
+};
+pub use compare_archive::{compare_from_archive, CompareFromArchiveResult};
 pub use cost::{
     cost_for_turn, cost_for_usage, lookup_model_rate, sum_costs, CostBreakdown, CostForUsageOptions,
 };


### PR DESCRIPTION
## Summary

Closes #269.

Ports `packages/analyze/src/compare.ts` and `compare-archive.ts` to Rust under `relayburn-analyze`.

- `compare::build_compare_table` is the in-memory `(model, activity)` rollup. Per-cell metrics: turns, edit / one-shot / priced counts, total cost, mean cost, one-shot rate, cache-hit rate, median retries, plus the mutually exclusive `no_data` / `insufficient_sample` flags. Cell ordering matches TS — rows by total cost DESC then ASCII-lex on the model id; columns by total turns DESC then by label ASC.
- `compare_archive::compare_from_archive` is a thin shell over `Ledger::query_turns` + `build_compare_table`. Per #259's redesign the SQLite ledger already exposes typed columns through the reader API, so the TS path's bespoke per-column SQL aggregation is unnecessary and we get the same per-cell parity for free. `analyzed_turns` is the pre-`models`-filter count, mirroring the TS `queryAll(q).length` semantics.
- Public surface (per the issue's acceptance bullet): `CompareCell`, `CompareTable`, `CompareTotals`, `CompareOptions`, `CompareCategory`, `DEFAULT_MIN_SAMPLE`, `build_compare_table`, `compare_from_archive`, `CompareFromArchiveResult`.

## Test plan

- [x] `cargo test -p relayburn-analyze` — 105 → 125 tests, +20 covering compare + compare-archive (parity, models filter pre-seed, since/project/session filters, min-sample flagging, empty / single-cell archives, unclassified bucketing, Codex `included_in_output` regression).
- [x] `cargo build --workspace --all-targets` — clean.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy -p relayburn-analyze --all-targets --no-deps -- -D warnings` — clean.
- [x] `cargo fmt --check -p relayburn-analyze` — clean.

https://claude.ai/code/session_01YJqf8ucCjrDCKeVNVY8UcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJqf8ucCjrDCKeVNVY8UcR)_