### PR TITLE
ci: auto-publish relayburn-sdk + relayburn-cli to crates.io in lockstep with npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,10 +84,12 @@ jobs:
       # Rust port build + test gates the whole publish job. If the Rust
       # tree is red at this commit, abort before npm ships anything so the
       # release tag points at a commit where both trees pass.
+      #
+      # `rustup toolchain install` (no args) reads rust-toolchain.toml and
+      # installs both the channel and the listed components — no explicit
+      # `rustup component add` needed.
       - name: Setup Rust toolchain
-        run: |
-          rustup toolchain install
-          rustup component add rustfmt clippy
+        run: rustup toolchain install
 
       - name: Cargo build + test
         run: |
@@ -592,8 +594,15 @@ jobs:
       # Both publishes are gated on whether the version is already on
       # crates.io, making `version: none` re-runs idempotent for partial
       # failure recovery.
+      #
+      # Always mint the token, including on dry runs:
+      #   1. `cargo publish --dry-run` historically required registry auth
+      #      (and the requirement varies by cargo version), so passing a
+      #      real token avoids version-dependent surprises on the runner.
+      #   2. Running the OIDC exchange on every dry run validates that the
+      #      crates.io trusted-publisher registration is healthy — the
+      #      whole point of running a dry run before a real release.
       - name: Mint crates.io token via OIDC
-        if: ${{ github.event.inputs.dry_run != 'true' }}
         id: cargo-auth
         uses: rust-lang/crates-io-auth-action@v1
 
@@ -622,16 +631,25 @@ jobs:
 
           # Wait for the new SDK version to land in the sparse index so
           # the CLI's dep resolution sees it. Poll rather than fixed-sleep.
+          # Fail loudly if the version never appears — letting the CLI
+          # publish proceed produces a confusing "unsatisfied dep" error
+          # that's harder to diagnose than an explicit timeout.
           if [ -z "$DRY" ] && [ "$sdk_published" = "0" ]; then
+            found=0
             for i in $(seq 1 30); do
               if curl -sf "https://index.crates.io/re/la/relayburn-sdk" \
                  | grep -q "\"vers\":\"$VER\""; then
                 echo "relayburn-sdk@$VER visible in index"
+                found=1
                 break
               fi
               echo "waiting for index... ($i/30)"
               sleep 10
             done
