### PR TITLE
relayburn: mechanical Rust cleanup (clippy + dedup + dead code)

### DIFF
--- a/crates/relayburn-cli/src/cli.rs
+++ b/crates/relayburn-cli/src/cli.rs
@@ -21,12 +21,6 @@ use clap::{Args as ClapArgs, Parser, Subcommand, ValueEnum};
 
 /// Parsed top-level argv — what every command handler receives via
 /// [`Args::globals`].
-//
-// `ledger_path` and `no_color` are unused on this branch because the
-// command stubs don't read them yet; Wave 2 presenter PRs are what
-// actually consume them. Suppress the resulting dead-code warnings
-// without losing the field on the struct.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct GlobalArgs {
     /// Emit machine-readable JSON instead of human-formatted output.

--- a/crates/relayburn-cli/src/commands/ingest.rs
+++ b/crates/relayburn-cli/src/commands/ingest.rs
@@ -114,7 +114,7 @@ fn run_once(globals: &GlobalArgs, quiet: bool) -> i32 {
 /// callbacks, etc.) needs to survive across ticks.
 fn run_watch(globals: &GlobalArgs, args: &IngestArgs) -> i32 {
     let interval_ms = match args.interval {
-        Some(n) if n == 0 => {
+        Some(0) => {
             eprintln!("burn: ingest --interval must be a positive integer in milliseconds");
             return EXIT_FLAG_MISUSE;
         }
@@ -277,7 +277,7 @@ fn open_handle(globals: &GlobalArgs) -> anyhow::Result<LedgerHandle> {
         Some(h) => LedgerOpenOptions::with_home(h),
         None => LedgerOpenOptions::default(),
     };
-    Ok(Ledger::open(opts)?)
+    Ledger::open(opts)
 }
 
 /// Format an `IngestReport` as the canonical TS log line. Kept as a

--- a/crates/relayburn-cli/src/commands/mcp_server.rs
+++ b/crates/relayburn-cli/src/commands/mcp_server.rs
@@ -76,7 +76,7 @@ fn open_handle(globals: &GlobalArgs) -> anyhow::Result<LedgerHandle> {
         Some(h) => LedgerOpenOptions::with_home(h),
         None => LedgerOpenOptions::default(),
     };
-    Ok(Ledger::open(opts)?)
+    Ledger::open(opts)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/relayburn-cli/src/commands/mod.rs
+++ b/crates/relayburn-cli/src/commands/mod.rs
@@ -27,18 +27,3 @@ pub mod overhead;
 pub mod run;
 pub mod state;
 pub mod summary;
-
-use crate::cli::GlobalArgs;
-use crate::render::error::report_unimplemented;
-
-/// Shared "not yet implemented" exit path for every subcommand stub.
-/// Honors `--json` via [`crate::render::error::report_unimplemented`].
-//
-// All Wave 2 D1–D8 PRs have wired their presenters; no command currently
-// calls this helper. Kept in place (with `#[allow(dead_code)]`) so a
-// future scaffold of a new stub subcommand has a ready landing pad and
-// doesn't have to re-derive the JSON-aware error envelope here.
-#[allow(dead_code)]
-pub(crate) fn not_yet_implemented(name: &str, globals: &GlobalArgs) -> i32 {
-    report_unimplemented(name, globals)
-}

--- a/crates/relayburn-cli/src/commands/overhead.rs
+++ b/crates/relayburn-cli/src/commands/overhead.rs
@@ -125,13 +125,11 @@ fn run_trim(
 /// integer-valued `f64`s print as bare integers (`0` not `0.0`), matching
 /// `JSON.stringify` semantics so the golden snapshots stay byte-equivalent.
 fn render_json_ts_compatible<T: serde::Serialize + ?Sized>(value: &T) -> io::Result<()> {
-    let mut json = serde_json::to_value(value)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let mut json = serde_json::to_value(value).map_err(io::Error::other)?;
     coerce_integer_floats(&mut json);
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    serde_json::to_writer_pretty(&mut handle, &json)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    serde_json::to_writer_pretty(&mut handle, &json).map_err(io::Error::other)?;
     handle.write_all(b"\n")?;
     handle.flush()
 }
@@ -449,7 +447,7 @@ fn format_int(n: u64) -> String {
     let bytes = s.as_bytes();
     let mut out = String::with_capacity(s.len() + s.len() / 3);
     for (i, b) in bytes.iter().enumerate() {
-        if i > 0 && (bytes.len() - i) % 3 == 0 {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
             out.push(',');
         }
         out.push(*b as char);

--- a/crates/relayburn-cli/src/render/error.rs
+++ b/crates/relayburn-cli/src/render/error.rs
@@ -98,7 +98,7 @@ fn write_json_envelope(value: &serde_json::Value) -> io::Result<()> {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     serde_json::to_writer(&mut handle, value)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(io::Error::other)?;
     handle.write_all(b"\n")?;
     handle.flush()
 }
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn generic_error_uses_exit_two() {
-        let err = std::io::Error::new(std::io::ErrorKind::Other, "boom");
+        let err = std::io::Error::other("boom");
         assert_eq!(report_error(&err, &human_globals()), EXIT_GENERIC_ERROR);
     }
 

--- a/crates/relayburn-cli/src/render/json.rs
+++ b/crates/relayburn-cli/src/render/json.rs
@@ -23,7 +23,7 @@ pub fn render_json<T: Serialize + ?Sized>(value: &T) -> io::Result<()> {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     serde_json::to_writer_pretty(&mut handle, value)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(io::Error::other)?;
     handle.write_all(b"\n")?;
     handle.flush()
 }
@@ -36,7 +36,7 @@ pub fn render_json_compact<T: Serialize + ?Sized>(value: &T) -> io::Result<()> {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     serde_json::to_writer(&mut handle, value)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(io::Error::other)?;
     handle.write_all(b"\n")?;
     handle.flush()
 }

--- a/crates/relayburn-sdk/src/analyze.rs
+++ b/crates/relayburn-sdk/src/analyze.rs
@@ -40,6 +40,7 @@ pub mod replacement_savings;
 pub mod subagent_tree;
 pub mod tool_call_patterns;
 pub mod tool_output_bloat;
+mod util;
 
 pub use claude_md::{
     attribute_claude_md, build_trim_recommendations, find_claude_md_files, load_claude_md_file,

--- a/crates/relayburn-sdk/src/analyze/findings.rs
+++ b/crates/relayburn-sdk/src/analyze/findings.rs
@@ -324,21 +324,7 @@ fn fmt_usd(n: f64) -> String {
     format!("${:.4}", n)
 }
 
-/// Format an integer with thousands separators, matching the JS
-/// `Number.prototype.toLocaleString()` output for plain en-US locale.
-fn format_with_commas(n: u64) -> String {
-    let s = n.to_string();
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let mut result = String::with_capacity(len + len / 3);
-    for (i, &b) in bytes.iter().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            result.push(',');
-        }
-        result.push(b as char);
-    }
-    result
-}
+use super::util::format_with_commas;
 
 pub fn retry_loop_to_finding(loop_: &RetryLoop) -> WasteFinding {
     let target = match &loop_.target {

--- a/crates/relayburn-sdk/src/analyze/ghost_surface.rs
+++ b/crates/relayburn-sdk/src/analyze/ghost_surface.rs
@@ -799,21 +799,7 @@ fn basename_of(path: &str) -> String {
         .unwrap_or_else(|| path.to_string())
 }
 
-/// `Number.prototype.toLocaleString()`-style thousands separator for
-/// `sizeTokens`. Mirrors the helper in `findings.rs`.
-fn format_with_commas(n: u64) -> String {
-    let s = n.to_string();
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let mut result = String::with_capacity(len + len / 3);
-    for (i, &b) in bytes.iter().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            result.push(',');
-        }
-        result.push(b as char);
-    }
-    result
-}
+use super::util::format_with_commas;
 
 pub fn ghost_surface_to_finding(
     ghost: &GhostSurfaceFinding,

--- a/crates/relayburn-sdk/src/analyze/tool_call_patterns.rs
+++ b/crates/relayburn-sdk/src/analyze/tool_call_patterns.rs
@@ -472,21 +472,7 @@ fn hotspots_action(session_id: &str) -> WasteAction {
     }
 }
 
-/// Format an integer with thousands separators, matching JS
-/// `Number.prototype.toLocaleString()` output for the en-US locale.
-fn format_with_commas(n: u64) -> String {
-    let s = n.to_string();
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let mut result = String::with_capacity(len + len / 3);
-    for (i, &b) in bytes.iter().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            result.push(',');
-        }
-        result.push(b as char);
-    }
-    result
-}
+use super::util::format_with_commas;
 
 pub fn tool_call_pattern_to_finding(finding: &ToolCallPatternFinding) -> WasteFinding {
     let evidence_str = if finding.evidence.is_empty() {

--- a/crates/relayburn-sdk/src/analyze/tool_output_bloat.rs
+++ b/crates/relayburn-sdk/src/analyze/tool_output_bloat.rs
@@ -83,21 +83,7 @@ fn fmt_usd(n: f64) -> String {
     format!("${:.4}", n)
 }
 
-/// Format an integer with thousands separators, matching the JS
-/// `Number.prototype.toLocaleString()` output for plain en-US locale.
-fn format_with_commas(n: u64) -> String {
-    let s = n.to_string();
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let mut out = String::with_capacity(len + len / 3);
-    for (i, &b) in bytes.iter().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            out.push(',');
-        }
-        out.push(b as char);
-    }
-    out
-}
+use super::util::format_with_commas;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/relayburn-sdk/src/analyze/util.rs
+++ b/crates/relayburn-sdk/src/analyze/util.rs
@@ -1,0 +1,17 @@
+//! Shared formatting helpers for the analyze module.
+
+/// Format an integer with thousands separators, matching JS
+/// `Number.prototype.toLocaleString()` output for the en-US locale.
+pub(crate) fn format_with_commas(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (i, &b) in bytes.iter().enumerate() {
+        if i > 0 && (len - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(b as char);
+    }
+    out
+}

--- a/crates/relayburn-sdk/src/ledger/reader.rs
+++ b/crates/relayburn-sdk/src/ledger/reader.rs
@@ -367,14 +367,3 @@ pub(crate) fn raw_record_jsons(conn: &Connection, table: &str) -> Result<Vec<Str
     Ok(rows)
 }
 
-#[allow(dead_code)]
-pub(crate) fn lookup_content_fingerprint(conn: &Connection, fingerprint: &str) -> Result<bool> {
-    let exists: Option<i64> = conn
-        .query_row(
-            "SELECT 1 FROM turns WHERE content_fingerprint = ? LIMIT 1",
-            params![fingerprint],
-            |r| r.get(0),
-        )
-        .ok();
-    Ok(exists.is_some())
-}

--- a/crates/relayburn-sdk/src/ledger/writer.rs
+++ b/crates/relayburn-sdk/src/ledger/writer.rs
@@ -345,7 +345,6 @@ pub(crate) fn synthesize_relationship(stamp: &Stamp) -> Option<SessionRelationsh
     })
 }
 
