### PR TITLE
relayburn-sdk: fix three small Rust correctness bugs

### DIFF
--- a/crates/relayburn-cli/src/commands/state.rs
+++ b/crates/relayburn-cli/src/commands/state.rs
@@ -377,7 +377,7 @@ fn run_prune(globals: &GlobalArgs, args: crate::cli::StatePruneArgs) -> i32 {
     };
 
     // The 2.0 content store stamps each row with a monotonic
-    // `ts:{:020}.{:09}` value (see `writer::now_iso`); compare by
+    // `ts:{:020}.{:09}` value (see `writer::now_lex_token`); compare by
     // computing a lex-comparable cutoff string in the SAME format from
     // the current wall-clock minus the retention window. Using a
     // narrower padding (e.g. `{:013}.000`) makes every stamped row
@@ -431,7 +431,7 @@ fn run_prune(globals: &GlobalArgs, args: crate::cli::StatePruneArgs) -> i32 {
 
 /// Format a wall-clock millisecond value as a `ts:{:020}.{:09}` string
 /// that is lexically comparable against the `content.created_at` rows
-/// stamped by `relayburn_sdk::ledger::writer::now_iso`. Both the seconds
+/// stamped by `relayburn_sdk::ledger::writer::now_lex_token`. Both the seconds
 /// (20 chars, zero-padded) and the nanosecond fraction (9 chars,
 /// zero-padded) widths must match exactly — any narrower padding flips
 /// the lexical ordering and breaks the `created_at < cutoff` filter.
@@ -500,7 +500,7 @@ fn report_anyhow(err: &anyhow::Error, globals: &GlobalArgs) -> i32 {
 mod tests {
     use super::{format_cutoff_ts, rel_to_home};
 
-    /// Mirror of `relayburn_sdk::ledger::writer::now_iso`'s format string.
+    /// Mirror of `relayburn_sdk::ledger::writer::now_lex_token`'s format string.
     /// Re-deriving it locally guards against the writer's format drifting
     /// without the cutoff helper following.
     fn writer_style_ts(secs: u64, nanos_part: u64) -> String {

--- a/crates/relayburn-sdk/src/ingest.rs
+++ b/crates/relayburn-sdk/src/ingest.rs
@@ -61,8 +61,8 @@ pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(()
 pub(crate) static TEST_GAP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 pub use cursors::{
-    load_cursors, save_cursor_changes, save_cursors, ClaudeCursor, CodexCumulative, CodexCursor,
-    Cursors, FileCursor, OpencodeCursor, OpencodeStreamCursor,
+    load_cursors, save_cursors, save_cursors_if_changed, ClaudeCursor, CodexCumulative,
+    CodexCursor, Cursors, FileCursor, OpencodeCursor, OpencodeStreamCursor,
 };
 pub use gap::{
     count_new_tool_calls, count_new_tool_results, count_tool_call_gaps, emit_gap_warning,

--- a/crates/relayburn-sdk/src/ingest/cursors.rs
+++ b/crates/relayburn-sdk/src/ingest/cursors.rs
@@ -160,10 +160,13 @@ pub fn save_cursors(ledger: &mut Ledger, cursors: &Cursors) -> LedgerResult<()> 
     ledger.write_cursors(&json)
 }
 
-/// Persist only the keys whose cursor value differs between `before` and
-/// `after`. Keys present in `before` but absent in `after` are deleted.
-/// Mirrors `saveCursorChanges` — minimizes lock window when nothing changed.
-pub fn save_cursor_changes(
+/// If `after` differs from `before`, persist `after` in full; otherwise
+/// no-op. The early-return spares the write lock when an ingest pass
+/// produced no cursor changes — it does NOT compute a per-key diff
+/// (despite an earlier name + doc that claimed it did). Per-key delta
+/// writes are tracked separately as a perf follow-up; today every
+/// non-empty change rewrites the whole cursor map.
+pub fn save_cursors_if_changed(
     ledger: &mut Ledger,
     before: &Cursors,
     after: &Cursors,

--- a/crates/relayburn-sdk/src/ingest/ingest.rs
+++ b/crates/relayburn-sdk/src/ingest/ingest.rs
@@ -36,7 +36,7 @@ use crate::reader::{
 
 use crate::ingest::cursors::{
     ClaudeCursor, CodexCumulative, CodexCursor, Cursors, FileCursor, OpencodeCursor, load_cursors,
-    save_cursor_changes,
+    save_cursors_if_changed,
 };
 use crate::ingest::gap::{
     AdapterName, count_new_tool_calls, count_new_tool_results, emit_gap_warning, record_session_gap,
@@ -206,7 +206,7 @@ pub async fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Re
     emit_gap_warning(AdapterName::Opencode, content_mode, on_warn);
 
     progress(opts, "saving ingest cursors");
-    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    save_cursors_if_changed(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
     Ok(report)
 }
 
@@ -225,7 +225,7 @@ pub async fn ingest_claude_projects(
         content_mode,
         opts.on_warn.as_ref().map(|f| f.as_ref() as &dyn Fn(&str)),
     );
-    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    save_cursors_if_changed(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
     Ok(report)
 }
 
@@ -250,7 +250,7 @@ pub async fn ingest_codex_sessions(
         content_mode,
         opts.on_warn.as_ref().map(|f| f.as_ref() as &dyn Fn(&str)),
     );
-    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    save_cursors_if_changed(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
     Ok(report)
 }
 
@@ -275,7 +275,7 @@ pub async fn ingest_opencode_sessions(
         content_mode,
         opts.on_warn.as_ref().map(|f| f.as_ref() as &dyn Fn(&str)),
     );
-    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    save_cursors_if_changed(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
     Ok(report)
 }
 
@@ -355,7 +355,7 @@ pub async fn ingest_claude_session(
     };
     let key = file.to_string_lossy().into_owned();
     after.insert(key, FileCursor::Claude(cursor));
-    save_cursor_changes(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    save_cursors_if_changed(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
 
     Ok(IngestReport {
         scanned_sessions: 1,

--- a/crates/relayburn-sdk/src/ingest/watch_loop.rs
+++ b/crates/relayburn-sdk/src/ingest/watch_loop.rs
@@ -222,7 +222,14 @@ pub fn start_watch_loop(opts: StartWatchLoopOptions) -> WatchController {
         if immediate {
             ticker.run_tick_skip_if_busy().await;
         }
-        let mut iv = tokio::time::interval(interval);
+        // Schedule the periodic ticker to first fire `interval` from now.
+        // `tokio::time::interval` fires immediately on the first `tick()`,
+        // so for the immediate path we'd want to skip that first tick;
+        // for the non-immediate path we'd want to wait `interval` before
+        // the first periodic run. `interval_at(now + interval, …)` covers
+        // both: the next tick lands `interval` after start in either case.
+        let start_at = tokio::time::Instant::now() + interval;
+        let mut iv = tokio::time::interval_at(start_at, interval);
         // Default `MissedTickBehavior::Burst` would fire catch-up ticks
         // back-to-back after a slow ingest pass, which can spike CPU/IO
         // exactly when the system is already under load. `Delay` schedules
@@ -230,10 +237,6 @@ pub fn start_watch_loop(opts: StartWatchLoopOptions) -> WatchController {
         // stable polling cadence — closer to TS `setInterval` pacing under
         // a single-threaded runner.
         iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        // First tick of `tokio::time::interval` fires immediately; skip it
-        // because we already ran one above (or because the caller asked us
-        // not to run an immediate tick at all).
-        iv.tick().await;
         loop {
             if ticker.stopped.load(Ordering::SeqCst) {
                 break;
@@ -302,6 +305,38 @@ mod tests {
         let runs = counter.load(Ordering::SeqCst);
         // Immediate tick + ≥1 periodic tick.
         assert!(runs >= 2, "expected ≥2 runs, got {runs}");
+    }
+
+    /// Non-immediate watch loop must fire its first periodic tick after
+    /// `interval`, not `2 * interval`. Regression test for an earlier
+    /// shape that called `iv.tick().await` to skip a tick that the
+    /// immediate branch hadn't actually produced.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn non_immediate_first_tick_lands_at_interval() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let opts = StartWatchLoopOptions::new(ingest_counting(counter.clone()))
+            .with_immediate(false)
+            .with_interval(Duration::from_millis(100));
+        let ctrl = start_watch_loop(opts);
+
+        // Let the spawned task park on its sleep, then advance time
+        // *just past* one interval. After this much paused time the
+        // loop should have fired exactly once.
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(101)).await;
+        // Yield again so the spawned task gets a chance to run the tick
+        // body before we read the counter.
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+        let runs_after_one_interval = counter.load(Ordering::SeqCst);
+
+        ctrl.stop().await;
+
+        assert_eq!(
+            runs_after_one_interval, 1,
+            "expected exactly 1 run after ~1 interval (was the loop firing at 2*interval?), got {runs_after_one_interval}"
+        );
     }
 
     #[tokio::test]

--- a/crates/relayburn-sdk/src/ledger/writer.rs
+++ b/crates/relayburn-sdk/src/ledger/writer.rs
@@ -23,15 +23,19 @@ use crate::ledger::fingerprint::{
 use crate::ledger::paths::is_valid_session_id;
 use crate::ledger::stamp::Stamp;
 
-fn now_iso() -> String {
+/// Sortable monotonic application-clock token used to stamp `written_at`
+/// and content `created_at`. Format is `ts:{secs:020}.{nanos:09}` — NOT
+/// ISO-8601. Ordering (lex == chronological) is the only contract; we
+/// don't pay for a calendar-formatting dep just for stamps. The widths
+/// matter — anything narrower flips the lex sort. See `format_cutoff_ts`
+/// in `relayburn-cli/src/commands/state.rs` for the matching cutoff
+/// helper.
+fn now_lex_token() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    // Application-clock string for `written_at`. We don't need calendar
-    // formatting here — ordering is the only contract — and rolling our
-    // own ISO formatter avoids a chrono / time dep just for stamps.
     let secs = nanos / 1_000_000_000;
     let nanos_part = nanos % 1_000_000_000;
     format!("ts:{:020}.{:09}", secs, nanos_part)
@@ -220,7 +224,7 @@ pub(crate) fn append_stamp(conn: &mut Connection, stamp: &Stamp) -> Result<()> {
     let synthesized = synthesize_relationship(stamp);
 
     let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-    let written_at = now_iso();
+    let written_at = now_lex_token();
     {
         tx.prepare(
             "INSERT INTO stamps (source, session_id, ts, selector_json, enrichment_json, written_at)
@@ -273,7 +277,7 @@ pub(crate) fn append_content(
                  (source, session_id, message_id, content_hash, body, byte_length, created_at)
              VALUES (?, ?, ?, ?, ?, ?, ?)",
         )?;
-        let now = now_iso();
+        let now = now_lex_token();
         for r in records {
             if !is_valid_session_id(&r.session_id) {
                 return Err(LedgerError::InvalidSessionId(r.session_id.clone()));
@@ -329,6 +333,6 @@ pub(crate) fn synthesize_relationship(stamp: &Stamp) -> Option<SessionRelationsh
 }
 
 pub(crate) fn debug_now() -> String {
-    now_iso()
+    now_lex_token()
 }
 


### PR DESCRIPTION
## Summary

Three small correctness fixes flagged in #337.

1. **Fix `watch_loop.rs` first-tick lag.** The non-immediate branch was unconditionally consuming the first interval tick to "skip" an immediate run that branch never produced, so the first periodic tick fired at `2 * interval`. Switch to `interval_at(now + interval, period)` so the first tick lands at `~interval` in both modes. Adds a deterministic regression test using `start_paused` + `tokio::time::advance`.

2. **Rename `now_iso` → `now_lex_token`.** The function emits `ts:NNN.NNN` (a sortable lex token), not ISO-8601; the column doc was misleading. Rename + expand doc to call out the format contract; update the matching cutoff helper's pointer in `burn state` prune. Pure naming/doc fix; no behavior change. Actual ISO-8601 adoption tracked in #331.

3. **Rename `save_cursor_changes` → `save_cursors_if_changed` + fix doc.** The doc claimed per-key diffing; the impl is an equality check + full save. Rename and rewrite the doc to match. Per-key delta writes deferred to a separate perf PR.

Closes #337.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` passes (incl. new `watch_loop` deterministic-timing test)
- [x] `cargo clippy --workspace --all-targets` no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)