+            if [ "$found" = "0" ]; then
+              echo "::error title=Sparse index timeout::relayburn-sdk@$VER not visible in index after 30 attempts (5 min). Aborting CLI publish to avoid a misleading dep-resolution error."
+              exit 1
+            fi
           fi
 
           cli_published=$(curl -sf "https://index.crates.io/re/la/relayburn-cli" 2>/dev/null \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,19 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+      # Rust port build + test gates the whole publish job. If the Rust
+      # tree is red at this commit, abort before npm ships anything so the
+      # release tag points at a commit where both trees pass.
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt clippy
+
+      - name: Cargo build + test
+        run: |
+          cargo build --workspace --all-targets
+          cargo test --workspace
+
       - name: Resolve target packages
         id: targets
         run: |
@@ -205,6 +218,23 @@ jobs:
             popd > /dev/null
           done
           echo "versions=${VERSIONS# }" >> "$GITHUB_OUTPUT"
+
+          # Lockstep the Rust workspace to the npm version. Any package's
+          # post-bump version works since they're all equal after the bump.
+          # The cli/sdk-node path-deps on relayburn-sdk pin MAJOR.MINOR
+          # (caret semantics) so the constraint only needs rewriting on
+          # minor/major bumps; patch bumps no-op the sed.
+          RUST_VER=$(node -p "require('./packages/relayburn/package.json').version")
+          RUST_MINOR=$(echo "$RUST_VER" | awk -F. '{print $1"."$2}')
+          echo "Rust workspace lockstep: $RUST_VER (minor pin: $RUST_MINOR)"
+
+          sed -i -E "s/^version = \"[^\"]+\"$/version = \"$RUST_VER\"/" Cargo.toml
+          for crate in relayburn-cli relayburn-sdk-node; do
+            sed -i -E "s|(relayburn-sdk = \\{ path = \"\\.\\./relayburn-sdk\", version = \")[^\"]+(\" \\})|\\1$RUST_MINOR\\2|" "crates/$crate/Cargo.toml"
+          done
+
+          # Refresh Cargo.lock to reflect the new workspace version.
+          cargo update --workspace
 
       # Belt-and-suspenders alongside the parity check above: even if the
       # local→npm baseline is in sync, the computed bump might collide with
@@ -531,7 +561,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packages/*/package.json packages/*/CHANGELOG.md CHANGELOG.md
+          git add packages/*/package.json packages/*/CHANGELOG.md CHANGELOG.md \
+                  Cargo.toml Cargo.lock \
+                  crates/relayburn-cli/Cargo.toml crates/relayburn-sdk-node/Cargo.toml
           if git diff --cached --quiet; then
             echo "No version changes to commit."
           else
@@ -543,6 +575,71 @@ jobs:
               MSG+=" $NPM_NAME@$version"
             done
             git commit -m "$MSG"
+          fi
+
+      # crates.io OIDC trusted publishing. The action exchanges this run's
+      # GitHub OIDC identity for a short-lived CARGO_REGISTRY_TOKEN — same
+      # trust model as the npm publish below, no long-lived secret.
+      #
+      # Both crates must be pre-registered as trusted publishers on
+      # crates.io (Settings → Trusted Publishing → GitHub) for this to
+      # mint a token. First-publish bootstrap (registering the crate name
+      # and configuring trusted publishing) is a one-time manual step
+      # documented in the PR that introduced this flow.
+      #
+      # Cargo runs BEFORE npm so a crate-side failure aborts before npm
+      # ships any tarball, pushes any tag, or commits any version bump.
+      # Both publishes are gated on whether the version is already on
+      # crates.io, making `version: none` re-runs idempotent for partial
+      # failure recovery.
+      - name: Mint crates.io token via OIDC
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        id: cargo-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Cargo publish (sdk → cli)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
+        run: |
+          set -euo pipefail
+          DRY=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY="--dry-run"
+          fi
+          VER=$(node -p "require('./packages/relayburn/package.json').version")
+
+          # Idempotent gate: skip if already on crates.io. Lets a partial
+          # failure (e.g. npm step below) be retried with `version: none`.
+          # `index.crates.io` shards by first-two/second-two of the crate
+          # name (`re/la/relayburn-sdk`).
+          sdk_published=$(curl -sf "https://index.crates.io/re/la/relayburn-sdk" 2>/dev/null \
+            | grep -c "\"vers\":\"$VER\"" || true)
+          if [ "$sdk_published" = "0" ]; then
+            cargo publish -p relayburn-sdk $DRY
+          else
+            echo "relayburn-sdk@$VER already on crates.io — skipping"
+          fi
+
+          # Wait for the new SDK version to land in the sparse index so
+          # the CLI's dep resolution sees it. Poll rather than fixed-sleep.
+          if [ -z "$DRY" ] && [ "$sdk_published" = "0" ]; then
+            for i in $(seq 1 30); do
+              if curl -sf "https://index.crates.io/re/la/relayburn-sdk" \
+                 | grep -q "\"vers\":\"$VER\""; then
+                echo "relayburn-sdk@$VER visible in index"
+                break
+              fi
+              echo "waiting for index... ($i/30)"
+              sleep 10
+            done
+          fi
+
+          cli_published=$(curl -sf "https://index.crates.io/re/la/relayburn-cli" 2>/dev/null \
+            | grep -c "\"vers\":\"$VER\"" || true)
+          if [ "$cli_published" = "0" ]; then
+            cargo publish -p relayburn-cli $DRY
+          else
+            echo "relayburn-cli@$VER already on crates.io — skipping"
           fi
 
       # npm >= 11.5.1 is required for the OIDC trusted-publisher flow.
@@ -602,13 +699,21 @@ jobs:
             version="${entry##*:}"
             NPM_NAME=$(node -p "require('./packages/$pkg/package.json').name")
             git tag -a "$pkg-v$version" -m "$NPM_NAME@$version"
+            # Lockstep: the Rust crates ship at the same workspace
+            # version, so reuse $version. Disambiguate from the npm
+            # `sdk-v…` / `cli-v…` tags via the `relayburn-` prefix.
+            if [ "$pkg" = "sdk" ]; then
+              git tag -a "relayburn-sdk-v$version" -m "relayburn-sdk@$version"
+            elif [ "$pkg" = "cli" ]; then
+              git tag -a "relayburn-cli-v$version" -m "relayburn-cli@$version"
+            fi
           done
           git push origin HEAD --follow-tags
 
       - name: Summary
         run: |
           {
-            echo "### Published"
+            echo "### Published (npm)"
             echo ""
             for entry in ${{ steps.bump.outputs.versions }}; do
               pkg="${entry%%:*}"
@@ -616,6 +721,12 @@ jobs:
               NPM_NAME=$(node -p "require('./packages/$pkg/package.json').name")
               echo "- \`$NPM_NAME@$version\`"
             done
+            echo ""
+            RUST_VER=$(node -p "require('./packages/relayburn/package.json').version")
+            echo "### Published (crates.io)"
+            echo ""
+            echo "- \`relayburn-sdk@$RUST_VER\`"
+            echo "- \`relayburn-cli@$RUST_VER\`"
             echo ""
             echo "- **dist-tag**: \`${{ github.event.inputs.tag }}\`"
             echo "- **dry run**: \`${{ github.event.inputs.dry_run }}\`"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relayburn-cli"
-version = "0.0.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "relayburn-sdk"
-version = "0.0.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "relayburn-sdk-node"
-version = "0.0.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.0.0"
+version = "1.10.0"
 edition = "2021"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/relayburn-cli/Cargo.toml
+++ b/crates/relayburn-cli/Cargo.toml
@@ -28,12 +28,12 @@ path = "src/lib.rs"
 # verb the binary surfaces will wrap a `relayburn-sdk` call once #248
 # fills in the CLI source.
 #
-# Version requirement is `0.0` (= `>=0.0.0, <0.1.0`) so the loose
-# 0.0.x prerelease line satisfies both the local workspace path
-# (currently 0.0.0) AND the published `relayburn-sdk` on crates.io
-# (currently 0.0.1) without forcing a lockstep bump on every release.
-# Tighten this once the SDK ships a stable 0.x line.
-relayburn-sdk = { path = "../relayburn-sdk", version = "0.0" }
+# Version requirement is the current MAJOR.MINOR (caret semantics:
+# `>=1.10.0, <2.0.0`). The publish workflow rewrites this to match
+# the workspace MAJOR.MINOR on every release so the local workspace
+# path (currently 1.10.0) and the published `relayburn-sdk` on
+# crates.io always satisfy the dep at publish time.
+relayburn-sdk = { path = "../relayburn-sdk", version = "1.10" }
 
 # clap v4 derive — argument parsing root and subcommand dispatch. The
 # scaffold defines globals + subcommand stubs only; per-command flag

--- a/crates/relayburn-sdk-node/Cargo.toml
+++ b/crates/relayburn-sdk-node/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 # this crate is consumed exclusively by the napi-rs CI matrix in #247-b
 # to produce the per-platform `.node` artifacts under
 # `packages/sdk-node/`.
-relayburn-sdk = { path = "../relayburn-sdk", version = "0.0" }
+relayburn-sdk = { path = "../relayburn-sdk", version = "1.10" }
 napi = { version = "2", default-features = false, features = ["napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

- Extends `.github/workflows/publish.yml` so each `workflow_dispatch` publish run also ships `relayburn-sdk` and `relayburn-cli` to crates.io, using OIDC trusted publishing (no long-lived `CARGO_REGISTRY_TOKEN`).
- Lockstep-versioned with the eight npm packages: bump step rewrites `[workspace.package].version` and the cli/sdk-node `relayburn-sdk` MAJOR.MINOR dep pin, refreshes `Cargo.lock`, and stages all Rust files alongside the npm version commit.
- Cargo publishes **before** npm so a crate-side failure aborts before any tarball, tag, or commit goes out. Both cargo steps are idempotent (skip if the version is already on crates.io), so a partial failure can be retried with `version: none`.
- Adds annotated `relayburn-sdk-v<ver>` / `relayburn-cli-v<ver>` tags (the `relayburn-` prefix disambiguates them from the existing npm `sdk-v…` / `cli-v…` tags).

## Pre-bump bootstrap (one-time alignment)

This PR aligns the Rust workspace with the current npm lockstep version:

- `Cargo.toml`: workspace version `0.0.0` → `1.10.0`.
- `crates/relayburn-cli/Cargo.toml` + `crates/relayburn-sdk-node/Cargo.toml`: `relayburn-sdk` dep version constraint `0.0` → `1.10` (caret = `>=1.10.0, <2.0.0`).
- `Cargo.lock` refreshed.

## Required maintainer steps before the first auto-publish run

The workflow can't mint OIDC tokens until trusted publishing is configured on crates.io. After this PR merges:

1. **Manually publish at 1.10.0** from a workstation using a personal API token:
   - `cargo publish -p relayburn-sdk`
   - Wait for sparse-index propagation (poll `https://index.crates.io/re/la/relayburn-sdk` for `1.10.0`).
   - `cargo publish -p relayburn-cli`
2. **Configure trusted publishing** on crates.io for both crates (Settings → Trusted Publishing → GitHub):
   - Repo: `AgentWorkforce/burn`, workflow filename: `publish.yml`, environment: empty.
3. **Revoke** the personal API token used in step 1.

After bootstrap, the next `workflow_dispatch` run with `version: patch` will land `1.10.1` everywhere in lockstep.

## Risks + mitigations

| Risk | Mitigation |
|---|---|
| Index propagation race between sdk and cli publish | Poll `index.crates.io/re/la/relayburn-sdk` for the new version with timeout |
| Partial failure (cargo OK, npm fails) | Cargo idempotent gate skips already-published versions; re-run picks up where it left off |
| Trusted-publisher misconfigured | First production run with `dry_run: true` validates the OIDC exchange without publishing |
| Rust port broken at release time | New `cargo build`/`test` step gates the whole job; npm doesn't ship if Rust is red |

## Test plan

- [x] Local: `cargo build --workspace && cargo test --workspace` passes on the bumped workspace.
- [ ] After merge, run `workflow_dispatch` with `dry_run: true`, `version: patch` to verify:
  - [ ] Rust toolchain installs and `cargo build`/`test` pass on the runner.
  - [ ] Bump step rewrites `Cargo.toml` workspace version + `crates/relayburn-{cli,sdk-node}/Cargo.toml` SDK constraints (visible in step log).
  - [ ] `rust-lang/crates-io-auth-action@v1` exchanges OIDC successfully.
  - [ ] `cargo publish --dry-run -p relayburn-sdk` and `-p relayburn-cli` succeed.
  - [ ] No git commit, no tags pushed, no npm publish.
- [ ] First real publish run (after bootstrap): verify 1.10.1 ships to both crates.io and npm; tags `relayburn-sdk-v1.10.1` and `relayburn-cli-v1.10.1` appear; `cargo install relayburn-cli` from a clean machine works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