-#[allow(dead_code)]
 pub(crate) fn debug_now() -> String {
     now_iso()
 }

--- a/crates/relayburn-sdk/src/reader/claude.rs
+++ b/crates/relayburn-sdk/src/reader/claude.rs
@@ -2990,7 +2990,7 @@ mod tests {
         let t = &res.turns[0];
         assert_eq!(t.tool_calls.len(), 3);
         assert_eq!(
-            t.files_touched.as_ref().map(|v| v.as_slice()),
+            t.files_touched.as_deref(),
             Some(["/src/a.ts".to_string(), "/src/b.ts".to_string()].as_slice())
         );
     }


### PR DESCRIPTION
## Summary

Mechanical Rust cleanup. No behavior change — pure cleanup that drops the workspace clippy warning count from **28 → 17** and removes ~90 LOC of duplication and dead code.

- Replace `io::Error::new(io::ErrorKind::Other, e)` with `io::Error::other(e)` (×6).
- Drop redundant `Ok(Ledger::open(opts)?)` wrapping (×2).
- Misc clippy fixes: `Some(0)`, `.is_multiple_of(3)`, `.as_deref()`.
- Consolidate four byte-identical copies of `format_with_commas` (findings, tool_call_patterns, tool_output_bloat, ghost_surface) into a new `analyze::util` module.
- Delete confirmed-dead `ledger::reader::lookup_content_fingerprint` and `commands::not_yet_implemented`.
- Drop incorrect `#[allow(dead_code)]` on `writer::debug_now` — it IS called from `ledger.rs`.
- Drop the stale `GlobalArgs` clippy allow now that Wave 2 D1–D8 consumes both `ledger_path` and `no_color`.

This is the lowest-risk slice of a larger Rust review punch list (perf wins, async hygiene, SQL filter pushdown, `std::env::set_var` removal, date-math consolidation) — those land separately.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` passes (729 tests, 0 failures)
- [x] `cargo clippy --workspace --all-targets` warning count drops from 28 → 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)