### PR TITLE
relayburn-sdk: split verbs into their own modules

### DIFF
--- a/crates/relayburn-sdk/src/export_verbs.rs
+++ b/crates/relayburn-sdk/src/export_verbs.rs
@@ -1,0 +1,9 @@
+//! Export + search verbs — `search`, `export_ledger`, `export_stamps`.
+//! Filled in by the follow-up to #246 PR1.
+//!
+//! Wraps the FTS5 search and JSONL export APIs on
+//! `relayburn_ledger::Ledger`.
+
+// TODO(#246): port the export + search verbs from `packages/sdk/index.js`
+// and `relayburn_ledger::Ledger::{search_content, export_ledger_jsonl,
+// export_stamps_jsonl}`.

--- a/crates/relayburn-sdk/src/ingest_verb.rs
+++ b/crates/relayburn-sdk/src/ingest_verb.rs
@@ -1,0 +1,7 @@
+//! Ingest verb — async wrapper over `relayburn_ingest::ingest_all`.
+//! Filled in by the follow-up to #246 PR1.
+//!
+//! Both an `impl LedgerHandle` method (`async fn ingest`) and a free
+//! function form (`pub async fn ingest`) live here.
+
+// TODO(#246): port the ingest verb from `packages/sdk/index.js`.

--- a/crates/relayburn-sdk/src/lib.rs
+++ b/crates/relayburn-sdk/src/lib.rs
@@ -36,6 +36,24 @@
 
 use std::path::PathBuf;
 
+// Verb modules — each is populated by a separate follow-up PR. They share
+// the `LedgerHandle` and `LedgerOpenOptions` types defined here, plus the
+// re-exports below. Keeping them in their own files lets the three
+// implementation PRs land in parallel without touching `lib.rs`.
+#[allow(unused_imports)]
+mod export_verbs;
+#[allow(unused_imports)]
+mod ingest_verb;
+#[allow(unused_imports)]
+mod query_verbs;
+
+#[allow(unused_imports)]
+pub use export_verbs::*;
+#[allow(unused_imports)]
+pub use ingest_verb::*;
+#[allow(unused_imports)]
+pub use query_verbs::*;
+
 // --- Re-exports ------------------------------------------------------------
 //
 // We expose every type a caller might need to construct an option struct or

--- a/crates/relayburn-sdk/src/query_verbs.rs
+++ b/crates/relayburn-sdk/src/query_verbs.rs
@@ -1,0 +1,8 @@
+//! Query verbs — `summary`, `session_cost`, `overhead`, `overhead_trim`,
+//! `hotspots`. Filled in by the follow-up to #246 PR1.
+//!
+//! Each verb appears as an `impl LedgerHandle` method (sync, returns
+//! `anyhow::Result`) plus a free-function form that opens its own ledger
+//! handle from `LedgerOpenOptions`.
+
+// TODO(#246): port the query verbs from `packages/sdk/index.js`.


### PR DESCRIPTION
## Summary
Pre-declares three empty module files (`query_verbs.rs`, `ingest_verb.rs`, `export_verbs.rs`) and wires them through `lib.rs`. The verbs themselves are filled in by three parallel follow-up PRs; this PR exists so each of those touches only its own file and they don't fight over `lib.rs`.

Part of #246.

## Test plan
- [x] \`cargo build -p relayburn-sdk\` clean
- [x] \`cargo doc --no-deps -p relayburn-sdk\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)