### PR TITLE
relayburn-sdk-node: shape conformance with TS @relayburn/sdk@1.x (#247c)

### DIFF
--- a/crates/relayburn-sdk-node/src/lib.rs
+++ b/crates/relayburn-sdk-node/src/lib.rs
@@ -468,7 +468,11 @@ pub struct SessionCostOptions {
 #[napi(object)]
 pub struct SessionCostResult {
     pub session_id: Option<String>,
-    /// Total cost in USD, rounded to 6 decimal places.
+    /// Total cost in USD, rounded to 6 decimal places. Surfaced as
+    /// `totalUSD` (screaming USD) to match `packages/sdk/index.d.ts`'s
+    /// 1.x contract — napi-rs would otherwise camelCase it to
+    /// `totalUsd`.
+    #[napi(js_name = "totalUSD")]
     pub total_usd: f64,
     pub total_tokens: BigInt,
     pub turn_count: BigInt,
@@ -569,8 +573,10 @@ pub struct OverheadTrimOptions {
     pub since: Option<String>,
     pub kind: Option<OverheadFileKind>,
     pub ledger_home: Option<String>,
-    /// Recommendations per file. Default 3.
-    pub top: Option<BigInt>,
+    /// Recommendations per file. Default 3. Plain `u32` rather than
+    /// `BigInt` — `top` is a small recommendation cap, never near 2^32,
+    /// and TS `packages/sdk/index.d.ts` types it as `number`.
+    pub top: Option<u32>,
     /// Include the unified-diff text per recommendation. Default true.
     pub include_diff: Option<bool>,
 }
@@ -591,16 +597,12 @@ pub fn overhead_trim(opts: Option<OverheadTrimOptions>) -> Result<BigIntPromotin
         top: None,
         include_diff: None,
     });
-    let top = match opts.top {
-        Some(b) => Some(bigint_to_u64(b)?),
-        None => None,
-    };
     let raw = sdk::OverheadTrimOptions {
         project: maybe_path(opts.project),
         since: opts.since,
         kind: opts.kind.map(Into::into),
         ledger_home: maybe_path(opts.ledger_home),
-        top,
+        top: opts.top.map(u64::from),
         include_diff: opts.include_diff,
     };
     let result = sdk::overhead_trim(raw).map_err(sdk_err)?;
@@ -694,7 +696,10 @@ pub struct CompareOptions {
     pub workflow: Option<String>,
     pub agent: Option<String>,
     pub provider: Option<Vec<String>>,
-    pub min_sample: Option<BigInt>,
+    /// Insufficient-sample threshold. Default 5. Plain `u32` — a turn
+    /// count never approaches 2^32, and TS
+    /// `packages/sdk/index.d.ts` types it as `number`.
+    pub min_sample: Option<u32>,
     /// One of `full`, `usage-only`, `aggregate-only`, `cost-only`, `partial`.
     pub min_fidelity: Option<String>,
     pub ledger_home: Option<String>,
@@ -705,10 +710,6 @@ pub struct CompareOptions {
 /// counts, etc.) cross as `BigInt` per the file-header rule.
 #[napi(ts_return_type = "import('./index').CompareResult")]
 pub fn compare(opts: CompareOptions) -> Result<BigIntPromoting, BurnError> {
-    let min_sample = match opts.min_sample {
-        Some(b) => Some(bigint_to_u64(b)?),
-        None => None,
-    };
     let raw = sdk::CompareOptions {
         models: opts.models,
         session: opts.session,
@@ -717,7 +718,7 @@ pub fn compare(opts: CompareOptions) -> Result<BigIntPromoting, BurnError> {
         workflow: opts.workflow,
         agent: opts.agent,
         provider: opts.provider,
-        min_sample,
+        min_sample: opts.min_sample.map(u64::from),
         min_fidelity: parse_fidelity_class(opts.min_fidelity.as_deref())?,
         ledger_home: maybe_path(opts.ledger_home),
     };
@@ -873,20 +874,36 @@ pub fn export_stamps(opts: Option<ExportStampsOptions>) -> Result<BigIntPromotin
 // ingest — async; returns a Promise<IngestReport> on the JS side.
 // ---------------------------------------------------------------------------
 
-#[napi(object)]
-pub struct IngestRoots {
-    /// `~/.claude/projects` override.
-    pub claude_projects_dir: Option<String>,
-    /// `~/.codex/sessions` override.
-    pub codex_sessions_dir: Option<String>,
-    /// `~/.local/share/opencode/storage` override.
-    pub opencode_storage_dir: Option<String>,
+/// Mirror of `packages/sdk/index.d.ts`'s
+/// `'claude-code' | 'codex' | 'opencode'` literal union. Surfaced as a
+/// `string_enum` so TS callers get the same string contract without a
+/// stringly-typed `harness: string` field.
+///
+/// Note: the SDK's `ingest_all` does not currently accept a per-harness
+/// filter — passing this is a forward-compat hook that mirrors the TS
+/// shape (`packages/sdk/index.js`'s `ingest()` likewise takes the option
+/// today and routes to `ingestAll()` without filtering).
+#[napi(string_enum = "kebab-case")]
+pub enum IngestHarness {
+    ClaudeCode,
+    Codex,
+    Opencode,
 }
 
+/// Mirrors `packages/sdk/index.d.ts`'s `IngestOptions` shape. The field
+/// set matches TS 1.x byte-for-byte; the binding routes to the SDK's
+/// fuller `sdk::IngestOptions` shape (with default `IngestRoots`) at the
+/// boundary.
 #[napi(object)]
 pub struct IngestOptions {
+    /// Reserved — TS 1.x accepts this option but `ingestAll()` ignores
+    /// it; mirrored here so the napi binding accepts the same caller
+    /// shape without a TypeError.
+    pub session_id: Option<String>,
+    /// Reserved — TS 1.x accepts this option but `ingestAll()` ignores
+    /// it; mirrored here for shape parity.
+    pub harness: Option<IngestHarness>,
     pub ledger_home: Option<String>,
-    pub roots: Option<IngestRoots>,
 }
 
 #[napi(object)]
@@ -925,23 +942,22 @@ impl From<sdk::IngestReport> for IngestReport {
 /// either fixes it or has to update the test in lockstep with the
 /// header docs.
 #[napi]
-pub async fn ingest(opts: Option<IngestOptions>) -> NapiResult<IngestReport> {
+pub async fn ingest(opts: Option<IngestOptions>) -> Result<IngestReport, NapiError> {
     let opts = opts.unwrap_or(IngestOptions {
+        session_id: None,
+        harness: None,
         ledger_home: None,
-        roots: None,
     });
-    let roots = opts.roots.unwrap_or(IngestRoots {
-        claude_projects_dir: None,
-        codex_sessions_dir: None,
-        opencode_storage_dir: None,
-    });
+    // session_id / harness are TS-shape mirror fields; the SDK's
+    // `ingest_all` takes neither, so we drop them here and rely on the
+    // SDK's discovery to pick up every session under the configured
+    // roots. Matches TS 1.x's behavior at packages/sdk/index.js's
+    // `ingest()`.
+    let _ = opts.session_id;
+    let _ = opts.harness;
     let raw = sdk::IngestOptions {
         ledger_home: maybe_path(opts.ledger_home),
-        roots: sdk::IngestRoots {
-            claude_projects_dir: maybe_path(roots.claude_projects_dir),
-            codex_sessions_dir: maybe_path(roots.codex_sessions_dir),
-            opencode_storage_dir: maybe_path(roots.opencode_storage_dir),
-        },
+        roots: sdk::IngestRoots::default(),
         on_progress: None,
         on_warn: None,
     };

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -7,3 +7,12 @@
   resolved via `optionalDependencies`, TS facade re-exporting the napi-rs
   binding, conformance scaffold against the TS 1.x SDK, esbuild bundle
   smoke test. (#247 part b)
+- Shape conformance with TS `@relayburn/sdk@1.x`: `Ledger.open()` returns
+  a `Promise<Ledger>` instance, `sessionCost()` emits `totalUSD`
+  (screaming USD), every read verb is `async` (`Promise<T>`),
+  `IngestOptions` is `{ sessionId, harness, ledgerHome }`, `top` and
+  `minSample` accept plain `number`, and `onLog` callbacks are accepted
+  on every read verb's options (silently dropped at the napi boundary
+  until the SDK wires fallback logging). Adds `search`, `exportLedger`,
+  `exportStamps`, `BurnErrorCode`, `OverheadFileKind`, and
+  `HotspotsGroupBy` as 2.x extensions over the 1.x surface. (#247 part c)

--- a/packages/sdk-node/src/index.cjs
+++ b/packages/sdk-node/src/index.cjs
@@ -1,19 +1,39 @@
 // CommonJS variant of the umbrella facade. Required for tools that resolve
 // `require('@relayburn/sdk')` through CJS — the ESM `src/index.js` is the
-// canonical entry point but pnpm / Node falls back to this when a consumer's
+// canonical entry point, but Node falls back to this when a consumer's
 // package is `"type": "commonjs"` and the `exports.require` map is honored.
+//
+// Mirrors the ESM facade verb-for-verb. The sync binding verbs are wrapped
+// in `async` so callers see `Promise<T>` (matching the 1.x TS contract);
+// see `src/index.js` for the rationale.
 
 'use strict';
 
 const binding = require('./binding.cjs');
 
+class Ledger {
+  constructor(home) {
+    this.home = home;
+  }
+  static async open(opts) {
+    const home = binding.ledgerOpen(opts);
+    return new Ledger(home);
+  }
+}
+
 module.exports = {
-  Ledger: binding.Ledger,
-  ingest: (opts) => binding.ingest(opts),
-  summary: (opts) => binding.summary(opts),
-  sessionCost: (opts) => binding.sessionCost(opts),
-  overhead: (opts) => binding.overhead(opts),
-  overheadTrim: (opts) => binding.overheadTrim(opts),
-  hotspots: (opts) => binding.hotspots(opts),
-  compare: (opts) => binding.compare(opts),
+  Ledger,
+  ingest: async (opts) => binding.ingest(opts),
+  summary: async (opts) => binding.summary(opts),
+  sessionCost: async (opts) => binding.sessionCost(opts),
+  overhead: async (opts) => binding.overhead(opts),
+  overheadTrim: async (opts) => binding.overheadTrim(opts),
+  hotspots: async (opts) => binding.hotspots(opts),
+  compare: async (opts) => binding.compare(opts),
+  search: async (opts) => binding.search(opts),
+  exportLedger: async (opts) => binding.exportLedger(opts),
+  exportStamps: async (opts) => binding.exportStamps(opts),
+  BurnErrorCode: binding.BurnErrorCode,
+  OverheadFileKind: binding.OverheadFileKind,
+  HotspotsGroupBy: binding.HotspotsGroupBy,
 };

--- a/packages/sdk-node/src/index.d.ts
+++ b/packages/sdk-node/src/index.d.ts
@@ -12,11 +12,25 @@
 // Source-of-truth comment: track `packages/sdk/index.d.ts`. Whenever a verb
 // shape changes in TS, mirror it here AND in the Rust napi-rs binding (#247-a).
 
-export interface LedgerOpenOptions { home?: string }
-export declare class Ledger { static open(opts?: LedgerOpenOptions): Promise<Ledger> }
+export interface LedgerOpenOptions { home?: string; contentHome?: string }
+/**
+ * Stateful ledger handle. The 1.x TS class only exposes the static
+ * `open()` constructor; instances are placeholders today, with `home`
+ * exposed for callers that want to confirm which ledger they attached
+ * to. Verb methods are a future PR.
+ */
+export declare class Ledger {
+  readonly home: string;
+  static open(opts?: LedgerOpenOptions): Promise<Ledger>;
+}
 
 export interface IngestOptions { sessionId?: string; harness?: 'claude-code'|'codex'|'opencode'; ledgerHome?: string }
-export declare function ingest(opts?: IngestOptions): Promise<unknown>
+export interface IngestReport {
+  scannedSessions: number | bigint;
+  ingestedSessions: number | bigint;
+  appendedTurns: number | bigint;
+}
+export declare function ingest(opts?: IngestOptions): Promise<IngestReport>
 
 export interface SummaryOptions {
   session?: string;
@@ -327,3 +341,82 @@ export interface CompareResult {
 
 /** Per-(model, activity) comparison shape. Powers `burn compare`. */
 export declare function compare(opts: CompareOptions): Promise<CompareResult>
+
+// ---------------------------------------------------------------------------
+// 2.x extensions — surfaces present in `relayburn-sdk` (the Rust crate)
+// but not in the TS 1.x `packages/sdk/index.d.ts`. Pre-1.0 widening per
+// the SDK shape rule; embedders that pinned to 1.x won't see these names
+// (the missing `onLog` etc. plus the absence of these is the only TS-vs-
+// napi gap the conformance gate measures).
+// ---------------------------------------------------------------------------
+
+export interface SearchQueryOptions {
+  /** FTS5 query string. Phrase, boolean, and prefix syntax supported. */
+  query: string;
+  /** Hit cap. Defaults to 25 when omitted. */
+  limit?: number | bigint;
+  /** Restrict to a single session_id. Omit to search all sessions. */
+  sessionId?: string;
+  ledgerHome?: string;
+}
+
+export interface SearchHit {
+  sessionId: string;
+  messageId: string;
+  source: string;
+  /** FTS5 BM25 rank (lower = better match). */
+  rank: number;
+  /** `<b>…</b>`-highlighted snippet around the matching tokens. */
+  snippet: string;
+}
+
+export interface SearchResult {
+  query: string;
+  hits: SearchHit[];
+}
+
+/** FTS5-backed message-content search. 2.x extension over the TS surface. */
+export declare function search(opts: SearchQueryOptions): Promise<SearchResult>
+
+export interface ExportLedgerOptions { ledgerHome?: string }
+export interface ExportStampsOptions { ledgerHome?: string }
+
+/**
+ * Stream every event row as a JSONL-shaped JSON object. Each value has
+ * the form `{ v: 1, kind: '<kind>', record: <json> }`. 2.x extension.
+ */
+export declare function exportLedger(opts?: ExportLedgerOptions): Promise<unknown[]>
+
+/** Stream every stamp row as a JSONL-shaped JSON object. 2.x extension. */
+export declare function exportStamps(opts?: ExportStampsOptions): Promise<unknown[]>
+
+/**
+ * Tagged error code surfaced on the thrown JS `Error.code` property.
+ * Sync verbs reject with one of these; the async `ingest` verb's
+ * rejection currently sets `code: 'GenericFailure'` — see the binding
+ * crate's `ingest` doc comment for the napi-rs-2.x rationale.
+ *
+ * The values are the literal strings written to `e.code`, matching the
+ * Rust constants `SDK_ERROR_CODE` / `IO_ERROR_CODE` / `INVALID_ARGUMENT_ERROR_CODE`.
+ */
+export declare const BurnErrorCode: {
+  readonly Sdk: 'BURN_SDK';
+  readonly Io: 'BURN_IO';
+  readonly InvalidArgument: 'BURN_INVALID_ARGUMENT';
+};
+export type BurnErrorCodeValue = (typeof BurnErrorCode)[keyof typeof BurnErrorCode];
+
+/** Wire-value enum for `OverheadOptions.kind` and `OverheadTrimOptions.kind`. */
+export declare const OverheadFileKind: {
+  readonly ClaudeMd: 'claude-md';
+  readonly AgentsMd: 'agents-md';
+};
+
+/** Wire-value enum for `HotspotsOptions.groupBy`. */
+export declare const HotspotsGroupBy: {
+  readonly Attribution: 'attribution';
+  readonly Bash: 'bash';
+  readonly BashVerb: 'bash-verb';
+  readonly File: 'file';
+  readonly Subagent: 'subagent';
+};

--- a/packages/sdk-node/src/index.js
+++ b/packages/sdk-node/src/index.js
@@ -1,44 +1,104 @@
-// Thin ESM facade over the napi-rs binding. No behavior — every function
-// here re-exports the matching `#[napi]` export from the platform package
-// resolved by `./binding.cjs`.
+// Thin ESM facade over the napi-rs binding. The verbs here re-export the
+// matching `#[napi]` exports from the platform package resolved by
+// `./binding.cjs`, with two adjustments to match the TS 1.x contract at
+// `packages/sdk/index.d.ts`:
+//
+//   1. The sync `#[napi]` verbs (`summary`, `sessionCost`, `overhead`,
+//      `overheadTrim`, `hotspots`, `compare`) are re-exported as `async`
+//      functions so callers receive `Promise<T>` (matching the 1.x
+//      `Promise<...>` return shape). Awaiting an `async` wrapper around a
+//      sync return is free and preserves the typed `e.code` thrown by the
+//      binding (`BurnErrorCode.Sdk` / `Io` / `InvalidArgument`).
+//   2. `Ledger.open()` is a JS-side wrapper around the binding's
+//      `ledgerOpen()` smoke verb. The 1.x `Ledger` class only exposes a
+//      static `open(opts)` that returns a placeholder instance, so we
+//      keep the same shape here without adding a stateful `#[napi]` class
+//      (which would force `Mutex<LedgerHandle>` plumbing for no benefit).
 //
 // All query / compute logic lives in the Rust SDK (`crates/relayburn-sdk`);
 // the binding crate (`crates/relayburn-sdk-node`) wraps it for napi-rs.
-// This file exists so the published TS surface stays identical to the
-// 1.x SDK (`packages/sdk/index.js`) — same import names, same option shapes,
-// same return types — while the runtime is Rust.
 
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const binding = require('./binding.cjs');
 
-export const Ledger = binding.Ledger;
+/**
+ * Stateful ledger handle. Mirrors the TS 1.x `Ledger` class shape from
+ * `packages/sdk/index.d.ts`. The 1.x version only exposes the static
+ * `open(opts)` constructor — instance methods are reserved for a future
+ * PR — so we replicate that surface and stash the resolved home for
+ * introspection.
+ */
+export class Ledger {
+  constructor(home) {
+    /** @type {string} */
+    this.home = home;
+  }
+  /**
+   * Open and validate a ledger at `opts.home` (or `RELAYBURN_HOME`).
+   * Returns a `Promise<Ledger>` to mirror the 1.x async signature even
+   * though the underlying `ledgerOpen` binding is synchronous.
+   *
+   * @param {{ home?: string, contentHome?: string }} [opts]
+   * @returns {Promise<Ledger>}
+   */
+  static async open(opts) {
+    const home = binding.ledgerOpen(opts);
+    return new Ledger(home);
+  }
+}
 
-export function ingest(opts) {
+export async function ingest(opts) {
   return binding.ingest(opts);
 }
 
-export function summary(opts) {
+export async function summary(opts) {
   return binding.summary(opts);
 }
 
-export function sessionCost(opts) {
+export async function sessionCost(opts) {
   return binding.sessionCost(opts);
 }
 
-export function overhead(opts) {
+export async function overhead(opts) {
   return binding.overhead(opts);
 }
 
-export function overheadTrim(opts) {
+export async function overheadTrim(opts) {
   return binding.overheadTrim(opts);
 }
 
-export function hotspots(opts) {
+export async function hotspots(opts) {
   return binding.hotspots(opts);
 }
 
-export function compare(opts) {
+export async function compare(opts) {
   return binding.compare(opts);
 }
+
+// 2.x extensions — exposed by the Rust SDK but not declared in
+// `packages/sdk/index.d.ts` (the 1.x TS surface). Per the SDK shape rule,
+// pre-1.0 widening is allowed; these are surfaced here so embedders can
+// reach the FTS5 search index and the JSONL export iterators without
+// dropping into the binding directly.
+export async function search(opts) {
+  return binding.search(opts);
+}
+
+export async function exportLedger(opts) {
+  return binding.exportLedger(opts);
+}
+
+export async function exportStamps(opts) {
+  return binding.exportStamps(opts);
+}
+
+// Re-exported enums from the Rust binding. These come across as plain
+// string-valued objects (`{ Sdk: 'BURN_SDK', ... }`) and let JS callers
+// branch on `e.code === BurnErrorCode.Sdk` without stringly-typed
+// literals. `OverheadFileKind` and `HotspotsGroupBy` are likewise the
+// canonical wire values for the matching option-struct fields.
+export const BurnErrorCode = binding.BurnErrorCode;
+export const OverheadFileKind = binding.OverheadFileKind;
+export const HotspotsGroupBy = binding.HotspotsGroupBy;


### PR DESCRIPTION
## Summary

PR α of the burn 2.0 cutover (epic #240, blocking #249). Brings the napi-rs umbrella `@relayburn/sdk@2.x` (binding crate at `crates/relayburn-sdk-node` + facade at `packages/sdk-node/src/`) into shape-parity with the TS 1.x SDK at `packages/sdk/index.d.ts`, modulo the already-documented `number | bigint` widening on u64 token-count fields.

## Punch-list

1. **`Ledger` class** — JS-side wrapper class in `src/index.{js,cjs}` that awaits `binding.ledgerOpen()` and stashes the resolved `home`. No `#[napi]` class on the Rust side (would have forced `Mutex<LedgerHandle>` plumbing for no benefit). `index.d.ts` declares `class Ledger { readonly home: string; static open(opts?: LedgerOpenOptions): Promise<Ledger> }`.
2. **`totalUSD` casing** — `#[napi(js_name = "totalUSD")]` override on `SessionCostResult.total_usd`. Verified end-to-end against a freshly built `.node`: `typeof sc.totalUSD === 'number'`, no `totalUsd` key.
3. **`onLog?: (msg) => void` on every read verb's options** — declared in TS at `index.d.ts` (already present from prior commits). The napi boundary silently drops it — `#[napi(object)]`'s `from_napi_value` codegen reads only declared fields, so extra props (like a JS function) ride through without a TypeError. Forward-compat hook for when `relayburn-sdk` grows fallback-log threading; `relayburn-sdk` does not currently expose an `OnLogCallback` type for read verbs.
4. **`IngestOptions` shape** — `{ sessionId, harness, ledgerHome }` matches TS 1.x byte-for-byte. The binding routes to `sdk::IngestRoots::default()` and ignores `sessionId` / `harness` (TS 1.x's `ingest()` likewise routes to `ingestAll()` without filtering — confirmed at `packages/sdk/index.js:127-129`). Drops the `IngestRoots` napi struct.
5. **Read verbs return `Promise<T>`** — every read verb is re-exported as an `async` function in the JS facade. The Rust side stays sync (returning `Result<T, BurnError>`) so the typed `BurnErrorCode` on `e.code` survives the wrapper. Verified: `await m.compare({ minFidelity: 'bogus' })` rejects with `e.code === BurnErrorCode.InvalidArgument`. `ingest`'s return type spelled `Result<IngestReport, NapiError>` so napi-derive's syntactic `Result` detection emits `Promise<IngestReport>` instead of treating the `NapiResult` alias as the literal return.
6. **`top` and `minSample` widening** — `Option<u32>` instead of `Option<BigInt>`. Both are small counts (`top` is a recommendation cap, `minSample` is a turn-count threshold) and TS types them as `number`; `u32 -> u64` is lossless on the way into the SDK.
7. **Re-export list** — adds `search`, `exportLedger`, `exportStamps`, `BurnErrorCode`, `OverheadFileKind`, `HotspotsGroupBy` as 2.x extensions to `index.{js,cjs,d.ts}`. `Ledger` re-exported via the wrapper class; `ledgerOpen` is internal-only.

## Out of scope

- `tests/fixtures/ledger/` seeding + flipping `RELAYBURN_SDK_NAPI_BUILT=1` — PR β.
- `binding.cjs` loader-path bug (the regenerated dispatcher looks for `index.<target>.node` next to `__dirname` = `src/`, but `napi build` drops the file at `packages/sdk-node/` root) — also PR β.
- `.github/workflows/napi-build.yml` — PR γ.

## Test plan

- [x] `cargo build -p relayburn-sdk-node --release` clean.
- [x] `cargo test -p relayburn-sdk-node` — 10 tests pass (no regressions in the BIGINT_FIELDS membership / runtime invariant tests).
- [x] `cd packages/sdk-node && pnpm run build:napi:debug` clean. Regenerated `binding.d.ts` shows `Promise<IngestReport>`, `totalUSD: number`, `top?: number`, `minSample?: number`, and the new `IngestHarness` enum.
- [x] `node --test test/esbuild-smoke.test.js` clean (esbuild bundles the umbrella facade with all the new exports).
- [x] `cargo build --workspace` clean.
- [x] `pnpm -r run build` clean.
- [x] End-to-end smoke against a real `.node`: `Ledger.open()` returns a Promise, `summary()`'s `totalTokens` is `bigint`, `sessionCost()`'s `totalUSD` is correctly cased, typed `e.code` survives the async wrapper, `onLog` callbacks are silently accepted.

## Notes for PR β / γ

- The regenerated `binding.cjs` (which I left out of the diff per instructions) destructures the napi exports at the top: `const { BurnErrorCode, summary, sessionCost, ..., IngestHarness, ingest, ledgerOpen } = nativeBinding`. The hand-written stub on `main` does `module.exports = nativeBinding;` and works for both shapes — so reverting binding.cjs in this PR doesn't break the umbrella facade. The CI matrix's regen overwrites it.
- The loader-path bug really does bite locally: napi-rs drops `index.darwin-arm64.node` at the package root (next to `package.json`), but the regenerated dispatcher does `existsSync(join(__dirname, 'index.darwin-arm64.node'))` where `__dirname` is `src/`. Worked around for this PR by copying the artifact into `src/` for the smoke test; PR β should align the build output and the loader.

Refs #247.