### PR TITLE
relayburn: install wrapper dispatches Rust burn binary via platform packages

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -1,0 +1,183 @@
+name: cli build
+
+# Build prebuilt `burn` binaries for every platform we publish to npm under
+# `@relayburn/cli-*`. PRs validate the matrix; tags / manual dispatch *would*
+# publish, but the publish step is stubbed off for now — the cutover publish
+# workflow integration lands as a follow-up to this PR.
+#
+# Mirrors `.github/workflows/napi-build.yml`: the napi-rs SDK uses the same
+# umbrella + per-platform-package shape, just with `.node` artifacts instead
+# of native executables.
+
+on:
+  pull_request:
+    paths:
+      - 'crates/relayburn-cli/**'
+      - 'crates/relayburn-sdk/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'packages/relayburn/**'
+      - '.github/workflows/cli-build.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/relayburn-cli/**'
+      - 'crates/relayburn-sdk/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'packages/relayburn/**'
+      - '.github/workflows/cli-build.yml'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish prebuilt artifacts to npm under the `next` tag (stubbed; full wiring lands with the cutover publish workflow)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build ${{ matrix.short }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+            short: darwin-x64
+          - target: aarch64-apple-darwin
+            os: macos-14
+            short: darwin-arm64
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            short: linux-x64-gnu
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            short: linux-arm64-gnu
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        # rust-toolchain.toml at the repo root pins the channel + components.
+        run: |
+          rustup toolchain install
+          rustup target add ${{ matrix.target }}
+
+      - name: Install aarch64-linux cross toolchain (linux-arm64 only)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        # `libsqlite3-sys` (a transitive dep via `rusqlite`) compiles bundled
+        # SQLite C source via `cc-rs`, which probes for `aarch64-linux-gnu-gcc`.
+        # Same setup as `napi-build.yml`'s aarch64-linux leg.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-cli-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-cli-${{ runner.os }}-${{ matrix.target }}-
+            cargo-cli-${{ runner.os }}-
+
+      - name: Build burn binary for ${{ matrix.target }}
+        # The binary name is `burn` (the `[[bin]]` rename in
+        # `crates/relayburn-cli/Cargo.toml`); the crate is `relayburn-cli`.
+        # CC_/linker env vars only take effect on the aarch64-linux leg
+        # (cargo ignores per-target vars when host == target); native legs
+        # are unaffected.
+        env:
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: |
+          cargo build --release --target ${{ matrix.target }} --bin burn -p relayburn-cli
+
+      - name: Strip binary
+        # Stripping cuts ~half the size off a release `burn` (debug info,
+        # symbol tables that aren't needed at runtime). On macOS use `-x` to
+        # strip non-global symbols only — fully stripping a Mach-O binary
+        # breaks codesigning. On linux, default `strip` is fine; when
+        # cross-compiling for aarch64 we use the matching cross-strip.
+        run: |
+          BIN="target/${{ matrix.target }}/release/burn"
+          case "${{ matrix.target }}" in
+            *-apple-darwin)
+              strip -x "$BIN"
+              ;;
+            aarch64-unknown-linux-gnu)
+              aarch64-linux-gnu-strip "$BIN"
+              ;;
+            *-unknown-linux-gnu)
+              strip "$BIN"
+              ;;
+          esac
+          ls -lh "$BIN"
+
+      - name: Stage binary into platform package
+        # Mirror the layout the publish step will rely on:
+        # `packages/relayburn/npm/<short>/bin/burn`. The directory is
+        # gitignored at rest; the artifact upload below is what survives
+        # the matrix run for the publish job to download.
+        run: |
+          mkdir -p packages/relayburn/npm/${{ matrix.short }}/bin
+          cp target/${{ matrix.target }}/release/burn packages/relayburn/npm/${{ matrix.short }}/bin/burn
+          chmod +x packages/relayburn/npm/${{ matrix.short }}/bin/burn
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: relayburn-cli-${{ matrix.short }}
+          path: packages/relayburn/npm/${{ matrix.short }}/bin/burn
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Smoke test (`burn --help`)
+        # Native legs only. The aarch64-linux leg cross-compiles on an x64
+        # host so the runner's interpreter cannot execute the binary.
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        run: |
+          packages/relayburn/npm/${{ matrix.short }}/bin/burn --help
+          packages/relayburn/npm/${{ matrix.short }}/bin/burn --version
+
+  publish:
+    # Stub. Real publish wiring lands as a follow-up that integrates with
+    # `.github/workflows/publish.yml`: download the matrix artifacts, drop
+    # each into the right `packages/relayburn/npm/<short>/bin/` directory,
+    # and `npm publish` the umbrella + each per-platform package via OIDC
+    # trusted publisher. Until then, calling `workflow_dispatch` with
+    # `publish: true` exercises the artifact download path so we catch
+    # wiring errors early without actually pushing to npm.
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: packages/relayburn/npm-artifacts
+
+      - name: Inspect artifacts (publish stub)
+        run: |
+          echo 'Publish step is currently a stub. Full wiring lands in the cutover publish.yml integration follow-up.'
+          ls -lahR packages/relayburn/npm-artifacts || true

--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -151,8 +151,24 @@ jobs:
         # host so the runner's interpreter cannot execute the binary.
         if: matrix.target != 'aarch64-unknown-linux-gnu'
         run: |
+          set -euo pipefail
           packages/relayburn/npm/${{ matrix.short }}/bin/burn --help
           packages/relayburn/npm/${{ matrix.short }}/bin/burn --version
+
+          smoke_dir="$(mktemp -d)"
+          umbrella_dir="$(mktemp -d)"
+          trap 'rm -rf "$smoke_dir" "$umbrella_dir"' EXIT
+          npm install --prefix "$smoke_dir" --no-save --omit=optional \
+            --ignore-scripts --no-audit --no-fund \
+            ./packages/relayburn/npm/${{ matrix.short }}
+          "$smoke_dir/node_modules/.bin/burn" --help
+          "$smoke_dir/node_modules/.bin/burn" --version
+
+          npm install --prefix "$umbrella_dir" --no-save --omit=optional \
+            --ignore-scripts --no-audit --no-fund \
+            ./packages/relayburn
+          NODE_PATH="$smoke_dir/node_modules" "$umbrella_dir/node_modules/.bin/burn" --help
+          NODE_PATH="$smoke_dir/node_modules" "$umbrella_dir/node_modules/.bin/burn" --version
 
   publish:
     # Stub. Real publish wiring lands as a follow-up that integrates with

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -221,6 +221,42 @@ jobs:
           done
           echo "versions=${VERSIONS# }" >> "$GITHUB_OUTPUT"
 
+          # `relayburn` points at prebuilt platform packages with exact
+          # optionalDependency versions. Keep those package manifests and
+          # the generic CLI fallback in lockstep with the umbrella version
+          # that npm version just computed.
+          node --input-type=module <<'SYNCEOF'
+          import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const formatJson = (value) => `${JSON.stringify(value, null, 2)}\n`;
+          const relayburnPath = 'packages/relayburn/package.json';
+          const relayburn = JSON.parse(readFileSync(relayburnPath, 'utf8'));
+          const version = relayburn.version;
+          const platformRoot = 'packages/relayburn/npm';
+
+          const platformPackages = readdirSync(platformRoot, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => {
+              const path = join(platformRoot, entry.name, 'package.json');
+              if (!existsSync(path)) return null;
+              const json = JSON.parse(readFileSync(path, 'utf8'));
+              json.version = version;
+              writeFileSync(path, formatJson(json));
+              return json.name;
+            })
+            .filter(Boolean)
+            .sort();
+
+          relayburn.optionalDependencies = {
+            '@relayburn/cli': version,
+            ...Object.fromEntries(platformPackages.map((name) => [name, version])),
+          };
+          writeFileSync(relayburnPath, formatJson(relayburn));
+
+          console.log(`relayburn optional dependencies and ${platformPackages.length} platform package(s) synced to ${version}.`);
+          SYNCEOF
+
           # Lockstep the Rust workspace to the npm version. Any package's
           # post-bump version works since they're all equal after the bump.
           # The cli/sdk-node path-deps on relayburn-sdk pin MAJOR.MINOR
@@ -564,6 +600,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add packages/*/package.json packages/*/CHANGELOG.md CHANGELOG.md \
+                  packages/relayburn/npm/*/package.json \
                   Cargo.toml Cargo.lock \
                   crates/relayburn-cli/Cargo.toml crates/relayburn-sdk-node/Cargo.toml
           if git diff --cached --quiet; then

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ target/
 # publish time. They should never be committed.
 packages/sdk-node/src/*.node
 packages/sdk-node/*.node
+
+# Prebuilt `burn` binaries for the Rust CLI — the cli-build matrix
+# produces these and the cutover publish workflow drops them into
+# `packages/relayburn/npm/<platform>/bin/` before `npm publish`. The
+# umbrella `relayburn` package resolves them at install time via
+# `optionalDependencies`. They should never be committed.
+packages/relayburn/npm/*/bin/

