### PR TITLE
relayburn-reader: port Claude Code parser (#255)

### DIFF
--- a/crates/relayburn-reader/src/claude.rs
+++ b/crates/relayburn-reader/src/claude.rs
@@ -3039,7 +3039,7 @@ mod tests {
     // `tests/fixtures/claude/` directory so the TS and Rust suites exercise
     // the same input bytes.
 
-    use crate::types::ActivityCategory;
+    use crate::types::{ActivityCategory, FidelityClass, UserTurnBlockKind};
     use std::io::Write as _;
 
     fn read_bytes(p: &std::path::Path) -> Vec<u8> {
@@ -3699,5 +3699,1164 @@ mod tests {
         assert_eq!(s2.agent_id.as_deref(), Some("u-sub2-user"));
         assert_eq!(s2.parent_agent_id.as_deref(), Some("u-sub1-user"));
         assert_eq!(s2.parent_tool_use_id.as_deref(), Some("toolu_inner"));
+    }
+
+    // ----- parseClaudeSession (synchronous) extended conformance -----
+    //
+    // Mirrors the remaining `it()` cases under the top
+    // `describe('parseClaudeSession', ...)` block in
+    // `packages/reader/src/claude.test.ts` (lines 17-311) so the Rust port
+    // gates on byte-equivalent assertions against the same shared fixtures.
+
+    #[test]
+    fn simple_turn_records_project_and_full_usage() {
+        // Mirrors `it('parses a simple one-turn session')` lines 18-38, adding
+        // the project field and the full Usage struct that the lighter
+        // `simple_turn_parses` test above does not check.
+        let path = fixture("simple-turn.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let t = &res.turns[0];
+        assert_eq!(t.project.as_deref(), Some("/tmp/project"));
+        assert_eq!(
+            t.usage,
+            Usage {
+                input: 10,
+                output: 5,
+                reasoning: 0,
+                cache_read: 500,
+                cache_create_5m: 80,
+                cache_create_1h: 20,
+            }
+        );
+    }
+
+    #[test]
+    fn multi_block_turn_keeps_usage_once() {
+        // Mirrors `it('dedupes a multi-block assistant message and keeps usage once')`
+        // (claude.test.ts:40). The four assistant lines for `msg_multi_1` repeat
+        // the same usage block; the parser must collapse to one turn that
+        // counts that usage exactly once.
+        let path = fixture("multi-block-turn.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let t = &res.turns[0];
+        assert_eq!(
+            t.usage,
+            Usage {
+                input: 3,
+                output: 43,
+                reasoning: 0,
+                cache_read: 11496,
+                cache_create_5m: 0,
+                cache_create_1h: 4773,
+            }
+        );
+    }
+
+    #[test]
+    fn stable_args_hash_for_identical_tool_inputs() {
+        // claude.test.ts:113 — `argsHash` is a content hash, so two parses of
+        // the same fixture must produce identical hashes; different inputs in
+        // the same turn must hash differently.
+        let path = fixture("multi-block-turn.jsonl");
+        let a = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let b = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert_eq!(
+            a.turns[0].tool_calls[0].args_hash,
+            b.turns[0].tool_calls[0].args_hash
+        );
+        assert_ne!(
+            a.turns[0].tool_calls[0].args_hash,
+            a.turns[0].tool_calls[1].args_hash
+        );
+    }
+
+    #[test]
+    fn marks_tool_call_is_error_when_tool_result_has_is_error_true() {
+        // claude.test.ts:120 — every Bash call in retry-loop.jsonl is followed
+        // by a tool_result carrying is_error=true. The parser back-populates
+        // ToolCall.isError so consumers don't need a separate join.
+        let path = fixture("retry-loop.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert_eq!(res.turns.len(), 4);
+        for t in &res.turns {
+            assert_eq!(t.tool_calls.len(), 1);
+            assert_eq!(t.tool_calls[0].name, "Bash");
+            assert_eq!(t.tool_calls[0].is_error, Some(true));
+        }
+    }
+
+    #[test]
+    fn back_populates_replacement_meta_from_tool_result() {
+        // claude.test.ts:130 — tool_result `_meta.replaces` and
+        // `_meta.collapsedCalls` are surfaced both on the originating ToolCall
+        // and on the matching ToolResultEventRecord. Calls without _meta keep
+        // the fields absent.
+        let path = fixture("replacement-meta.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let all: Vec<&ToolCall> = res.turns.iter().flat_map(|t| t.tool_calls.iter()).collect();
+        let search = all
+            .iter()
+            .find(|tc| tc.name == "relaywash__Search")
+            .expect("search tool call present");
+        let read = all
+            .iter()
+            .find(|tc| tc.name == "Read")
+            .expect("read tool call present");
+        assert_eq!(
+            search.replaced_tools.as_deref(),
+            Some(["Glob".to_string(), "Grep".to_string(), "Read".to_string()].as_slice())
+        );
+        assert_eq!(search.collapsed_calls, Some(9));
+        assert!(read.replaced_tools.is_none());
+        assert!(read.collapsed_calls.is_none());
+
+        let search_event = res
+            .tool_result_events
+            .iter()
+            .find(|e| e.tool_use_id == "tu_search_1")
+            .expect("search tool_result event present");
+        assert_eq!(
+            search_event.replaced_tools.as_deref(),
+            Some(["Glob".to_string(), "Grep".to_string(), "Read".to_string()].as_slice())
+        );
+        assert_eq!(search_event.collapsed_calls, Some(9));
+    }
+
+    #[test]
+    fn extracts_edit_pre_and_post_hashes() {
+        // claude.test.ts:151 — Edit tool calls carry editPreHash / editPostHash
+        // derived from old_string / new_string. A revert (second edit's post ==
+        // first edit's pre) is detectable by comparing the hashes.
+        let path = fixture("edit-revert.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let edits: Vec<&ToolCall> = res
+            .turns
+            .iter()
+            .flat_map(|t| t.tool_calls.iter())
+            .filter(|tc| tc.name == "Edit")
+            .collect();
+        assert_eq!(edits.len(), 2);
+        assert!(edits[0].edit_pre_hash.is_some());
+        assert!(edits[0].edit_post_hash.is_some());
+        assert_eq!(edits[1].edit_post_hash, edits[0].edit_pre_hash);
+        assert_eq!(edits[1].edit_pre_hash, edits[0].edit_post_hash);
+    }
+
+    #[test]
+    fn tool_result_events_chronological_with_full_metadata() {
+        // claude.test.ts:165 — every tool_result block in retry-loop.jsonl
+        // becomes a ToolResultEventRecord. Status is `errored`, contentLength
+        // and contentHash are populated, and eventIndex is monotonic.
+        let path = fixture("retry-loop.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert_eq!(res.tool_result_events.len(), 4);
+        for ev in &res.tool_result_events {
+            assert_eq!(ev.v, 1);
+            assert_eq!(ev.source, SourceKind::ClaudeCode);
+            assert_eq!(ev.event_source, ToolResultEventSource::ToolResult);
+            assert_eq!(ev.status, ToolResultStatus::Errored);
+            assert_eq!(ev.is_error, Some(true));
+            assert!(ev.content_length.is_some());
+            assert!(ev.content_hash.is_some());
+        }
+        for w in res.tool_result_events.windows(2) {
+            assert!(w[1].event_index > w[0].event_index);
+        }
+    }
+
+    #[test]
+    fn relationships_root_plus_subagent_per_invocation() {
+        // claude.test.ts:187 — one root row per session, one subagent row per
+        // distinct invocation (agentId). Outer's parent is the main session
+        // id; inner's parent is the outer invocation's agentId. Source is
+        // `native-claude` per the TS spec (not `claude-code`) — that flag
+        // separates harness-emitted edges from cross-source spawn-env edges.
+        let path = fixture("nested-subagent.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let roots: Vec<_> = res
+            .relationships
+            .iter()
+            .filter(|r| matches!(r.relationship_type, RelationshipType::Root))
+            .collect();
+        let subs: Vec<_> = res
+            .relationships
+            .iter()
+            .filter(|r| matches!(r.relationship_type, RelationshipType::Subagent))
+            .collect();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].session_id, "55555555-5555-5555-5555-555555555555");
+        assert_eq!(subs.len(), 2);
+
+        let outer = subs
+            .iter()
+            .find(|r| r.subagent_type.as_deref() == Some("Explore"))
+            .expect("outer subagent row present");
+        let inner = subs
+            .iter()
+            .find(|r| r.subagent_type.as_deref() == Some("code-reviewer"))
+            .expect("inner subagent row present");
+
+        assert_eq!(outer.agent_id.as_deref(), Some("u-sub1-user"));
+        assert_eq!(outer.source, RelationshipSourceKind::NativeClaude);
+        assert_eq!(outer.parent_tool_use_id.as_deref(), Some("toolu_outer"));
+        assert_eq!(
+            outer.related_session_id.as_deref(),
+            Some("55555555-5555-5555-5555-555555555555")
+        );
+        assert_eq!(outer.description.as_deref(), Some("Research the codebase"));
+
+        assert_eq!(inner.agent_id.as_deref(), Some("u-sub2-user"));
+        assert_eq!(inner.parent_tool_use_id.as_deref(), Some("toolu_inner"));
+        assert_eq!(inner.related_session_id.as_deref(), Some("u-sub1-user"));
+    }
+
+    #[test]
+    fn tool_result_events_join_to_spawned_subagent_via_agent_id() {
+        // claude.test.ts:216 — Agent/Task tool_results inherit the spawned
+        // subagent's agentId so cross-table joins work without a separate
+        // subagent index.
+        let path = fixture("nested-subagent.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let outer = res
+            .tool_result_events
+            .iter()
+            .find(|e| e.tool_use_id == "toolu_outer")
+            .expect("outer Agent tool_result event present");
+        let inner = res
+            .tool_result_events
+            .iter()
+            .find(|e| e.tool_use_id == "toolu_inner")
+            .expect("inner Agent tool_result event present");
+        assert_eq!(outer.agent_id.as_deref(), Some("u-sub1-user"));
+        assert_eq!(inner.agent_id.as_deref(), Some("u-sub2-user"));
+    }
+
+    #[test]
+    fn system_subagent_notification_emits_tool_result_event() {
+        // claude.test.ts:228 — a `system` line with subtype
+        // `subagent_completed` becomes a ToolResultEventRecord (not a
+        // CompactionEvent), with eventSource=`subagent_notification` and the
+        // child session id surfaced.
+        let path = fixture("system-subagent-notification.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert_eq!(res.events.len(), 0);
+        assert_eq!(res.tool_result_events.len(), 1);
+        let ev = &res.tool_result_events[0];
+        assert_eq!(ev.source, SourceKind::ClaudeCode);
+        assert_eq!(ev.session_id, "22222222-2222-2222-2222-222222222222");
+        assert_eq!(ev.tool_use_id, "toolu_system");
+        assert_eq!(ev.event_source, ToolResultEventSource::SubagentNotification);
+        assert_eq!(ev.status, ToolResultStatus::Completed);
+        assert_eq!(ev.agent_id.as_deref(), Some("agent-system-1"));
+        assert_eq!(
+            ev.subagent_session_id.as_deref(),
+            Some("session-system-child")
+        );
+        assert_eq!(ev.call_index, Some(0));
+        assert_eq!(ev.event_index, 0);
+        assert!(ev.content_length.is_some());
+        assert!(ev.content_hash.is_some());
+    }
+
+    #[test]
+    fn fidelity_full_coverage_on_normal_turn() {
+        // claude.test.ts:248 — simple-turn carries every usage field, so the
+        // turn surfaces full coverage and class=Full. tool/relationship flags
+        // are capability-level (always true for Claude even on a no-tool turn);
+        // reasoning is always false because the harness doesn't surface it.
+        let path = fixture("simple-turn.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let t = &res.turns[0];
+        let f = t.fidelity.as_ref().expect("fidelity should be populated");
+        assert_eq!(f.granularity, UsageGranularity::PerTurn);
+        assert!(f.coverage.has_input_tokens);
+        assert!(f.coverage.has_output_tokens);
+        assert!(f.coverage.has_cache_read_tokens);
+        assert!(f.coverage.has_cache_create_tokens);
+        assert!(!f.coverage.has_reasoning_tokens);
+        assert!(f.coverage.has_tool_calls);
+        assert!(f.coverage.has_tool_result_events);
+        assert!(f.coverage.has_session_relationships);
+        assert_eq!(f.class, FidelityClass::Full);
+    }
+
+    #[test]
+    fn fidelity_marks_missing_output_tokens_as_partial() {
+        // claude.test.ts:270 — Usage.output is forced to 0 (the wire shape
+        // requires *some* number) but coverage.hasOutputTokens=false makes the
+        // distinction visible. Class falls below Full to Partial because not
+        // all required fields are populated.
+        let path = fixture("missing-output-tokens.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let t = &res.turns[0];
+        assert_eq!(t.usage.output, 0);
+        let f = t.fidelity.as_ref().unwrap();
+        assert!(f.coverage.has_input_tokens);
+        assert!(!f.coverage.has_output_tokens);
+        assert!(!f.coverage.has_cache_read_tokens);
+        assert!(!f.coverage.has_cache_create_tokens);
+        assert_eq!(f.class, FidelityClass::Partial);
+    }
+
+    #[test]
+    fn fidelity_has_tool_calls_on_tool_use_turn() {
+        // claude.test.ts:289 — the Coverage flag is capability-level, so a
+        // turn that *did* emit tool_use blocks must reflect that; class stays
+        // Full because every required field is populated.
+        let path = fixture("multi-block-turn.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let f = res.turns[0].fidelity.as_ref().unwrap();
+        assert!(f.coverage.has_tool_calls);
+        assert_eq!(f.class, FidelityClass::Full);
+    }
+
+    #[test]
+    fn compact_boundary_emits_compaction_event() {
+        // claude.test.ts:297 — a `system` line with subtype `compact_boundary`
+        // produces one CompactionEvent anchored to the assistant turn that
+        // immediately preceded it. tokensBeforeCompact mirrors that turn's
+        // cacheRead.
+        let path = fixture("compact-boundary.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert_eq!(res.events.len(), 1);
+        let ev = &res.events[0];
+        assert_eq!(ev.source, SourceKind::ClaudeCode);
+        assert_eq!(ev.session_id, "compact-session");
+        assert_eq!(ev.preceding_message_id.as_deref(), Some("msg_c_1"));
+        let preceding = res
+            .turns
+            .iter()
+            .find(|t| t.message_id == "msg_c_1")
+            .unwrap();
+        assert_eq!(ev.tokens_before_compact, Some(preceding.usage.cache_read));
+        assert_eq!(ev.tokens_before_compact, Some(9000));
+    }
+
+    // ----- parseClaudeSession user-turn block sizes (issue #2) -----
+
+    #[test]
+    fn user_turn_blocks_text_and_tool_results() {
+        // claude.test.ts:314 — three user lines → three UserTurnRecord rows.
+        // The first is plain text, the second carries Bash + Read tool_results
+        // (the Read body is much larger than the Bash body), the third carries
+        // an errored tool_result. precedingMessageId is undefined for the
+        // first user turn (no prior assistant) and otherwise points at the
+        // immediately-prior assistant message; followingMessageId points at
+        // the next assistant.
+        let path = fixture("user-turn-blocks.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert_eq!(res.user_turns.len(), 3);
+
+        let first = &res.user_turns[0];
+        assert_eq!(first.user_uuid, "u-user-1");
+        assert!(first.preceding_message_id.is_none());
+        assert_eq!(first.following_message_id.as_deref(), Some("msg_utb_1"));
+        assert_eq!(first.blocks.len(), 1);
+        assert_eq!(first.blocks[0].kind, UserTurnBlockKind::Text);
+        assert_eq!(
+            first.blocks[0].byte_len,
+            "please fix the build".len() as u64
+        );
+        // The TS test asserts `4` (cl100k). The Rust port has not wired
+        // cl100k yet — see #246 — so the heuristic counter (`ceil(byteLen/4)`)
+        // is the default, which makes this 5 for the same 20-byte prompt.
+        // The `user_turn_heuristic_tokenizer_explicit_opt_in` test pins the
+        // heuristic formula explicitly; once cl100k lands here we'll flip
+        // this back to `4` to match TS byte-for-byte.
+        assert_eq!(
+            first.blocks[0].approx_tokens,
+            ("please fix the build".len() as u64).div_ceil(4)
+        );
+
+        let second = &res.user_turns[1];
+        assert_eq!(second.preceding_message_id.as_deref(), Some("msg_utb_1"));
+        assert_eq!(second.following_message_id.as_deref(), Some("msg_utb_2"));
+        assert_eq!(second.blocks.len(), 2);
+        let bash = second
+            .blocks
+            .iter()
+            .find(|b| b.tool_use_id.as_deref() == Some("tu_bash_1"))
+            .unwrap();
+        let read = second
+            .blocks
+            .iter()
+            .find(|b| b.tool_use_id.as_deref() == Some("tu_read_1"))
+            .unwrap();
+        assert_eq!(bash.kind, UserTurnBlockKind::ToolResult);
+        assert_eq!(bash.byte_len, "a\nb\n".len() as u64);
+        assert_eq!(read.byte_len, 100);
+        assert!(read.byte_len > bash.byte_len);
+        assert!(bash.is_error.is_none());
+        assert!(read.is_error.is_none());
+
+        let third = &res.user_turns[2];
+        assert_eq!(third.preceding_message_id.as_deref(), Some("msg_utb_2"));
+        assert_eq!(third.following_message_id.as_deref(), Some("msg_utb_3"));
+        assert_eq!(third.blocks.len(), 1);
+        let err_block = &third.blocks[0];
+        assert_eq!(err_block.kind, UserTurnBlockKind::ToolResult);
+        assert_eq!(err_block.tool_use_id.as_deref(), Some("tu_bash_2"));
+        assert_eq!(err_block.is_error, Some(true));
+    }
+
+    #[test]
+    fn user_turn_input_delta_is_positive_for_real_io() {
+        // claude.test.ts:355 — sanity gate: when there's real I/O across a
+        // (precedingMessageId, followingMessageId) pair, both the
+        // input-side delta and the per-block token sum must be positive. The
+        // ±5% reconciliation in the TS test depends on the cl100k tokenizer,
+        // which the Rust port has not wired (HeuristicCounter is still the
+        // default — see #246), so we only enforce the positive-on-both-sides
+        // invariant here.
+        let path = fixture("user-turn-blocks.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        let by_mid: HashMap<&str, &TurnRecord> = res
+            .turns
+            .iter()
+            .map(|t| (t.message_id.as_str(), t))
+            .collect();
+        for u in &res.user_turns {
+            let prev_id = match u.preceding_message_id.as_deref() {
+                Some(p) => p,
+                None => continue,
+            };
+            let next_id = match u.following_message_id.as_deref() {
+                Some(n) => n,
+                None => continue,
+            };
+            let prev = by_mid.get(prev_id).unwrap();
+            let next = by_mid.get(next_id).unwrap();
+            let input_delta =
+                (next.usage.input + next.usage.cache_create_5m + next.usage.cache_create_1h) as i64
+                    - prev.usage.output as i64;
+            let user_tokens: u64 = u.blocks.iter().map(|b| b.approx_tokens).sum();
+            assert!(
+                user_tokens > 0,
+                "user turn {} should contribute tokens",
+                u.user_uuid
+            );
+            assert!(input_delta > 0, "delta for {} should be positive", next_id);
+        }
+    }
+
+    #[test]
+    fn user_turn_heuristic_tokenizer_explicit_opt_in() {
+        // claude.test.ts:378 — with the heuristic tokenizer the first text
+        // block's approxTokens is `ceil(byte_len / 4)`. The Rust default is
+        // also heuristic, but mirroring the TS test means asking for it
+        // explicitly so we exercise the option plumbing.
+        let path = fixture("user-turn-blocks.jsonl");
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                tokenizer: Some(UserTurnTokenizer::Heuristic),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let first = &res.user_turns[0];
+        assert_eq!(
+            first.blocks[0].byte_len,
+            "please fix the build".len() as u64
+        );
+        let expected = ("please fix the build".len() as u64).div_ceil(4);
+        assert_eq!(first.blocks[0].approx_tokens, expected);
+    }
+
+    #[test]
+    fn user_turn_present_for_simple_text_session() {
+        // claude.test.ts:405 — even a one-turn session emits one UserTurnRecord
+        // with a single text block. (The TS comment explains why simple-turn
+        // is the right fixture instead of sidechain-turn.)
+        let path = fixture("simple-turn.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert_eq!(res.user_turns.len(), 1);
+        assert_eq!(res.user_turns[0].blocks.len(), 1);
+        assert_eq!(res.user_turns[0].blocks[0].kind, UserTurnBlockKind::Text);
+    }
+
+    // ----- parseClaudeSession content capture -----
+
+    #[test]
+    fn content_default_off_returns_empty() {
+        // claude.test.ts:418 — without `contentMode`, the parser does not
+        // capture text bodies. Hash-only is the same shape (also empty) — the
+        // sidecar handles hashing separately.
+        let path = fixture("simple-turn.jsonl");
+        let res = parse_claude_session(&path, &ParseOptions::default()).unwrap();
+        assert!(res.content.is_empty());
+    }
+
+    #[test]
+    fn content_hash_only_returns_empty() {
+        // claude.test.ts:423 — hash-only mode is also empty at the parser
+        // level (the writer derives sidecar entries downstream).
+        let path = fixture("simple-turn.jsonl");
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                content_mode: Some(ContentStoreMode::HashOnly),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(res.content.is_empty());
+    }
+
+    #[test]
+    fn content_full_captures_user_and_assistant_text() {
+        // claude.test.ts:430 — `contentMode: 'full'` returns one user text
+        // record and one assistant text record with full provenance.
+        let path = fixture("simple-turn.jsonl");
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                content_mode: Some(ContentStoreMode::Full),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(res.content.len(), 2);
+        let user = res
+            .content
+            .iter()
+            .find(|c| matches!(c.role, ContentRole::User))
+            .expect("user content present");
+        assert_eq!(user.kind, ContentKind::Text);
+        assert_eq!(user.text.as_deref(), Some("hello"));
+        assert_eq!(user.session_id, "11111111-1111-1111-1111-111111111111");
+        let asst = res
+            .content
+            .iter()
+            .find(|c| matches!(c.role, ContentRole::Assistant))
+            .expect("assistant content present");
+        assert_eq!(asst.kind, ContentKind::Text);
+        assert_eq!(asst.text.as_deref(), Some("Hello!"));
+        assert_eq!(asst.message_id, "msg_simple_1");
+        assert_eq!(asst.source, SourceKind::ClaudeCode);
+    }
+
+    #[test]
+    fn content_chronological_across_interleaved_turns() {
+        // claude.test.ts:448 — content rows preserve interleaved turn order
+        // across user/assistant pairs.
+        let path = fixture("interleaved-turns.jsonl");
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                content_mode: Some(ContentStoreMode::Full),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let sequence: Vec<String> = res
+            .content
+            .iter()
+            .map(|c| {
+                let role = match c.role {
+                    ContentRole::User => "user",
+                    ContentRole::Assistant => "assistant",
+                    ContentRole::ToolResult => "tool_result",
+                };
+                format!("{}:{}", role, c.text.as_deref().unwrap_or(""))
+            })
+            .collect();
+        assert_eq!(
+            sequence,
+            vec![
+                "user:first question".to_string(),
+                "assistant:first answer".to_string(),
+                "user:second question".to_string(),
+                "assistant:second answer".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn content_captures_tool_use_blocks_in_multi_block_turn() {
+        // claude.test.ts:462 — assistant content for a multi-block turn
+        // surfaces the text + two tool_use blocks. The empty-string thinking
+        // block is omitted (per parser policy: skip thinking blocks with no
+        // body).
+        let path = fixture("multi-block-turn.jsonl");
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                content_mode: Some(ContentStoreMode::Full),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let asst: Vec<&ContentRecord> = res
+            .content
+            .iter()
+            .filter(|c| matches!(c.role, ContentRole::Assistant))
+            .collect();
+        let mut kinds: Vec<&str> = asst
+            .iter()
+            .map(|c| match c.kind {
+                ContentKind::Text => "text",
+                ContentKind::Thinking => "thinking",
+                ContentKind::ToolUse => "tool_use",
+                ContentKind::ToolResult => "tool_result",
+            })
+            .collect();
+        kinds.sort();
+        assert_eq!(kinds, vec!["text", "tool_use", "tool_use"]);
+        let tool_uses: Vec<&ContentRecord> = asst
+            .iter()
+            .copied()
+            .filter(|c| matches!(c.kind, ContentKind::ToolUse))
+            .collect();
+        let bash_use = tool_uses
+            .iter()
+            .find(|c| c.tool_use.as_ref().map(|tu| tu.name.as_str()) == Some("Bash"))
+            .expect("Bash tool_use surfaced");
+        let agent_use = tool_uses
+            .iter()
+            .find(|c| c.tool_use.as_ref().map(|tu| tu.name.as_str()) == Some("Agent"))
+            .expect("Agent tool_use surfaced");
+        let bash_input = &bash_use.tool_use.as_ref().unwrap().input;
+        assert_eq!(bash_input.len(), 1);
+        assert_eq!(
+            bash_input.get("command").and_then(|v| v.as_str()),
+            Some("ls -la /tmp/project")
+        );
+        assert_eq!(agent_use.tool_use.as_ref().unwrap().name, "Agent");
+    }
+
+    // ----- parseClaudeSession fork / continuation relationships (#112) -----
+    //
+    // Mirrors `describe('parseClaudeSession fork / continuation relationships')`
+    // (claude.test.ts:991-1267). These exercise the per-file relationship
+    // evidence and the cross-file `reconcile_claude_session_relationships`
+    // pass.
+
+    #[test]
+    fn resume_marker_emits_continuation_with_provenance() {
+        // claude.test.ts:992 — a `/resume <id>` slash command produces a
+        // continuation row whose relatedSessionId is the resume target. The
+        // file basename (`resume-marker`) becomes sessionId; the in-log
+        // sessionId surfaces as sourceSessionId.
+        let path = fixture("resume-marker.jsonl");
+        let session_path = path.to_string_lossy().into_owned();
+        let res = parse_claude_session_incremental(
+            &path,
+            &ParseIncrementalOptions {
+                session_path: Some(session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let cont = res
+            .relationships
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Continuation))
+            .expect("/resume marker must produce a continuation row");
+        assert_eq!(cont.session_id, "resume-marker");
+        assert_eq!(
+            cont.related_session_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        assert_eq!(
+            cont.source_session_id.as_deref(),
+            Some("99999999-9999-9999-9999-999999999999")
+        );
+        assert_eq!(cont.source_version.as_deref(), Some("2.1.97"));
+    }
+
+    #[test]
+    fn resume_marker_root_carries_provenance_when_in_log_id_differs() {
+        // claude.test.ts:1010 — when the file basename and in-log sessionId
+        // disagree, both the continuation row and the root row carry the
+        // mismatched in-log id as sourceSessionId plus the version banner.
+        let path = fixture("resume-marker.jsonl");
+        let session_path = path.to_string_lossy().into_owned();
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                session_path: Some(session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let root = res
+            .relationships
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Root))
+            .expect("root row should still be emitted");
+        assert_eq!(root.session_id, "resume-marker");
+        assert_eq!(
+            root.source_session_id.as_deref(),
+            Some("99999999-9999-9999-9999-999999999999")
+        );
+        assert_eq!(root.source_version.as_deref(), Some("2.1.97"));
+    }
+
+    #[test]
+    fn explicit_line_continuedfrom_and_fork_session_id() {
+        // claude.test.ts:1020 — `continuedFromSessionId` and `forkSessionId`
+        // on a line surface as continuation and fork rows respectively.
+        // Evidence carries the explicit target ids so reconciliation can dedup
+        // against them.
+        let path = fixture("explicit-line-relationships.jsonl");
+        let session_path = path.to_string_lossy().into_owned();
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                session_path: Some(session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let cont = res
+            .relationships
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Continuation))
+            .expect("continuedFromSessionId must produce a continuation row");
+        let fork = res
+            .relationships
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Fork))
+            .expect("forkSessionId must produce a fork row");
+        assert_eq!(cont.session_id, "explicit-line-relationships");
+        assert_eq!(cont.related_session_id.as_deref(), Some("original-session"));
+        assert_eq!(
+            cont.source_session_id.as_deref(),
+            Some("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        );
+        assert_eq!(cont.source_version.as_deref(), Some("2.1.98"));
+        assert_eq!(fork.session_id, "explicit-line-relationships");
+        assert_eq!(
+            fork.related_session_id.as_deref(),
+            Some("fork-source-session")
+        );
+        assert_eq!(
+            fork.source_session_id.as_deref(),
+            Some("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        );
+        assert_eq!(fork.source_version.as_deref(), Some("2.1.98"));
+
+        assert_eq!(
+            res.evidence
+                .explicit_continuation_target_session_ids
+                .as_deref(),
+            Some(["original-session".to_string()].as_slice())
+        );
+        assert_eq!(
+            res.evidence.explicit_fork_target_session_ids.as_deref(),
+            Some(["fork-source-session".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn reconciliation_skips_explicit_continuation_edge() {
+        // claude.test.ts:1042 — when a file already emits a
+        // `continuedFromSessionId` continuation row, the cross-file
+        // parentUuid pass must not re-emit the same edge. Otherwise the
+        // ledger would dedup but only after writing duplicates.
+        let original_path = fixture("original-session.jsonl");
+        let explicit_path = fixture("explicit-line-relationships.jsonl");
+        let original_session_path = original_path.to_string_lossy().into_owned();
+        let explicit_session_path = explicit_path.to_string_lossy().into_owned();
+        let original = parse_claude_session(
+            &original_path,
+            &ParseOptions {
+                session_path: Some(original_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let explicit = parse_claude_session(
+            &explicit_path,
+            &ParseOptions {
+                session_path: Some(explicit_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(explicit.relationships.iter().any(|r| matches!(
+            r.relationship_type,
+            RelationshipType::Continuation
+        ) && r.session_id
+            == "explicit-line-relationships"
+            && r.related_session_id.as_deref() == Some("original-session")));
+
+        let reconciled = reconcile_claude_session_relationships(&[
+            ReconcileClaudeRelationshipsInput {
+                evidence: original.evidence,
+            },
+            ReconcileClaudeRelationshipsInput {
+                evidence: explicit.evidence,
+            },
+        ]);
+        let dup = reconciled.iter().any(|r| {
+            matches!(r.relationship_type, RelationshipType::Continuation)
+                && r.session_id == "explicit-line-relationships"
+                && r.related_session_id.as_deref() == Some("original-session")
+        });
+        assert!(
+            !dup,
+            "cross-file parentUuid inference must not duplicate the explicit edge"
+        );
+    }
+
+    #[test]
+    fn first_parent_uuid_skips_leading_sidechain_user_line() {
+        // claude.test.ts:1077 — the `firstParentUuid` evidence is gated to
+        // the first non-sidechain user line, so a sidechain user line that
+        // happens to come first is ignored. (The TS gate uses a module-level
+        // WeakSet; the Rust port tracks `user_seen` inline.)
+        let path = fixture("sidechain-leading-then-main.jsonl");
+        let session_path = path.to_string_lossy().into_owned();
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                session_path: Some(session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            res.evidence.first_parent_uuid.as_deref(),
+            Some("u-original-asst")
+        );
+    }
+
+    #[test]
+    fn evidence_exposes_per_file_signals_for_reconciliation() {
+        // claude.test.ts:1083 — evidence carries everything the cross-file
+        // reconciler needs: file id, source version, the resume-marker flag
+        // and target, and the seenUuids set the cross-file pass joins on.
+        let path = fixture("resume-marker.jsonl");
+        let session_path = path.to_string_lossy().into_owned();
+        let res = parse_claude_session(
+            &path,
+            &ParseOptions {
+                session_path: Some(session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let ev = &res.evidence;
+        assert_eq!(ev.file_session_id.as_deref(), Some("resume-marker"));
+        assert_eq!(ev.source_version.as_deref(), Some("2.1.97"));
+        assert!(ev.has_resume_marker);
+        assert_eq!(
+            ev.resume_target_session_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        // The first non-sidechain user line's parentUuid is null in this
+        // fixture, so firstParentUuid stays None.
+        assert!(ev.first_parent_uuid.is_none());
+        assert!(ev.seen_uuids.iter().any(|s| s == "u-resume-1"));
+        assert!(ev.seen_uuids.iter().any(|s| s == "u-asst-r"));
+    }
+
+    #[test]
+    fn reconcile_emits_continuation_when_parent_uuid_lives_in_other_file() {
+        // claude.test.ts:1098 — the cross-file pass joins one file's
+        // firstParentUuid onto another file's seenUuids set, producing a
+        // continuation row that the local pass alone could not have emitted
+        // (no /resume marker).
+        let original_path = fixture("original-session.jsonl");
+        let cross_path = fixture("cross-file-parent.jsonl");
+        let original_session_path = original_path.to_string_lossy().into_owned();
+        let cross_session_path = cross_path.to_string_lossy().into_owned();
+        let original = parse_claude_session(
+            &original_path,
+            &ParseOptions {
+                session_path: Some(original_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let cross = parse_claude_session(
+            &cross_path,
+            &ParseOptions {
+                session_path: Some(cross_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            cross.evidence.first_parent_uuid.as_deref(),
+            Some("u-original-asst")
+        );
+        assert!(!cross
+            .relationships
+            .iter()
+            .any(|r| matches!(r.relationship_type, RelationshipType::Continuation)));
+
+        let reconciled = reconcile_claude_session_relationships(&[
+            ReconcileClaudeRelationshipsInput {
+                evidence: original.evidence,
+            },
+            ReconcileClaudeRelationshipsInput {
+                evidence: cross.evidence,
+            },
+        ]);
+        let cont = reconciled
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Continuation))
+            .expect("cross-file parentUuid match must produce a continuation row");
+        assert_eq!(cont.session_id, "cross-file-parent");
+        assert_eq!(cont.related_session_id.as_deref(), Some("original-session"));
+        assert_eq!(cont.source_version.as_deref(), Some("2.1.97"));
+    }
+
+    #[test]
+    fn reconcile_emits_fork_rows_when_two_files_share_source_session_id() {
+        // claude.test.ts:1128 — two branches with the same in-log sessionId
+        // (different filenames) get one fork row each pointing at the shared
+        // sourceSessionId.
+        let a_path = fixture("fork-branch-a.jsonl");
+        let b_path = fixture("fork-branch-b.jsonl");
+        let a_session_path = a_path.to_string_lossy().into_owned();
+        let b_session_path = b_path.to_string_lossy().into_owned();
+        let a = parse_claude_session(
+            &a_path,
+            &ParseOptions {
+                session_path: Some(a_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let b = parse_claude_session(
+            &b_path,
+            &ParseOptions {
+                session_path: Some(b_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let root_a = a
+            .relationships
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Root))
+            .unwrap();
+        let root_b = b
+            .relationships
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Root))
+            .unwrap();
+        assert_eq!(root_a.session_id, "fork-branch-a");
+        assert_eq!(root_b.session_id, "fork-branch-b");
+        assert_eq!(
+            root_a.source_session_id.as_deref(),
+            Some("00000000-0000-0000-0000-000000000fff")
+        );
+        assert_eq!(
+            root_b.source_session_id.as_deref(),
+            Some("00000000-0000-0000-0000-000000000fff")
+        );
+
+        let reconciled = reconcile_claude_session_relationships(&[
+            ReconcileClaudeRelationshipsInput {
+                evidence: a.evidence,
+            },
+            ReconcileClaudeRelationshipsInput {
+                evidence: b.evidence,
+            },
+        ]);
+        let forks: Vec<&SessionRelationshipRecord> = reconciled
+            .iter()
+            .filter(|r| matches!(r.relationship_type, RelationshipType::Fork))
+            .collect();
+        assert_eq!(forks.len(), 2);
+        let mut sids: Vec<&str> = forks.iter().map(|r| r.session_id.as_str()).collect();
+        sids.sort();
+        assert_eq!(sids, vec!["fork-branch-a", "fork-branch-b"]);
+        for f in forks {
+            assert_eq!(
+                f.related_session_id.as_deref(),
+                Some("00000000-0000-0000-0000-000000000fff")
+            );
+            assert_eq!(
+                f.source_session_id.as_deref(),
+                Some("00000000-0000-0000-0000-000000000fff")
+            );
+            assert_eq!(f.source_version.as_deref(), Some("2.1.97"));
+        }
+    }
+
+    #[test]
+    fn reconcile_does_not_emit_fork_for_strict_continuation() {
+        // claude.test.ts:1162 — when file B's firstParentUuid lives in file A
+        // (a strict continuation), reconciliation must not double-emit a fork
+        // row even though both files share a sourceSessionId.
+        let a_path = fixture("original-session.jsonl");
+        let b_path = fixture("cross-file-parent.jsonl");
+        let a_session_path = a_path.to_string_lossy().into_owned();
+        let b_session_path = b_path.to_string_lossy().into_owned();
+        let a = parse_claude_session(
+            &a_path,
+            &ParseOptions {
+                session_path: Some(a_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let b = parse_claude_session(
+            &b_path,
+            &ParseOptions {
+                session_path: Some(b_session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let reconciled = reconcile_claude_session_relationships(&[
+            ReconcileClaudeRelationshipsInput {
+                evidence: a.evidence,
+            },
+            ReconcileClaudeRelationshipsInput {
+                evidence: b.evidence,
+            },
+        ]);
+        let forks = reconciled
+            .iter()
+            .filter(|r| matches!(r.relationship_type, RelationshipType::Fork))
+            .count();
+        let conts = reconciled
+            .iter()
+            .filter(|r| matches!(r.relationship_type, RelationshipType::Continuation))
+            .count();
+        assert_eq!(forks, 0);
+        assert_eq!(conts, 1);
+    }
+
+    #[test]
+    fn reparsing_same_session_yields_stable_relationship_keys() {
+        // claude.test.ts:1182 — re-ingesting the same session must produce
+        // relationship rows that hash to the same dedup key, so the writer's
+        // existing dedup folds them. We reproduce the canonical key here
+        // (source + sessionId + relationshipType + relatedSessionId + agentId
+        // + parentToolUseId) instead of importing it across the
+        // reader/ledger boundary, matching the TS test exactly.
+        fn key_of(r: &SessionRelationshipRecord) -> String {
+            let source = match r.source {
+                RelationshipSourceKind::ClaudeCode => "claude-code",
+                RelationshipSourceKind::Codex => "codex",
+                RelationshipSourceKind::Opencode => "opencode",
+                RelationshipSourceKind::AnthropicApi => "anthropic-api",
+                RelationshipSourceKind::OpenaiApi => "openai-api",
+                RelationshipSourceKind::GeminiApi => "gemini-api",
+                RelationshipSourceKind::SpawnEnv => "spawn-env",
+                RelationshipSourceKind::NativeClaude => "native-claude",
+                RelationshipSourceKind::NativeOpencode => "native-opencode",
+            };
+            let kind = match r.relationship_type {
+                RelationshipType::Root => "root",
+                RelationshipType::Continuation => "continuation",
+                RelationshipType::Fork => "fork",
+                RelationshipType::Subagent => "subagent",
+            };
+            format!(
+                "{}|{}|{}|{}|{}|{}",
+                source,
+                r.session_id,
+                kind,
+                r.related_session_id.as_deref().unwrap_or(""),
+                r.agent_id.as_deref().unwrap_or(""),
+                r.parent_tool_use_id.as_deref().unwrap_or(""),
+            )
+        }
+        let path = fixture("resume-marker.jsonl");
+        let session_path = path.to_string_lossy().into_owned();
+        let opts = ParseOptions {
+            session_path: Some(session_path),
+            ..Default::default()
+        };
+        let a = parse_claude_session(&path, &opts).unwrap();
+        let b = parse_claude_session(&path, &opts).unwrap();
+        let mut ids_a: Vec<String> = a.relationships.iter().map(key_of).collect();
+        let mut ids_b: Vec<String> = b.relationships.iter().map(key_of).collect();
+        let unique_a: std::collections::HashSet<&String> = ids_a.iter().collect();
+        assert_eq!(
+            unique_a.len(),
+            a.relationships.len(),
+            "every row should hash uniquely on first parse"
+        );
+        ids_a.sort();
+        ids_b.sort();
+        assert_eq!(ids_a, ids_b);
+    }
+
+    #[test]
+    fn reconcile_skips_duplicate_continuation_when_local_resume_named_same_parent() {
+        // claude.test.ts:1216 — when the local /resume already emitted a
+        // continuation row for the same edge the cross-file pass would
+        // produce, reconciliation must not double-emit. We construct evidence
+        // pairs in memory (parent file + child file) that line up exactly:
+        // the child's firstParentUuid lives in the parent's seenUuids, AND
+        // the child's resume marker names the parent's file id. (The TS test
+        // builds partial objects; in Rust we set the fields explicitly,
+        // including the private `user_seen` gate, since we are inside the
+        // same module.)
+        let parent_evidence = ClaudeRelationshipEvidence {
+            file_session_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            in_log_session_ids: vec!["11111111-1111-1111-1111-111111111111".to_string()],
+            seen_uuids: vec!["u-original-asst".to_string()],
+            ..ClaudeRelationshipEvidence::default()
+        };
+        let child_evidence = ClaudeRelationshipEvidence {
+            file_session_id: Some("resume-marker".to_string()),
+            in_log_session_ids: vec!["99999999-9999-9999-9999-999999999999".to_string()],
+            seen_uuids: vec![],
+            has_resume_marker: true,
+            resume_target_session_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            first_parent_uuid: Some("u-original-asst".to_string()),
+            source_version: Some("2.1.97".to_string()),
+            ..ClaudeRelationshipEvidence::default()
+        };
+        let reconciled = reconcile_claude_session_relationships(&[
+            ReconcileClaudeRelationshipsInput {
+                evidence: parent_evidence,
+            },
+            ReconcileClaudeRelationshipsInput {
+                evidence: child_evidence,
+            },
+        ]);
+        let dup = reconciled
+            .iter()
+            .filter(|r| {
+                matches!(r.relationship_type, RelationshipType::Continuation)
+                    && r.session_id == "resume-marker"
+                    && r.related_session_id.as_deref()
+                        == Some("11111111-1111-1111-1111-111111111111")
+            })
+            .count();
+        assert_eq!(dup, 0);
+    }
+
+    #[test]
+    fn subagent_rows_carry_provenance_when_basename_differs_from_in_log_id() {
+        // claude.test.ts:1252 — copy nested-subagent.jsonl to a tmp filename
+        // distinct from its in-log sessionId. Subagent rows must carry the
+        // mismatched in-log id as sourceSessionId, just like roots do, so
+        // cross-source joins can group all rows under one provenance banner.
+        let dir = tempfile::tempdir().unwrap();
+        let working = dir.path().join("session.jsonl");
+        let src = fixture("nested-subagent.jsonl");
+        std::fs::copy(&src, &working).unwrap();
+        let session_path = working.to_string_lossy().into_owned();
+        let res = parse_claude_session(
+            &working,
+            &ParseOptions {
+                session_path: Some(session_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let sub = res
+            .relationships
+            .iter()
+            .find(|r| matches!(r.relationship_type, RelationshipType::Subagent))
+            .expect("fixture has subagent rows");
+        assert_eq!(
+            sub.source_session_id.as_deref(),
+            Some("55555555-5555-5555-5555-555555555555")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The synchronous parser, incremental parser, and cross-file reconciler shipped in PRs #262 and #265 (both merged); this PR ports the remaining `packages/reader/src/claude.test.ts` cases into native `cargo test` assertions so the Rust port now gates on the same shared `tests/fixtures/claude/` JSONL inputs as the TS suite.
- Adds 35 new conformance tests covering tool-call back-population, fidelity coverage, compaction events, user-turn block sizing, content capture, and the full fork / continuation relationship suite — including in-memory evidence pairs that exercise the dedup paths in `reconcile_claude_session_relationships`.
- Two judgment calls (also documented inline): user-turn token counts assert the heuristic shape because cl100k is not wired in Rust yet (tracked in #246), and the relationship dedup test reproduces the canonical key inline rather than crossing the reader/ledger crate boundary, matching the TS test's own workaround.

## Test plan

- [x] `cargo test -p relayburn-reader` (199 pass; 51 in `claude::`)
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green
- [x] `pnpm run build && pnpm run test` (873 TS tests still pass)
- [x] `cargo fmt --check` and `cargo clippy --tests` clean on the new code (pre-existing warnings on this file untouched)

Closes #255.