### PR TITLE
relayburn-sdk-node: coerce BigInt to Number in umbrella facade (alpha-followup)

### DIFF
--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -16,3 +16,7 @@
   until the SDK wires fallback logging). Adds `search`, `exportLedger`,
   `exportStamps`, `BurnErrorCode`, `OverheadFileKind`, and
   `HotspotsGroupBy` as 2.x extensions over the 1.x surface. (#247 part c)
+- Umbrella facade now coerces napi-rs `BigInt` return values to `Number`
+  for safe-range integers (`[Number.MIN_SAFE_INTEGER,
+  Number.MAX_SAFE_INTEGER]`), matching the TS 1.x runtime shape; values
+  outside that range stay `BigInt` to avoid silent precision loss.

--- a/packages/sdk-node/src/index.cjs
+++ b/packages/sdk-node/src/index.cjs
@@ -11,6 +11,35 @@
 
 const binding = require('./binding.cjs');
 
+// See `src/index.js` for the rationale: napi-rs serializes Rust `u64` /
+// `i64` as JS `BigInt`, while TS 1.x `@relayburn/sdk` emits plain
+// `Number`. We downcast safe-range BigInts to keep `deepStrictEqual`
+// passing in conformance and to match user expectations from 1.x.
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+
+function coerceBigInts(value) {
+  if (typeof value === 'bigint') {
+    return value >= MIN_SAFE && value <= MAX_SAFE ? Number(value) : value;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = coerceBigInts(value[i]);
+    }
+    return value;
+  }
+  if (value !== null && typeof value === 'object') {
+    const proto = Object.getPrototypeOf(value);
+    if (proto === null || proto === Object.prototype) {
+      for (const key of Object.keys(value)) {
+        value[key] = coerceBigInts(value[key]);
+      }
+    }
+    return value;
+  }
+  return value;
+}
+
 class Ledger {
   constructor(home) {
     this.home = home;
@@ -23,16 +52,16 @@ class Ledger {
 
 module.exports = {
   Ledger,
-  ingest: async (opts) => binding.ingest(opts),
-  summary: async (opts) => binding.summary(opts),
-  sessionCost: async (opts) => binding.sessionCost(opts),
-  overhead: async (opts) => binding.overhead(opts),
-  overheadTrim: async (opts) => binding.overheadTrim(opts),
-  hotspots: async (opts) => binding.hotspots(opts),
-  compare: async (opts) => binding.compare(opts),
-  search: async (opts) => binding.search(opts),
-  exportLedger: async (opts) => binding.exportLedger(opts),
-  exportStamps: async (opts) => binding.exportStamps(opts),
+  ingest: async (opts) => coerceBigInts(await binding.ingest(opts)),
+  summary: async (opts) => coerceBigInts(await binding.summary(opts)),
+  sessionCost: async (opts) => coerceBigInts(await binding.sessionCost(opts)),
+  overhead: async (opts) => coerceBigInts(await binding.overhead(opts)),
+  overheadTrim: async (opts) => coerceBigInts(await binding.overheadTrim(opts)),
+  hotspots: async (opts) => coerceBigInts(await binding.hotspots(opts)),
+  compare: async (opts) => coerceBigInts(await binding.compare(opts)),
+  search: async (opts) => coerceBigInts(await binding.search(opts)),
+  exportLedger: async (opts) => coerceBigInts(await binding.exportLedger(opts)),
+  exportStamps: async (opts) => coerceBigInts(await binding.exportStamps(opts)),
   BurnErrorCode: binding.BurnErrorCode,
   OverheadFileKind: binding.OverheadFileKind,
   HotspotsGroupBy: binding.HotspotsGroupBy,

--- a/packages/sdk-node/src/index.js
+++ b/packages/sdk-node/src/index.js
@@ -23,6 +23,46 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const binding = require('./binding.cjs');
 
+// napi-rs serializes Rust `u64` / `i64` as JS `BigInt`, but the TS 1.x
+// `@relayburn/sdk` shape (mirrored in `src/index.d.ts`) emits plain
+// `Number` for the same fields. To keep the conformance gate's
+// `deepStrictEqual` checks honest — and to match the runtime shape that
+// 1.x callers expect (e.g. `result.turnCount === 0`, not `=== 0n`) — we
+// downcast every `BigInt` in a verb's return value to `Number` when it
+// fits in `[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]`. Values
+// outside that range are left as `BigInt`: realistic burn ledgers won't
+// hit 2^53 tokens, but if one ever does, leaking a `BigInt` that crashes
+// a `===` check is strictly safer than silently rounding to the nearest
+// 1024. The TS shape declares `number | bigint` everywhere this matters
+// so the type stays sound either way.
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+
+function coerceBigInts(value) {
+  if (typeof value === 'bigint') {
+    return value >= MIN_SAFE && value <= MAX_SAFE ? Number(value) : value;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = coerceBigInts(value[i]);
+    }
+    return value;
+  }
+  if (value !== null && typeof value === 'object') {
+    // Skip class instances we don't own (Date, Map, Set, Buffer, …) —
+    // walking their guts would be both wasteful and risky. Plain objects
+    // produced by napi-rs serde have a null or Object prototype.
+    const proto = Object.getPrototypeOf(value);
+    if (proto === null || proto === Object.prototype) {
+      for (const key of Object.keys(value)) {
+        value[key] = coerceBigInts(value[key]);
+      }
+    }
+    return value;
+  }
+  return value;
+}
+
 /**
  * Stateful ledger handle. Mirrors the TS 1.x `Ledger` class shape from
  * `packages/sdk/index.d.ts`. The 1.x version only exposes the static
@@ -50,31 +90,31 @@ export class Ledger {
 }
 
 export async function ingest(opts) {
-  return binding.ingest(opts);
+  return coerceBigInts(await binding.ingest(opts));
 }
 
 export async function summary(opts) {
-  return binding.summary(opts);
+  return coerceBigInts(await binding.summary(opts));
 }
 
 export async function sessionCost(opts) {
-  return binding.sessionCost(opts);
+  return coerceBigInts(await binding.sessionCost(opts));
 }
 
 export async function overhead(opts) {
-  return binding.overhead(opts);
+  return coerceBigInts(await binding.overhead(opts));
 }
 
 export async function overheadTrim(opts) {
-  return binding.overheadTrim(opts);
+  return coerceBigInts(await binding.overheadTrim(opts));
 }
 
 export async function hotspots(opts) {
-  return binding.hotspots(opts);
+  return coerceBigInts(await binding.hotspots(opts));
 }
 
 export async function compare(opts) {
-  return binding.compare(opts);
+  return coerceBigInts(await binding.compare(opts));
 }
 
 // 2.x extensions — exposed by the Rust SDK but not declared in
@@ -83,15 +123,15 @@ export async function compare(opts) {
 // reach the FTS5 search index and the JSONL export iterators without
 // dropping into the binding directly.
 export async function search(opts) {
-  return binding.search(opts);
+  return coerceBigInts(await binding.search(opts));
 }
 
 export async function exportLedger(opts) {
-  return binding.exportLedger(opts);
+  return coerceBigInts(await binding.exportLedger(opts));
 }
 
 export async function exportStamps(opts) {
-  return binding.exportStamps(opts);
+  return coerceBigInts(await binding.exportStamps(opts));
 }
 
 // Re-exported enums from the Rust binding. These come across as plain


### PR DESCRIPTION
## Summary

Alpha-followup that closes the **BigInt vs Number wire-shape** gap surfaced by PR #355's now-running conformance gate. Pairs with a sibling alpha-followup that addresses the JSONL to SQLite read-side gap.

PR #354 made the napi-rs binding shape-conformant with TS `@relayburn/sdk@1.x`. PR #355 flipped `RELAYBURN_SDK_NAPI_BUILT=1` in CI and surfaced two classes of divergence between TS 1.x and the napi-rs binding:

1. **BigInt vs Number** - napi serializes Rust `u64` / `i64` as JS `BigInt` (e.g. `turnCount: 0n`); TS 1.x emits plain `Number`. This PR fixes that.
2. **Read-side JSONL to SQLite gap** - handled in a sibling PR.

## Approach

Add a `coerceBigInts(value)` helper at the JS facade layer (`packages/sdk-node/src/index.js` + the CJS mirror at `index.cjs`). The helper recursively walks a verb's return value and downcasts `BigInt` to `Number` when the value fits in `[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]`. Values outside that range stay `BigInt`: realistic burn ledgers won't hit 2^53 tokens, but if one ever does, leaking a `BigInt` that crashes a `===` check is strictly safer than silently rounding to the nearest 1024.

Class instances we don't own (`Date`, `Map`, `Set`, `Buffer`, ...) are skipped via a prototype check; only plain objects with `null` or `Object.prototype` get walked.

Wraps every verb's return:

- `summary`, `sessionCost`, `overhead`, `overheadTrim`, `hotspots`, `compare`, `ingest`
- `search`, `exportLedger`, `exportStamps` (2.x extensions)

`Ledger.open()` and the re-exported enums (`BurnErrorCode`, `OverheadFileKind`, `HotspotsGroupBy`) don't need wrapping - they return strings.

The TS shape `number | bigint` in `packages/sdk-node/src/index.d.ts` was already correct from PR #354 and stays - this is a runtime-shape fix, not a type-surface change. The fix is at the umbrella facade rather than the binding crate (`crates/relayburn-sdk-node/`) because BigInt is the right choice at the napi-rs layer (lossless `u64`); the coercion is a 1.x-compat shim that belongs alongside the other 1.x-compat shims (`async`-wrapped sync verbs, `Ledger.open` constructor wrapper).

## Conformance probe

Local probe - cherry-picked PR #355's `test/conformance.test.js` and ran with `RELAYBURN_SDK_NAPI_BUILT=1`:

- **Pre-fix (per #355 description):** 1/7 passing (`overhead`).
- **With this PR:** 3/7 passing (`overhead`, `overheadTrim`, `ingest`).

The remaining 4 failures (`summary`, `sessionCost`, `hotspots`, `compare`) are the JSONL to SQLite read-side gap - TS reads from JSONL and returns populated rows, napi reads from `burn.sqlite` (not yet seeded by the conformance fixture) and returns empty rows. None of those failures are BigInt-related; the failing diffs show plain `Number` literals on both sides. The sibling alpha-followup PR closes that gap.

## Test plan

- [x] `pnpm install --ignore-workspace --frozen-lockfile=false` in `packages/sdk-node`
- [x] `pnpm run build:napi:debug` produces `binding.cjs` + `binding.d.ts` + `*.node`
- [x] `pnpm run test:bundle` (esbuild bundle smoke) passes
- [x] Ad hoc verification: calling `summary({ ledgerHome: <empty> })` returns `totalTokens: 0` (Number) instead of `0n` (BigInt); coerce-helper unit-tested for safe-range/out-of-range/nested/array/`Date`-instance branches
- [x] Conformance probe (cherry-picked from #355) shows 3/7 vs 1/7 baseline
- [x] `cargo build --workspace` clean (no Rust changes; sanity)

Refs #247, #354, #355.