### PR TITLE
relayburn-sdk-node: wire conformance suite in CI (#247d)

### DIFF
--- a/.github/workflows/napi-build.yml
+++ b/.github/workflows/napi-build.yml
@@ -176,14 +176,29 @@ jobs:
         working-directory: packages/sdk-node
         run: node --test 'test/esbuild-smoke.test.js'
 
-      - name: Conformance test (skipped until #247-a binding lands)
-        # While #247-a is in flight the binding crate has no exports, so
-        # the conformance suite skips itself. Once those bindings land,
-        # flipping `RELAYBURN_SDK_NAPI_BUILT=1` here turns the skip into a
-        # real deep-equal gate against TS @relayburn/sdk@1.x.
+      - name: Build TS workspace (for conformance step)
+        # Conformance imports `packages/sdk/index.js` (the TS 1.x SDK), which
+        # imports `@relayburn/{ledger,analyze,ingest,reader}`. Those packages
+        # ship as `dist/index.js` so they need a `tsc --build` pass before
+        # they can be required at runtime. The matrix runs `pnpm install` at
+        # the root above, but no build — flip that here so the conformance
+        # step's TS-side import resolves cleanly.
+        run: pnpm run build
+
+      - name: Conformance test (TS @relayburn/sdk@1.x vs napi-rs @2.0.0-pre)
+        # The conformance suite seeds a deterministic ledger via
+        # `tests/fixtures/cli-golden/scripts/build-ledger.mjs`, runs each of
+        # the 7 verbs against both impls into matched tmp homes, and asserts
+        # `deepStrictEqual`. With α (#354) shape-conformant, this gate is
+        # the acceptance test for #247.
+        #
+        # If conformance fails on a verb, the failure is α follow-up scope —
+        # see the test header for the seeding strategy and the
+        # `tests/fixtures/cli-golden/ledger/.gitignore` note about the
+        # JSONL→SQLite replay the Rust SDK requires.
         working-directory: packages/sdk-node
         env:
-          RELAYBURN_SDK_NAPI_BUILT: '0'
+          RELAYBURN_SDK_NAPI_BUILT: '1'
         run: node --test 'test/conformance.test.js'
 
   publish:

--- a/.github/workflows/napi-build.yml
+++ b/.github/workflows/napi-build.yml
@@ -123,8 +123,22 @@ jobs:
       - name: Build napi binding for ${{ matrix.target }}
         # `napi build` reads `packages/sdk-node/package.json`'s `napi`
         # block to learn the binary name, then dispatches to `cargo build`
-        # under the hood. The output is a per-target `.node` file and a
-        # generated `binding.cjs` / `binding.d.ts` co-located with it.
+        # under the hood. The output is a per-target `.node` file plus a
+        # generated `binding.cjs` / `binding.d.ts`.
+        #
+        # We pass `src` as the positional `[destDir]` so all three outputs
+        # (`.node`, `binding.cjs`, `binding.d.ts`) land in `src/` next to
+        # `index.js`. The generated `binding.cjs` resolves the local `.node`
+        # via `existsSync(join(__dirname, 'index.<target>.node'))`, and
+        # `__dirname` is `packages/sdk-node/src/`, so co-locating the
+        # artifacts is the simplest way to make the local-binding branch
+        # actually fire (without it, the loader silently falls through to
+        # `require('@relayburn/sdk-<target>')`, which isn't installed in
+        # dev). The `--js` / `--dts` paths are relative to the destDir so
+        # `pnpm exec napi build … --js binding.cjs --dts binding.d.ts src`
+        # writes to `src/binding.{cjs,d.ts}` (passing `src/binding.cjs` plus
+        # `src` would double-prefix to `src/src/binding.cjs`).
+        #
         # `--cargo-cwd` points at the binding crate (which lives under
         # `crates/relayburn-sdk-node/`, not co-located with the npm package)
         # so the `cargo metadata` step that resolves the cdylib succeeds.
@@ -142,14 +156,15 @@ jobs:
             --release \
             --target ${{ matrix.target }} \
             --cargo-cwd ../../crates/relayburn-sdk-node \
-            --js src/binding.cjs \
-            --dts src/binding.d.ts
+            --js binding.cjs \
+            --dts binding.d.ts \
+            src
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: relayburn-sdk-${{ matrix.short }}
-          path: packages/sdk-node/*.node
+          path: packages/sdk-node/src/*.node
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/napi-build.yml
+++ b/.github/workflows/napi-build.yml
@@ -183,6 +183,13 @@ jobs:
         # they can be required at runtime. The matrix runs `pnpm install` at
         # the root above, but no build — flip that here so the conformance
         # step's TS-side import resolves cleanly.
+        #
+        # Skipped on the aarch64-linux leg: that leg cross-compiles on an
+        # x64 host, so `node` (the runner's interpreter) cannot load the
+        # arm64 `.node` artifact we just built. Building the TS workspace
+        # is wasted work on that leg too — the conformance step below is
+        # also gated off there.
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
         run: pnpm run build
 
       - name: Conformance test (TS @relayburn/sdk@1.x vs napi-rs @2.0.0-pre)
@@ -192,10 +199,23 @@ jobs:
         # `deepStrictEqual`. With α (#354) shape-conformant, this gate is
         # the acceptance test for #247.
         #
+        # Skipped on the aarch64-linux leg: that leg is a CROSS-COMPILE
+        # (host=ubuntu-latest x64, target=aarch64-unknown-linux-gnu), so
+        # the only `.node` artifact present is the arm64 binary. The
+        # x64 `node` interpreter on the runner cannot load it — and
+        # `binding.cjs` resolves the binding by `process.arch`, so it
+        # tries to load `index.linux-x64-gnu.node` (or the matching
+        # optionalDependency, which isn't installed in dev) and crashes
+        # the import before the test body's `t.skip` can fire. The other
+        # three legs (x64-darwin, arm64-darwin, x64-linux) are all native
+        # and exercise the same conformance contract; this leg's job is
+        # purely to validate the cross-compile build + artifact upload.
+        #
         # If conformance fails on a verb, the failure is α follow-up scope —
         # see the test header for the seeding strategy and the
         # `tests/fixtures/cli-golden/ledger/.gitignore` note about the
         # JSONL→SQLite replay the Rust SDK requires.
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
         working-directory: packages/sdk-node
         env:
           RELAYBURN_SDK_NAPI_BUILT: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ dist/
 # Rust / Cargo
 target/
 **/*.rs.bk
+
+# napi-rs prebuilt bindings — `napi build` regenerates these into
+# `packages/sdk-node/src/`. CI uploads them as job artifacts; PR γ
+# (#249) wires them into the per-platform `npm/<short>/` packages at
+# publish time. They should never be committed.
+packages/sdk-node/src/*.node
+packages/sdk-node/*.node

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,15 @@
+# Hoist `@relayburn/*` workspace packages into the root `node_modules/`.
+#
+# Why: scripts under `tests/fixtures/cli-golden/scripts/` (`build-ledger.mjs`,
+# `capture-snapshots.mjs`) import `@relayburn/ledger` directly. Node ESM
+# resolution walks up `node_modules/` from the script's location, and those
+# scripts live outside any workspace package — so without hoisting, the
+# resolver never finds the symlinks pnpm puts under each consumer's
+# `packages/<pkg>/node_modules/@relayburn/`. The conformance test
+# (`packages/sdk-node/test/conformance.test.js`) and `pnpm run golden:capture`
+# both spawn `build-ledger.mjs`, so both break in clean checkouts without this.
+#
+# Hoisting workspace siblings to the root is safe — they're our own packages,
+# not third-party — and matches pnpm's recommended pattern for tooling that
+# runs outside workspace package boundaries.
+public-hoist-pattern[]=@relayburn/*

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -16,3 +16,9 @@
   until the SDK wires fallback logging). Adds `search`, `exportLedger`,
   `exportStamps`, `BurnErrorCode`, `OverheadFileKind`, and
   `HotspotsGroupBy` as 2.x extensions over the 1.x surface. (#247 part c)
+- Conformance suite is now wired into CI: `napi build` writes its outputs
+  (`.node`, `binding.cjs`, `binding.d.ts`) into `src/` so the generated
+  loader's local-file branch resolves; the suite seeds a deterministic
+  ledger via `tests/fixtures/cli-golden/scripts/build-ledger.mjs` and
+  flips `RELAYBURN_SDK_NAPI_BUILT=1` to enable the `deepStrictEqual` gate
+  against TS `@relayburn/sdk@1.x`. (#247 part d)

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -24,8 +24,8 @@
   ],
   "scripts": {
     "build": "node -e \"process.exit(0)\"",
-    "build:napi": "napi build --platform --release --cargo-cwd ../../crates/relayburn-sdk-node --js src/binding.cjs --dts src/binding.d.ts",
-    "build:napi:debug": "napi build --platform --cargo-cwd ../../crates/relayburn-sdk-node --js src/binding.cjs --dts src/binding.d.ts",
+    "build:napi": "napi build --platform --release --cargo-cwd ../../crates/relayburn-sdk-node --js binding.cjs --dts binding.d.ts src",
+    "build:napi:debug": "napi build --platform --cargo-cwd ../../crates/relayburn-sdk-node --js binding.cjs --dts binding.d.ts src",
     "test": "node --test 'test/**/*.test.js'",
     "test:bundle": "node test/esbuild-smoke.test.js"
   },

--- a/packages/sdk-node/test/conformance.test.js
+++ b/packages/sdk-node/test/conformance.test.js
@@ -2,31 +2,44 @@
 //
 // For each of the 7 verbs (`ingest`, `summary`, `sessionCost`, `overhead`,
 // `overheadTrim`, `hotspots`, `compare`), run both implementations against
-// the existing fixture ledger and assert `deepStrictEqual` on the return
+// the same seeded fixture ledger and assert `deepStrictEqual` on the return
 // value. This is the gate that says "the Rust port is behavior-equivalent
 // to the TS port" — it's the test #247 cites as the acceptance criterion.
 //
-// **Status (2026-05-06): scaffolded but skipped.** The napi-rs bindings
-// land in #247-a (parallel agent worktree). Until that crate is published
-// and the umbrella's `src/binding.cjs` resolves a real native package, the
-// `loadNapiSdk()` helper below throws and the suite skips. Flip the
-// `RELAYBURN_SDK_NAPI_BUILT=1` env var (CI sets this once #247-a's bindings
-// produce a valid `*.node` artifact) to enable the comparison.
+// **Fixture strategy.** Rather than commit a binary-ish ledger snapshot to
+// `tests/fixtures/ledger/`, we seed a fresh ledger on every test run by
+// invoking the deterministic builder at
+// `tests/fixtures/cli-golden/scripts/build-ledger.mjs`. That script is the
+// hand-curated source of truth for the cli-golden suite — it exercises all
+// three readers (claude-code / codex / opencode), multi-session shapes,
+// edits + tool calls + stamps + relationships — and is byte-deterministic.
+// We `cpSync` its output into two tmp homes (one for each impl) so reads
+// happen against identical state. This keeps conformance self-contained
+// (no committed `tests/fixtures/ledger/` to drift silently) and keeps the
+// fixture in lock-step with the cli-golden tests that already maintain it.
 //
-// What's stubbed and why:
-//   - The local `@relayburn/sdk` npm package in this directory is the 2.x
-//     umbrella; its facade resolves the binding lazily on import. So
-//     `await import('@relayburn/sdk')` succeeds, but the first verb call
-//     throws "binding not found" until #247-a ships. We catch that
-//     specific error and skip rather than fail.
-//   - We fix `RELAYBURN_HOME` to a tmp dir for both runs so they share
-//     state. The TS 1.x `@relayburn/sdk` is loaded via a relative file:
-//     reference (`packages/sdk`) to avoid name collision with the 2.x
-//     umbrella in this package's `node_modules`.
+// **Ingest is read-only here.** `ingest` is one of the 7 verbs we conform,
+// and ingesting via the live `ingestAll()` would scan the runner's real
+// `~/.claude/projects/`, `~/.codex/sessions/`, etc., making the test
+// non-deterministic. We isolate `HOME` to an empty tmp dir for both impls,
+// so `ingest` returns the trivial `{ scannedSessions: 0, ... }` report on
+// both sides. Deep ingest conformance against a corpus is tracked as a
+// follow-up — see the comment on the ingest test below.
+//
+// **Loader contract.** The local `@relayburn/sdk` (this package) is the 2.x
+// umbrella; its facade resolves the binding lazily on import. So
+// `await import('./src/index.js')` succeeds but the first verb call throws
+// if the binding is missing. We catch that specific error and skip rather
+// than fail.
+//
+// Set `RELAYBURN_SDK_NAPI_BUILT=1` to actually run the comparison;
+// `napi-build.yml` flips the gate after `pnpm run build:napi` produces a
+// resolvable `.node`.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, cpSync, existsSync, readFileSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, cpSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -34,12 +47,16 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../..');
 
-// Fixture ledger location. CI seeds `tests/fixtures/ledger/` from the
-// reader corpus during the `prepare-fixture-ledger` step. When
-// `RELAYBURN_SDK_NAPI_BUILT=1` is set this directory MUST exist —
-// `ensureFixtureLedger()` below throws if it's missing so the gate can't
-// silently pass on empty homes.
-const FIXTURE_LEDGER_DIR = join(REPO_ROOT, 'tests', 'fixtures', 'ledger');
+// Seeder script — see header. The script reads `RELAYBURN_HOME` and writes
+// `ledger.jsonl` + `ledger.idx` + `ledger.content.idx` into it.
+const SEEDER_SCRIPT = join(
+  REPO_ROOT,
+  'tests',
+  'fixtures',
+  'cli-golden',
+  'scripts',
+  'build-ledger.mjs',
+);
 
 const NAPI_READY = process.env.RELAYBURN_SDK_NAPI_BUILT === '1';
 
@@ -54,7 +71,8 @@ async function loadTsSdk() {
 async function loadNapiSdk() {
   // Resolve the in-tree umbrella facade. Throws if the binding is missing —
   // the per-test guard below converts that to a skip so the suite stays
-  // green while #247-a is in flight.
+  // green when the build artifact isn't present (e.g. `npm test` without
+  // `pnpm run build:napi` first).
   const napiSdkPath = join(__dirname, '..', 'src', 'index.js');
   return import(napiSdkPath);
 }
@@ -63,138 +81,68 @@ function bindingMissing(err) {
   return /native binding not found/i.test(String(err && err.message));
 }
 
-// When the gate is on (`RELAYBURN_SDK_NAPI_BUILT=1`) the fixture ledger MUST
-// exist AND be well-formed enough to actually exercise the verbs — otherwise
-// both implementations would compare against empty/garbage homes and the
-// deep-equality checks would tautologically pass on noise (both sides see the
-// same nothing). Throwing here turns "fixture missing or malformed" into a
-// loud failure instead of a silent green.
-//
-// The fixture lives at `tests/fixtures/ledger/` and mirrors the on-disk shape
-// of `~/.relayburn/`: a canonical `ledger.jsonl` (see
-// `packages/ledger/src/paths.ts::ledgerPath`) plus a `content/` sidecar. CI's
-// `prepare-fixture-ledger` step seeds it from the reader corpus before
-// flipping the gate.
-//
-// Preconditions checked:
-//   1. The fixture directory exists.
-//   2. `ledger.jsonl` exists and is non-empty.
-//   3. The first line of `ledger.jsonl` parses as JSON and matches the
-//      `LedgerLine` shape (`v: 1` + `kind: <known>`) defined in
-//      `packages/ledger/src/schema.ts`. This catches the easy "I copied the
-//      wrong thing" failure mode (e.g. a stray text file) without doing a
-//      full schema sweep.
-//   4. At least one `kind: 'turn'` line is present anywhere in the file —
-//      verbs like `summary` / `hotspots` / `compare` need turns to produce
-//      non-trivial output, so a stamp-only fixture would still let the
-//      conformance gate pass on empty rows.
-const KNOWN_LEDGER_KINDS = new Set([
-  'turn',
-  'stamp',
-  'compaction',
-  'relationship',
-  'tool_result_event',
-  'user_turn',
-]);
+// Module-scoped seed dir, populated by `seedFixture()` on first use and
+// reused across tests. Cleaned up by the `after` hook below.
+let SEED_HOME = null;
 
-function fixtureSeedHint() {
-  return (
-    `Seed it (e.g. cp -R ~/.relayburn tests/fixtures/ledger) before ` +
-    `running with RELAYBURN_SDK_NAPI_BUILT=1, or unset the env var to ` +
-    `skip the conformance suite.`
-  );
-}
-
-function ensureFixtureLedger() {
-  if (!existsSync(FIXTURE_LEDGER_DIR)) {
-    throw new Error(
-      `conformance fixture ledger missing at ${FIXTURE_LEDGER_DIR}. ` +
-        fixtureSeedHint(),
-    );
-  }
-  const ledgerJsonl = join(FIXTURE_LEDGER_DIR, 'ledger.jsonl');
-  if (!existsSync(ledgerJsonl)) {
-    throw new Error(
-      `conformance fixture ledger malformed: expected ${ledgerJsonl} ` +
-        `(canonical ledger filename per packages/ledger/src/paths.ts). ` +
-        fixtureSeedHint(),
-    );
-  }
-  if (statSync(ledgerJsonl).size === 0) {
-    throw new Error(
-      `conformance fixture ledger malformed: ${ledgerJsonl} is empty. ` +
-        fixtureSeedHint(),
-    );
-  }
-  // Cheap sanity sweep: confirm the file looks like a JSONL ledger and
-  // contains at least one turn line. We read the whole file because real
-  // fixtures are small (kilobytes); if that ever stops being true, switch to
-  // a streaming scan.
-  const lines = readFileSync(ledgerJsonl, 'utf8').split('\n').filter((l) => l.length > 0);
-  if (lines.length === 0) {
-    throw new Error(
-      `conformance fixture ledger malformed: ${ledgerJsonl} has no JSONL ` +
-        `lines. ` +
-        fixtureSeedHint(),
-    );
-  }
-  let firstLine;
-  try {
-    firstLine = JSON.parse(lines[0]);
-  } catch (err) {
-    throw new Error(
-      `conformance fixture ledger malformed: ${ledgerJsonl} first line is ` +
-        `not valid JSON (${err && err.message}). ` +
-        fixtureSeedHint(),
-    );
-  }
-  if (
-    !firstLine ||
-    typeof firstLine !== 'object' ||
-    firstLine.v !== 1 ||
-    typeof firstLine.kind !== 'string' ||
-    !KNOWN_LEDGER_KINDS.has(firstLine.kind)
-  ) {
-    throw new Error(
-      `conformance fixture ledger malformed: ${ledgerJsonl} first line ` +
-        `does not match the LedgerLine shape (expected v:1 + kind:<known>, ` +
-        `got ${JSON.stringify({ v: firstLine && firstLine.v, kind: firstLine && firstLine.kind })}). ` +
-        fixtureSeedHint(),
-    );
-  }
-  // Require at least one turn so summary/hotspots/compare have something to
-  // diff against. A pure stamp/relationship-only fixture would still let
-  // both impls return empty rows and pass on noise.
-  const hasTurn = lines.some((line) => {
-    try {
-      const parsed = JSON.parse(line);
-      return parsed && parsed.v === 1 && parsed.kind === 'turn';
-    } catch {
-      return false;
-    }
+function seedFixture() {
+  if (SEED_HOME !== null) return SEED_HOME;
+  const dir = mkdtempSync(join(tmpdir(), 'relayburn-conformance-seed-'));
+  // Spawn the deterministic builder in a fresh process so its imports
+  // resolve from the workspace root regardless of our `cwd`. The script
+  // uses `@relayburn/ledger` etc., which need the workspace built (see
+  // `pnpm run build` in CI before this test runs).
+  const result = spawnSync(process.execPath, [SEEDER_SCRIPT], {
+    env: { ...process.env, RELAYBURN_HOME: dir },
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
-  if (!hasTurn) {
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString() ?? '';
+    const stdout = result.stdout?.toString() ?? '';
     throw new Error(
-      `conformance fixture ledger malformed: ${ledgerJsonl} contains no ` +
-        `kind:'turn' lines, so verbs like summary/hotspots/compare would ` +
-        `compare empty results on both sides. ` +
-        fixtureSeedHint(),
+      `conformance fixture seeder failed (exit ${result.status}):\n` +
+        `--- stderr ---\n${stderr}\n--- stdout ---\n${stdout}`,
     );
   }
+  SEED_HOME = dir;
+  return dir;
 }
 
-function makeHome() {
-  const home = mkdtempSync(join(tmpdir(), 'relayburn-conformance-'));
-  cpSync(FIXTURE_LEDGER_DIR, home, { recursive: true });
+test.after(() => {
+  if (SEED_HOME) rmSync(SEED_HOME, { recursive: true, force: true });
+});
+
+// Empty fake-HOME tree. `ingest` discovers session stores under
+// `~/.claude/projects/`, `~/.codex/sessions/`, and
+// `~/.local/share/opencode/storage/` (see `packages/ingest/src/ingest.ts`).
+// We seed empty dirs so both impls return the trivial empty report instead
+// of scanning the real user's session logs.
+function makeEmptyHome() {
+  const home = mkdtempSync(join(tmpdir(), 'relayburn-conformance-home-'));
+  mkdirSync(join(home, '.claude', 'projects'), { recursive: true });
+  mkdirSync(join(home, '.codex', 'sessions'), { recursive: true });
+  mkdirSync(join(home, '.local', 'share', 'opencode', 'storage'), {
+    recursive: true,
+  });
   return home;
 }
 
+function makeLedgerHome() {
+  const seed = seedFixture();
+  const home = mkdtempSync(join(tmpdir(), 'relayburn-conformance-ledger-'));
+  cpSync(seed, home, { recursive: true });
+  return home;
+}
+
+// Run both impls' `verb(opts)` against fresh-but-identical seeded ledger
+// homes and return their results. Caller asserts `deepStrictEqual` on the
+// pair. If the napi binding isn't loadable yet, returns `{ skipped: true }`
+// so callers can skip the test rather than fail.
 async function callBoth(verb, opts) {
-  ensureFixtureLedger();
   const ts = await loadTsSdk();
   const napi = await loadNapiSdk();
-  const tsHome = makeHome();
-  const napiHome = makeHome();
+  const tsHome = makeLedgerHome();
+  const napiHome = makeLedgerHome();
   try {
     const tsResult = await ts[verb]({ ...opts, ledgerHome: tsHome });
     let napiResult;
@@ -213,9 +161,16 @@ async function callBoth(verb, opts) {
 
 const VERBS = [
   { name: 'summary', opts: {} },
-  { name: 'sessionCost', opts: { session: 'fixture-session-1' } },
-  { name: 'overhead', opts: { project: REPO_ROOT } },
-  { name: 'overheadTrim', opts: { project: REPO_ROOT, includeDiff: false } },
+  // `11111111-...` is the Claude session A id seeded by build-ledger.mjs;
+  // it has 4 turns of edits + tests + bash so sessionCost has real numbers
+  // to diff against. See `tests/fixtures/cli-golden/scripts/build-ledger.mjs`.
+  { name: 'sessionCost', opts: { session: '11111111-1111-1111-1111-111111111111' } },
+  // overhead/overheadTrim need a project path that resolves; the seeded
+  // ledger uses `/tmp/golden-project` as its project, but that won't have
+  // settings on disk. Both impls see the same missing-project state, so the
+  // returned shape (typically empty rows + zero counts) still deep-equals.
+  { name: 'overhead', opts: { project: '/tmp/golden-project' } },
+  { name: 'overheadTrim', opts: { project: '/tmp/golden-project', includeDiff: false } },
   { name: 'hotspots', opts: {} },
   // compare() requires >=2 models; pick a stable pair that may or may not
   // appear in the fixture — both implementations see the same input so
@@ -229,19 +184,17 @@ const VERBS = [
       minFidelity: 'partial',
     },
   },
-  // ingest is exercised separately because both impls mutate the ledger;
-  // we run it last in its own block.
 ];
 
 for (const { name, opts } of VERBS) {
   test(`conformance: ${name}() matches TS 1.x`, async (t) => {
     if (!NAPI_READY) {
-      t.skip('napi-rs binding not built — set RELAYBURN_SDK_NAPI_BUILT=1 once #247-a lands');
+      t.skip('napi-rs binding not built — set RELAYBURN_SDK_NAPI_BUILT=1');
       return;
     }
     const out = await callBoth(name, opts);
     if (out.skipped) {
-      t.skip('napi-rs binding load failed — #247-a binding artifact missing');
+      t.skip('napi-rs binding load failed — build artifact missing');
       return;
     }
     assert.deepStrictEqual(out.napiResult, out.tsResult);
@@ -250,17 +203,46 @@ for (const { name, opts } of VERBS) {
 
 test('conformance: ingest() matches TS 1.x', async (t) => {
   if (!NAPI_READY) {
-    t.skip('napi-rs binding not built — set RELAYBURN_SDK_NAPI_BUILT=1 once #247-a lands');
+    t.skip('napi-rs binding not built — set RELAYBURN_SDK_NAPI_BUILT=1');
     return;
   }
-  // ingest mutates the ledger, so we deep-equal the *returned report*.
-  // Once the napi binding is wired up we may also want to compare a
-  // follow-up summary() across both homes to confirm the two
-  // implementations wrote the same rows; that's tracked separately.
-  const out = await callBoth('ingest', {});
-  if (out.skipped) {
-    t.skip('napi-rs binding load failed — #247-a binding artifact missing');
-    return;
+  // Both impls scan session stores via `homedir()` (no env override). To
+  // keep this deterministic we point HOME at an empty tmp tree so ingest
+  // returns the trivial `{ scannedSessions: 0, ingestedSessions: 0,
+  // appendedTurns: 0 }` report on both sides. Deep-corpus ingest
+  // conformance — point both impls at the same `~/.claude/projects/`
+  // tree of fixture session logs and compare the resulting ledgers — is
+  // tracked as an α follow-up; the seeded ledger here is hand-curated, not
+  // ingest output, so it can't double as that test.
+  const ts = await loadTsSdk();
+  const napi = await loadNapiSdk();
+  const fakeHome = makeEmptyHome();
+  const tsLedgerHome = makeLedgerHome();
+  const napiLedgerHome = makeLedgerHome();
+  const prevHome = process.env.HOME;
+  const prevUserprofile = process.env.USERPROFILE;
+  try {
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome; // win32 fallback in node:os.homedir()
+    const tsResult = await ts.ingest({ ledgerHome: tsLedgerHome });
+    let napiResult;
+    try {
+      napiResult = await napi.ingest({ ledgerHome: napiLedgerHome });
+    } catch (err) {
+      if (bindingMissing(err)) {
+        t.skip('napi-rs binding load failed — build artifact missing');
+        return;
+      }
+      throw err;
+    }
+    assert.deepStrictEqual(napiResult, tsResult);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserprofile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserprofile;
+    rmSync(fakeHome, { recursive: true, force: true });
+    rmSync(tsLedgerHome, { recursive: true, force: true });
+    rmSync(napiLedgerHome, { recursive: true, force: true });
   }
-  assert.deepStrictEqual(out.napiResult, out.tsResult);
 });


### PR DESCRIPTION
## Summary

Three-blocker fix that makes the napi-rs conformance suite *actually run*
in CI against the now-merged shape-conformant bindings (alpha / #354). Each
blocker lands as its own commit:

- **Blocker 1 - loader path bug.** `napi build` was emitting
  `index.<target>.node` at the package root while the regenerated loader
  at `src/binding.cjs` checked `__dirname` (`src/`). Pass `src` as the
  positional `[destDir]` so all three artifacts (`.node`, `binding.cjs`,
  `binding.d.ts`) co-locate. Update artifact upload glob + `.gitignore`.
- **Blocker 2 - fixture ledger.** `tests/fixtures/ledger/` was never
  seeded. The suite now spawns
  `tests/fixtures/cli-golden/scripts/build-ledger.mjs` (the existing
  hand-curated, byte-deterministic builder) into a tmp dir on each run
  and `cpSync`s the output into per-impl tmp homes. No committed
  binary-ish fixture, no drift.
- **Blocker 3 - flip the gate.** `RELAYBURN_SDK_NAPI_BUILT=1` in the
  workflow + a `pnpm run build` step so the TS 1.x SDK's `dist/`-shaped
  deps resolve before the conformance step runs.

Closes the beta slice of #247.

## Alpha follow-ups surfaced by the now-running gate

The conformance step is now *real* and currently flags two classes of
divergence between TS @relayburn/sdk@1.x and the napi-rs binding (#354).
Beta does not fix these - both are alpha-scope:

1. **BigInt vs Number wire-shape**: napi serializes `u64`/`i64` as
   `BigInt` (e.g. `turnCount: 0n`), TS 1.x uses plain `Number`. Affects
   `summary.{turnCount,totalTokens}`, `sessionCost.{turnCount,totalTokens}`,
   `overheadTrim.summary.{filesAnalyzed,filesWithRecommendations}`,
   `compare.{analyzedTurns, fidelity.excluded.*, totals.*.turns,
   minSample, fidelity.summary.*}`, `hotspots` (multiple), `ingest.*`.
2. **Read-side JSONL->SQLite gap**: the Rust SDK reads from
   `burn.sqlite`, the seeded fixture is JSONL only. So napi reads return
   empty rows while TS reads return populated data. Fixable by either
   (a) auto-replaying JSONL->SQLite in the Rust `Ledger::open` path, or
   (b) pre-bootstrapping `burn.sqlite` in the conformance fixture (the
   `relayburn-cli/tests/golden.rs::bootstrap_sqlite_from_jsonl` helper
   already does this for the CLI golden tests). Currently 6/7 verbs
   diverge; only `overhead()` passes (returns shape-equal empty results
   on both sides because the project path doesn't exist).

## PR gamma note (publish wiring)

The per-platform `package.json` files in `packages/sdk-node/npm/<short>/`
declare `main: "relayburn-sdk.<target>.node"`, but `napi build`
generates the file as `index.<target>.node` (because `napi.binaryName`
in `package.json` is *not* the field napi-rs reads - it looks for
`napi.name`, defaulting to `"index"` when missing). PR gamma will need to
either rename the artifact or set `napi.name = "relayburn-sdk"`.

## Test plan

- [ ] `pnpm install --ignore-workspace` in `packages/sdk-node`
- [ ] `pnpm run build:napi:debug` produces `src/index.<target>.node` +
      `src/binding.cjs` + `src/binding.d.ts`
- [ ] `node -e "require('./src/binding.cjs')"` loads without throwing
- [ ] `RELAYBURN_SDK_NAPI_BUILT=1 node --test test/conformance.test.js`
      runs all 7 verbs (failures are expected alpha follow-ups; see above)
- [ ] `node test/esbuild-smoke.test.js` still passes
- [ ] `cargo build --workspace && pnpm -r run build` clean

Refs #247.