--- a/packages/relayburn/CHANGELOG.md
+++ b/packages/relayburn/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `relayburn`.
 
 ## [Unreleased]
 
+### Changed
+
+- `relayburn` now installs the prebuilt Rust `burn` binary via per-platform `@relayburn/cli-<platform>` packages instead of dispatching through the TS `@relayburn/cli`. The umbrella declares the platform packages as `optionalDependencies`; the `burn` shim resolves and execs the matching binary.
+
 ## [1.6.2] - 2026-05-02
 
 ### Changed

--- a/packages/relayburn/CHANGELOG.md
+++ b/packages/relayburn/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `relayburn`.
 
 ### Changed
 
-- `relayburn` now installs the prebuilt Rust `burn` binary via per-platform `@relayburn/cli-<platform>` packages instead of dispatching through the TS `@relayburn/cli`. The umbrella declares the platform packages as `optionalDependencies`; the `burn` shim resolves and execs the matching binary.
+- `relayburn` now prefers the prebuilt Rust `burn` binary from per-platform `@relayburn/cli-<platform>` packages, with `@relayburn/cli` kept as a fallback for unsupported or missing native packages.
 
 ## [1.6.2] - 2026-05-02
 

--- a/packages/relayburn/README.md
+++ b/packages/relayburn/README.md
@@ -6,7 +6,10 @@ Install the [`burn`](https://github.com/AgentWorkforce/burn) CLI globally:
 npm i -g relayburn
 ```
 
-This is a thin wrapper that depends on [`@relayburn/cli`](https://www.npmjs.com/package/@relayburn/cli) and exposes the `burn` command. Both names produce the same binary; pick whichever you find easier to type.
+This package is a thin install wrapper. It declares the per-platform
+`@relayburn/cli-<platform>` packages as `optionalDependencies`; npm's
+`os` / `cpu` filters install only the one matching your machine, and the
+`burn` shim resolves and execs the prebuilt Rust binary it ships.
 
 ```sh
 burn --help
@@ -14,4 +17,9 @@ burn summary --since 7d
 burn hotspots --since 7d
 ```
 
-See the project [README](https://github.com/AgentWorkforce/burn#readme) for full documentation.
+Supported platforms: `darwin-arm64`, `darwin-x64`, `linux-arm64-gnu`
+(glibc), `linux-x64-gnu` (glibc). Windows support is tracked in
+[#359](https://github.com/AgentWorkforce/burn/issues/359).
+
+See the project [README](https://github.com/AgentWorkforce/burn#readme)
+for full documentation.

--- a/packages/relayburn/README.md
+++ b/packages/relayburn/README.md
@@ -9,7 +9,9 @@ npm i -g relayburn
 This package is a thin install wrapper. It declares the per-platform
 `@relayburn/cli-<platform>` packages as `optionalDependencies`; npm's
 `os` / `cpu` filters install only the one matching your machine, and the
-`burn` shim resolves and execs the prebuilt Rust binary it ships.
+`burn` shim resolves and execs the prebuilt Rust binary it ships. If a
+native package is not available, the shim falls back to the generic
+TypeScript `@relayburn/cli` package.
 
 ```sh
 burn --help
@@ -17,8 +19,9 @@ burn summary --since 7d
 burn hotspots --since 7d
 ```
 
-Supported platforms: `darwin-arm64`, `darwin-x64`, `linux-arm64-gnu`
-(glibc), `linux-x64-gnu` (glibc). Windows support is tracked in
+Prebuilt platforms: `darwin-arm64`, `darwin-x64`, `linux-arm64-gnu`
+(glibc), `linux-x64-gnu` (glibc). Other hosts use the TypeScript CLI
+fallback. Windows native binary support is tracked in
 [#359](https://github.com/AgentWorkforce/burn/issues/359).
 
 See the project [README](https://github.com/AgentWorkforce/burn#readme)

--- a/packages/relayburn/bin/burn.js
+++ b/packages/relayburn/bin/burn.js
@@ -2,10 +2,10 @@
 // Platform-resolving spawner for the `burn` Rust binary. Mirrors the
 // `@relayburn/sdk` napi-rs dispatcher pattern (see
 // `packages/sdk-node/src/binding.cjs`): the umbrella `relayburn` package
-// declares the per-platform packages as `optionalDependencies`, npm
-// installs the one matching `os` + `cpu` filters, and this script
-// `require.resolve`s the prebuilt `burn` binary out of it and spawns it
-// with the user's argv.
+// declares the per-platform packages plus the generic `@relayburn/cli`
+// fallback as `optionalDependencies`, npm installs the matching native
+// package when available, and this script `require.resolve`s the native
+// `burn` binary first, then falls back to the TS CLI when needed.
 //
 // The actual binaries live in `packages/relayburn/npm/<platform>/bin/burn`
 // and are dropped there by the cli-build CI matrix at publish time. They
@@ -22,7 +22,7 @@ const require = createRequire(import.meta.url);
 // Map (process.platform, process.arch) → platform-package short string.
 // Linux glibc-vs-musl detection follows the same `process.report` probe
 // the napi-rs loader uses; we only ship glibc artifacts today, so a musl
-// host falls through to the unsupported-platform error below.
+// host falls through to the generic CLI fallback below.
 function detectShort() {
   const { platform, arch } = process;
 
@@ -56,34 +56,65 @@ function binSuffix() {
 }
 
 const short = detectShort();
-if (!short) {
-  process.stderr.write(
-    `relayburn: unsupported platform ${process.platform}-${process.arch}.\n` +
-      `Supported: darwin-arm64, darwin-x64, linux-arm64-gnu (glibc), linux-x64-gnu (glibc).\n` +
-      `Track Windows support at https://github.com/AgentWorkforce/burn/issues/359.\n`,
-  );
-  process.exit(1);
+const fallbackSpecifier = '@relayburn/cli/dist/cli.js';
+const passthroughArgs = process.argv.slice(2);
+
+function formatError(err) {
+  return err && err.message ? err.message : String(err);
 }
 
