### PR TITLE
publish.yml: add crates.io section to GitHub Release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1170,6 +1170,14 @@ jobs:
             lines.push(`- \`${entry.npmName}@${entry.ver}\` (tag: \`${entry.tag}\`)`);
           }
 
+          // Crates section — `relayburn-sdk` and `relayburn-cli` ship to
+          // crates.io in lockstep with the npm umbrellas at the same
+          // workspace version. Tags `relayburn-{sdk,cli}-v<ver>` are pushed
+          // by the publish job's "Tag + push" step.
+          lines.push('', '## Crates', '');
+          lines.push(`- \`relayburn-sdk@${releaseVersion}\` (tag: \`relayburn-sdk-v${releaseVersion}\`) — https://crates.io/crates/relayburn-sdk/${releaseVersion}`);
+          lines.push(`- \`relayburn-cli@${releaseVersion}\` (tag: \`relayburn-cli-v${releaseVersion}\`) — https://crates.io/crates/relayburn-cli/${releaseVersion}`);
+
           const rootNotes = extractChangelogBody('CHANGELOG.md', releaseVersion);
           // Only the umbrellas + mcp ship hand-curated changelogs; platform
           // packages don't (they're implementation detail tracking the


### PR DESCRIPTION
The 2.0.0 release body (https://github.com/AgentWorkforce/burn/releases/tag/relayburn-v2.0.0) lists all 11 npm packages but doesn't mention the two crates.io publishes (\`relayburn-sdk@2.0.0\`, \`relayburn-cli@2.0.0\`) that ship in lockstep on every release.

Adds a \`## Crates\` section right after \`## Packages\`, with crate name, tag, and crates.io URL.

Future release bodies will look like:

```
## Packages

- \`relayburn@2.x.y\` (tag: \`relayburn-v2.x.y\`)
- ...

## Crates

- \`relayburn-sdk@2.x.y\` (tag: \`relayburn-sdk-v2.x.y\`) — https://crates.io/crates/relayburn-sdk/2.x.y
- \`relayburn-cli@2.x.y\` (tag: \`relayburn-cli-v2.x.y\`) — https://crates.io/crates/relayburn-cli/2.x.y

## Release Notes
...
```

The 2.0.0 release body has already shipped — happy to follow up with a \`gh release edit relayburn-v2.0.0 --notes ...\` to backfill it if you want, but that's a one-shot manual action and out of scope for this PR.