### PR TITLE
relayburn-sdk: reader cleanup deferred subset (#346)

### DIFF
--- a/crates/relayburn-sdk/src/reader/codex.rs
+++ b/crates/relayburn-sdk/src/reader/codex.rs
@@ -152,15 +152,20 @@ pub fn parse_codex_session(
         start_offset: Some(0),
         resume: None,
     };
-    let r = parse_codex_session_incremental(file_path, &inc_opts)?;
-    Ok(ParseCodexResult {
-        turns: r.turns,
-        content: r.content,
-        events: r.events,
-        user_turns: r.user_turns,
-        relationships: r.relationships,
-        tool_result_events: r.tool_result_events,
-    })
+    parse_codex_session_incremental(file_path, &inc_opts).map(ParseCodexResult::from)
+}
+
+impl From<ParseCodexIncrementalResult> for ParseCodexResult {
+    fn from(r: ParseCodexIncrementalResult) -> Self {
+        Self {
+            turns: r.turns,
+            content: r.content,
+            events: r.events,
+            user_turns: r.user_turns,
+            relationships: r.relationships,
+            tool_result_events: r.tool_result_events,
+        }
+    }
 }
 
 pub fn parse_codex_session_incremental(
@@ -389,7 +394,7 @@ fn parse_codex_buffer(
 
     let mut p: usize = 0;
     while p < buf.len() {
-        let nl_idx = match memchr_newline(&buf[p..]) {
+        let nl_idx = match find_newline(&buf[p..]) {
             Some(idx) => p + idx,
             None => break,
         };
@@ -1092,10 +1097,6 @@ fn parse_codex_buffer(
         }
     }
 
-    // Suppress unused warnings: these are kept for parity with the TS state
-    // machine even when their values aren't read after the loop.
-    let _ = (next_event_index, tool_result_counters);
-
     // Emit only committed turns.
     let committed = &finalized[..committed_finalized_count];
     let mut turns: Vec<TurnRecord> = Vec::with_capacity(committed.len());
@@ -1184,18 +1185,6 @@ fn parse_codex_buffer(
         }
     }
 
-    // Silence unused-mutable warnings for snapshot mirrors that are written
-    // but only read indirectly.
-    let _ = (
-        cumulative,
-        session_id,
-        session_cwd,
-        turn_contexts,
-        seen_session_meta_keys,
-        root_session_emitted,
-        last_completed_turn,
-    );
-
     ParseCodexIncrementalResult {
         turns,
         content: content_out,
@@ -1228,7 +1217,7 @@ fn resolve_token_counter(
     }
 }
 
-fn memchr_newline(buf: &[u8]) -> Option<usize> {
+fn find_newline(buf: &[u8]) -> Option<usize> {
     buf.iter().position(|&b| b == b'\n')
 }
 

--- a/crates/relayburn-sdk/src/reader/opencode.rs
+++ b/crates/relayburn-sdk/src/reader/opencode.rs
@@ -88,15 +88,20 @@ pub fn parse_opencode_session(
         tokenizer: options.tokenizer,
         seen_message_ids: None,
     };
-    let r = parse_opencode_session_incremental(session_file_path, &inc_opts)?;
-    Ok(ParseOpencodeResult {
-        turns: r.turns,
-        content: r.content,
-        events: r.events,
-        user_turns: r.user_turns,
-        relationships: r.relationships,
-        tool_result_events: r.tool_result_events,
-    })
+    parse_opencode_session_incremental(session_file_path, &inc_opts).map(ParseOpencodeResult::from)
+}
+
+impl From<ParseOpencodeIncrementalResult> for ParseOpencodeResult {
+    fn from(r: ParseOpencodeIncrementalResult) -> Self {
+        Self {
+            turns: r.turns,
+            content: r.content,
+            events: r.events,
+            user_turns: r.user_turns,
+            relationships: r.relationships,
+            tool_result_events: r.tool_result_events,
+        }
+    }
 }
 
 pub fn parse_opencode_session_incremental(


### PR DESCRIPTION
## Summary

Picks up the items from #346 that #352 explicitly deferred as "riskier."

- **codex.rs / opencode.rs (item 1, partial):** replace the manual repack of the incremental result inside `parse_codex_session` / `parse_opencode_session` with `From<ParseCodexIncrementalResult> for ParseCodexResult` (and the opencode equivalent). The session entry points now just `.map(...::from)`.
- **codex.rs (item 3):** drop the two `let _ = (...)` "suppress unused warnings" blocks at the tail of `parse_codex_buffer`. Audit confirms every `committed_*` snapshot they justified is read post-loop (resume state or emitted records), so the trailing working values are genuinely dead. Removing the silencing blocks introduces no new compiler warnings.
- **codex.rs (item 6):** rename `memchr_newline` to `find_newline`. The previous name implied a `memchr`-crate optimization that wasn't there (the body is `iter().position(|&b| b == b'\n')`); not adding the crate, just dropping the misleading name.

### Deferred

**claude.rs parser duplication (item 1, claude path)** stays deferred. The non-incremental `ParseState` emits in-progress turns (records with `stop_reason.is_none()`), while `run_incremental` deliberately defers them so the next call's start cursor is honest. Collapsing the two paths would change observable output for partially-written sessions and needs a flag on `run_incremental` plus broader fixture validation.

**string-field helpers (item 2), `verb()` two-arm match (item 4), `resolve_uncached` fallback (item 5)** all already landed in #352.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 618 SDK tests + integration + doc tests pass
- [x] `cargo clippy --workspace --all-targets` — no new warnings introduced (pre-existing warnings unrelated to this change)

https://claude.ai/code/session_01GHEd4Sv87QoUTd1BN6FbAF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHEd4Sv87QoUTd1BN6FbAF)_