### PR TITLE
Wire remaining burn hotspots CLI modes (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,12 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ### Added
 
-- `relayburn-cli` / `relayburn-sdk`: `burn hotspots` now wires
-  `--session <id>`, `--workflow <id>`, `--provider <csv>`, `--patterns [csv]`,
-  and `--findings` over the existing SDK surface. `HotspotsOptions` gains
-  `workflow` + `provider` filter fields (also exposed through `@relayburn/sdk`
-  via napi). The per-session aggregate view (`--session` with no id) and
-  `--explain-drift` remain explicit stubs that exit 2 with a directed message.
-  (#376)
+- `relayburn-cli`: `burn hotspots` accepts `--session <id>`, `--workflow <id>`,
+  `--provider <csv>`, `--patterns [csv]`, and `--findings`. The per-session
+  aggregate view (`--session` with no id) and `--explain-drift` remain
+  explicit stubs that exit 2.
+- `relayburn-sdk`: `HotspotsOptions` gains `workflow` and `provider` filter
+  fields, matching the shape `compare()` already exposes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Added
+
+- `relayburn-cli` / `relayburn-sdk`: `burn hotspots` now wires
+  `--session <id>`, `--workflow <id>`, `--provider <csv>`, `--patterns [csv]`,
+  and `--findings` over the existing SDK surface. `HotspotsOptions` gains
+  `workflow` + `provider` filter fields (also exposed through `@relayburn/sdk`
+  via napi). The per-session aggregate view (`--session` with no id) and
+  `--explain-drift` remain explicit stubs that exit 2 with a directed message.
+  (#376)
+
 ### Changed
 
 - `relayburn-cli` / `relayburn-sdk`: `burn summary` now accepts repeatable

--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ subagents.
 |---|---|
 | `--since <range>` | Limit to a relative range or ISO timestamp. |
 | `--project <path>` | Limit to a project. |
+| `--session <id>` | Limit to a single session id. |
+| `--workflow <id>` | Limit to turns folded under a `workflowId` enrichment stamp. |
+| `--provider <csv>` | Restrict to providers (case-insensitive CSV — e.g. `anthropic,openai`). |
 | `--all` | Show every row instead of the top 10. |
 | `--group-by <dim>` | Focus one rollup: `attribution`, `bash`, `bash-verb`, `file`, or `subagent`. |
+| `--patterns [csv]` | Run waste-pattern detectors instead of the attribution view. Pass without a value to enable every detector, or pass a CSV (e.g. `retry-loop,failure-run`). |
+| `--findings` | Emit the unified findings table instead of the per-detector grouping. Implies `--patterns` if not already set. |
 | `--json` | Emit machine-readable output. |
 
 | Example | Result |
@@ -72,6 +77,13 @@ subagents.
 | `burn hotspots --since 7d` | Top costly files, bash commands, and subagents for the week. |
 | `burn hotspots --all --project .` | Full project hotspot list. |
 | `burn hotspots --group-by bash-verb --since 7d` | Bash verbs ranked by cost. |
+| `burn hotspots --session <uuid>` | Restrict the standard attribution view to one session. |
+| `burn hotspots --patterns retry-loop,failure-run` | Surface retry/failure waste-pattern findings only. |
+| `burn hotspots --findings --since 7d` | Unified severity-ranked findings list across every detector. |
+| `burn hotspots --provider anthropic` | Restrict attribution to Anthropic-served turns. |
+
+The per-session aggregate view (`--session` with no id) and `--explain-drift`
+are not yet ported — passing them exits 2 with a directed message.
 
 ## `burn overhead`
 

--- a/crates/relayburn-cli/src/commands/hotspots.rs
+++ b/crates/relayburn-cli/src/commands/hotspots.rs
@@ -29,7 +29,8 @@ use relayburn_sdk::{
     hotspots as sdk_hotspots, ingest_all, AttributionMethod, BashAggregation,
     BashVerbAggregation, FileAggregation, HotspotsAttributionResult, HotspotsExcludedBreakdown,
     HotspotsExcludedSourceRow, HotspotsGroupBy, HotspotsOptions, HotspotsResult,
-    HotspotsSessionTotal, Ledger, LedgerOpenOptions, SubagentAggregation,
+    HotspotsSessionTotal, Ledger, LedgerOpenOptions, SubagentAggregation, WasteFinding,
+    WasteSeverity,
 };
 use serde_json::{json, Map, Value};
 
@@ -85,6 +86,50 @@ pub struct HotspotsArgs {
     /// summary. Implies `--patterns` if it isn't already set.
     #[arg(long)]
     pub findings: bool,
+
+    /// Surface session relationship drift on top of the default attribution
+    /// view. Currently a stub in the Rust port — the relationship drift
+    /// query verb is not yet exposed by the SDK.
+    #[arg(long = "explain-drift")]
+    pub explain_drift: bool,
+}
+
+const PATTERN_KINDS: &[&str] = &[
+    "retry-loop",
+    "failure-run",
+    "cancellation-run",
+    "compaction",
+    "edit-revert",
+    "edit-heavy",
+    "opencode-skill-recall",
+    "opencode-skill-pruning",
+    "opencode-system-prompt",
+    "ghost-surface",
+    "tool-output-bloat",
+    "tool-call-pattern",
+];
+
+fn resolve_pattern_selection(raw: &str) -> Result<Vec<String>, String> {
+    if raw.is_empty() {
+        return Ok(PATTERN_KINDS.iter().map(|s| (*s).to_string()).collect());
+    }
+    let mut out: Vec<String> = Vec::new();
+    for piece in raw.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+        if !PATTERN_KINDS.iter().any(|k| *k == piece) {
+            return Err(format!(
+                "unknown --patterns value \"{}\". Valid: {}",
+                piece,
+                PATTERN_KINDS.join(", ")
+            ));
+        }
+        if !out.iter().any(|s| s == piece) {
+            out.push(piece.to_string());
+        }
+    }
+    if out.is_empty() {
+        return Ok(PATTERN_KINDS.iter().map(|s| (*s).to_string()).collect());
+    }
+    Ok(out)
 }
 
 pub fn run(globals: &GlobalArgs, args: HotspotsArgs) -> i32 {
@@ -95,26 +140,42 @@ pub fn run(globals: &GlobalArgs, args: HotspotsArgs) -> i32 {
 }
 
 fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
-    if args.session.is_some() {
+    // The TS surface treats `--session` (no value) as "drop into the
+    // per-session aggregate / gap report." That view weaves session
+    // relationships, tool-result chronology, and per-session attribution —
+    // none of which the SDK exposes yet. Keep it a clear stub.
+    if matches!(args.session.as_deref(), Some("")) {
         eprintln!(
-            "burn: per-session hotspots view (--session) is not yet implemented in the Rust port"
+            "burn: per-session aggregate view (`--session` with no id) is not yet implemented in the Rust port. Pass a session id to filter the standard hotspots view."
         );
         return Ok(2);
     }
-    if args.patterns.is_some() || args.findings {
+    if args.explain_drift {
         eprintln!(
-            "burn: --patterns / --findings are not yet implemented in the Rust port (#248 D1 covers default attribution; follow-ups will add the waste-pattern detectors)"
+            "burn: --explain-drift is not yet implemented in the Rust port (relationship-drift query verb hasn't landed in relayburn-sdk yet)."
         );
         return Ok(2);
     }
-    if args.workflow.is_some() {
-        eprintln!("burn: --workflow filter is not yet implemented in the Rust port");
-        return Ok(2);
-    }
-    if args.provider.is_some() {
-        eprintln!("burn: --provider filter is not yet implemented in the Rust port");
-        return Ok(2);
-    }
+
+    // `--findings` standalone means "render findings unified view"; pin it
+    // to `--patterns` (all detectors) so the resolver below sees a value.
+    let patterns_arg: Option<&str> = if args.patterns.is_some() {
+        args.patterns.as_deref()
+    } else if args.findings {
+        Some("")
+    } else {
+        None
+    };
+    let patterns_selection: Option<Vec<String>> = match patterns_arg {
+        None => None,
+        Some(raw) => match resolve_pattern_selection(raw) {
+            Ok(sel) => Some(sel),
+            Err(msg) => {
+                eprintln!("burn: {msg}");
+                return Ok(2);
+            }
+        },
+    };
 
     let group_by = match args.group_by.as_deref() {
         None => None,
@@ -132,6 +193,22 @@ fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
         }
     };
 
+    if group_by.is_some() && patterns_selection.is_some() {
+        eprintln!(
+            "burn: --group-by and --patterns/--findings are mutually exclusive (group-by selects an attribution rollup; patterns/findings drive the detector view)."
+        );
+        return Ok(2);
+    }
+
+    let provider_filter: Option<Vec<String>> = args.provider.as_deref().and_then(|raw| {
+        let parts: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        (!parts.is_empty()).then_some(parts)
+    });
+
     // Open + ingest. We open the handle locally so ingest sees the same
     // sealed `RELAYBURN_HOME` the verb call does.
     let ledger_home = globals.ledger_path.clone();
@@ -148,12 +225,19 @@ fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
     rt.block_on(ingest_all(handle.raw_mut(), &raw_opts))?;
     drop(handle);
 
+    let session_filter = match args.session.as_deref() {
+        Some(s) if !s.is_empty() => Some(s.to_string()),
+        _ => None,
+    };
+
     let result = sdk_hotspots(HotspotsOptions {
-        session: None,
+        session: session_filter,
         project: args.project.clone(),
         since: args.since.clone(),
         group_by,
-        patterns: None,
+        patterns: patterns_selection,
+        workflow: args.workflow.clone(),
+        provider: provider_filter,
         ledger_home,
     })?;
 
@@ -162,7 +246,7 @@ fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
         return Ok(0);
     }
     let limit = if args.all { usize::MAX } else { DEFAULT_TOP_N };
-    emit_human(&result, limit);
+    emit_human(&result, limit, args.findings);
     Ok(0)
 }
 
@@ -411,7 +495,7 @@ fn subagent_to_json(s: &SubagentAggregation) -> Value {
 
 // ---------- human rendering ----------
 
-fn emit_human(result: &HotspotsResult, limit: usize) {
+fn emit_human(result: &HotspotsResult, limit: usize, findings_view: bool) {
     match result {
         HotspotsResult::Attribution(a) => emit_human_attribution(a, limit),
         // The single-axis group_by surfaces aren't yet tied to a golden
@@ -488,9 +572,99 @@ fn emit_human(result: &HotspotsResult, limit: usize) {
             rows.iter().take(limit).map(subagent_row),
             &["subagent", "calls", "initial(tok)", "persist(tok)", "cost"],
         ),
-        HotspotsResult::Findings { .. } => {
-            eprintln!("burn: --patterns / --findings rendering is not yet implemented");
+        HotspotsResult::Findings { findings, .. } => {
+            if findings_view {
+                emit_findings_unified(findings);
+            } else {
+                emit_findings_grouped(findings, limit);
+            }
         }
+    }
+}
+
+fn emit_findings_unified(findings: &[WasteFinding]) {
+    let mut out: Vec<String> = Vec::new();
+    out.push(String::new());
+    out.push(format!("findings: {}", format_uint(findings.len() as u64)));
+    out.push(String::new());
+    if findings.is_empty() {
+        out.push("  (no hotspot findings)".to_string());
+        out.push(String::new());
+        print!("{}", out.join("\n"));
+        return;
+    }
+    let mut rows: Vec<Vec<String>> = vec![vec![
+        "severity".into(),
+        "kind".into(),
+        "session".into(),
+        "usd".into(),
+        "title".into(),
+    ]];
+    for f in findings {
+        let usd = f
+            .estimated_savings
+            .usd_per_session
+            .map(format_usd)
+            .unwrap_or_else(|| "—".to_string());
+        rows.push(vec![
+            severity_label(f.severity).to_string(),
+            f.kind.clone(),
+            f.session_id.chars().take(8).collect(),
+            usd,
+            truncate(&f.title, 80),
+        ]);
+    }
+    out.push(render_table(&rows));
+    out.push(String::new());
+    print!("{}", out.join("\n"));
+}
+
+fn emit_findings_grouped(findings: &[WasteFinding], limit: usize) {
+    let mut out: Vec<String> = Vec::new();
+    out.push(String::new());
+    out.push(format!("findings: {}", format_uint(findings.len() as u64)));
+    out.push(String::new());
+    if findings.is_empty() {
+        out.push("  (no hotspot findings)".to_string());
+        out.push(String::new());
+        print!("{}", out.join("\n"));
+        return;
+    }
+    // Group by detector kind, preserving severity-sorted order of the
+    // sdk-emitted slice. Within each group we cap at `limit`.
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<&str, Vec<&WasteFinding>> = BTreeMap::new();
+    for f in findings {
+        groups.entry(f.kind.as_str()).or_default().push(f);
+    }
+    for (kind, items) in &groups {
+        out.push(format!("{} ({})", kind, format_uint(items.len() as u64)));
+        let mut rows: Vec<Vec<String>> =
+            vec![vec!["severity".into(), "session".into(), "usd".into(), "title".into()]];
+        for f in items.iter().take(limit) {
+            let usd = f
+                .estimated_savings
+                .usd_per_session
+                .map(format_usd)
+                .unwrap_or_else(|| "—".to_string());
+            rows.push(vec![
+                severity_label(f.severity).to_string(),
+                f.session_id.chars().take(8).collect(),
+                usd,
+                truncate(&f.title, 70),
+            ]);
+        }
+        out.push(render_table(&rows));
+        out.push(String::new());
+    }
+    print!("{}", out.join("\n"));
+}
+
+fn severity_label(s: WasteSeverity) -> &'static str {
+    match s {
+        WasteSeverity::High => "high",
+        WasteSeverity::Warn => "warn",
+        WasteSeverity::Info => "info",
     }
 }
 

--- a/crates/relayburn-cli/src/commands/hotspots.rs
+++ b/crates/relayburn-cli/src/commands/hotspots.rs
@@ -94,16 +94,23 @@ pub struct HotspotsArgs {
     pub explain_drift: bool,
 }
 
+// Detector kinds the SDK's `run_hotspots_findings` filter expects. These are
+// the *finding* kind strings emitted by `WasteFinding.kind` (e.g.
+// `compaction-loss`, `skill-recall-dup`), NOT the detector-input names. The
+// SDK matches `wanted_set.contains(&f.kind)` for pattern-derived findings and
+// also keys `tool-output-bloat` / `ghost-surface` / `tool-call-pattern` off
+// the same set, so this list has to use the finding-kind spelling on every
+// row.
 const PATTERN_KINDS: &[&str] = &[
     "retry-loop",
     "failure-run",
     "cancellation-run",
-    "compaction",
+    "compaction-loss",
     "edit-revert",
     "edit-heavy",
-    "opencode-skill-recall",
-    "opencode-skill-pruning",
-    "opencode-system-prompt",
+    "skill-recall-dup",
+    "skill-pruning-protection",
+    "system-prompt-tax",
     "ghost-surface",
     "tool-output-bloat",
     "tool-call-pattern",

--- a/crates/relayburn-cli/tests/smoke.rs
+++ b/crates/relayburn-cli/tests/smoke.rs
@@ -182,3 +182,55 @@ fn unknown_subcommand_exits_non_zero() {
 fn run_subcommand_is_not_registered() {
     burn().args(["run", "--help"]).assert().failure();
 }
+
+#[test]
+fn hotspots_session_without_id_is_an_explicit_stub() {
+    // `--session` with no value is the per-session aggregate / gap report
+    // mode in the TS surface. The Rust port doesn't expose a relationship
+    // / chronology query verb yet, so we exit 2 with a directed message
+    // pointing users at the supported `--session <id>` filter. Cover the
+    // tripwire so a future PR that lands the per-session view is forced
+    // to update this assertion alongside the wiring.
+    burn()
+        .args(["hotspots", "--session"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "per-session aggregate view (`--session` with no id)",
+        ));
+}
+
+#[test]
+fn hotspots_explain_drift_is_an_explicit_stub() {
+    burn()
+        .args(["hotspots", "--explain-drift"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("--explain-drift"));
+}
+
+#[test]
+fn hotspots_unknown_pattern_value_is_rejected() {
+    // `--patterns` accepts a CSV of detector kinds; an unknown kind is a
+    // hard fail (exit 2) rather than a silent ignore.
+    burn()
+        .args(["hotspots", "--patterns", "definitely-not-a-detector"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("unknown --patterns value"));
+}
+
+#[test]
+fn hotspots_group_by_and_patterns_are_mutually_exclusive() {
+    burn()
+        .args([
+            "hotspots",
+            "--group-by",
+            "file",
+            "--patterns",
+            "retry-loop",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("mutually exclusive"));
+}

--- a/crates/relayburn-sdk-node/src/lib.rs
+++ b/crates/relayburn-sdk-node/src/lib.rs
@@ -941,6 +941,8 @@ pub struct HotspotsOptions {
     pub since: Option<String>,
     pub group_by: Option<HotspotsGroupBy>,
     pub patterns: Option<Vec<String>>,
+    pub workflow: Option<String>,
+    pub provider: Option<Vec<String>>,
     pub ledger_home: Option<String>,
 }
 
@@ -958,6 +960,8 @@ pub fn hotspots(opts: Option<HotspotsOptions>) -> Result<BigIntPromoting, BurnEr
         since: None,
         group_by: None,
         patterns: None,
+        workflow: None,
+        provider: None,
         ledger_home: None,
     });
     let raw = sdk::HotspotsOptions {
@@ -966,6 +970,8 @@ pub fn hotspots(opts: Option<HotspotsOptions>) -> Result<BigIntPromoting, BurnEr
         since: opts.since,
         group_by: opts.group_by.map(Into::into),
         patterns: opts.patterns,
+        workflow: opts.workflow,
+        provider: opts.provider,
         ledger_home: maybe_path(opts.ledger_home),
     };
     let result = sdk::hotspots(raw).map_err(sdk_err)?;

--- a/crates/relayburn-sdk/src/query_verbs.rs
+++ b/crates/relayburn-sdk/src/query_verbs.rs
@@ -28,7 +28,7 @@ use crate::analyze::{
     detect_patterns, detect_tool_call_patterns, detect_tool_output_bloat, find_overhead_files,
     findings_from_patterns, ghost_surface_to_finding, has_minimum_fidelity, load_claude_settings,
     load_overhead_file, load_pricing, project_claude_settings_path,
-    render_unified_diff_for_recommendation, sum_costs, summarize_fidelity,
+    render_unified_diff_for_recommendation, sort_findings, sum_costs, summarize_fidelity,
     summarize_fidelity_from_iter, summarize_replacement_savings, tool_call_pattern_to_finding,
     tool_output_bloat_to_finding, user_claude_settings_path,
 };
@@ -1144,9 +1144,14 @@ fn run_hotspots_attribution(
     }
 
     let session_ids: HashSet<String> = eligible.iter().map(|t| t.session_id.clone()).collect();
+    // Propagate `enrichment` (e.g. workflowId folds) into side queries so a
+    // partial-session workflow stamp doesn't pull unrelated user-turns /
+    // tool-result events into the per-session buckets and skew attribution
+    // outside the requested slice.
     let side_q = Query {
         session_id: q.session_id.clone(),
         since: q.since.clone(),
+        enrichment: q.enrichment.clone(),
         ..Default::default()
     };
     let user_turns_by_session = bucket_user_turns_by_session(handle, &side_q, Some(&session_ids))?;
@@ -1334,9 +1339,14 @@ fn run_hotspots_findings(
     let wanted_set: HashSet<String> = wanted.into_iter().collect();
     let mut findings: Vec<WasteFinding> = Vec::new();
 
+    // Propagate `enrichment` (e.g. workflowId folds) into side queries so a
+    // partial-session workflow stamp doesn't pull unrelated user-turns /
+    // tool-result events into the per-session buckets and skew attribution
+    // outside the requested slice.
     let side_q = Query {
         session_id: q.session_id.clone(),
         since: q.since.clone(),
+        enrichment: q.enrichment.clone(),
         ..Default::default()
     };
 
@@ -1404,6 +1414,12 @@ fn run_hotspots_findings(
             findings.push(tool_call_pattern_to_finding(&p));
         }
     }
+
+    // `findings_from_patterns` already sorts the slice it returns, but the
+    // tool-output-bloat / ghost-surface / tool-call-pattern batches above
+    // are appended afterwards. Re-sort once so the global slice is
+    // severity-descending → usdPerSession-descending end-to-end (TS parity).
+    sort_findings(&mut findings);
 
     Ok(HotspotsResult::Findings {
         findings,

--- a/crates/relayburn-sdk/src/query_verbs.rs
+++ b/crates/relayburn-sdk/src/query_verbs.rs
@@ -922,6 +922,11 @@ pub struct HotspotsOptions {
     pub since: Option<String>,
     pub group_by: Option<HotspotsGroupBy>,
     pub patterns: Option<Vec<String>>,
+    /// Restrict to turns whose `enrichment.workflowId` matches.
+    pub workflow: Option<String>,
+    /// Restrict to turns whose derived provider is in the given set
+    /// (case-insensitive). `None` / empty = no provider filter.
+    pub provider: Option<Vec<String>>,
     pub ledger_home: Option<PathBuf>,
 }
 
@@ -1061,12 +1066,23 @@ impl LedgerHandle {
             .as_ref()
             .map(|v| !v.is_empty())
             .unwrap_or(false);
-        let q = build_query(
+        let mut q = build_query(
             opts.session.as_deref(),
             opts.project.as_deref(),
             opts.since.as_deref(),
         )?;
-        let turns = collect_turns(self, &q)?;
+        if let Some(workflow) = opts.workflow.as_ref() {
+            let mut enrichment = q.enrichment.unwrap_or_default();
+            enrichment.insert("workflowId".to_string(), workflow.clone());
+            q.enrichment = Some(enrichment);
+        }
+        let mut turns = collect_turns(self, &q)?;
+        if let Some(filter) = normalize_provider_filter(opts.provider.clone()) {
+            turns.retain(|t| {
+                let provider = crate::analyze::provider_for(t).provider;
+                filter.contains(&provider.to_ascii_lowercase())
+            });
+        }
         let pricing = load_pricing(None);
 
         if using_patterns {
@@ -2234,6 +2250,100 @@ mod tests {
                 assert!(summary.is_object());
             }
             other => panic!("expected findings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hotspots_session_filter_narrows_to_session() {
+        let (_dir, handle) = fixture_handle();
+        // Match: fixture has 2 turns under sess-a.
+        let r_match = handle
+            .hotspots(HotspotsOptions {
+                session: Some("sess-a".into()),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match r_match {
+            HotspotsResult::Attribution(a) => assert_eq!(a.turns_analyzed, 2),
+            other => panic!("expected attribution, got {other:?}"),
+        }
+        // No match: nonexistent session id.
+        let r_none = handle
+            .hotspots(HotspotsOptions {
+                session: Some("ghost".into()),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match r_none {
+            HotspotsResult::Attribution(a) => assert_eq!(a.turns_analyzed, 0),
+            other => panic!("expected attribution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hotspots_workflow_filter_uses_enrichment_stamp() {
+        let (_dir, mut handle) = fixture_handle();
+        let mut enrichment = crate::Enrichment::new();
+        enrichment.insert("workflowId".into(), "wf-1".into());
+        let stamp = crate::Stamp::new(
+            "2026-04-23T00:00:30.000Z",
+            crate::StampSelector {
+                session_id: Some("sess-a".into()),
+                ..Default::default()
+            },
+            enrichment,
+        )
+        .unwrap();
+        handle.raw_mut().append_stamp(&stamp).unwrap();
+
+        // Match: sess-a turns are stamped with wf-1.
+        let r_match = handle
+            .hotspots(HotspotsOptions {
+                workflow: Some("wf-1".into()),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match r_match {
+            HotspotsResult::Attribution(a) => assert_eq!(a.turns_analyzed, 2),
+            other => panic!("expected attribution, got {other:?}"),
+        }
+        // No match: a workflow id no stamp folds onto.
+        let r_none = handle
+            .hotspots(HotspotsOptions {
+                workflow: Some("wf-missing".into()),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match r_none {
+            HotspotsResult::Attribution(a) => assert_eq!(a.turns_analyzed, 0),
+            other => panic!("expected attribution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hotspots_provider_filter_drops_non_matching_provider() {
+        let (_dir, handle) = fixture_handle();
+        // Both fixture turns are claude-sonnet-4-6 (provider=anthropic);
+        // filtering to anthropic keeps them, filtering to openai drops them.
+        let keep = handle
+            .hotspots(HotspotsOptions {
+                provider: Some(vec!["anthropic".into()]),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match keep {
+            HotspotsResult::Attribution(a) => assert_eq!(a.turns_analyzed, 2),
+            other => panic!("expected attribution, got {other:?}"),
+        }
+        let drop = handle
+            .hotspots(HotspotsOptions {
+                provider: Some(vec!["openai".into()]),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match drop {
+            HotspotsResult::Attribution(a) => assert_eq!(a.turns_analyzed, 0),
+            other => panic!("expected attribution, got {other:?}"),
         }
     }
 

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -16,7 +16,7 @@
   need the same fidelity-exclusion breakdown used by `compare()`.
 - `hotspots()` options now accept `workflow` (folded `workflowId` enrichment
   filter) and `provider` (case-insensitive provider allow-list) — same shape
-  the `compare()` options expose. (#376)
+  the `compare()` options expose.
 
 ### Changed
 

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -14,6 +14,9 @@
   enrichment filtering and cost/token grouping.
 - Exported `computeCompareExcluded()` from the Node facade for callers that
   need the same fidelity-exclusion breakdown used by `compare()`.
+- `hotspots()` options now accept `workflow` (folded `workflowId` enrichment
+  filter) and `provider` (case-insensitive provider allow-list) — same shape
+  the `compare()` options expose. (#376)
 
 ### Changed
 

--- a/packages/sdk-node/src/index.d.ts
+++ b/packages/sdk-node/src/index.d.ts
@@ -215,6 +215,10 @@ export interface HotspotsOptions {
   since?: string;
   groupBy?: HotspotsGroupBy;
   patterns?: string[];
+  /** Restrict to turns folded under a `workflowId` enrichment stamp. */
+  workflow?: string;
+  /** Provider allow-list (case-insensitive). */
+  provider?: string[];
   ledgerHome?: string;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,17 +24,17 @@ importers:
   packages/relayburn:
     optionalDependencies:
       '@relayburn/cli-darwin-arm64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/cli-darwin-x64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/cli-linux-arm64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/cli-linux-x64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
 
   packages/relayburn/npm/darwin-arm64: {}
 
@@ -54,17 +54,17 @@ importers:
         version: 0.25.12
     optionalDependencies:
       '@relayburn/sdk-darwin-arm64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/sdk-darwin-x64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/sdk-linux-arm64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/sdk-linux-x64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
 
   packages/sdk-node/npm/darwin-arm64: {}
 
@@ -237,54 +237,54 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@relayburn/cli-darwin-arm64@2.3.0':
-    resolution: {integrity: sha512-r2CknL1aPjA970Sg0k7doZRwFZVUyXafyRlO/Ip6DxMzFfHI4VgYZK/KOxRLfWQxj+qCT3pxzJOD/rEsW3kQCw==}
+  '@relayburn/cli-darwin-arm64@2.4.0':
+    resolution: {integrity: sha512-MbvkSlaQ4FtwexKH56zJpISaXwiH2F9S2G2o1wx4n2TpYcJP8FKLbwfpz0sv4OX06JyLIj9uzvxLxZm6b+TFCw==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-darwin-x64@2.3.0':
-    resolution: {integrity: sha512-o6wbTEEnAmYLwkPfHeacG7jIDkuGUM2s4hCjQMCQVUu7aH9i71HkMvswHwSUXbRJ/joCpcSodkYphMfOxqSzHw==}
+  '@relayburn/cli-darwin-x64@2.4.0':
+    resolution: {integrity: sha512-gXsCrn4oWMyYULwyv4DYqaE21uHs/KBPe/1DrMfBXxhmilYFZciXSRVPm3t3grupWoijeyPklyBCkvXWP7zNkQ==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.3.0':
-    resolution: {integrity: sha512-+3vEM8gsmhkozLmYm7Y6A6jlvG9xzbDLMH52RC76Z56EqQbQbimLbwGStYCyN71TZroNHuRYZ6U2bGjsqY4ypQ==}
+  '@relayburn/cli-linux-arm64-gnu@2.4.0':
+    resolution: {integrity: sha512-bahzWErFd2skzEO62tAoOyRbDB76fjZyTjVMpVWu24WKKZPS1G3Ek4VIr3/bXDN+MXAK0MonXMXMpr/2asM45A==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/cli-linux-x64-gnu@2.3.0':
-    resolution: {integrity: sha512-eZSqJpV5ihYWFDfD6LKdR8v5Mgl4RhEAKiHBieodGDzIq6T0N7zdFA7xKURgG+H0dE7fmFG6ALpo6kY7CHtDTA==}
+  '@relayburn/cli-linux-x64-gnu@2.4.0':
+    resolution: {integrity: sha512-lEXxAwM739VkFir/Nno0qFC85AwSnCjTliU/3Ar/lnzgqxTopAv+j4tkW1UKOMNXWyH4ATZlT3XQLE7haGoGFg==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/sdk-darwin-arm64@2.3.0':
-    resolution: {integrity: sha512-O0vYF/RrXghOBXgA4oBJ6+ZdtBq37RJV0iGvgDuqipBalREZXthUU9eQDcdlPDqUknBLSEUWy2VucUvWI7dozA==}
+  '@relayburn/sdk-darwin-arm64@2.4.0':
+    resolution: {integrity: sha512-+PIfY583utAqoXuu5Ig2fuQWXFP6yp9F5ACLp7+78lH7r99lI8Iqao3Y6nXCo1wFI4kejfS5FdRpTKx0COGH2A==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@relayburn/sdk-darwin-x64@2.3.0':
-    resolution: {integrity: sha512-hdqY71XqC3dfdYhZ83Xs9CFwTbyLz5w7lhF7jOaEeR8k3pQLPLGaEp0iflqU2pCYE+QIH8emkUiZxrwCQPCUIA==}
+  '@relayburn/sdk-darwin-x64@2.4.0':
+    resolution: {integrity: sha512-uQ7yOhzM8U16q+t+drgw9L9ahiencU+b+7x77a+lYNkb/lBJsW4w6g6hPQhSN7oxNcVplNBAIvAv86HuEDzAMA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@relayburn/sdk-linux-arm64-gnu@2.3.0':
-    resolution: {integrity: sha512-Jsl1p/NBlXGVMkKqTaE3Dtvxh/CbPcvHu62bpSZ7eZr9Y/j/+8vzhQs9ig+E3/FGhyL06ziYtB1rrxXWYo6Pqw==}
+  '@relayburn/sdk-linux-arm64-gnu@2.4.0':
+    resolution: {integrity: sha512-sl0+x0QcHHEpgixmP7wl/AB/f24nVvzxucPlj6Pz3ZurASkh29XMl+nzOlE1VYE9/wUrwgCHdlQPM7TjMpq5ZQ==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@relayburn/sdk-linux-x64-gnu@2.3.0':
-    resolution: {integrity: sha512-TRgPnQ/wB+yWlu7J7iULoWQ/T9JppFpeJwKx1p7nisHqGD3nIclMd8FlJ1CYbqaYRaRD/HMuBVqo02xzYXCl8Q==}
+  '@relayburn/sdk-linux-x64-gnu@2.4.0':
+    resolution: {integrity: sha512-RqmOZaHD/7xWYJljS41dW3F5aAn+YYbBbz9W0frhQKpirQqrjVG+N2pS90u/4cQ5DHhuRnFR5/jgxl8WnvWF+A==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
@@ -387,28 +387,28 @@ snapshots:
 
   '@napi-rs/cli@2.18.4': {}
 
-  '@relayburn/cli-darwin-arm64@2.3.0':
+  '@relayburn/cli-darwin-arm64@2.4.0':
     optional: true
 
-  '@relayburn/cli-darwin-x64@2.3.0':
+  '@relayburn/cli-darwin-x64@2.4.0':
     optional: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.3.0':
+  '@relayburn/cli-linux-arm64-gnu@2.4.0':
     optional: true
 
-  '@relayburn/cli-linux-x64-gnu@2.3.0':
+  '@relayburn/cli-linux-x64-gnu@2.4.0':
     optional: true
 
-  '@relayburn/sdk-darwin-arm64@2.3.0':
+  '@relayburn/sdk-darwin-arm64@2.4.0':
     optional: true
 
-  '@relayburn/sdk-darwin-x64@2.3.0':
+  '@relayburn/sdk-darwin-x64@2.4.0':
     optional: true
 
-  '@relayburn/sdk-linux-arm64-gnu@2.3.0':
+  '@relayburn/sdk-linux-arm64-gnu@2.4.0':
     optional: true
 
-  '@relayburn/sdk-linux-x64-gnu@2.3.0':
+  '@relayburn/sdk-linux-x64-gnu@2.4.0':
     optional: true
 
   '@types/node@22.19.18':


### PR DESCRIPTION
Closes #376.

## Summary

Wires the remaining `burn hotspots` flags from the 1.x surface over the existing SDK plumbing (and lights up the few SDK fields that were missing).

- `--session <id>` now flows the existing `HotspotsOptions.session` through the SDK instead of erroring out at the CLI guard.
- `--workflow <id>` and `--provider <csv>` are added to `HotspotsOptions`, threaded into `build_query` enrichment + a post-query provider filter matching the shape `compare()` already uses, and surfaced through the napi facade and `@relayburn/sdk` types.
- `--patterns [csv]` and `--findings` dispatch to the SDK's existing `run_hotspots_findings` path. A CLI-side detector validator rejects unknown kinds, and a human renderer renders per-detector groupings by default — `--findings` swaps in the unified severity-ranked table.
- `--group-by` and `--patterns/--findings` are explicitly mutually exclusive (group-by selects an attribution rollup; patterns/findings drive the detector view).
- The per-session aggregate view (`--session` with no id) and `--explain-drift` remain stubs but now exit 2 with directed messaging — the relationship-drift / chronology query verbs aren't yet exposed by the SDK.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (3 new SDK integration tests for `--session`, `--workflow`, `--provider`; 4 new CLI smoke tests)
- [x] `BURN_GOLDEN=1 cargo test --test golden -- --include-ignored` (existing snapshots remain byte-identical)
- [ ] Manual: `burn hotspots --patterns retry-loop --json` and `burn hotspots --findings` against a populated ledger


---
_Generated by [Claude Code](https://claude.ai/code/session_01XsmBKf322ypQRiskHjXZUP)_