### PR TITLE
Implement Rust summary parity

### DIFF
--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -1,12 +1,9 @@
 //! `burn summary` — aggregate session usage and cost.
 //!
 //! Thin presenter over the `relayburn_sdk` query helpers. Mirrors the TS
-//! `packages/cli/src/commands/summary.ts` byte-for-byte for the default
-//! (group-by-model) flow that drives the golden snapshots; the wider TS
-//! surface (`--by-provider`, `--by-tool`, `--by-subagent-type`,
-//! `--by-relationship`, `--subagent-tree`, `--quality`) is enumerated as
-//! flag wiring + a stub-mode error path so behavior gaps surface as a
-//! human message rather than silently dropping the flag.
+//! `packages/cli/src/commands/summary.ts` surface: grouped model/provider
+//! summaries, tool attribution, subagent views, relationship rollups, workflow
+//! / agent / provider filters, and the optional quality footer.
 //!
 //! ## Wiring
 //!
@@ -26,14 +23,21 @@
 //!    [`relayburn_sdk::summarize_replacement_savings`].
 //! 5. Render JSON or human format.
 
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+
 use clap::Args;
 use indexmap::IndexMap;
 use relayburn_sdk::{
-    aggregate_by_provider, cost_for_turn, ingest_all, load_pricing, normalize_since, sum_costs,
-    summarize_fidelity, summarize_replacement_savings, AggregateByProviderOptions, CostBreakdown,
-    Coverage, CoverageField, FidelityClass, FidelitySummary, Ledger, LedgerHandle,
-    LedgerOpenOptions, ProviderAggregateRow, Query, RowCoverage, TurnRecord, UsageCostAggregateRow,
+    aggregate_by_provider, aggregate_subagent_type_stats, build_subagent_tree, compute_quality,
+    cost_for_turn, ingest_all, load_pricing, normalize_since, provider_for, sum_costs,
+    summarize_fidelity, summarize_replacement_savings, AggregateByProviderOptions,
+    BuildSubagentTreeOptions, ComputeQualityOptions, ContentRecord, CostBreakdown, Coverage,
+    CoverageField, EnrichedTurn, FidelityClass, FidelitySummary, Ledger, LedgerHandle,
+    LedgerOpenOptions, OutcomeLabel, ProviderAggregateRow, QualityResult, Query, RawLedger,
+    RelationshipType, RowCoverage, SessionRelationshipRecord, SubagentTreeNode, SubagentTypeStats,
+    TurnRecord, UsageCostAggregateRow, UserTurnBlockKind, UserTurnRecord,
 };
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 
 use crate::cli::GlobalArgs;
@@ -155,36 +159,13 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         }
     }
 
-    // The TS CLI exits 2 with a clear message for surfaces that haven't
-    // been ported yet (`--by-tool`, `--by-subagent-type`,
-    // `--by-relationship`, `--subagent-tree`, `--quality`, `--agent`,
-    // `--workflow`, `--provider`). The Wave 2 D1 contract is the default
-    // group-by-model + `--by-provider` flow; the rest land in follow-ups.
-    if args.by_tool {
-        eprintln!(
-            "burn: --by-tool is not yet implemented in the Rust port (#248 D1 covers default + --by-provider; follow-ups will add by-tool / subagent / relationship / quality)"
-        );
-        return Ok(2);
-    }
-    if args.by_subagent_type
-        || args.by_relationship.is_some()
-        || args.subagent_tree.is_some()
-        || args.agent.is_some()
-        || args.quality
-    {
-        eprintln!(
-            "burn: subagent / relationship / quality summary modes are not yet implemented in the Rust port"
-        );
-        return Ok(2);
-    }
-    if args.workflow.is_some() {
-        eprintln!("burn: --workflow filter is not yet implemented in the Rust port");
-        return Ok(2);
-    }
-    if args.provider.is_some() {
-        eprintln!("burn: --provider filter is not yet implemented in the Rust port");
-        return Ok(2);
-    }
+    let provider_filter = match parse_provider_filter(args.provider.as_deref()) {
+        Ok(filter) => filter,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return Ok(2);
+        }
+    };
 
     let opts = match globals.ledger_path.as_deref() {
         Some(h) => LedgerOpenOptions::with_home(h),
@@ -195,16 +176,52 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
     let ingest_report = run_ingest(&mut handle)?;
 
     let q = build_query(&args)?;
-    let turns: Vec<TurnRecord> = handle
-        .raw()
-        .query_turns(&q)?
-        .into_iter()
-        .map(|e| e.turn)
-        .collect();
+    let agent_session_ids = match args.agent.as_deref() {
+        Some(agent_id) => Some(resolve_agent_session_tree(handle.raw(), agent_id)?),
+        None => None,
+    };
 
+    if let Some(tree_flag) = args.subagent_tree.as_deref() {
+        return render_subagent_tree_mode(
+            globals,
+            handle.raw(),
+            tree_flag,
+            &q,
+            args.agent.as_deref(),
+            agent_session_ids.as_ref(),
+            provider_filter.as_ref(),
+        );
+    }
+
+    let enriched = handle.raw().query_turns(&q)?;
+    let enriched = filter_enriched_turns(
+        enriched,
+        args.agent.as_deref(),
+        agent_session_ids.as_ref(),
+        provider_filter.as_ref(),
+    );
+    let turns = turns_from_enriched(&enriched);
     let pricing = load_pricing(None);
+
+    if args.by_subagent_type {
+        return render_subagent_type_mode(globals, &turns, &pricing);
+    }
+
+    if let Some(rel_flag) = args.by_relationship.as_deref() {
+        return render_relationship_mode(globals, handle.raw(), &turns, &pricing, &q, rel_flag);
+    }
+
+    if args.by_tool {
+        return render_by_tool_mode(globals, handle.raw(), &turns, &ingest_report, &pricing);
+    }
+
     let fidelity = summarize_fidelity(&turns);
     let savings = summarize_replacement_savings(&turns, None);
+    let quality = if args.quality && !globals.json {
+        Some(compute_quality_for_turns(handle.raw(), &turns)?)
+    } else {
+        None
+    };
 
     if args.by_provider {
         let rows = aggregate_by_provider(&turns, AggregateByProviderOptions::new(&pricing));
@@ -216,9 +233,9 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
             &provider_rows,
             &turns,
             &ingest_report,
-            &pricing,
             &fidelity,
             &savings,
+            quality.as_ref(),
         );
     } else {
         let rows = aggregate_by_model(&turns, &pricing);
@@ -228,12 +245,154 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
             &rows,
             &turns,
             &ingest_report,
-            &pricing,
             &fidelity,
             &savings,
+            quality.as_ref(),
         );
     }
     Ok(0)
+}
+
+fn parse_provider_filter(raw: Option<&str>) -> Result<Option<BTreeSet<String>>, &'static str> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let providers: BTreeSet<String> = raw
+        .split(',')
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if providers.is_empty() {
+        return Err("burn: --provider requires a value");
+    }
+    Ok(Some(providers))
+}
+
+fn filter_enriched_turns(
+    turns: Vec<EnrichedTurn>,
+    agent_id: Option<&str>,
+    agent_session_ids: Option<&HashSet<String>>,
+    provider_filter: Option<&BTreeSet<String>>,
+) -> Vec<EnrichedTurn> {
+    turns
+        .into_iter()
+        .filter(|t| agent_passes(t, agent_id, agent_session_ids))
+        .filter(|t| provider_passes(&t.turn, provider_filter))
+        .collect()
+}
+
+fn agent_passes(
+    t: &EnrichedTurn,
+    agent_id: Option<&str>,
+    session_ids: Option<&HashSet<String>>,
+) -> bool {
+    let Some(agent_id) = agent_id else {
+        return true;
+    };
+    if t.enrichment.get("agentId").map(String::as_str) == Some(agent_id) {
+        return true;
+    }
+    if t.enrichment.get("parentAgentId").map(String::as_str) == Some(agent_id) {
+        return true;
+    }
+    session_ids
+        .map(|ids| ids.contains(&t.turn.session_id))
+        .unwrap_or(false)
+}
+
+fn provider_passes(t: &TurnRecord, provider_filter: Option<&BTreeSet<String>>) -> bool {
+    let Some(filter) = provider_filter else {
+        return true;
+    };
+    let provider = provider_for(t).provider.to_ascii_lowercase();
+    filter.contains(&provider)
+}
+
+fn turns_from_enriched(enriched: &[EnrichedTurn]) -> Vec<TurnRecord> {
+    enriched.iter().map(|e| e.turn.clone()).collect()
+}
+
+fn resolve_agent_session_tree(
+    ledger: &RawLedger,
+    agent_id: &str,
+) -> anyhow::Result<HashSet<String>> {
+    Ok(collect_agent_session_tree(
+        &ledger.query_relationships(&Query::default())?,
+        agent_id,
+    ))
+}
+
+fn collect_agent_session_tree(
+    relationships: &[SessionRelationshipRecord],
+    agent_id: &str,
+) -> HashSet<String> {
+    let mut by_parent: HashMap<String, Vec<&SessionRelationshipRecord>> = HashMap::new();
+    for r in relationships {
+        if r.relationship_type != RelationshipType::Subagent {
+            continue;
+        }
+        let Some(parent) = r.related_session_id.as_deref() else {
+            continue;
+        };
+        if parent.is_empty() {
+            continue;
+        }
+        by_parent.entry(parent.to_string()).or_default().push(r);
+    }
+
+    let mut sessions = HashSet::new();
+    let mut seen = HashSet::new();
+    let mut queue = VecDeque::from([agent_id.to_string()]);
+    while let Some(parent) = queue.pop_front() {
+        if !seen.insert(parent.clone()) {
+            continue;
+        }
+        for child in by_parent.get(&parent).into_iter().flatten() {
+            sessions.insert(child.session_id.clone());
+            queue.push_back(child.session_id.clone());
+            if let Some(agent) = child.agent_id.as_ref() {
+                if !agent.is_empty() {
+                    queue.push_back(agent.clone());
+                }
+            }
+        }
+    }
+    sessions
+}
+
+fn compute_quality_for_turns(
+    ledger: &RawLedger,
+    turns: &[TurnRecord],
+) -> anyhow::Result<QualityResult> {
+    let content_by_session = load_content_for_quality(ledger, turns)?;
+    Ok(compute_quality(
+        turns,
+        &ComputeQualityOptions {
+            content_by_session: Some(&content_by_session),
+            now_ms: None,
+        },
+    ))
+}
+
+fn load_content_for_quality(
+    ledger: &RawLedger,
+    turns: &[TurnRecord],
+) -> anyhow::Result<HashMap<String, Vec<ContentRecord>>> {
+    let mut seen = HashSet::new();
+    let mut out = HashMap::new();
+    for t in turns {
+        if !seen.insert(t.session_id.clone()) {
+            continue;
+        }
+        let records = ledger.query_content(&Query {
+            session_id: Some(t.session_id.clone()),
+            ..Default::default()
+        })?;
+        if !records.is_empty() {
+            out.insert(t.session_id.clone(), records);
+        }
+    }
+    Ok(out)
 }
 
 fn build_query(args: &SummaryArgs) -> anyhow::Result<Query> {
@@ -246,6 +405,11 @@ fn build_query(args: &SummaryArgs) -> anyhow::Result<Query> {
     }
     if let Some(since) = normalize_since(args.since.as_deref())? {
         q.since = Some(since);
+    }
+    if let Some(workflow) = &args.workflow {
+        let mut enrichment = std::collections::BTreeMap::new();
+        enrichment.insert("workflowId".to_string(), workflow.clone());
+        q.enrichment = Some(enrichment);
     }
     Ok(q)
 }
