### PR TITLE
perf(sdk): cache pricing snapshot, hoist regex statics, slim sum_costs alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+- `relayburn-sdk` (Rust): cache the bundled `models.dev` pricing snapshot
+  behind a `LazyLock` so the JSON parses once, hoist per-call regexes in
+  `analyze::ghost_surface`, `analyze::claude_md`, and `reader::classifier`
+  to module-scope statics (deduplicating the two `KEY=` cells in
+  `classifier`), and switch `CostBreakdown::model` to `Cow<'static, str>` so
+  `sum_costs` no longer allocates `"aggregate"` per call. (#344)
+
 ## [2.4.0] - 2026-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
   `analyze::ghost_surface`, `analyze::claude_md`, and `reader::classifier`
   to module-scope statics (deduplicating the two `KEY=` cells in
   `classifier`), and switch `CostBreakdown::model` to `Cow<'static, str>` so
-  `sum_costs` no longer allocates `"aggregate"` per call. (#344)
+  `sum_costs` no longer allocates `"aggregate"` per call. **Breaking
+  (Rust SDK):** downstream code that constructs `CostBreakdown` via struct
+  literals must now pass a `Cow<'static, str>` (e.g. `model: my_string.into()`
+  or `Cow::Borrowed("..."`). (#344)
 
 ## [2.4.0] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
   from offset 0; `--force --reingest` runs that ingest sweep in the
   same invocation. Replaces the prior "not yet implemented" stub.
   (#341)
+
 ### Changed
 
 - `relayburn-sdk` (Rust): reduced hot-path CPU/alloc overhead in pricing and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,11 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
-- `relayburn-sdk` (Rust): cache the bundled `models.dev` pricing snapshot
-  behind a `LazyLock` so the JSON parses once, hoist per-call regexes in
-  `analyze::ghost_surface`, `analyze::claude_md`, and `reader::classifier`
-  to module-scope statics (deduplicating the two `KEY=` cells in
-  `classifier`), and switch `CostBreakdown::model` to `Cow<'static, str>` so
-  `sum_costs` no longer allocates `"aggregate"` per call. **Breaking
-  (Rust SDK):** downstream code that constructs `CostBreakdown` via struct
-  literals must now pass a `Cow<'static, str>` (e.g. `model: my_string.into()`
-  or `Cow::Borrowed("..."`). (#344)
+- `relayburn-sdk` (Rust): reduced hot-path CPU/alloc overhead in pricing and
+  classifier parsing by caching the bundled pricing snapshot and reusing
+  compiled regexes. **Breaking (Rust SDK):** `CostBreakdown::model` is now
+  `Cow<'static, str>`; struct-literal construction must pass a `Cow` (for
+  example, `model: value.into()`).
 
 ## [2.4.0] - 2026-05-08
 

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -656,7 +656,7 @@ fn empty_row(label: &str) -> UsageCostAggregateRow {
         turns: 0,
         usage: relayburn_sdk::Usage::default(),
         cost: CostBreakdown {
-            model: label.to_string(),
+            model: label.to_string().into(),
             total: 0.0,
             input: 0.0,
             output: 0.0,
@@ -873,7 +873,7 @@ fn print_json(value: &Value) {
 
 fn cost_breakdown_to_json(c: &CostBreakdown) -> Value {
     json!({
-        "model": c.model,
+        "model": c.model.as_ref(),
         "total": c.total,
         "input": c.input,
         "output": c.output,

--- a/crates/relayburn-sdk/src/analyze/claude_md.rs
+++ b/crates/relayburn-sdk/src/analyze/claude_md.rs
@@ -12,6 +12,7 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use indexmap::IndexMap;
 use regex::Regex;
@@ -245,9 +246,13 @@ struct HeadingInfo {
     text: String,
 }
 
+static OPEN_FENCE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(`{3,}|~{3,})").unwrap());
+static HEADING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(#{1,6})\s+(.*\S)\s*$").unwrap());
+
 fn find_headings(lines: &[&str]) -> Vec<HeadingInfo> {
-    let open_re = Regex::new(r"^(`{3,}|~{3,})").unwrap();
-    let heading_re = Regex::new(r"^(#{1,6})\s+(.*\S)\s*$").unwrap();
+    let open_re = &*OPEN_FENCE_RE;
+    let heading_re = &*HEADING_RE;
     let mut out = Vec::new();
     let mut fence_char: Option<char> = None;
     let mut fence_len: usize = 0;

--- a/crates/relayburn-sdk/src/analyze/cost.rs
+++ b/crates/relayburn-sdk/src/analyze/cost.rs
@@ -6,6 +6,8 @@
 //! drift stays bounded by the documented 1e-9 USD precision contract that the
 //! later overhead sub-issue depends on.
 
+use std::borrow::Cow;
+
 use crate::reader::{SourceKind, TurnRecord, Usage};
 
 use crate::analyze::pricing::{ModelCost, PricingTable, ReasoningMode};
@@ -13,7 +15,11 @@ use crate::analyze::provider_reattribution::resolve_provider;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CostBreakdown {
-    pub model: String,
+    /// Model identifier this breakdown is attributed to. Uses
+    /// `Cow<'static, str>` so common labels like `"aggregate"` (from
+    /// [`sum_costs`]) can be carried as a `'static` borrow with no allocation,
+    /// while per-turn breakdowns can still own a `String`.
+    pub model: Cow<'static, str>,
     pub total: f64,
     pub input: f64,
     pub output: f64,
@@ -50,7 +56,7 @@ pub fn cost_for_usage(
         / PER_MILLION)
         * rate.cache_write;
     Some(CostBreakdown {
-        model: model.to_string(),
+        model: Cow::Owned(model.to_string()),
         total: input + output + reasoning + cache_read + cache_create,
         input,
         output,
@@ -129,7 +135,7 @@ where
     B: std::borrow::Borrow<CostBreakdown>,
 {
     let mut acc = CostBreakdown {
-        model: "aggregate".to_string(),
+        model: Cow::Borrowed("aggregate"),
         total: 0.0,
         input: 0.0,
         output: 0.0,

--- a/crates/relayburn-sdk/src/analyze/ghost_surface.rs
+++ b/crates/relayburn-sdk/src/analyze/ghost_surface.rs
@@ -36,6 +36,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use regex::Regex;
 use crate::reader::SourceKind;
@@ -295,12 +296,12 @@ fn is_plain_text_surface(name: &str) -> bool {
 // Slash-command observation
 // ---------------------------------------------------------------------------
 
-fn claude_command_name_re() -> Regex {
-    // `<command-name>...</command-name>` — accept optional leading `/` and
-    // trailing whitespace inside the wrapper. Capture the first non-space
-    // chunk inside.
+// `<command-name>...</command-name>` — accept optional leading `/` and
+// trailing whitespace inside the wrapper. Capture the first non-space
+// chunk inside.
+static CLAUDE_COMMAND_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)<command-name>\s*/?([\w./:\-]+?)\s*</command-name>").unwrap()
-}
+});
 
 pub fn mine_claude_command_names(
     user_turn_text_by_session: Option<&HashMap<String, Vec<String>>>,
@@ -310,7 +311,7 @@ pub fn mine_claude_command_names(
         Some(m) if !m.is_empty() => m,
         _ => return out,
     };
-    let re = claude_command_name_re();
+    let re = &*CLAUDE_COMMAND_NAME_RE;
     for texts in map.values() {
         for text in texts {
             if text.is_empty() {

--- a/crates/relayburn-sdk/src/analyze/pricing.rs
+++ b/crates/relayburn-sdk/src/analyze/pricing.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -87,10 +88,17 @@ type ModelsDevRoot = IndexMap<String, ModelsDevProvider>;
 /// the tarball without network access.
 const BUILTIN_PRICING_JSON: &str = include_str!("../../data/models.dev.json");
 
-/// Load the bundled `models.dev` snapshot. No I/O — the JSON is embedded at
-/// compile time via `include_str!`.
-pub fn load_builtin_pricing() -> PricingTable {
+/// Parsed `BUILTIN_PRICING_JSON`. Parsing the snapshot allocates a
+/// `HashMap` of several hundred entries, and `load_builtin_pricing` is on the
+/// hot path of multiple SDK verbs that each used to re-parse it.
+static BUILTIN_PRICING: LazyLock<PricingTable> = LazyLock::new(|| {
     parse_pricing(BUILTIN_PRICING_JSON).expect("bundled models.dev.json must parse")
+});
+
+/// Load the bundled `models.dev` snapshot. No I/O — the JSON is embedded at
+/// compile time via `include_str!` and parsed once into a `LazyLock` cache.
+pub fn load_builtin_pricing() -> PricingTable {
+    BUILTIN_PRICING.clone()
 }
 
 /// Load pricing, optionally merging an override file over the builtin. When

--- a/crates/relayburn-sdk/src/analyze/provider.rs
+++ b/crates/relayburn-sdk/src/analyze/provider.rs
@@ -294,7 +294,7 @@ fn empty_provider_row(provider: &str) -> ProviderAggregateRow {
         turns: 0,
         usage: Usage::default(),
         cost: CostBreakdown {
-            model: provider.to_string(),
+            model: provider.to_string().into(),
             total: 0.0,
             input: 0.0,
             output: 0.0,

--- a/crates/relayburn-sdk/src/reader/classifier.rs
+++ b/crates/relayburn-sdk/src/reader/classifier.rs
@@ -150,6 +150,11 @@ static BRAINSTORM_RE: LazyLock<Regex> = LazyLock::new(|| {
 static PLANNING_RE: LazyLock<Regex> =
     LazyLock::new(|| build_re(r"(?i)\b(plan(?:ning)?|outline|roadmap|strategy)\b"));
 
+/// Matches a leading `KEY=` shell env-assignment token. Shared between
+/// `skip_env_assignments` and `env_command_args` so the same compiled regex
+/// is reused.
+static ENV_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"^[A-Za-z_][A-Za-z0-9_]*="));
+
 // ---------------------------------------------------------------------------
 // BashRule — pattern plus optional `forbid` clause that emulates the TS
 // negative-lookahead idioms (e.g. `(?!.*--check\b)`). Encodes intent as data
@@ -675,9 +680,8 @@ fn shell_words(segment: &str) -> Option<Vec<String>> {
 }
 
 fn skip_env_assignments(tokens: &[String], start: usize) -> usize {
-    static RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"^[A-Za-z_][A-Za-z0-9_]*="));
     let mut i = start;
-    while i < tokens.len() && RE.is_match(&tokens[i]) {
+    while i < tokens.len() && ENV_ASSIGN_RE.is_match(&tokens[i]) {
         i += 1;
     }
     i
@@ -720,7 +724,6 @@ fn shell_command_arg(tokens: &[String], start: usize) -> Option<String> {
 }
 
 fn env_command_args(tokens: &[String], start: usize) -> Vec<String> {
-    static RE: LazyLock<Regex> = LazyLock::new(|| build_re(r"^[A-Za-z_][A-Za-z0-9_]*="));
     let mut i = start;
     while i < tokens.len() {
         let token = &tokens[i];
@@ -728,7 +731,7 @@ fn env_command_args(tokens: &[String], start: usize) -> Vec<String> {
             i += 1;
             break;
         }
-        if RE.is_match(token) {
+        if ENV_ASSIGN_RE.is_match(token) {
             i += 1;
             continue;
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,17 +24,17 @@ importers:
   packages/relayburn:
     optionalDependencies:
       '@relayburn/cli-darwin-arm64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/cli-darwin-x64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/cli-linux-arm64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/cli-linux-x64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
 
   packages/relayburn/npm/darwin-arm64: {}
 
@@ -54,17 +54,17 @@ importers:
         version: 0.25.12
     optionalDependencies:
       '@relayburn/sdk-darwin-arm64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/sdk-darwin-x64':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/sdk-linux-arm64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@relayburn/sdk-linux-x64-gnu':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
 
   packages/sdk-node/npm/darwin-arm64: {}
 
@@ -237,54 +237,54 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@relayburn/cli-darwin-arm64@2.3.0':
-    resolution: {integrity: sha512-r2CknL1aPjA970Sg0k7doZRwFZVUyXafyRlO/Ip6DxMzFfHI4VgYZK/KOxRLfWQxj+qCT3pxzJOD/rEsW3kQCw==}
+  '@relayburn/cli-darwin-arm64@2.4.0':
+    resolution: {integrity: sha512-MbvkSlaQ4FtwexKH56zJpISaXwiH2F9S2G2o1wx4n2TpYcJP8FKLbwfpz0sv4OX06JyLIj9uzvxLxZm6b+TFCw==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-darwin-x64@2.3.0':
-    resolution: {integrity: sha512-o6wbTEEnAmYLwkPfHeacG7jIDkuGUM2s4hCjQMCQVUu7aH9i71HkMvswHwSUXbRJ/joCpcSodkYphMfOxqSzHw==}
+  '@relayburn/cli-darwin-x64@2.4.0':
+    resolution: {integrity: sha512-gXsCrn4oWMyYULwyv4DYqaE21uHs/KBPe/1DrMfBXxhmilYFZciXSRVPm3t3grupWoijeyPklyBCkvXWP7zNkQ==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.3.0':
-    resolution: {integrity: sha512-+3vEM8gsmhkozLmYm7Y6A6jlvG9xzbDLMH52RC76Z56EqQbQbimLbwGStYCyN71TZroNHuRYZ6U2bGjsqY4ypQ==}
+  '@relayburn/cli-linux-arm64-gnu@2.4.0':
+    resolution: {integrity: sha512-bahzWErFd2skzEO62tAoOyRbDB76fjZyTjVMpVWu24WKKZPS1G3Ek4VIr3/bXDN+MXAK0MonXMXMpr/2asM45A==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/cli-linux-x64-gnu@2.3.0':
-    resolution: {integrity: sha512-eZSqJpV5ihYWFDfD6LKdR8v5Mgl4RhEAKiHBieodGDzIq6T0N7zdFA7xKURgG+H0dE7fmFG6ALpo6kY7CHtDTA==}
+  '@relayburn/cli-linux-x64-gnu@2.4.0':
+    resolution: {integrity: sha512-lEXxAwM739VkFir/Nno0qFC85AwSnCjTliU/3Ar/lnzgqxTopAv+j4tkW1UKOMNXWyH4ATZlT3XQLE7haGoGFg==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/sdk-darwin-arm64@2.3.0':
-    resolution: {integrity: sha512-O0vYF/RrXghOBXgA4oBJ6+ZdtBq37RJV0iGvgDuqipBalREZXthUU9eQDcdlPDqUknBLSEUWy2VucUvWI7dozA==}
+  '@relayburn/sdk-darwin-arm64@2.4.0':
+    resolution: {integrity: sha512-+PIfY583utAqoXuu5Ig2fuQWXFP6yp9F5ACLp7+78lH7r99lI8Iqao3Y6nXCo1wFI4kejfS5FdRpTKx0COGH2A==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@relayburn/sdk-darwin-x64@2.3.0':
-    resolution: {integrity: sha512-hdqY71XqC3dfdYhZ83Xs9CFwTbyLz5w7lhF7jOaEeR8k3pQLPLGaEp0iflqU2pCYE+QIH8emkUiZxrwCQPCUIA==}
+  '@relayburn/sdk-darwin-x64@2.4.0':
+    resolution: {integrity: sha512-uQ7yOhzM8U16q+t+drgw9L9ahiencU+b+7x77a+lYNkb/lBJsW4w6g6hPQhSN7oxNcVplNBAIvAv86HuEDzAMA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@relayburn/sdk-linux-arm64-gnu@2.3.0':
-    resolution: {integrity: sha512-Jsl1p/NBlXGVMkKqTaE3Dtvxh/CbPcvHu62bpSZ7eZr9Y/j/+8vzhQs9ig+E3/FGhyL06ziYtB1rrxXWYo6Pqw==}
+  '@relayburn/sdk-linux-arm64-gnu@2.4.0':
+    resolution: {integrity: sha512-sl0+x0QcHHEpgixmP7wl/AB/f24nVvzxucPlj6Pz3ZurASkh29XMl+nzOlE1VYE9/wUrwgCHdlQPM7TjMpq5ZQ==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@relayburn/sdk-linux-x64-gnu@2.3.0':
-    resolution: {integrity: sha512-TRgPnQ/wB+yWlu7J7iULoWQ/T9JppFpeJwKx1p7nisHqGD3nIclMd8FlJ1CYbqaYRaRD/HMuBVqo02xzYXCl8Q==}
+  '@relayburn/sdk-linux-x64-gnu@2.4.0':
+    resolution: {integrity: sha512-RqmOZaHD/7xWYJljS41dW3F5aAn+YYbBbz9W0frhQKpirQqrjVG+N2pS90u/4cQ5DHhuRnFR5/jgxl8WnvWF+A==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
@@ -387,28 +387,28 @@ snapshots:
 
   '@napi-rs/cli@2.18.4': {}
 
-  '@relayburn/cli-darwin-arm64@2.3.0':
+  '@relayburn/cli-darwin-arm64@2.4.0':
     optional: true
 
-  '@relayburn/cli-darwin-x64@2.3.0':
+  '@relayburn/cli-darwin-x64@2.4.0':
     optional: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.3.0':
+  '@relayburn/cli-linux-arm64-gnu@2.4.0':
     optional: true
 
-  '@relayburn/cli-linux-x64-gnu@2.3.0':
+  '@relayburn/cli-linux-x64-gnu@2.4.0':
     optional: true
 
-  '@relayburn/sdk-darwin-arm64@2.3.0':
+  '@relayburn/sdk-darwin-arm64@2.4.0':
     optional: true
 
-  '@relayburn/sdk-darwin-x64@2.3.0':
+  '@relayburn/sdk-darwin-x64@2.4.0':
     optional: true
 
-  '@relayburn/sdk-linux-arm64-gnu@2.3.0':
+  '@relayburn/sdk-linux-arm64-gnu@2.4.0':
     optional: true
 
-  '@relayburn/sdk-linux-x64-gnu@2.3.0':
+  '@relayburn/sdk-linux-x64-gnu@2.4.0':
     optional: true
 
   '@types/node@22.19.18':


### PR DESCRIPTION
Closes #344.

Mechanical perf cleanups for the Rust analyze + reader hot paths called out in the May 2026 review.

## Summary

- **`analyze::pricing`** — parse the embedded `models.dev` JSON snapshot once into a `LazyLock<PricingTable>`. `load_builtin_pricing()` is invoked from at least five public verbs in `query_verbs.rs`; it now clones the cached table instead of reparsing the snapshot on every call.
- **`analyze::ghost_surface`** — `claude_command_name_re()` becomes a module-scope `static CLAUDE_COMMAND_NAME_RE: LazyLock<Regex>`.
- **`analyze::claude_md`** — `open_re` / `heading_re` lifted out of `find_headings` into `OPEN_FENCE_RE` / `HEADING_RE` `LazyLock<Regex>` statics so the overhead loop reuses one compilation.
- **`reader::classifier`** — collapse the two duplicate `^[A-Za-z_][A-Za-z0-9_]*=` `LazyLock` cells in `skip_env_assignments` and `env_command_args` into a single shared `ENV_ASSIGN_RE` static.
- **`analyze::cost`** — `CostBreakdown::model` is now `Cow<'static, str>`. `sum_costs` carries the `"aggregate"` label as `Cow::Borrowed` (no allocation regardless of input length), while per-turn / per-label call sites still own their `String` via `Cow::Owned` / `.into()`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 620 SDK unit tests + integration tests pass; including the existing `sum_costs_*` cases that pin `model == "aggregate"`.
- [ ] CI conformance gate stays green.

---
_Generated by [Claude Code](https://claude.ai/code/session_018vSHkmKSuzKthriM2dbjNz)_