-const pkg = `@relayburn/cli-${short}`;
-const binSpecifier = `${pkg}/bin/burn${binSuffix()}`;
+function writeResolveFailure(prebuiltError, fallbackError) {
+  if (!short) {
+    process.stderr.write(
+      `relayburn: unsupported prebuilt platform ${process.platform}-${process.arch}.\n` +
+        `Supported prebuilt packages: darwin-arm64, darwin-x64, linux-arm64-gnu (glibc), linux-x64-gnu (glibc).\n` +
+        `Track native Windows support at https://github.com/AgentWorkforce/burn/issues/359.\n` +
+        `Tried generic TypeScript CLI fallback \`${fallbackSpecifier}\`, but it was not installed.\n` +
+        `Reinstall \`relayburn\` with optional dependencies enabled or install \`@relayburn/cli\`.\n` +
+        `\nFallback resolution error: ${formatError(fallbackError)}\n`,
+    );
+    return;
+  }
 
-let binPath;
-try {
-  binPath = require.resolve(binSpecifier);
-} catch (err) {
+  const pkg = `@relayburn/cli-${short}`;
   process.stderr.write(
     `relayburn: failed to resolve prebuilt \`burn\` binary for ${short}.\n` +
       `Expected the optional dependency \`${pkg}\` to be installed; it ships the binary\n` +
       `at \`bin/burn${binSuffix()}\`. This usually means \`npm install\` skipped the optional\n` +
       `dependency (e.g. \`--no-optional\`, a lockfile pinned without it, or an unsupported\n` +
-      `platform filter). Reinstall \`relayburn\` without \`--no-optional\` and try again.\n` +
-      `\nUnderlying error: ${err && err.message ? err.message : err}\n`,
+      `platform filter).\n` +
+      `Tried generic TypeScript CLI fallback \`${fallbackSpecifier}\`, but it also failed.\n` +
+      `Reinstall \`relayburn\` without \`--no-optional\` and try again.\n` +
+      `\nPrebuilt resolution error: ${formatError(prebuiltError)}\n` +
+      `Fallback resolution error: ${formatError(fallbackError)}\n`,
   );
-  process.exit(1);
 }
 
-const child = spawnSync(binPath, process.argv.slice(2), {
+let command = null;
+let childArgs = passthroughArgs;
+let prebuiltError = null;
+
+if (short) {
+  const pkg = `@relayburn/cli-${short}`;
+  const binSpecifier = `${pkg}/bin/burn${binSuffix()}`;
+  try {
+    command = require.resolve(binSpecifier);
+  } catch (err) {
+    prebuiltError = err;
+  }
+}
+
+if (!command) {
+  try {
+    command = process.execPath;
+    childArgs = [require.resolve(fallbackSpecifier), ...passthroughArgs];
+  } catch (fallbackError) {
+    writeResolveFailure(prebuiltError, fallbackError);
+    process.exit(1);
+  }
+}
+
+const child = spawnSync(command, childArgs, {
   stdio: 'inherit',
   windowsHide: false,
 });

--- a/packages/relayburn/bin/burn.js
+++ b/packages/relayburn/bin/burn.js
@@ -1,2 +1,108 @@
 #!/usr/bin/env node
-import '@relayburn/cli/dist/cli.js';
+// Platform-resolving spawner for the `burn` Rust binary. Mirrors the
+// `@relayburn/sdk` napi-rs dispatcher pattern (see
+// `packages/sdk-node/src/binding.cjs`): the umbrella `relayburn` package
+// declares the per-platform packages as `optionalDependencies`, npm
+// installs the one matching `os` + `cpu` filters, and this script
+// `require.resolve`s the prebuilt `burn` binary out of it and spawns it
+// with the user's argv.
+//
+// The actual binaries live in `packages/relayburn/npm/<platform>/bin/burn`
+// and are dropped there by the cli-build CI matrix at publish time. They
+// are gitignored at rest.
+//
+// ESM is fine here — the umbrella declares `"type": "module"` and engines
+// pins Node >=22.
+
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+
+const require = createRequire(import.meta.url);
+
+// Map (process.platform, process.arch) → platform-package short string.
+// Linux glibc-vs-musl detection follows the same `process.report` probe
+// the napi-rs loader uses; we only ship glibc artifacts today, so a musl
+// host falls through to the unsupported-platform error below.
+function detectShort() {
+  const { platform, arch } = process;
+
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64';
+  if (platform === 'darwin' && arch === 'x64') return 'darwin-x64';
+  if (platform === 'linux' && arch === 'arm64' && !isMusl()) return 'linux-arm64-gnu';
+  if (platform === 'linux' && arch === 'x64' && !isMusl()) return 'linux-x64-gnu';
+
+  // Forward-compat for #359 (Windows). The win32-x64 package is not
+  // published yet, so resolution will fail with the same actionable
+  // error path as any other unsupported platform — but the mapping is
+  // here so #359 only needs to add a matrix leg + optionalDependency,
+  // not touch this dispatcher.
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64';
+
+  return null;
+}
+
+function isMusl() {
+  if (!process.report) return false;
+  try {
+    const { glibcVersionRuntime } = (process.report.getReport() || {}).header || {};
+    return !glibcVersionRuntime;
+  } catch {
+    return false;
+  }
+}
+
+function binSuffix() {
+  return process.platform === 'win32' ? '.exe' : '';
+}
+
+const short = detectShort();
+if (!short) {
+  process.stderr.write(
+    `relayburn: unsupported platform ${process.platform}-${process.arch}.\n` +
+      `Supported: darwin-arm64, darwin-x64, linux-arm64-gnu (glibc), linux-x64-gnu (glibc).\n` +
+      `Track Windows support at https://github.com/AgentWorkforce/burn/issues/359.\n`,
+  );
+  process.exit(1);
+}
+
+const pkg = `@relayburn/cli-${short}`;
+const binSpecifier = `${pkg}/bin/burn${binSuffix()}`;
+
+let binPath;
+try {
+  binPath = require.resolve(binSpecifier);
+} catch (err) {
+  process.stderr.write(
+    `relayburn: failed to resolve prebuilt \`burn\` binary for ${short}.\n` +
+      `Expected the optional dependency \`${pkg}\` to be installed; it ships the binary\n` +
+      `at \`bin/burn${binSuffix()}\`. This usually means \`npm install\` skipped the optional\n` +
+      `dependency (e.g. \`--no-optional\`, a lockfile pinned without it, or an unsupported\n` +
+      `platform filter). Reinstall \`relayburn\` without \`--no-optional\` and try again.\n` +
+      `\nUnderlying error: ${err && err.message ? err.message : err}\n`,
+  );
+  process.exit(1);
+}
+
+const child = spawnSync(binPath, process.argv.slice(2), {
+  stdio: 'inherit',
+  windowsHide: false,
+});
+
+if (child.error) {
+  process.stderr.write(`relayburn: failed to spawn \`burn\`: ${child.error.message}\n`);
+  process.exit(1);
+}
+
+// Propagate signal exits the same way Node's own child-process docs
+// recommend — POSIX shells map signal-terminated children to
+// `128 + signo`, and many CI environments key off that exact code.
+if (child.signal) {
+  // `os.constants.signals` is the Node-side mapping, but it's keyed by
+  // signal name and we have it in hand already; defer to the standard
+  // 128+signo formula via `process.kill` fallback for unknown names.
+  const { constants } = await import('node:os');
+  const signo = constants.signals[child.signal];
+  process.exit(typeof signo === 'number' ? 128 + signo : 1);
+}
+
+process.exit(child.status ?? 1);

--- a/packages/relayburn/npm/darwin-arm64/README.md
+++ b/packages/relayburn/npm/darwin-arm64/README.md
@@ -1,0 +1,7 @@
+# @relayburn/cli-darwin-arm64
+
+Prebuilt `burn` binary for `darwin-arm64`. You should not depend on this
+package directly — install [`relayburn`](https://www.npmjs.com/package/relayburn)
+and the right platform binary is resolved via `optionalDependencies`.
+
+See <https://github.com/AgentWorkforce/burn>.

--- a/packages/relayburn/npm/darwin-arm64/package.json
+++ b/packages/relayburn/npm/darwin-arm64/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@relayburn/cli-darwin-arm64",
+  "version": "1.10.0",
+  "description": "Prebuilt `burn` binary for darwin-arm64.",
+  "bin": {
+    "burn": "./bin/burn"
+  },
+  "files": [
+    "bin/",
+    "package.json",
+    "README.md"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/burn",
+    "directory": "packages/relayburn/npm/darwin-arm64"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "next"
+  }
+}

--- a/packages/relayburn/npm/darwin-x64/README.md
+++ b/packages/relayburn/npm/darwin-x64/README.md
@@ -1,0 +1,7 @@
+# @relayburn/cli-darwin-x64
+
+Prebuilt `burn` binary for `darwin-x64`. You should not depend on this
+package directly — install [`relayburn`](https://www.npmjs.com/package/relayburn)
+and the right platform binary is resolved via `optionalDependencies`.
+
+See <https://github.com/AgentWorkforce/burn>.

--- a/packages/relayburn/npm/darwin-x64/package.json
+++ b/packages/relayburn/npm/darwin-x64/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@relayburn/cli-darwin-x64",
+  "version": "1.10.0",
+  "description": "Prebuilt `burn` binary for darwin-x64.",
+  "bin": {
+    "burn": "./bin/burn"
+  },
+  "files": [
+    "bin/",
+    "package.json",
+    "README.md"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/burn",
+    "directory": "packages/relayburn/npm/darwin-x64"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "next"
+  }
+}

--- a/packages/relayburn/npm/linux-arm64-gnu/README.md
+++ b/packages/relayburn/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,7 @@
+# @relayburn/cli-linux-arm64-gnu
+
+Prebuilt `burn` binary for `linux-arm64-gnu` (glibc). You should not depend
+on this package directly — install [`relayburn`](https://www.npmjs.com/package/relayburn)
+and the right platform binary is resolved via `optionalDependencies`.
+
+See <https://github.com/AgentWorkforce/burn>.

--- a/packages/relayburn/npm/linux-arm64-gnu/package.json
+++ b/packages/relayburn/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@relayburn/cli-linux-arm64-gnu",
+  "version": "1.10.0",
+  "description": "Prebuilt `burn` binary for linux-arm64-gnu (glibc).",
+  "bin": {
+    "burn": "./bin/burn"
+  },
+  "files": [
+    "bin/",
+    "package.json",
+    "README.md"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/burn",
+    "directory": "packages/relayburn/npm/linux-arm64-gnu"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "next"
+  }
+}

--- a/packages/relayburn/npm/linux-x64-gnu/README.md
+++ b/packages/relayburn/npm/linux-x64-gnu/README.md
@@ -1,0 +1,7 @@
+# @relayburn/cli-linux-x64-gnu
+
+Prebuilt `burn` binary for `linux-x64-gnu` (glibc). You should not depend
+on this package directly — install [`relayburn`](https://www.npmjs.com/package/relayburn)
+and the right platform binary is resolved via `optionalDependencies`.
+
+See <https://github.com/AgentWorkforce/burn>.

--- a/packages/relayburn/npm/linux-x64-gnu/package.json
+++ b/packages/relayburn/npm/linux-x64-gnu/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@relayburn/cli-linux-x64-gnu",
+  "version": "1.10.0",
+  "description": "Prebuilt `burn` binary for linux-x64-gnu (glibc).",
+  "bin": {
+    "burn": "./bin/burn"
+  },
+  "files": [
+    "bin/",
+    "package.json",
+    "README.md"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/burn",
+    "directory": "packages/relayburn/npm/linux-x64-gnu"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "next"
+  }
+}

--- a/packages/relayburn/package.json
+++ b/packages/relayburn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relayburn",
   "version": "1.10.0",
-  "description": "Token usage & cost attribution for agent CLIs (installs the `burn` command). Resolves a prebuilt Rust binary from the `@relayburn/cli-<platform>` packages at install time.",
+  "description": "Token usage & cost attribution for agent CLIs (installs the `burn` command). Resolves a prebuilt Rust binary from the `@relayburn/cli-<platform>` packages with a TypeScript CLI fallback.",
   "type": "module",
   "bin": {
     "burn": "./bin/burn.js"
@@ -19,6 +19,7 @@
     "node": ">=22"
   },
   "optionalDependencies": {
+    "@relayburn/cli": "1.10.0",
     "@relayburn/cli-darwin-arm64": "1.10.0",
     "@relayburn/cli-darwin-x64": "1.10.0",
     "@relayburn/cli-linux-arm64-gnu": "1.10.0",

--- a/packages/relayburn/package.json
+++ b/packages/relayburn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relayburn",
   "version": "1.10.0",
-  "description": "Token usage & cost attribution for agent CLIs (installs the `burn` command)",
+  "description": "Token usage & cost attribution for agent CLIs (installs the `burn` command). Resolves a prebuilt Rust binary from the `@relayburn/cli-<platform>` packages at install time.",
   "type": "module",
   "bin": {
     "burn": "./bin/burn.js"
@@ -18,8 +18,11 @@
   "engines": {
     "node": ">=22"
   },
-  "dependencies": {
-    "@relayburn/cli": "workspace:*"
+  "optionalDependencies": {
+    "@relayburn/cli-darwin-arm64": "1.10.0",
+    "@relayburn/cli-darwin-x64": "1.10.0",
+    "@relayburn/cli-linux-arm64-gnu": "1.10.0",
+    "@relayburn/cli-linux-x64-gnu": "1.10.0"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,11 +84,7 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
 
-  packages/relayburn:
-    dependencies:
-      '@relayburn/cli':
-        specifier: workspace:*
-        version: link:../cli
+  packages/relayburn: {}
 
   packages/sdk:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,6 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
 
-  packages/relayburn: {}
-
   packages/sdk:
     dependencies:
       '@relayburn/analyze':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,17 @@ packages:
   # consumers; the napi-rs CI matrix and conformance test scaffolding
   # operate on `packages/sdk-node` directly via path.
   - '!packages/sdk-node'
+  # Exclude `packages/relayburn` from the workspace for the same shape of
+  # reason as `sdk-node` above: it declares the per-platform Rust binary
+  # packages (`@relayburn/cli-darwin-arm64`, `@relayburn/cli-linux-x64-gnu`,
+  # …) as `optionalDependencies`, and those don't exist on npm until the
+  # cutover publish workflow ships them. With the package in the workspace,
+  # `pnpm install --frozen-lockfile` in CI rejects the lockfile because the
+  # optional specifiers in `package.json` aren't represented (pnpm 10 drops
+  # unresolvable optional deps from the lockfile silently, then frozen-mode
+  # complains they were "added"). Nothing in-repo consumes `relayburn` (it's
+  # a thin install wrapper that spawns the Rust binary), so dropping it from
+  # the workspace is a no-op for everyone except the install-time path. The
+  # cli-build CI matrix and the cutover publish workflow operate on
+  # `packages/relayburn` directly via path.
+  - '!packages/relayburn'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,8 @@ packages:
   # Exclude `packages/relayburn` from the workspace for the same shape of
   # reason as `sdk-node` above: it declares the per-platform Rust binary
   # packages (`@relayburn/cli-darwin-arm64`, `@relayburn/cli-linux-x64-gnu`,
-  # …) as `optionalDependencies`, and those don't exist on npm until the
+  # …) plus the generic `@relayburn/cli` fallback as `optionalDependencies`,
+  # and the platform packages don't exist on npm until the
   # cutover publish workflow ships them. With the package in the workspace,
   # `pnpm install --frozen-lockfile` in CI rejects the lockfile because the
   # optional specifiers in `package.json` aren't represented (pnpm 10 drops


### PR DESCRIPTION
## Summary

Switches `npm i -g relayburn` to install the prebuilt Rust `burn` binary instead of dispatching through the TS `@relayburn/cli`. Same shape the napi-rs `@relayburn/sdk` umbrella already uses for `@relayburn/sdk-<platform>` packages — except we ship native executables instead of `.node` files.

- New per-platform packages under `packages/relayburn/npm/<short>/`: `@relayburn/cli-darwin-arm64`, `@relayburn/cli-darwin-x64`, `@relayburn/cli-linux-arm64-gnu`, `@relayburn/cli-linux-x64-gnu`. Each carries `os` / `cpu` (and `libc` for linux glibc) filters, version-pinned at `1.10.0` to match the workspace.
- The umbrella `relayburn` package drops its `@relayburn/cli` workspace dep and adds the four platform packages as `optionalDependencies`. npm's filters install only the matching one; the `burn` shim `require.resolve`s `@relayburn/cli-<platform>/bin/burn` and `spawnSync`s it with the user's argv. Exit codes propagate; signal exits map to `128 + signo`.
- The dispatcher is forward-compat for Windows (#359) — `process.platform === 'win32'` already maps to `win32-x64` and appends `.exe`, so #359 only needs to add a matrix leg + `optionalDependencies` entry.
- `.github/workflows/cli-build.yml` builds the four-platform matrix on PR / push (mirroring `napi-build.yml`): darwin-x64 on `macos-15-intel`, darwin-arm64 on `macos-14`, linux-x64-gnu and linux-arm64-gnu on `ubuntu-latest` with the aarch64 cross-compiler. Each leg strips the binary, stages it under `packages/relayburn/npm/<short>/bin/burn`, runs a `--help` smoke test (skipped on aarch64-linux because cross-compile), and uploads it as a build artifact. The `publish:` job is a stub — full publish.yml integration is the follow-up PR.
- `bin/` under each platform package is gitignored at rest; only `package.json` + `README.md` are committed.

## Naming

Settled on `@relayburn/cli-<platform>` to be parallel with `@relayburn/sdk-<platform>`. No collision with the existing `@relayburn/cli` (the TS CLI package keeps that name without a platform suffix).

## End-to-end manual probe (darwin-arm64)

Built `cargo build --release --target aarch64-apple-darwin --bin burn -p relayburn-cli`, staged into `packages/relayburn/npm/darwin-arm64/bin/burn`, `npm pack`ed both the platform package and the umbrella, then `npm install --global --prefix $TESTDIR` of both tarballs into a tmpdir. `$TESTDIR/bin/burn --help` prints the Rust CLI's help, `$TESTDIR/bin/burn summary --help` works, `$TESTDIR/bin/burn --version` prints `burn 1.10.0`. `diff <(installed-burn --help) <(cargo-built-burn --help)` produces zero output (identical). No surprises.

## Out of scope

- `.github/workflows/publish.yml` — cutover integration is the next PR.
- Removing `packages/cli/` — TS CLI is still source of truth for `@relayburn/cli@1.x` until 2.0 promotes.
- Windows binaries — tracked in #359.
- Rust workspace version bump — stays at 1.10.0.

Refs #240, forward-compat for #359.

## Test plan

- [ ] `cli-build` matrix passes on all four legs (darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu).
- [ ] CI `build-and-test` + `cargo-build-and-test` jobs still pass.
- [ ] Smoke test inside cli-build passes for the three native legs (`burn --help` and `burn --version`).