@@ -390,9 +554,9 @@ fn emit_grouped(
     rows: &[UsageCostAggregateRow],
     turns: &[TurnRecord],
     ingest_report: &relayburn_sdk::IngestReport,
-    _pricing: &relayburn_sdk::PricingTable,
     fidelity: &FidelitySummary,
     savings: &relayburn_sdk::ReplacementSavingsSummary,
+    quality: Option<&QualityResult>,
 ) {
     let total_cost = sum_costs(rows.iter().map(|r| &r.cost));
 
@@ -415,6 +579,7 @@ fn emit_grouped(
         &total_cost,
         fidelity,
         savings,
+        quality,
     );
 }
 
@@ -497,6 +662,1006 @@ fn cost_breakdown_to_json(c: &CostBreakdown) -> Value {
         "cacheRead": c.cache_read,
         "cacheCreate": c.cache_create,
     })
+}
+
+#[derive(Debug, Default, Clone)]
+struct ToolAgg {
+    calls: u64,
+    cost: f64,
+    sized_cost: f64,
+    even_split_cost: f64,
+}
+
+#[derive(Debug, Default)]
+struct UserTurnSizeBucket {
+    tool_bytes_by_id: HashMap<String, u64>,
+    total_bytes: u64,
+}
+
+fn render_by_tool_mode(
+    globals: &GlobalArgs,
+    ledger: &RawLedger,
+    turns: &[TurnRecord],
+    ingest_report: &relayburn_sdk::IngestReport,
+    pricing: &relayburn_sdk::PricingTable,
+) -> anyhow::Result<i32> {
+    let user_turns_by_session = load_user_turns_for_by_tool(ledger, turns)?;
+    let (by_tool, unattributed) = attribute_cost_to_tools(turns, pricing, &user_turns_by_session);
+    let fidelity = summarize_fidelity(turns);
+    let savings = summarize_replacement_savings(turns, None);
+    let mut sorted: Vec<(String, ToolAgg)> = by_tool.into_iter().collect();
+    sorted.sort_by(|a, b| {
+        b.1.cost
+            .partial_cmp(&a.1.cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    if globals.json {
+        let by_tool_json: Vec<Value> = sorted
+            .iter()
+            .map(|(tool, agg)| {
+                let mut row = Map::new();
+                row.insert("tool".into(), json!(tool));
+                row.insert("calls".into(), json!(agg.calls));
+                row.insert("attributedCost".into(), json!(agg.cost));
+                row.insert(
+                    "attributionMethod".into(),
+                    json!(tool_attribution_method(agg)),
+                );
+                if let Some(s) = savings.by_tool.get(tool) {
+                    row.insert(
+                        "savings".into(),
+                        json!({
+                            "calls": s.calls,
+                            "collapsedCalls": s.collapsed_calls,
+                            "estimatedTokensSaved": s.estimated_tokens_saved,
+                        }),
+                    );
+                }
+                Value::Object(row)
+            })
+            .collect();
+        let mut payload = json!({
+            "ingest": {
+                "ingestedSessions": ingest_report.ingested_sessions,
+                "appendedTurns": ingest_report.appended_turns,
+            },
+            "turns": turns.len(),
+            "byTool": by_tool_json,
+            "unattributed": unattributed,
+            "fidelity": { "summary": fidelity_summary_to_json(&fidelity) },
+        });
+        if savings.calls > 0 {
+            payload.as_object_mut().unwrap().insert(
+                "replacementSavings".into(),
+                replacement_savings_to_json(&savings),
+            );
+        }
+        coerce_whole_f64_to_int(&mut payload);
+        print_json(&payload);
+        return Ok(0);
+    }
+
+    let mut out = Vec::new();
+    out.push(String::new());
+    out.push(format!(
+        "turns analyzed: {}",
+        format_uint(turns.len() as u64)
+    ));
+    out.push(String::new());
+    if sorted.is_empty() {
+        out.push("no tool calls found for filters.".to_string());
+        let mut text = out.join("\n");
+        text.push('\n');
+        print!("{text}");
+        return Ok(0);
+    }
+
+    let has_savings = savings.calls > 0;
+    let mut rows: Vec<Vec<String>> = if has_savings {
+        vec![vec![
+            "tool".into(),
+            "calls".into(),
+            "attributedCost".into(),
+            "savedTokens".into(),
+        ]]
+    } else {
+        vec![vec!["tool".into(), "calls".into(), "attributedCost".into()]]
+    };
+    for (tool, agg) in &sorted {
+        let mut row = vec![tool.clone(), format_uint(agg.calls), format_usd(agg.cost)];
+        if has_savings {
+            let saved = savings
+                .by_tool
+                .get(tool)
+                .map(|s| format_uint(s.estimated_tokens_saved))
+                .unwrap_or_else(|| "-".to_string());
+            row.push(saved);
+        }
+        rows.push(row);
+    }
+    out.push(render_table(&rows));
+    out.push(String::new());
+    out.push(
+        "attributedCost = turn N ingest cost assigned to turn N-1 tool_use blocks by user-turn byte size when available, otherwise split evenly.".to_string(),
+    );
+    out.push(format!(
+        "unattributed cost (no prior tool call or non-tool user text): {}",
+        format_usd(unattributed),
+    ));
+    if has_savings {
+        out.push(format_replacement_savings_line(&savings));
+    }
+    out.push(String::new());
+    print!("{}", out.join("\n"));
+    Ok(0)
+}
+
+fn load_user_turns_for_by_tool(
+    ledger: &RawLedger,
+    turns: &[TurnRecord],
+) -> anyhow::Result<HashMap<String, Vec<UserTurnRecord>>> {
+    let mut seen = HashSet::new();
+    let mut out = HashMap::new();
+    for t in turns {
+        if !seen.insert(t.session_id.clone()) {
+            continue;
+        }
+        let rows = ledger.query_user_turns(&Query {
+            session_id: Some(t.session_id.clone()),
+            ..Default::default()
+        })?;
+        if !rows.is_empty() {
+            out.insert(t.session_id.clone(), rows);
+        }
+    }
+    Ok(out)
+}
+
+fn attribute_cost_to_tools(
+    turns: &[TurnRecord],
+    pricing: &relayburn_sdk::PricingTable,
+    user_turns_by_session: &HashMap<String, Vec<UserTurnRecord>>,
+) -> (IndexMap<String, ToolAgg>, f64) {
+    let mut by_tool: IndexMap<String, ToolAgg> = IndexMap::new();
+    let mut unattributed = 0.0;
+    let mut by_session: IndexMap<String, Vec<&TurnRecord>> = IndexMap::new();
+    for t in turns {
+        by_session.entry(t.session_id.clone()).or_default().push(t);
+    }
+
+    for (session_id, mut list) in by_session {
+        list.sort_by_key(|t| t.turn_index);
+        let user_turn_size_index = index_user_turn_block_sizes(
+            user_turns_by_session
+                .get(&session_id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
+        );
+        for i in 0..list.len() {
+            let turn = list[i];
+            let Some(c) = cost_for_turn(turn, pricing) else {
+                continue;
+            };
+            let ingest_cost = c.input + c.cache_read + c.cache_create;
+
+            for tc in &turn.tool_calls {
+                by_tool.entry(tc.name.clone()).or_default().calls += 1;
+            }
+
+            if i == 0 {
+                unattributed += ingest_cost;
+                continue;
+            }
+            let prior = list[i - 1];
+            if prior.tool_calls.is_empty() {
+                unattributed += ingest_cost;
+                continue;
+            }
+
+            let key = bridge_key(&prior.message_id, &turn.message_id);
+            let sizes = user_turn_size_index.get(&key);
+            let sized_bytes: u64 = match sizes {
+                Some(s) => prior
+                    .tool_calls
+                    .iter()
+                    .map(|tc| *s.tool_bytes_by_id.get(&tc.id).unwrap_or(&0))
+                    .sum(),
+                None => 0,
+            };
+            if let Some(sizes) = sizes.filter(|_| sized_bytes > 0) {
+                let allocatable_cost = if sizes.total_bytes > 0 {
+                    ingest_cost * (sized_bytes as f64 / sizes.total_bytes as f64).min(1.0)
+                } else {
+                    ingest_cost
+                };
+                unattributed += ingest_cost - allocatable_cost;
+                let mut raw_shares: Vec<(String, f64)> = Vec::new();
+                for tc in &prior.tool_calls {
+                    let bytes = *sizes.tool_bytes_by_id.get(&tc.id).unwrap_or(&0);
+                    if bytes == 0 {
+                        continue;
+                    }
+                    raw_shares.push((
+                        tc.name.clone(),
+                        (bytes as f64 / sized_bytes as f64) * allocatable_cost,
+                    ));
+                }
+                let raw_subtotal: f64 = raw_shares.iter().map(|(_, cost)| *cost).sum();
+                let scale = if raw_subtotal > allocatable_cost && raw_subtotal > 0.0 {
+                    allocatable_cost / raw_subtotal
+                } else {
+                    1.0
+                };
+                for (tool, cost) in raw_shares {
+                    let share = cost * scale;
+                    let agg = by_tool.entry(tool).or_default();
+                    agg.cost += share;
+                    agg.sized_cost += share;
+                }
+            } else {
+                let share = ingest_cost / prior.tool_calls.len() as f64;
+                for tc in &prior.tool_calls {
+                    let agg = by_tool.entry(tc.name.clone()).or_default();
+                    agg.cost += share;
+                    agg.even_split_cost += share;
+                }
+            }
+        }
+    }
+
+    (by_tool, unattributed)
+}
+
+fn index_user_turn_block_sizes(
+    user_turns: &[UserTurnRecord],
+) -> HashMap<String, UserTurnSizeBucket> {
+    let mut out: HashMap<String, UserTurnSizeBucket> = HashMap::new();
+    for user_turn in user_turns {
+        let (Some(preceding), Some(following)) = (
+            user_turn.preceding_message_id.as_ref(),
+            user_turn.following_message_id.as_ref(),
+        ) else {
+            continue;
+        };
+        let bucket = out.entry(bridge_key(preceding, following)).or_default();
+        for block in &user_turn.blocks {
+            let bytes = block.byte_len;
+            bucket.total_bytes += bytes;
+            if block.kind != UserTurnBlockKind::ToolResult {
+                continue;
+            }
+            let Some(tool_use_id) = block.tool_use_id.as_ref() else {
+                continue;
+            };
+            *bucket
+                .tool_bytes_by_id
+                .entry(tool_use_id.clone())
+                .or_default() += bytes;
+        }
+    }
+    out
+}
+
+fn bridge_key(preceding_message_id: &str, following_message_id: &str) -> String {
+    format!("{preceding_message_id}\0{following_message_id}")
+}
+
+fn tool_attribution_method(agg: &ToolAgg) -> &'static str {
+    if agg.sized_cost == 0.0 && agg.even_split_cost == 0.0 {
+        "unattributed"
+    } else if agg.sized_cost >= agg.even_split_cost {
+        "sized"
+    } else {
+        "even-split"
+    }
+}
+
+fn render_subagent_type_mode(
+    globals: &GlobalArgs,
+    turns: &[TurnRecord],
+    pricing: &relayburn_sdk::PricingTable,
+) -> anyhow::Result<i32> {
+    let stats = aggregate_subagent_type_stats(turns, &BuildSubagentTreeOptions::new(pricing));
+    if globals.json {
+        let mut value = serde_json::to_value(&stats)?;
+        coerce_whole_f64_to_int(&mut value);
+        print_json(&value);
+        return Ok(0);
+    }
+
+    let mut out = Vec::new();
+    out.push(String::new());
+    out.push(format!(
+        "subagent invocations: {}",
+        format_uint(stats.iter().map(|s| s.invocations).sum()),
+    ));
+    out.push(String::new());
+    if stats.is_empty() {
+        out.push("  (no subagent turns in range)".to_string());
+        out.push(String::new());
+        print!("{}", out.join("\n"));
+        return Ok(0);
+    }
+    out.push(render_subagent_stats_table(&stats));
+    out.push(String::new());
+    print!("{}", out.join("\n"));
+    Ok(0)
+}
+
+fn render_subagent_stats_table(stats: &[SubagentTypeStats]) -> String {
+    let mut rows = vec![vec![
+        "subagentType".into(),
+        "invocations".into(),
+        "turns".into(),
+        "total".into(),
+        "median".into(),
+        "p95".into(),
+        "mean".into(),
+    ]];
+    for s in stats {
+        rows.push(vec![
+            s.subagent_type.clone(),
+            format_uint(s.invocations),
+            format_uint(s.turns),
+            format_usd(s.total_cost),
+            format_usd(s.median_cost),
+            format_usd(s.p95_cost),
+            format_usd(s.mean_cost),
+        ]);
+    }
+    render_table(&rows)
+}
+
+const NO_RELATIONSHIPS_MESSAGE: &str =
+    "no SessionRelationshipRecord rows found for the matched slice; ingest a session with execution-graph wiring or run `burn state rebuild` once relationship backfill is available";
+
+const RELATIONSHIP_ORDER: [RelationshipType; 4] = [
+    RelationshipType::Root,
+    RelationshipType::Continuation,
+    RelationshipType::Fork,
+    RelationshipType::Subagent,
+];
+
+#[derive(Debug, Clone)]
+struct RelationshipMatch {
+    relationship_type: RelationshipType,
+    session_id: String,
+    subagent_type: Option<String>,
+    turn_count: u64,
+    cost: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RelationshipStats {
+    relationship_type: RelationshipType,
+    count: u64,
+    session_count: u64,
+    turn_count: u64,
+    total_cost: f64,
+    median_cost: f64,
+    p95_cost: f64,
+    mean_cost: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RelationshipSubagentStats {
+    subagent_type: String,
+    invocations: u64,
+    turns: u64,
+    total_cost: f64,
+    median_cost: f64,
+    p95_cost: f64,
+    mean_cost: f64,
+}
+
+fn render_relationship_mode(
+    globals: &GlobalArgs,
+    ledger: &RawLedger,
+    turns: &[TurnRecord],
+    pricing: &relayburn_sdk::PricingTable,
+    q: &Query,
+    flag: &str,
+) -> anyhow::Result<i32> {
+    let relationships = ledger.query_relationships(&relationship_query_for_turn_slice(q))?;
+    let matches = match_relationships_to_turns(&relationships, turns, pricing);
+    let stats = aggregate_relationship_stats(&matches);
+
+    if flag == "subagent" {
+        return render_relationship_subagent_mode(globals, &stats, &matches);
+    }
+    if stats.is_empty() {
+        return Ok(render_no_relationships(globals));
+    }
+
+    if globals.json {
+        let mut value = json!({ "relationships": stats });
+        coerce_whole_f64_to_int(&mut value);
+        print_json(&value);
+        return Ok(0);
+    }
+
+    let mut out = Vec::new();
+    out.push(String::new());
+    out.push(format!(
+        "relationships: {}",
+        format_uint(stats.iter().map(|s| s.session_count).sum()),
+    ));
+    out.push(String::new());
+    let mut rows = vec![vec![
+        "relationshipType".into(),
+        "sessionCount".into(),
+        "turnCount".into(),
+        "total".into(),
+        "median".into(),
+        "p95".into(),
+        "mean".into(),
+    ]];
+    for s in &stats {
+        rows.push(vec![
+            s.relationship_type.wire_str().to_string(),
+            format_uint(s.session_count),
+            format_uint(s.turn_count),
+            format_usd(s.total_cost),
+            format_usd(s.median_cost),
+            format_usd(s.p95_cost),
+            format_usd(s.mean_cost),
+        ]);
+    }
+    out.push(render_table(&rows));
+    out.push(String::new());
+    print!("{}", out.join("\n"));
+    Ok(0)
+}
+
+fn render_relationship_subagent_mode(
+    globals: &GlobalArgs,
+    stats: &[RelationshipStats],
+    matches: &[RelationshipMatch],
+) -> anyhow::Result<i32> {
+    let subagent_stats = aggregate_relationship_subagent_stats(matches);
+    if subagent_stats.is_empty() {
+        return Ok(render_no_relationships(globals));
+    }
+    if globals.json {
+        let subagent_relationships: Vec<&RelationshipStats> = stats
+            .iter()
+            .filter(|s| s.relationship_type == RelationshipType::Subagent)
+            .collect();
+        let mut value = json!({
+            "relationships": subagent_relationships,
+            "subagentTypes": subagent_stats,
+        });
+        coerce_whole_f64_to_int(&mut value);
+        print_json(&value);
+        return Ok(0);
+    }
+
+    let mut out = Vec::new();
+    out.push(String::new());
+    out.push(format!(
+        "subagent invocations: {}",
+        format_uint(subagent_stats.iter().map(|s| s.invocations).sum()),
+    ));
+    out.push(String::new());
+    let mut rows = vec![vec![
+        "subagentType".into(),
+        "invocations".into(),
+        "turns".into(),
+        "total".into(),
+        "median".into(),
+        "p95".into(),
+        "mean".into(),
+    ]];
+    for s in &subagent_stats {
+        rows.push(vec![
+            s.subagent_type.clone(),
+            format_uint(s.invocations),
+            format_uint(s.turns),
+            format_usd(s.total_cost),
+            format_usd(s.median_cost),
+            format_usd(s.p95_cost),
+            format_usd(s.mean_cost),
+        ]);
+    }
+    out.push(render_table(&rows));
+    out.push(String::new());
+    print!("{}", out.join("\n"));
+    Ok(0)
+}
+
+fn render_no_relationships(globals: &GlobalArgs) -> i32 {
+    if globals.json {
+        print_json(&json!({
+            "relationships": [],
+            "message": NO_RELATIONSHIPS_MESSAGE,
+        }));
+    } else {
+        println!("{NO_RELATIONSHIPS_MESSAGE}");
+    }
+    0
+}
+
+fn relationship_query_for_turn_slice(q: &Query) -> Query {
+    Query {
+        session_id: q.session_id.clone(),
+        source: q.source,
+        ..Default::default()
+    }
+}
+
+struct RelationshipTurnIndex<'a> {
+    all_by_session: HashMap<String, Vec<&'a TurnRecord>>,
+    main_by_session: HashMap<String, Vec<&'a TurnRecord>>,
+    sidechain_by_session: HashMap<String, Vec<&'a TurnRecord>>,
+    subagent_by_session_agent: HashMap<String, Vec<&'a TurnRecord>>,
+}
+
+fn match_relationships_to_turns(
+    relationships: &[SessionRelationshipRecord],
+    turns: &[TurnRecord],
+    pricing: &relayburn_sdk::PricingTable,
+) -> Vec<RelationshipMatch> {
+    let index = build_relationship_turn_index(turns);
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for r in relationships {
+        let key = relationship_instance_key(r);
+        if !seen.insert(key) {
+            continue;
+        }
+        let matched_turns = turns_for_relationship(r, &index);
+        if matched_turns.is_empty() {
+            continue;
+        }
+        let cost = matched_turns
+            .iter()
+            .map(|t| cost_for_turn(t, pricing).map(|c| c.total).unwrap_or(0.0))
+            .sum();
+        out.push(RelationshipMatch {
+            relationship_type: r.relationship_type,
+            session_id: r.session_id.clone(),
+            subagent_type: relationship_subagent_type(r, &matched_turns),
+            turn_count: matched_turns.len() as u64,
+            cost,
+        });
+    }
+    out
+}
+
+fn build_relationship_turn_index(turns: &[TurnRecord]) -> RelationshipTurnIndex<'_> {
+    let mut index = RelationshipTurnIndex {
+        all_by_session: HashMap::new(),
+        main_by_session: HashMap::new(),
+        sidechain_by_session: HashMap::new(),
+        subagent_by_session_agent: HashMap::new(),
+    };
+    for turn in turns {
+        index
+            .all_by_session
+            .entry(turn.session_id.clone())
+            .or_default()
+            .push(turn);
+        if is_main_thread_turn(turn) {
+            index
+                .main_by_session
+                .entry(turn.session_id.clone())
+                .or_default()
+                .push(turn);
+        }
+        if turn
+            .subagent
+            .as_ref()
+            .map(|s| s.is_sidechain)
+            .unwrap_or(false)
+        {
+            index
+                .sidechain_by_session
+                .entry(turn.session_id.clone())
+                .or_default()
+                .push(turn);
+        }
+        if let Some(agent_id) = turn.subagent.as_ref().and_then(|s| s.agent_id.as_ref()) {
+            if !agent_id.is_empty() {
+                index
+                    .subagent_by_session_agent
+                    .entry(session_agent_key(&turn.session_id, agent_id))
+                    .or_default()
+                    .push(turn);
+            }
+        }
+    }
+    index
+}
+
+fn turns_for_relationship<'a>(
+    r: &SessionRelationshipRecord,
+    index: &'a RelationshipTurnIndex<'a>,
+) -> Vec<&'a TurnRecord> {
+    match r.relationship_type {
+        RelationshipType::Root => index
+            .main_by_session
+            .get(&r.session_id)
+            .cloned()
+            .unwrap_or_default(),
+        RelationshipType::Subagent => {
+            if let Some(agent_id) = r.agent_id.as_ref().filter(|s| !s.is_empty()) {
+                let key = session_agent_key(&r.session_id, agent_id);
+                if let Some(direct) = index.subagent_by_session_agent.get(&key) {
+                    if !direct.is_empty() {
+                        return direct.clone();
+                    }
+                }
+                if r.session_id == *agent_id {
+                    return index
+                        .all_by_session
+                        .get(&r.session_id)
+                        .cloned()
+                        .unwrap_or_default();
+                }
+            }
+            if let Some(sidechain) = index.sidechain_by_session.get(&r.session_id) {
+                if !sidechain.is_empty() {
+                    return sidechain.clone();
+                }
+            }
+            if r.source.wire_str() == "spawn-env" {
+                return index
+                    .all_by_session
+                    .get(&r.session_id)
+                    .cloned()
+                    .unwrap_or_default();
+            }
+            Vec::new()
+        }
+        RelationshipType::Continuation | RelationshipType::Fork => index
+            .all_by_session
+            .get(&r.session_id)
+            .cloned()
+            .unwrap_or_default(),
+    }
+}
+
+fn aggregate_relationship_stats(matches: &[RelationshipMatch]) -> Vec<RelationshipStats> {
+    let mut by_type: HashMap<RelationshipType, HashMap<String, (u64, f64)>> = HashMap::new();
+    for m in matches {
+        let by_session = by_type.entry(m.relationship_type).or_default();
+        let current = by_session.entry(m.session_id.clone()).or_default();
+        current.0 += m.turn_count;
+        current.1 += m.cost;
+    }
+
+    let mut out = Vec::new();
+    for relationship_type in RELATIONSHIP_ORDER {
+        let Some(by_session) = by_type.get(&relationship_type) else {
+            continue;
+        };
+        if by_session.is_empty() {
+            continue;
+        }
+        let mut costs: Vec<f64> = by_session.values().map(|(_, cost)| *cost).collect();
+        costs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let total_cost: f64 = costs.iter().sum();
+        let session_count = by_session.len() as u64;
+        out.push(RelationshipStats {
+            relationship_type,
+            count: session_count,
+            session_count,
+            turn_count: by_session.values().map(|(turns, _)| *turns).sum(),
+            total_cost,
+            median_cost: percentile(&costs, 0.5),
+            p95_cost: percentile(&costs, 0.95),
+            mean_cost: if session_count > 0 {
+                total_cost / session_count as f64
+            } else {
+                0.0
+            },
+        });
+    }
+    out
+}
+
+fn aggregate_relationship_subagent_stats(
+    matches: &[RelationshipMatch],
+) -> Vec<RelationshipSubagentStats> {
+    struct Agg {
+        turns: u64,
+        total: f64,
+        costs: Vec<f64>,
+    }
+    let mut by_type: IndexMap<String, Agg> = IndexMap::new();
+    for m in matches {
+        if m.relationship_type != RelationshipType::Subagent {
+            continue;
+        }
+        let ty = m
+            .subagent_type
+            .clone()
+            .unwrap_or_else(|| "(unknown)".to_string());
+        let agg = by_type.entry(ty).or_insert_with(|| Agg {
+            turns: 0,
+            total: 0.0,
+            costs: Vec::new(),
+        });
+        agg.turns += m.turn_count;
+        agg.total += m.cost;
+        agg.costs.push(m.cost);
+    }
+
+    let mut out = Vec::new();
+    for (subagent_type, mut agg) in by_type {
+        agg.costs
+            .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let invocations = agg.costs.len() as u64;
+        out.push(RelationshipSubagentStats {
+            subagent_type,
+            invocations,
+            turns: agg.turns,
+            total_cost: agg.total,
+            median_cost: percentile(&agg.costs, 0.5),
+            p95_cost: percentile(&agg.costs, 0.95),
+            mean_cost: if invocations > 0 {
+                agg.total / invocations as f64
+            } else {
+                0.0
+            },
+        });
+    }
+    out.sort_by(|a, b| {
+        b.total_cost
+            .partial_cmp(&a.total_cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    out
+}
+
+fn relationship_subagent_type(
+    relationship: &SessionRelationshipRecord,
+    turns: &[&TurnRecord],
+) -> Option<String> {
+    if let Some(st) = &relationship.subagent_type {
+        return Some(st.clone());
+    }
+    turns.iter().find_map(|t| {
+        t.subagent
+            .as_ref()
+            .and_then(|s| s.subagent_type.as_ref())
+            .cloned()
+    })
+}
+
+fn relationship_instance_key(r: &SessionRelationshipRecord) -> String {
+    [
+        r.source.wire_str(),
+        r.relationship_type.wire_str(),
+        &r.session_id,
+        r.related_session_id.as_deref().unwrap_or(""),
+        r.agent_id.as_deref().unwrap_or(""),
+        r.parent_tool_use_id.as_deref().unwrap_or(""),
+    ]
+    .join("\0")
+}
+
+fn session_agent_key(session_id: &str, agent_id: &str) -> String {
+    format!("{session_id}\0{agent_id}")
+}
+
+fn is_main_thread_turn(turn: &TurnRecord) -> bool {
+    match &turn.subagent {
+        None => true,
+        Some(sub) => !sub.is_sidechain || sub.agent_id.as_deref() == Some(&turn.session_id),
+    }
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let rank =
+        ((p * sorted.len() as f64).ceil() as i64 - 1).clamp(0, sorted.len() as i64 - 1) as usize;
+    sorted[rank]
+}
+
+fn render_subagent_tree_mode(
+    globals: &GlobalArgs,
+    ledger: &RawLedger,
+    flag: &str,
+    q: &Query,
+    agent_filter: Option<&str>,
+    agent_session_ids: Option<&HashSet<String>>,
+    provider_filter: Option<&BTreeSet<String>>,
+) -> anyhow::Result<i32> {
+    let session_id = if !flag.is_empty() {
+        flag.to_string()
+    } else if let Some(session) = &q.session_id {
+        session.clone()
+    } else {
+        eprintln!("burn: --subagent-tree requires a session id (positional or --session)");
+        return Ok(2);
+    };
+
+    let relationships = collect_subagent_tree_relationships(ledger, &session_id, q)?;
+    let enriched = load_subagent_tree_turns(ledger, &session_id, &relationships, q)?;
+    let enriched =
+        filter_enriched_turns(enriched, agent_filter, agent_session_ids, provider_filter);
+    let turns = turns_from_enriched(&enriched);
+    let pricing = load_pricing(None);
+    let opts = BuildSubagentTreeOptions::new(&pricing).with_relationships(&relationships);
+    let trees = build_subagent_tree(&turns, &opts);
+    let root = trees
+        .get(&session_id)
+        .cloned()
+        .or_else(|| find_tree_node(trees.values(), &session_id));
+    let Some(root) = root else {
+        println!("no turns found for session {session_id}");
+        return Ok(0);
+    };
+
+    if globals.json {
+        let mut value = serde_json::to_value(&root)?;
+        coerce_whole_f64_to_int(&mut value);
+        print_json(&value);
+        return Ok(0);
+    }
+
+    let mut out = Vec::new();
+    out.push(String::new());
+    out.push(format!("session: {session_id}"));
+    out.push(format!(
+        "total: {} across {} turn{}",
+        format_usd(root.cumulative_cost),
+        format_uint(root.cumulative_turns),
+        if root.cumulative_turns == 1 { "" } else { "s" },
+    ));
+    out.push(String::new());
+    out.extend(render_tree(&root));
+    out.push(String::new());
+    print!("{}", out.join("\n"));
+    Ok(0)
+}
+
+fn collect_subagent_tree_relationships(
+    ledger: &RawLedger,
+    session_id: &str,
+    q: &Query,
+) -> anyhow::Result<Vec<SessionRelationshipRecord>> {
+    let query_base = relationship_query_for_turn_slice(q);
+    let mut out: IndexMap<String, SessionRelationshipRecord> = IndexMap::new();
+    let mut seen_ids = HashSet::new();
+    let mut queue = VecDeque::from([session_id.to_string()]);
+
+    while let Some(id) = queue.pop_front() {
+        if !seen_ids.insert(id.clone()) {
+            continue;
+        }
+        let rows = ledger.query_relationships(&Query {
+            session_id: Some(id),
+            ..query_base.clone()
+        })?;
+        for r in rows {
+            for next in relationship_connected_ids(&r) {
+                if !next.is_empty() && !seen_ids.contains(&next) {
+                    queue.push_back(next);
+                }
+            }
+            out.insert(relationship_instance_key(&r), r);
+        }
+    }
+    Ok(out.into_values().collect())
+}
+
+fn relationship_connected_ids(r: &SessionRelationshipRecord) -> Vec<String> {
+    let mut ids = vec![r.session_id.clone()];
+    if let Some(related) = &r.related_session_id {
+        ids.push(related.clone());
+    }
+    if let Some(agent) = &r.agent_id {
+        ids.push(agent.clone());
+    }
+    ids
+}
+
+fn load_subagent_tree_turns(
+    ledger: &RawLedger,
+    session_id: &str,
+    relationships: &[SessionRelationshipRecord],
+    q: &Query,
+) -> anyhow::Result<Vec<EnrichedTurn>> {
+    let mut session_ids = HashSet::from([session_id.to_string()]);
+    for r in relationships {
+        session_ids.insert(r.session_id.clone());
+    }
+
+    let mut by_key: IndexMap<String, EnrichedTurn> = IndexMap::new();
+    for id in session_ids {
+        let turns = ledger.query_turns(&Query {
+            session_id: Some(id),
+            ..q.clone()
+        })?;
+        for t in turns {
+            let key = format!(
+                "{}|{}|{}",
+                t.turn.source.wire_str(),
+                t.turn.session_id,
+                t.turn.message_id,
+            );
+            by_key.insert(key, t);
+        }
+    }
+    Ok(by_key.into_values().collect())
+}
+
+fn find_tree_node<'a>(
+    trees: impl IntoIterator<Item = &'a SubagentTreeNode>,
+    node_id: &str,
+) -> Option<SubagentTreeNode> {
+    for root in trees {
+        if let Some(found) = find_node(root, node_id) {
+            return Some(found.clone());
+        }
+    }
+    None
+}
+
+fn find_node<'a>(node: &'a SubagentTreeNode, node_id: &str) -> Option<&'a SubagentTreeNode> {
+    if node.node_id == node_id {
+        return Some(node);
+    }
+    for child in &node.children {
+        if let Some(found) = find_node(child, node_id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn render_tree(root: &SubagentTreeNode) -> Vec<String> {
+    let mut out = Vec::new();
+    out.push(render_node_line(root, ""));
+    render_children(root, "", &mut out);
+    out
+}
+
+fn render_children(node: &SubagentTreeNode, prefix: &str, out: &mut Vec<String>) {
+    let n = node.children.len();
+    for (i, child) in node.children.iter().enumerate() {
+        let is_last = i == n - 1;
+        let branch = if is_last { "└─ " } else { "├─ " };
+        out.push(render_node_line(child, &format!("{prefix}{branch}")));
+        let child_prefix = if is_last {
+            format!("{prefix}   ")
+        } else {
+            format!("{prefix}│  ")
+        };
+        render_children(child, &child_prefix, out);
+    }
+}
+
+fn render_node_line(node: &SubagentTreeNode, indent: &str) -> String {
+    let relationship = if node.relationship_type != RelationshipType::Root
+        && node.relationship_type != RelationshipType::Subagent
+    {
+        format!(" [{}]", node.relationship_type.wire_str())
+    } else {
+        String::new()
+    };
+    let model = if node.models.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", node.models.join(", "))
+    };
+    format!(
+        "{}{}{}{}  {}  [{} turn{}]",
+        indent,
+        node.label,
+        relationship,
+        model,
+        format_usd(node.cumulative_cost),
+        format_uint(node.cumulative_turns),
+        if node.cumulative_turns == 1 { "" } else { "s" },
+    )
 }
 
 /// Emit the FidelitySummary in TS-CLI key order so JSON output is
@@ -636,6 +1801,7 @@ fn emit_human(
     total_cost: &CostBreakdown,
     fidelity: &FidelitySummary,
     savings: &relayburn_sdk::ReplacementSavingsSummary,
+    quality: Option<&QualityResult>,
 ) {
     let mut lines: Vec<String> = Vec::new();
     lines.push(String::new());
@@ -727,9 +1893,62 @@ fn emit_human(
         lines.push(String::new());
     }
 
+    if let Some(q) = quality {
+        lines.push(render_quality(q));
+        lines.push(String::new());
+    }
+
     let out = lines.join("\n");
     // TS uses `process.stdout.write(lines.join('\n'))` — no trailing newline.
     print!("{}", out);
+}
+
+fn render_quality(q: &QualityResult) -> String {
+    if q.outcomes.is_empty() {
+        return "quality: (no sessions)".to_string();
+    }
+    let mut completed = 0u64;
+    let mut abandoned = 0u64;
+    let mut errored = 0u64;
+    let mut unknown = 0u64;
+    for outcome in &q.outcomes {
+        match outcome.outcome {
+            OutcomeLabel::Completed => completed += 1,
+            OutcomeLabel::Abandoned => abandoned += 1,
+            OutcomeLabel::Errored => errored += 1,
+            OutcomeLabel::Unknown => unknown += 1,
+        }
+    }
+    let mut edit_turns = 0u64;
+    let mut one_shot_turns = 0u64;
+    for metric in &q.one_shot {
+        edit_turns += metric.edit_turns;
+        one_shot_turns += metric.one_shot_turns;
+    }
+    let one_shot_line = if edit_turns == 0 {
+        "  one-shot rate: n/a (no edit turns)".to_string()
+    } else {
+        format!(
+            "  one-shot rate: {:.1}% across {} edit turns",
+            (one_shot_turns as f64 / edit_turns as f64) * 100.0,
+            format_uint(edit_turns),
+        )
+    };
+    [
+        format!(
+            "quality — sessions: {}",
+            format_uint(q.outcomes.len() as u64)
+        ),
+        format!(
+            "  outcomes: {} completed / {} abandoned / {} errored / {} unknown",
+            format_uint(completed),
+            format_uint(abandoned),
+            format_uint(errored),
+            format_uint(unknown),
+        ),
+        one_shot_line,
+    ]
+    .join("\n")
 }
 
 fn format_replacement_savings_line(s: &relayburn_sdk::ReplacementSavingsSummary) -> String {
@@ -804,4 +2023,166 @@ fn render_fidelity_notice(f: &FidelitySummary) -> Option<String> {
         "fidelity: {} (use --json for per-field coverage)",
         parts.join(" / ")
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use relayburn_sdk::{RelationshipSourceKind, SourceKind, ToolCall, Usage, UserTurnBlock};
+
+    #[test]
+    fn parse_provider_filter_trims_and_lowercases_csv() {
+        let got = parse_provider_filter(Some(" Anthropic,OPENAI ,,"))
+            .unwrap()
+            .unwrap();
+        assert!(got.contains("anthropic"));
+        assert!(got.contains("openai"));
+        assert_eq!(got.len(), 2);
+        assert_eq!(
+            parse_provider_filter(Some(" , ")),
+            Err("burn: --provider requires a value"),
+        );
+    }
+
+    #[test]
+    fn collect_agent_session_tree_follows_nested_child_sessions_and_agent_ids() {
+        let rels = vec![
+            relationship("child-session", "root-agent", Some("child-agent")),
+            relationship("grandchild-session", "child-session", Some("grand-agent")),
+            relationship("great-grandchild-session", "child-agent", None),
+        ];
+
+        let sessions = collect_agent_session_tree(&rels, "root-agent");
+
+        assert!(sessions.contains("child-session"));
+        assert!(sessions.contains("grandchild-session"));
+        assert!(sessions.contains("great-grandchild-session"));
+        assert_eq!(sessions.len(), 3);
+    }
+
+    #[test]
+    fn by_tool_attribution_uses_user_turn_block_byte_shares() {
+        let pricing = load_pricing(None);
+        let turns = vec![
+            turn(
+                0,
+                "assistant-1",
+                Usage::default(),
+                vec![tool("call-read", "Read"), tool("call-edit", "Edit")],
+            ),
+            turn(
+                1,
+                "assistant-2",
+                Usage {
+                    input: 1_000,
+                    ..Usage::default()
+                },
+                Vec::new(),
+            ),
+        ];
+        let mut user_turns_by_session = HashMap::new();
+        user_turns_by_session.insert(
+            "session".to_string(),
+            vec![UserTurnRecord {
+                v: 1,
+                source: SourceKind::ClaudeCode,
+                session_id: "session".to_string(),
+                user_uuid: "user-1".to_string(),
+                ts: "2026-04-20T00:00:01.000Z".to_string(),
+                preceding_message_id: Some("assistant-1".to_string()),
+                following_message_id: Some("assistant-2".to_string()),
+                blocks: vec![
+                    tool_result_block("call-read", 75),
+                    tool_result_block("call-edit", 25),
+                ],
+            }],
+        );
+
+        let (by_tool, unattributed) =
+            attribute_cost_to_tools(&turns, &pricing, &user_turns_by_session);
+        let read = by_tool.get("Read").expect("read agg");
+        let edit = by_tool.get("Edit").expect("edit agg");
+
+        assert_eq!(read.calls, 1);
+        assert_eq!(edit.calls, 1);
+        assert!(read.cost > edit.cost * 2.9);
+        assert!(read.cost < edit.cost * 3.1);
+        assert!(unattributed.abs() < 1e-12);
+        assert_eq!(tool_attribution_method(read), "sized");
+    }
+
+    fn relationship(
+        session_id: &str,
+        related_session_id: &str,
+        agent_id: Option<&str>,
+    ) -> SessionRelationshipRecord {
+        SessionRelationshipRecord {
+            v: 1,
+            source: RelationshipSourceKind::SpawnEnv,
+            session_id: session_id.to_string(),
+            related_session_id: Some(related_session_id.to_string()),
+            relationship_type: RelationshipType::Subagent,
+            ts: None,
+            source_session_id: None,
+            source_version: None,
+            parent_tool_use_id: None,
+            agent_id: agent_id.map(str::to_string),
+            subagent_type: None,
+            description: None,
+        }
+    }
+
+    fn turn(
+        turn_index: u64,
+        message_id: &str,
+        usage: Usage,
+        tool_calls: Vec<ToolCall>,
+    ) -> TurnRecord {
+        TurnRecord {
+            v: 1,
+            source: SourceKind::ClaudeCode,
+            session_id: "session".to_string(),
+            session_path: None,
+            message_id: message_id.to_string(),
+            turn_index,
+            ts: format!("2026-04-20T00:00:0{turn_index}.000Z"),
+            model: "claude-sonnet-4-6".to_string(),
+            project: None,
+            project_key: None,
+            usage,
+            tool_calls,
+            files_touched: None,
+            subagent: None,
+            stop_reason: None,
+            activity: None,
+            retries: None,
+            has_edits: None,
+            fidelity: None,
+        }
+    }
+
+    fn tool(id: &str, name: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            target: None,
+            args_hash: "args".to_string(),
+            is_error: None,
+            edit_pre_hash: None,
+            edit_post_hash: None,
+            skill_name: None,
+            replaced_tools: None,
+            collapsed_calls: None,
+        }
+    }
+
+    fn tool_result_block(tool_use_id: &str, byte_len: u64) -> UserTurnBlock {
+        UserTurnBlock {
+            kind: UserTurnBlockKind::ToolResult,
+            tool_use_id: Some(tool_use_id.to_string()),
+            byte_len,
+            approx_tokens: 0,
+            is_error: None,
+        }
+    }
 }

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -167,6 +167,8 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         }
     };
 
+    let _archive_guard = ArchiveOverride::activate(args.no_archive);
+
     let opts = match globals.ledger_path.as_deref() {
         Some(h) => LedgerOpenOptions::with_home(h),
         None => LedgerOpenOptions::default(),
@@ -194,6 +196,7 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
     }
 
     let enriched = handle.raw().query_turns(&q)?;
+    let attribution_turns = turns_from_enriched(&enriched);
     let enriched = filter_enriched_turns(
         enriched,
         args.agent.as_deref(),
@@ -212,7 +215,14 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
     }
 
     if args.by_tool {
-        return render_by_tool_mode(globals, handle.raw(), &turns, &ingest_report, &pricing);
+        return render_by_tool_mode(
+            globals,
+            handle.raw(),
+            &turns,
+            &attribution_turns,
+            &ingest_report,
+            &pricing,
+        );
     }
 
     let fidelity = summarize_fidelity(&turns);
@@ -422,6 +432,43 @@ fn run_ingest(handle: &mut LedgerHandle) -> anyhow::Result<relayburn_sdk::Ingest
         .build()?;
     let opts = relayburn_sdk::RawIngestOptions::default();
     rt.block_on(ingest_all(handle.raw_mut(), &opts))
+}
+
+/// Drop-in for `RELAYBURN_ARCHIVE=0`. The Rust SDK is already SQLite-native,
+/// but this preserves the TS CLI flag contract for any lower layer that checks
+/// the env escape hatch.
+struct ArchiveOverride {
+    previous: Option<String>,
+    activated: bool,
+}
+
+impl ArchiveOverride {
+    fn activate(no_archive: bool) -> Self {
+        if !no_archive {
+            return Self {
+                previous: None,
+                activated: false,
+            };
+        }
+        let previous = std::env::var("RELAYBURN_ARCHIVE").ok();
+        std::env::set_var("RELAYBURN_ARCHIVE", "0");
+        Self {
+            previous,
+            activated: true,
+        }
+    }
+}
+
+impl Drop for ArchiveOverride {
+    fn drop(&mut self) {
+        if !self.activated {
+            return;
+        }
+        match self.previous.take() {
+            Some(v) => std::env::set_var("RELAYBURN_ARCHIVE", v),
+            None => std::env::remove_var("RELAYBURN_ARCHIVE"),
+        }
+    }
 }
 
 fn aggregate_by_model(
@@ -682,11 +729,18 @@ fn render_by_tool_mode(
     globals: &GlobalArgs,
     ledger: &RawLedger,
     turns: &[TurnRecord],
+    attribution_turns: &[TurnRecord],
     ingest_report: &relayburn_sdk::IngestReport,
     pricing: &relayburn_sdk::PricingTable,
 ) -> anyhow::Result<i32> {
-    let user_turns_by_session = load_user_turns_for_by_tool(ledger, turns)?;
-    let (by_tool, unattributed) = attribute_cost_to_tools(turns, pricing, &user_turns_by_session);
+    let user_turns_by_session = load_user_turns_for_by_tool(ledger, attribution_turns)?;
+    let selected_turns = selected_turn_keys(turns);
+    let (by_tool, unattributed) = attribute_cost_to_tools(
+        attribution_turns,
+        pricing,
+        &user_turns_by_session,
+        Some(&selected_turns),
+    );
     let fidelity = summarize_fidelity(turns);
     let savings = summarize_replacement_savings(turns, None);
     let mut sorted: Vec<(String, ToolAgg)> = by_tool.into_iter().collect();
@@ -801,27 +855,31 @@ fn load_user_turns_for_by_tool(
     ledger: &RawLedger,
     turns: &[TurnRecord],
 ) -> anyhow::Result<HashMap<String, Vec<UserTurnRecord>>> {
-    let mut seen = HashSet::new();
+    let session_ids: HashSet<String> = turns.iter().map(|t| t.session_id.clone()).collect();
     let mut out = HashMap::new();
-    for t in turns {
-        if !seen.insert(t.session_id.clone()) {
+    if session_ids.is_empty() {
+        return Ok(out);
+    }
+    for row in ledger.query_user_turns(&Query::default())? {
+        if !session_ids.contains(&row.session_id) {
             continue;
         }
-        let rows = ledger.query_user_turns(&Query {
-            session_id: Some(t.session_id.clone()),
-            ..Default::default()
-        })?;
-        if !rows.is_empty() {
-            out.insert(t.session_id.clone(), rows);
-        }
+        out.entry(row.session_id.clone())
+            .or_insert_with(Vec::new)
+            .push(row);
     }
     Ok(out)
+}
+
+fn selected_turn_keys(turns: &[TurnRecord]) -> HashSet<String> {
+    turns.iter().map(turn_identity_key).collect()
 }
 
 fn attribute_cost_to_tools(
     turns: &[TurnRecord],
     pricing: &relayburn_sdk::PricingTable,
     user_turns_by_session: &HashMap<String, Vec<UserTurnRecord>>,
+    selected_turns: Option<&HashSet<String>>,
 ) -> (IndexMap<String, ToolAgg>, f64) {
     let mut by_tool: IndexMap<String, ToolAgg> = IndexMap::new();
     let mut unattributed = 0.0;
@@ -840,6 +898,9 @@ fn attribute_cost_to_tools(
         );
         for i in 0..list.len() {
             let turn = list[i];
+            if !turn_is_selected(turn, selected_turns) {
+                continue;
+            }
             let Some(c) = cost_for_turn(turn, pricing) else {
                 continue;
             };
@@ -911,6 +972,21 @@ fn attribute_cost_to_tools(
     }
 
     (by_tool, unattributed)
+}
+
+fn turn_is_selected(turn: &TurnRecord, selected_turns: Option<&HashSet<String>>) -> bool {
+    selected_turns
+        .map(|keys| keys.contains(&turn_identity_key(turn)))
+        .unwrap_or(true)
+}
+
+fn turn_identity_key(turn: &TurnRecord) -> String {
+    format!(
+        "{}\0{}\0{}",
+        turn.source.wire_str(),
+        turn.session_id,
+        turn.message_id
+    )
 }
 
 fn index_user_turn_block_sizes(
@@ -1527,29 +1603,47 @@ fn collect_subagent_tree_relationships(
     session_id: &str,
     q: &Query,
 ) -> anyhow::Result<Vec<SessionRelationshipRecord>> {
-    let query_base = relationship_query_for_turn_slice(q);
+    let relationships = ledger.query_relationships(&Query {
+        source: q.source,
+        ..Default::default()
+    })?;
+    Ok(collect_connected_relationships(&relationships, session_id))
+}
+
+fn collect_connected_relationships(
+    relationships: &[SessionRelationshipRecord],
+    session_id: &str,
+) -> Vec<SessionRelationshipRecord> {
+    let mut by_id: HashMap<String, Vec<usize>> = HashMap::new();
+    for (idx, r) in relationships.iter().enumerate() {
+        for id in relationship_connected_ids(r) {
+            if !id.is_empty() {
+                by_id.entry(id).or_default().push(idx);
+            }
+        }
+    }
+
     let mut out: IndexMap<String, SessionRelationshipRecord> = IndexMap::new();
     let mut seen_ids = HashSet::new();
     let mut queue = VecDeque::from([session_id.to_string()]);
-
     while let Some(id) = queue.pop_front() {
         if !seen_ids.insert(id.clone()) {
             continue;
         }
-        let rows = ledger.query_relationships(&Query {
-            session_id: Some(id),
-            ..query_base.clone()
-        })?;
-        for r in rows {
-            for next in relationship_connected_ids(&r) {
+        let Some(rows) = by_id.get(&id) else {
+            continue;
+        };
+        for idx in rows {
+            let r = &relationships[*idx];
+            for next in relationship_connected_ids(r) {
                 if !next.is_empty() && !seen_ids.contains(&next) {
                     queue.push_back(next);
                 }
             }
-            out.insert(relationship_instance_key(&r), r);
+            out.insert(relationship_instance_key(r), r.clone());
         }
     }
-    Ok(out.into_values().collect())
+    out.into_values().collect()
 }
 
 fn relationship_connected_ids(r: &SessionRelationshipRecord) -> Vec<String> {
@@ -2061,6 +2155,22 @@ mod tests {
     }
 
     #[test]
+    fn collect_connected_relationships_follows_related_sessions_and_agent_ids() {
+        let rels = vec![
+            relationship("child-session", "root-session", Some("child-agent")),
+            relationship("grandchild-session", "child-agent", None),
+            relationship("unrelated-session", "other-session", None),
+        ];
+
+        let connected = collect_connected_relationships(&rels, "root-session");
+        let session_ids: HashSet<&str> = connected.iter().map(|r| r.session_id.as_str()).collect();
+
+        assert!(session_ids.contains("child-session"));
+        assert!(session_ids.contains("grandchild-session"));
+        assert!(!session_ids.contains("unrelated-session"));
+    }
+
+    #[test]
     fn by_tool_attribution_uses_user_turn_block_byte_shares() {
         let pricing = load_pricing(None);
         let turns = vec![
@@ -2099,7 +2209,7 @@ mod tests {
         );
 
         let (by_tool, unattributed) =
-            attribute_cost_to_tools(&turns, &pricing, &user_turns_by_session);
+            attribute_cost_to_tools(&turns, &pricing, &user_turns_by_session, None);
         let read = by_tool.get("Read").expect("read agg");
         let edit = by_tool.get("Edit").expect("edit agg");
 
@@ -2109,6 +2219,43 @@ mod tests {
         assert!(read.cost < edit.cost * 3.1);
         assert!(unattributed.abs() < 1e-12);
         assert_eq!(tool_attribution_method(read), "sized");
+    }
+
+    #[test]
+    fn by_tool_attribution_uses_real_predecessor_when_selection_skips_turns() {
+        let pricing = load_pricing(None);
+        let turns = vec![
+            turn(
+                0,
+                "assistant-1",
+                Usage::default(),
+                vec![tool("call-read", "Read")],
+            ),
+            turn(
+                1,
+                "assistant-2",
+                Usage::default(),
+                vec![tool("call-edit", "Edit")],
+            ),
+            turn(
+                2,
+                "assistant-3",
+                Usage {
+                    input: 1_000,
+                    ..Usage::default()
+                },
+                Vec::new(),
+            ),
+        ];
+        let selected = HashSet::from([turn_identity_key(&turns[2])]);
+        let user_turns_by_session: HashMap<String, Vec<UserTurnRecord>> = HashMap::new();
+
+        let (by_tool, unattributed) =
+            attribute_cost_to_tools(&turns, &pricing, &user_turns_by_session, Some(&selected));
+
+        assert!(by_tool.get("Edit").expect("edit agg").cost > 0.0);
+        assert_eq!(by_tool.get("Read").map(|agg| agg.cost).unwrap_or(0.0), 0.0);
+        assert_eq!(unattributed, 0.0);
     }
 
     fn relationship(

--- a/crates/relayburn-sdk/src/ledger.rs
+++ b/crates/relayburn-sdk/src/ledger.rs
@@ -128,10 +128,7 @@ impl Ledger {
         writer::append_stamp(&mut self.conns.burn, stamp)
     }
 
-    pub fn append_content(
-        &mut self,
-        records: &[crate::reader::ContentRecord],
-    ) -> Result<usize> {
+    pub fn append_content(&mut self, records: &[crate::reader::ContentRecord]) -> Result<usize> {
         writer::append_content(&mut self.conns.content, records)
     }
 
@@ -141,10 +138,7 @@ impl Ledger {
         reader::query_turns(&self.conns.burn, q)
     }
 
-    pub fn query_compactions(
-        &self,
-        q: &Query,
-    ) -> Result<Vec<crate::reader::CompactionEvent>> {
+    pub fn query_compactions(&self, q: &Query) -> Result<Vec<crate::reader::CompactionEvent>> {
         reader::query_compactions(&self.conns.burn, q)
     }
 
@@ -162,10 +156,7 @@ impl Ledger {
         reader::query_tool_result_events(&self.conns.burn, q)
     }
 
-    pub fn query_user_turns(
-        &self,
-        q: &Query,
-    ) -> Result<Vec<crate::reader::UserTurnRecord>> {
+    pub fn query_user_turns(&self, q: &Query) -> Result<Vec<crate::reader::UserTurnRecord>> {
         reader::query_user_turns(&self.conns.burn, q)
     }
 
@@ -179,6 +170,10 @@ impl Ledger {
 
     pub fn count_content(&self) -> Result<i64> {
         content::count_content(&self.conns.content)
+    }
+
+    pub fn query_content(&self, q: &Query) -> Result<Vec<crate::reader::ContentRecord>> {
+        content::query(&self.conns.content, q)
     }
 
     /// Distinct session ids that have at least one content row in
@@ -214,7 +209,13 @@ impl Ledger {
     /// to what a 1.x JSONL ledger would have written for the same set of
     /// records, sufficient for `jq`/`grep` debugging.
     pub fn export_ledger_jsonl<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
-        for kind in ["turn", "compaction", "relationship", "tool_result_event", "user_turn"] {
+        for kind in [
+            "turn",
+            "compaction",
+            "relationship",
+            "tool_result_event",
+            "user_turn",
+        ] {
             let table = match kind {
                 "turn" => "turns",
                 "compaction" => "compactions",

--- a/crates/relayburn-sdk/src/ledger/content.rs
+++ b/crates/relayburn-sdk/src/ledger/content.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::ledger::error::Result;
 use crate::ledger::paths::is_valid_session_id;
+use crate::ledger::query::Query;
+use crate::reader::ContentRecord;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SearchHit {
@@ -112,10 +114,7 @@ pub(crate) fn prune_older_than(conn: &mut Connection, cutoff: &str) -> Result<Pr
             |r| r.get(0),
         )
         .unwrap_or(0);
-    let deleted = tx.execute(
-        "DELETE FROM content WHERE created_at < ?",
-        params![cutoff],
-    )?;
+    let deleted = tx.execute("DELETE FROM content WHERE created_at < ?", params![cutoff])?;
     tx.commit()?;
     Ok(PruneStats {
         rows_deleted: deleted,
@@ -126,6 +125,48 @@ pub(crate) fn prune_older_than(conn: &mut Connection, cutoff: &str) -> Result<Pr
 pub(crate) fn count_content(conn: &Connection) -> Result<i64> {
     let count: i64 = conn.query_row("SELECT COUNT(*) FROM content", [], |r| r.get(0))?;
     Ok(count)
+}
+
+pub(crate) fn query(conn: &Connection, q: &Query) -> Result<Vec<ContentRecord>> {
+    let mut stmt = conn.prepare("SELECT body FROM content ORDER BY rowid")?;
+    let rows = stmt
+        .query_map([], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut out = Vec::new();
+    for json in rows {
+        let record: ContentRecord = match serde_json::from_str(&json) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if content_passes(&record, q) {
+            out.push(record);
+        }
+    }
+    Ok(out)
+}
+
+fn content_passes(r: &ContentRecord, q: &Query) -> bool {
+    if let Some(ref since) = q.since {
+        if &r.ts < since {
+            return false;
+        }
+    }
+    if let Some(ref until) = q.until {
+        if &r.ts > until {
+            return false;
+        }
+    }
+    if let Some(ref sid) = q.session_id {
+        if &r.session_id != sid {
+            return false;
+        }
+    }
+    if let Some(source) = q.source {
+        if r.source != source {
+            return false;
+        }
+    }
+    true
 }
 
 /// Distinct `session_id` values present in `content.sqlite`. Powers the

--- a/crates/relayburn-sdk/src/ledger/content.rs
+++ b/crates/relayburn-sdk/src/ledger/content.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use rusqlite::{params, Connection};
+use rusqlite::{params, params_from_iter, Connection};
 use serde::{Deserialize, Serialize};
 
 use crate::ledger::error::Result;
@@ -128,12 +128,28 @@ pub(crate) fn count_content(conn: &Connection) -> Result<i64> {
 }
 
 pub(crate) fn query(conn: &Connection, q: &Query) -> Result<Vec<ContentRecord>> {
-    let mut stmt = conn.prepare("SELECT body FROM content ORDER BY rowid")?;
-    let rows = stmt
-        .query_map([], |r| r.get::<_, String>(0))?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut sql = String::from("SELECT body FROM content");
+    let mut clauses = Vec::new();
+    let mut params = Vec::new();
+    if let Some(session_id) = &q.session_id {
+        clauses.push("session_id = ?");
+        params.push(session_id.clone());
+    }
+    if let Some(source) = q.source {
+        clauses.push("source = ?");
+        params.push(source.wire_str().to_string());
+    }
+    if !clauses.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+    sql.push_str(" ORDER BY rowid");
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(params.iter()), |r| r.get::<_, String>(0))?;
     let mut out = Vec::new();
-    for json in rows {
+    for row in rows {
+        let json = row?;
         let record: ContentRecord = match serde_json::from_str(&json) {
             Ok(r) => r,
             Err(_) => continue,

--- a/crates/relayburn-sdk/src/lib.rs
+++ b/crates/relayburn-sdk/src/lib.rs
@@ -76,8 +76,8 @@ pub use crate::reader::{
     ContentStoreMode, ContentToolResult, ContentToolUse, Coverage, Fidelity, FidelityClass,
     Harness, ProjectResolver, RelationshipSourceKind, RelationshipType, ResolvedProject,
     SessionRelationshipRecord, SourceKind, Subagent, ToolCall, ToolResultEventRecord,
-    ToolResultEventSource, ToolResultStatus, TurnRecord, Usage, UsageAttribution,
-    UsageGranularity, UserTurnBlock, UserTurnBlockKind, UserTurnRecord,
+    ToolResultEventSource, ToolResultStatus, TurnRecord, Usage, UsageAttribution, UsageGranularity,
+    UserTurnBlock, UserTurnBlockKind, UserTurnRecord,
 };
 
 pub use crate::ledger::{
@@ -89,21 +89,24 @@ pub use crate::ledger::{
 
 pub use crate::analyze::{
     aggregate_by_bash, aggregate_by_bash_verb, aggregate_by_file, aggregate_by_provider,
-    aggregate_by_subagent, attribute_hotspots, attribute_overhead, build_compare_table,
-    build_trim_recommendations, compare_from_archive, cost_for_turn, cost_for_usage,
-    describe_applies_to, detect_patterns, detect_tool_call_patterns, detect_tool_output_bloat,
-    find_overhead_files, findings_from_patterns, has_minimum_fidelity, load_overhead_file,
-    load_pricing, render_unified_diff_for_recommendation, summarize_fidelity,
-    summarize_replacement_savings, sum_costs, AggregateByProviderOptions, AttributeOverheadInput,
-    AttributionMethod, BashAggregation, BashVerbAggregation, CompareCategory, CompareCell,
-    CompareFromArchiveResult, CompareOptions as AnalyzeCompareOptions, CompareTable,
-    CompareTotals, CostBreakdown, CoverageField, FidelitySummary, FieldCoverage, FileAggregation,
+    aggregate_by_subagent, aggregate_subagent_type_stats, attribute_hotspots, attribute_overhead,
+    build_compare_table, build_subagent_tree, build_trim_recommendations, compare_from_archive,
+    compute_quality, cost_for_turn, cost_for_usage, describe_applies_to, detect_patterns,
+    detect_tool_call_patterns, detect_tool_output_bloat, find_overhead_files,
+    findings_from_patterns, has_minimum_fidelity, load_overhead_file, load_pricing, provider_for,
+    render_unified_diff_for_recommendation, sum_costs, summarize_fidelity,
+    summarize_replacement_savings, AggregateByProviderOptions, AttributeOverheadInput,
+    AttributionMethod, BashAggregation, BashVerbAggregation, BuildSubagentTreeOptions,
+    CompareCategory, CompareCell, CompareFromArchiveResult,
+    CompareOptions as AnalyzeCompareOptions, CompareTable, CompareTotals, ComputeQualityOptions,
+    CostBreakdown, CoverageField, FidelitySummary, FieldCoverage, FileAggregation,
     HotspotsOptions as AnalyzeHotspotsOptions, HotspotsResult as AnalyzeHotspotsResult,
-    MarkdownSection, ModelCost, OverheadAttribution, OverheadFile, OverheadFileAttribution,
-    OverheadFileKind, ParsedOverheadFile, PricingTable, ProviderAggregateRow, ReasoningMode,
-    ReplacementSavingsSummary, RowCoverage, SessionClaudeMdCost, SessionTotals,
-    SubagentAggregation, ToolAttribution, TrimRecommendation, UsageCostAggregateRow, WasteFinding,
-    WasteSeverity, DEFAULT_MIN_SAMPLE,
+    MarkdownSection, ModelCost, OneShotMetrics, OutcomeLabel, OverheadAttribution, OverheadFile,
+    OverheadFileAttribution, OverheadFileKind, ParsedOverheadFile, PricingTable,
+    ProviderAggregateRow, QualityResult, ReasoningMode, ReplacementSavingsSummary, RowCoverage,
+    SessionClaudeMdCost, SessionOutcome, SessionTotals, SubagentAggregation, SubagentTreeNode,
+    SubagentTypeStats, ToolAttribution, TrimRecommendation, TurnProvider, UsageCostAggregateRow,
+    WasteFinding, WasteSeverity, DEFAULT_MIN_SAMPLE,
 };
 
 pub use crate::ingest::{


### PR DESCRIPTION
## Summary

- implements Rust `burn summary` parity for workflow/agent/provider filters
- wires `--by-tool`, `--by-subagent-type`, `--by-relationship`, `--subagent-tree`, and `--quality`
- adds SDK content querying and exports needed by the Rust CLI presenter
- covers provider parsing, nested agent-session resolution, and by-tool byte-share attribution

## Tests

- `cargo test -p relayburn-cli`
- `cargo test -p relayburn-sdk`
- `BURN_GOLDEN=1 cargo test -p relayburn-cli --test golden -- --nocapture`
