### PR TITLE
relayburn-cli: codex HarnessAdapter via pending-stamp factory (#248 D6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+- `relayburn-cli` (Rust): wire codex `HarnessAdapter` via `pending_stamp::adapter_static` factory; registered in `RUNTIME_ADAPTERS`. (#248 D6)
 - `relayburn-cli` (Rust): wire `burn compare` as a presenter over `relayburn_sdk::analyze::compare` building blocks (`build_compare_table` + the per-turn fidelity gate), matching the TS CLI flag set (positional comma-separated model list, `--include-partial` / `--fidelity` / `--since` / `--project` / `--session` / `--min-sample` / `--csv` / `--no-archive`) and producing byte-equivalent stdout for the cli-golden `compare` / `compare-json` invocations. (#248 D3)
 - `relayburn-cli` (Rust): port `burn overhead` and `burn overhead trim` as thin presenters over `relayburn_sdk::overhead` / `::overhead_trim`. Output (human + `--json`) is byte-equivalent with the TS CLI. (#248 D2)
 - `relayburn-cli` (Rust): wire `burn state` as a typed clap subcommand with `status` (default), `rebuild`, `prune`, and `reset` verbs over `relayburn-sdk`. `state status` reports per-table row counts in `burn.sqlite`, the row count in `content.sqlite`, the `archive_state` schema/last-built/last-rebuild fields, and the resolved retention config; `--json` emits the structured `StateStatus` payload. `state rebuild {index,content,archive,all}` drives `Ledger::rebuild_derivable`; `state prune` drives `Ledger::prune_content_older_than`. `state reset` and standalone `state rebuild classify` are stubbed pending a follow-up. (#248 D4)

--- a/crates/relayburn-cli/src/harnesses/codex.rs
+++ b/crates/relayburn-cli/src/harnesses/codex.rs
@@ -73,6 +73,32 @@ pub fn adapter() -> &'static dyn HarnessAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serialize tests that mutate `$HOME` so a parallel test (in this
+    /// module or another using the same env var) can't observe a
+    /// half-set state. Mirrors the `ENV_LOCK` pattern in
+    /// `relayburn_sdk::query_verbs::state_status` tests. Poisoned-mutex
+    /// recovery is intentional — a panicking test shouldn't break
+    /// every subsequent run.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Runs `f` with `$HOME` pinned to `home`, restoring (or removing)
+    /// the prior value before returning. Holds `ENV_LOCK` for the whole
+    /// closure so concurrent tests serialize on the env mutation.
+    fn with_test_home(home: &str, f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", home);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        match prev {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
+    }
 
     /// `config()` returns a `PendingStampAdapter` named `codex` with the
     /// standard 1s tick interval. Sanity check that the constructor wires
@@ -83,13 +109,14 @@ mod tests {
         assert_eq!(cfg.name, "codex");
         // session_root closure resolves to `$HOME/.codex/sessions`. Use a
         // controlled $HOME so the assertion doesn't depend on the
-        // developer's actual home dir.
-        std::env::set_var("HOME", "/tmp/burn-codex-test-home");
-        let resolved = (cfg.session_root)();
-        assert_eq!(
-            resolved,
-            PathBuf::from("/tmp/burn-codex-test-home/.codex/sessions")
-        );
+        // developer's actual home dir; restored after via `with_test_home`.
+        with_test_home("/tmp/burn-codex-test-home", || {
+            let resolved = (cfg.session_root)();
+            assert_eq!(
+                resolved,
+                PathBuf::from("/tmp/burn-codex-test-home/.codex/sessions")
+            );
+        });
     }
 
     /// `adapter()` round-trips through the trait surface — name, session
@@ -100,10 +127,11 @@ mod tests {
     fn adapter_round_trip() {
         let a: &'static dyn HarnessAdapter = adapter();
         assert_eq!(a.name(), "codex");
-        std::env::set_var("HOME", "/tmp/burn-codex-test-home");
-        assert_eq!(
-            a.session_root(),
-            PathBuf::from("/tmp/burn-codex-test-home/.codex/sessions")
-        );
+        with_test_home("/tmp/burn-codex-test-home", || {
+            assert_eq!(
+                a.session_root(),
+                PathBuf::from("/tmp/burn-codex-test-home/.codex/sessions")
+            );
+        });
     }
 }

--- a/crates/relayburn-cli/src/harnesses/codex.rs
+++ b/crates/relayburn-cli/src/harnesses/codex.rs
@@ -1,0 +1,109 @@
+//! Codex `HarnessAdapter` — Rust port of `packages/cli/src/harnesses/codex.ts`.
+//!
+//! Codex shares the pending-stamp + watch-loop shape with OpenCode, so the
+//! adapter is constructed via [`super::pending_stamp::adapter_static`]
+//! instead of re-implementing the trait. The only codex-specific bits are:
+//!
+//! * `name = "codex"` — the dispatch key and log-line label.
+//! * `session_root` — `$HOME/.codex/sessions`, resolved lazily so tests
+//!   that override `$HOME` see the override.
+//! * `ingest_sessions` — opens a fresh ledger handle and runs
+//!   [`relayburn_sdk::ingest_codex_sessions`] (the codex-only ingest pass).
+//!   The TS sibling calls `ingestCodexSessions()` directly here; the Rust
+//!   SDK function takes `&mut Ledger`, so the closure opens a handle each
+//!   call. That mirrors the TS lock-then-write-then-close shape, and the
+//!   per-tick open is cheap (SQLite WAL, no DDL after first open).
+//!
+//! The factory's [`super::pending_stamp::adapter_static`] does the
+//! `Box::leak` so the registry can store the result as
+//! `&'static dyn HarnessAdapter`. See the factory module for the leak
+//! rationale (codex/opencode are the only two callers; runtime cost is
+//! a few dozen bytes per process).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use relayburn_sdk::{ingest_codex_sessions, Ledger, LedgerOpenOptions, RawIngestOptions};
+
+use super::pending_stamp::{self, IngestSessionsFn, PendingStampAdapter};
+use super::HarnessAdapter;
+
+/// Resolve the codex session-store root. Mirrors the TS sibling
+/// (`path.join(homedir(), '.codex', 'sessions')`) and the SDK's internal
+/// `codex_sessions_dir` default. Resolved on every call so tests that
+/// flip `$HOME` between runs see the override.
+fn codex_sessions_dir() -> PathBuf {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    home.join(".codex").join("sessions")
+}
+
+/// Build the [`PendingStampAdapter`] config for codex. Exposed as a
+/// constructor function (rather than a `static`) because the closure
+/// captures and the `Arc<dyn Fn>`s inside don't fit a const initializer.
+/// The registry calls this once and feeds the result to
+/// [`pending_stamp::adapter_static`].
+pub fn config() -> PendingStampAdapter {
+    let session_root: Arc<dyn Fn() -> PathBuf + Send + Sync> = Arc::new(codex_sessions_dir);
+    let ingest_sessions: IngestSessionsFn = Arc::new(|| {
+        Box::pin(async move {
+            // Open a fresh ledger handle per tick. The TS sibling's
+            // `ingestCodexSessions` does the same via `withLock('ledger', …)`;
+            // SQLite WAL keeps the per-call open cheap (no DDL after first
+            // open). Defaults pull `$RELAYBURN_HOME` (or `~/.relayburn`)
+            // and the same per-harness session-store root the factory's
+            // `session_root` closure resolves above.
+            let mut handle = Ledger::open(LedgerOpenOptions::default())?;
+            let opts = RawIngestOptions::default();
+            ingest_codex_sessions(handle.raw_mut(), &opts).await
+        })
+    });
+    PendingStampAdapter::new("codex", session_root, ingest_sessions)
+}
+
+/// Convenience: hand out a `&'static dyn HarnessAdapter` for the codex
+/// adapter. The registry calls this once at lazy-init time. See
+/// [`pending_stamp::adapter_static`] for the leak semantics — codex is
+/// one of two callers and the leaked footprint is bytes, not megabytes.
+pub fn adapter() -> &'static dyn HarnessAdapter {
+    pending_stamp::adapter_static(config())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `config()` returns a `PendingStampAdapter` named `codex` with the
+    /// standard 1s tick interval. Sanity check that the constructor wires
+    /// the name through the factory contract.
+    #[test]
+    fn config_has_codex_name() {
+        let cfg = config();
+        assert_eq!(cfg.name, "codex");
+        // session_root closure resolves to `$HOME/.codex/sessions`. Use a
+        // controlled $HOME so the assertion doesn't depend on the
+        // developer's actual home dir.
+        std::env::set_var("HOME", "/tmp/burn-codex-test-home");
+        let resolved = (cfg.session_root)();
+        assert_eq!(
+            resolved,
+            PathBuf::from("/tmp/burn-codex-test-home/.codex/sessions")
+        );
+    }
+
+    /// `adapter()` round-trips through the trait surface — name, session
+    /// root, and the `&'static` lifetime the registry requires. Mirrors
+    /// the registry's `pending_stamp_adapter_static_fits_runtime_registry`
+    /// check, but pinned to the codex configuration specifically.
+    #[test]
+    fn adapter_round_trip() {
+        let a: &'static dyn HarnessAdapter = adapter();
+        assert_eq!(a.name(), "codex");
+        std::env::set_var("HOME", "/tmp/burn-codex-test-home");
+        assert_eq!(
+            a.session_root(),
+            PathBuf::from("/tmp/burn-codex-test-home/.codex/sessions")
+        );
+    }
+}

--- a/crates/relayburn-cli/src/harnesses/mod.rs
+++ b/crates/relayburn-cli/src/harnesses/mod.rs
@@ -44,6 +44,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use relayburn_sdk::{Enrichment, IngestReport, WatchController};
 
+pub mod codex;
 pub mod pending_stamp;
 pub mod registry;
 

--- a/crates/relayburn-cli/src/harnesses/registry.rs
+++ b/crates/relayburn-cli/src/harnesses/registry.rs
@@ -54,7 +54,7 @@ use std::sync::LazyLock;
 
 use phf::phf_map;
 
-use super::HarnessAdapter;
+use super::{codex, HarnessAdapter};
 
 /// Compile-time perfect-hash map from harness name to a `&'static dyn
 /// HarnessAdapter`. Holds eager / unit-struct adapters whose value is a
@@ -89,7 +89,11 @@ static EAGER_ADAPTERS: phf::Map<&'static str, &'static dyn HarnessAdapter> = phf
 ///     });
 /// ```
 static RUNTIME_ADAPTERS: LazyLock<HashMap<&'static str, &'static dyn HarnessAdapter>> =
-    LazyLock::new(HashMap::new);
+    LazyLock::new(|| {
+        let mut m = HashMap::new();
+        m.insert("codex", codex::adapter()); // #248-e (Wave 2 D6)
+        m
+    });
 
 /// Sibling list of runtime adapter names in stable, deterministic
 /// order. Read by [`list_harness_names`] so the CLI's `--help` output
@@ -106,11 +110,9 @@ static RUNTIME_ADAPTERS: LazyLock<HashMap<&'static str, &'static dyn HarnessAdap
 /// `RUNTIME_ADAPTER_NAMES` entry. The deterministic-ordering test in
 /// this module's `tests` block pins the resulting order.
 static RUNTIME_ADAPTER_NAMES: &[&str] = &[
-    // Wave 2 PRs will populate these slots in lockstep with
-    // RUNTIME_ADAPTERS:
-    //
-    // "codex",     // #248-e
-    // "opencode",  // #248-f
+    // Wave 2 PRs populate these slots in lockstep with RUNTIME_ADAPTERS:
+    "codex", // #248-e (Wave 2 D6)
+             // "opencode",  // #248-f (Wave 2 D7)
 ];
 
 /// Look up an adapter by name. Returns `None` for unknown names; the
@@ -243,8 +245,8 @@ mod tests {
             // appear in EAGER_ADAPTERS / RUNTIME_ADAPTER_NAMES:
             //
             // "claude",    // #248-d (eager)
-            // "codex",     // #248-e (runtime)
-            // "opencode",  // #248-f (runtime)
+            "codex", // #248-e (runtime)
+                     // "opencode",  // #248-f (runtime)
         ];
 
         let names = list_harness_names();

--- a/crates/relayburn-sdk/src/lib.rs
+++ b/crates/relayburn-sdk/src/lib.rs
@@ -109,10 +109,11 @@ pub use crate::analyze::{
 };
 
 pub use crate::ingest::{
-    cleanup_stale_pending_stamps, ingest_all, run_ingest_tick, start_watch_loop,
-    write_pending_stamp, ErrorSink, IngestFn, IngestOptions as RawIngestOptions, IngestReport,
-    IngestRoots, PendingStamp, PendingStampHarness, PendingStampWriteResult, ReportSink,
-    StartWatchLoopOptions, WatchController, WriteOptions as PendingStampWriteOptions,
+    cleanup_stale_pending_stamps, ingest_all, ingest_codex_sessions, ingest_opencode_sessions,
+    run_ingest_tick, start_watch_loop, write_pending_stamp, ErrorSink, IngestFn,
+    IngestOptions as RawIngestOptions, IngestReport, IngestRoots, PendingStamp,
+    PendingStampHarness, PendingStampWriteResult, ReportSink, StartWatchLoopOptions,
+    WatchController, WriteOptions as PendingStampWriteOptions,
 };
 
 // --- LedgerOpenOptions -----------------------------------------------------


### PR DESCRIPTION
## Summary

Wires the codex adapter into the Rust CLI harness registry through the pre-existing `pending_stamp::adapter_static` factory. Codex shares the pending-stamp + watch-loop shape with OpenCode, so the adapter is a one-file constructor (`harnesses/codex.rs`) plus three lockstep registry edits.

## Scope

- **`crates/relayburn-cli/src/harnesses/codex.rs` (new)** — `config()` builds a `PendingStampAdapter` named `codex` whose `session_root` resolves to `$HOME/.codex/sessions` (matching the TS sibling and the SDK's internal `codex_sessions_dir` default), and whose `ingest_sessions` closure opens a fresh `Ledger` handle and runs `ingest_codex_sessions`. `adapter()` runs `pending_stamp::adapter_static` to hand back the `&'static dyn HarnessAdapter` the registry stores.
- **`crates/relayburn-cli/src/harnesses/mod.rs`** — `pub mod codex;`.
- **`crates/relayburn-cli/src/harnesses/registry.rs`** — three lockstep edits:
  1. `RUNTIME_ADAPTERS` gains `("codex", codex::adapter())`.
  2. `RUNTIME_ADAPTER_NAMES` gains `"codex"` so `list_harness_names` (the cold-start `--help` path) surfaces it without forcing the `LazyLock`.
  3. The `EXPECTED_HARNESS_NAMES` snapshot in `list_harness_names_is_deterministic` is updated to `["codex"]`.
- **`crates/relayburn-sdk/src/lib.rs`** — re-export `ingest_codex_sessions` and `ingest_opencode_sessions` from the crate root. The functions already existed inside `crate::ingest`; this is a pure additive surface change so external embedders (the CLI, `relayburn-sdk-node`, future harnesses) can call the per-harness ingest passes without reaching into private modules.
- **`CHANGELOG.md`** — one impact-first bullet under `[Unreleased]`.

## How it plugs in

```
lookup("codex")
  → EAGER_ADAPTERS.get("codex")  // miss (eager tier holds claude when D5 lands)
  → RUNTIME_ADAPTERS.get("codex") // hit, returns &'static dyn HarnessAdapter
```

The trait calls fan out as the factory documents:

```
plan         → SpawnPlan::new("codex", ctx.passthrough)
before_spawn → write_pending_stamp(harness=Codex, ...) + log basename
start_watcher→ start_watch_loop(immediate=false, on_report → ingest_codex_sessions)
after_exit   → ingest_codex_sessions(...)
```

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` green — all 610 SDK tests, 13 CLI harness tests (including two new `codex::tests::*`), and the registry's `list_harness_names_is_deterministic` / `runtime_adapter_names_match_runtime_adapters` invariants pass.
- [x] `harnesses::lookup("codex")` returns `Some(adapter)` (covered by `runtime_adapter_names_match_runtime_adapters` walking `RUNTIME_ADAPTER_NAMES` through `lookup`).
- [x] New `codex::tests::config_has_codex_name` and `codex::tests::adapter_round_trip` assert the adapter resolves `$HOME/.codex/sessions` (with a controlled `$HOME`) and round-trips through the trait surface as `&'static dyn HarnessAdapter`.
- [ ] D7 (opencode) will rebase against this branch when it lands; the registry's two-row pattern is already pinned by codex.

## Notes

- The closure inside `ingest_sessions` opens a fresh `Ledger` per tick, mirroring the TS sibling's `withLock('ledger', …)` open-write-close shape. SQLite WAL keeps the per-call cost cheap (no DDL after first open).
- `adapter()` calls `pending_stamp::adapter_static` which `Box::leak`s the implementation; see the factory module for the leak rationale (codex/opencode are the only two callers, leaked footprint is bytes).
