### PR TITLE
publish.yml: locate staged CLI binary with find (fixes 2.0 publish run)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -832,18 +832,24 @@ jobs:
           for short in darwin-arm64 darwin-x64 linux-arm64-gnu linux-x64-gnu; do
             # CLI: drop `burn` at packages/relayburn/npm/<short>/bin/burn.
             #
-            # `upload-artifact@v4` preserves the full directory hierarchy for
-            # single-file uploads (cli-build.yml uploads
-            # `packages/relayburn/npm/<short>/bin/burn` as the `path` input,
-            # so the artifact retains that nested structure on download).
-            # The SDK leg uses a glob (`*.node`) which strips the prefix up
-            # to the first wildcard, so its `find` lookup at line ~860 stays
-            # generic.
-            cli_src="/tmp/cli-artifacts/relayburn-cli-${short}/packages/relayburn/npm/${short}/bin/burn"
+            # `upload-artifact@v4` flattens single-file uploads to the
+            # artifact root (the binary lands at
+            # `/tmp/cli-artifacts/relayburn-cli-<short>/burn`, NOT at the
+            # original `packages/relayburn/npm/<short>/bin/burn` path).
+            # Locate the binary defensively with `find` so a future
+            # upload-artifact behavior change can't silently break staging
+            # — same pattern the SDK leg uses for `*.node`.
+            cli_src_dir="/tmp/cli-artifacts/relayburn-cli-${short}"
             cli_dst_dir="packages/relayburn/npm/${short}/bin"
-            if [ ! -f "$cli_src" ]; then
-              echo "::error title=Missing CLI artifact::expected $cli_src" >&2
-              ls -la "/tmp/cli-artifacts/relayburn-cli-${short}/" 2>/dev/null || true
+            if [ ! -d "$cli_src_dir" ]; then
+              echo "::error title=Missing CLI artifact dir::expected $cli_src_dir" >&2
+              ls -la /tmp/cli-artifacts/ 2>/dev/null || true
+              exit 1
+            fi
+            cli_src=$(find "$cli_src_dir" -maxdepth 6 -name 'burn' -type f -print -quit)
+            if [ -z "$cli_src" ]; then
+              echo "::error title=Missing CLI artifact::no 'burn' file under $cli_src_dir" >&2
+              ls -laR "$cli_src_dir" 2>/dev/null || true
               exit 1
             fi
             mkdir -p "$cli_dst_dir"


### PR DESCRIPTION
## What

The 2.0 cutover publish run failed at the *Stage prebuilt binaries into platform packages* step: https://github.com/AgentWorkforce/burn/actions/runs/25503503514/job/74844319389

The hard-coded `cli_src` path expected `upload-artifact@v4` to preserve the full directory hierarchy for single-file uploads (per a CodeRabbit web-search suggestion in #362 review). Empirically, it doesn't — the binary lands at the artifact root:

```
/tmp/cli-artifacts/relayburn-cli-darwin-arm64/burn   # actual
/tmp/cli-artifacts/relayburn-cli-darwin-arm64/packages/relayburn/npm/darwin-arm64/bin/burn   # what the script expected
```

## Fix

Locate the binary with `find` rather than hard-coding either layout, mirroring the SDK leg's pattern for `*.node`. Survives future upload-artifact behavior changes.

## State of the cutover release

The previous run did successfully:
- Build all 8 binaries (4 CLI + 4 SDK) ✓
- Bump versions to 2.0.0 across the 11 keepers ✓
- Push the version-bump commit `3c1c080` ✓
- Publish `relayburn-sdk@2.0.0` and `relayburn-cli@2.0.0` to crates.io ✓

It failed AFTER cargo publish but BEFORE npm publish, so:
- crates.io: 2.0.0 is shipped (irrevocable)
- npm: nothing was published

After this PR merges, re-trigger the workflow with `version: none` to skip the bump (already done) and re-run cargo publish (idempotent — version check skips if already published) and proceed to npm publish.