### PR TITLE
Polish CLI UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -70,7 +70,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -136,6 +136,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -217,6 +223,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +297,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -356,6 +394,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -444,6 +506,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +529,24 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -516,6 +609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,7 +631,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -599,6 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +717,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -695,6 +812,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "predicates"
@@ -822,15 +945,20 @@ dependencies = [
  "async-trait",
  "clap",
  "comfy-table",
+ "console",
+ "dialoguer",
  "indexmap",
+ "indicatif",
  "phf",
  "predicates",
  "relayburn-sdk",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -849,7 +977,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -891,8 +1019,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -962,6 +1096,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1131,12 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1016,7 +1171,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1027,11 +1182,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1046,6 +1221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,7 +1241,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1069,6 +1253,67 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1106,6 +1351,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -1153,6 +1404,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,12 +1522,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1336,6 +1715,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/crates/relayburn-cli/Cargo.toml
+++ b/crates/relayburn-cli/Cargo.toml
@@ -45,6 +45,17 @@ clap = { workspace = true }
 # of rows. Wave 2 commands render tabular output through this helper.
 comfy-table = "7"
 
+# TTY-only spinners for long-running CLI work. The draw target is stderr so
+# stdout stays script-friendly.
+indicatif = "0.17"
+console = "0.15"
+dialoguer = "0.11"
+
+# Structured diagnostics for people debugging burn itself. Normal CLI output
+# stays quiet; set RELAYBURN_LOG or RUST_LOG to enable compact stderr logs.
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
 # Used by `render::json` to emit the structured-output mode the TS CLI's
 # `--json` global produces. `serde` derive lives here too because the
 # rendering helpers are generic over `Serialize` types from the SDK.

--- a/crates/relayburn-cli/src/commands/compare.rs
+++ b/crates/relayburn-cli/src/commands/compare.rs
@@ -22,6 +22,7 @@ use serde_json::{json, Value};
 use crate::cli::{CompareArgs, GlobalArgs};
 use crate::render::error::report_error;
 use crate::render::json::render_json;
+use crate::render::progress::TaskProgress;
 
 const FIDELITY_CHOICES: &[&str] = &[
     "full",
@@ -155,11 +156,14 @@ fn run_inner(globals: &GlobalArgs, args: CompareArgs) -> Result<i32> {
     }
 
     // 8. Open ledger and walk turns.
+    let progress = TaskProgress::new(globals, "compare");
     let ledger_opts = match globals.ledger_path.as_deref() {
         Some(p) => LedgerOpenOptions::with_home(p),
         None => LedgerOpenOptions::default(),
     };
+    progress.set_task("opening ledger");
     let handle = Ledger::open(ledger_opts)?;
+    progress.set_task("loading turns");
     let queried_turns: Vec<EnrichedTurn> = handle.raw().query_turns(&q)?;
 
     // 9. Provider filter is rejected up-front (see step 4). Pipeline
@@ -191,7 +195,9 @@ fn run_inner(globals: &GlobalArgs, args: CompareArgs) -> Result<i32> {
         models: Some(models.clone()),
         min_sample: Some(min_sample),
     };
+    progress.set_task("building comparison");
     let table = build_compare_table(&filtered_turns, &opts);
+    progress.finish_and_clear();
 
     // 12. Render.
     if globals.json {

--- a/crates/relayburn-cli/src/commands/hotspots.rs
+++ b/crates/relayburn-cli/src/commands/hotspots.rs
@@ -12,8 +12,7 @@
 //!
 //! 1. Open a [`relayburn_sdk::LedgerHandle`] honoring `--ledger-path` /
 //!    `RELAYBURN_HOME`.
-//! 2. Run [`relayburn_sdk::ingest_all`] silently (no progress spinner —
-//!    that's a TTY-only concern that breaks golden output).
+//! 2. Run [`relayburn_sdk::ingest_all`] with TTY-only progress.
 //! 3. Call [`relayburn_sdk::hotspots`] (verb-form) with the resolved
 //!    [`relayburn_sdk::HotspotsOptions`]. The SDK enforces the coverage
 //!    gate, picks the `Sized` vs `EvenSplit` attribution method per
@@ -26,8 +25,8 @@
 
 use clap::Args;
 use relayburn_sdk::{
-    hotspots as sdk_hotspots, ingest_all, AttributionMethod, BashAggregation,
-    BashVerbAggregation, FileAggregation, HotspotsAttributionResult, HotspotsExcludedBreakdown,
+    hotspots as sdk_hotspots, ingest_all, AttributionMethod, BashAggregation, BashVerbAggregation,
+    FileAggregation, HotspotsAttributionResult, HotspotsExcludedBreakdown,
     HotspotsExcludedSourceRow, HotspotsGroupBy, HotspotsOptions, HotspotsResult,
     HotspotsSessionTotal, Ledger, LedgerOpenOptions, SubagentAggregation, WasteFinding,
     WasteSeverity,
@@ -37,6 +36,7 @@ use serde_json::{json, Map, Value};
 use crate::cli::GlobalArgs;
 use crate::render::error::report_error;
 use crate::render::format::{coerce_whole_f64_to_int, format_uint, format_usd, render_table};
+use crate::render::progress::TaskProgress;
 
 const DEFAULT_TOP_N: usize = 10;
 
@@ -219,16 +219,19 @@ fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
     // Open + ingest. We open the handle locally so ingest sees the same
     // sealed `RELAYBURN_HOME` the verb call does.
     let ledger_home = globals.ledger_path.clone();
+    let progress = TaskProgress::new(globals, "hotspots");
     let opts = match &ledger_home {
         Some(h) => LedgerOpenOptions::with_home(h),
         None => LedgerOpenOptions::default(),
     };
+    progress.set_task("opening ledger");
     let mut handle = Ledger::open(opts)?;
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    let raw_opts = relayburn_sdk::RawIngestOptions::default();
+    progress.set_task("refreshing ledger");
+    let raw_opts = progress.ingest_options(ledger_home.clone());
     rt.block_on(ingest_all(handle.raw_mut(), &raw_opts))?;
     drop(handle);
 
@@ -237,6 +240,7 @@ fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
         _ => None,
     };
 
+    progress.set_task("analyzing hotspots");
     let result = sdk_hotspots(HotspotsOptions {
         session: session_filter,
         project: args.project.clone(),
@@ -247,6 +251,7 @@ fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
         provider: provider_filter,
         ledger_home,
     })?;
+    progress.finish_and_clear();
 
     if globals.json {
         emit_json(&result);
@@ -646,8 +651,12 @@ fn emit_findings_grouped(findings: &[WasteFinding], limit: usize) {
     }
     for (kind, items) in &groups {
         out.push(format!("{} ({})", kind, format_uint(items.len() as u64)));
-        let mut rows: Vec<Vec<String>> =
-            vec![vec!["severity".into(), "session".into(), "usd".into(), "title".into()]];
+        let mut rows: Vec<Vec<String>> = vec![vec![
+            "severity".into(),
+            "session".into(),
+            "usd".into(),
+            "title".into(),
+        ]];
         for f in items.iter().take(limit) {
             let usd = f
                 .estimated_savings

--- a/crates/relayburn-cli/src/commands/ingest.rs
+++ b/crates/relayburn-cli/src/commands/ingest.rs
@@ -38,11 +38,12 @@ use std::time::Duration;
 
 use relayburn_sdk::{
     ingest_all, start_watch_loop, IngestReport, Ledger, LedgerHandle, LedgerOpenOptions,
-    RawIngestOptions, StartWatchLoopOptions,
+    StartWatchLoopOptions,
 };
 
 use crate::cli::{GlobalArgs, IngestArgs};
 use crate::render::error::report_error;
+use crate::render::progress::TaskProgress;
 
 /// Exit codes mirror the TS CLI:
 /// - `0` happy path (including hook-mode empty-payload no-op).
@@ -82,19 +83,31 @@ pub fn run(globals: &GlobalArgs, args: IngestArgs) -> i32 {
 fn run_once(globals: &GlobalArgs, quiet: bool) -> i32 {
     let _ = quiet; // `--quiet` is hook-only (clap `requires = "hook"`); kept in
                    // the dispatch signature for symmetry with run_watch / run_hook.
+    let progress = TaskProgress::new(globals, "ingest");
+    progress.set_task("opening ledger");
     let mut handle = match open_handle(globals) {
         Ok(h) => h,
-        Err(err) => return report_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_error(&err, globals);
+        }
     };
+    progress.set_task("starting runtime");
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
     {
         Ok(rt) => rt,
-        Err(err) => return report_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_error(&err, globals);
+        }
     };
-    let opts = RawIngestOptions::default();
-    match rt.block_on(ingest_all(handle.raw_mut(), &opts)) {
+    progress.set_task("scanning sessions");
+    let opts = progress.ingest_options(globals.ledger_path.clone());
+    let result = rt.block_on(ingest_all(handle.raw_mut(), &opts));
+    progress.finish_and_clear();
+    match result {
         Ok(report) => {
             log_report_oneshot(&report);
             0
@@ -122,49 +135,82 @@ fn run_watch(globals: &GlobalArgs, args: &IngestArgs) -> i32 {
         None => 1000,
     };
 
+    let progress = TaskProgress::new(globals, "ingest");
+    progress.set_task("opening ledger");
     let handle = match open_handle(globals) {
         Ok(h) => h,
-        Err(err) => return report_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_error(&err, globals);
+        }
     };
 
+    progress.set_task("starting watcher");
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
     {
         Ok(rt) => rt,
-        Err(err) => return report_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_error(&err, globals);
+        }
     };
 
     let quiet = args.quiet;
+    let watch_message = format!("watching every {interval_ms}ms; Ctrl-C to stop");
     if !quiet {
-        eprintln!(
-            "[burn] ingest: foreground ingest every {interval_ms}ms; Ctrl-C to stop",
-        );
+        if progress.is_visible() {
+            progress.set_task(watch_message.clone());
+        } else {
+            eprintln!("[burn] ingest: foreground ingest every {interval_ms}ms; Ctrl-C to stop",);
+        }
     }
 
+    let ledger_home = globals.ledger_path.clone();
+    let progress_for_loop = progress.clone();
     rt.block_on(async move {
         let handle_arc: Arc<tokio::sync::Mutex<LedgerHandle>> =
             Arc::new(tokio::sync::Mutex::new(handle));
         let handle_for_ingest = handle_arc.clone();
+        let progress_for_ingest = progress_for_loop.clone();
+        let watch_message_for_ingest = watch_message.clone();
         let ingest_fn: relayburn_sdk::IngestFn = Arc::new(move || {
             let h = handle_for_ingest.clone();
+            let progress = progress_for_ingest.clone();
+            let ledger_home = ledger_home.clone();
+            let watch_message = watch_message_for_ingest.clone();
             Box::pin(async move {
+                progress.set_task("scanning sessions");
                 let mut guard = h.lock().await;
-                ingest_all(guard.raw_mut(), &RawIngestOptions::default()).await
+                let opts = if quiet {
+                    TaskProgress::quiet_ingest_options(ledger_home)
+                } else {
+                    progress.ingest_options(ledger_home)
+                };
+                let result = ingest_all(guard.raw_mut(), &opts).await;
+                progress.set_task(watch_message);
+                result
             })
         });
 
+        let progress_for_report = progress_for_loop.clone();
         let on_report: relayburn_sdk::ReportSink = Arc::new(move |report: &IngestReport| {
             // Match TS: only log a summary when the tick actually
             // appended turns. Empty ticks would otherwise drown the
             // user with zero-progress lines.
             if !quiet && report.appended_turns > 0 {
-                eprint!("{}", render_ingest_line(report));
+                progress_for_report.suspend(|| {
+                    eprint!("{}", render_ingest_line(report));
+                });
             }
         });
 
-        let on_error: relayburn_sdk::ErrorSink = Arc::new(|err: &anyhow::Error| {
-            eprintln!("[burn] ingest: {err}");
+        let progress_for_error = progress_for_loop.clone();
+        let on_error: relayburn_sdk::ErrorSink = Arc::new(move |err: &anyhow::Error| {
+            progress_for_error.suspend(|| {
+                eprintln!("[burn] ingest: {err}");
+            });
         });
 
         let opts = StartWatchLoopOptions::new(ingest_fn)
@@ -177,6 +223,7 @@ fn run_watch(globals: &GlobalArgs, args: &IngestArgs) -> i32 {
         wait_for_stop_signal().await;
         controller.stop().await;
     });
+    progress.finish_and_clear();
 
     0
 }
@@ -236,26 +283,49 @@ fn run_hook(globals: &GlobalArgs, hook: &str, quiet: bool) -> i32 {
     // hook fires for. Matches the TS hook's "ingest the matching
     // session" intent — the Claude transcript that just changed will
     // be picked up by `ingest_claude_into` on the same sweep.
+    let progress = (!quiet).then(|| TaskProgress::new(globals, "ingest"));
+    if let Some(progress) = &progress {
+        progress.set_task("opening ledger");
+    }
     let mut handle = match open_handle(globals) {
         Ok(h) => h,
         Err(err) => {
             // Hook policy: never fail the parent.
+            if let Some(progress) = &progress {
+                progress.finish_and_clear();
+            }
             eprintln!("[burn] ingest: {err}");
             return 0;
         }
     };
+    if let Some(progress) = &progress {
+        progress.set_task("starting runtime");
+    }
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
     {
         Ok(rt) => rt,
         Err(err) => {
+            if let Some(progress) = &progress {
+                progress.finish_and_clear();
+            }
             eprintln!("[burn] ingest: {err}");
             return 0;
         }
     };
-    let opts = RawIngestOptions::default();
-    match rt.block_on(ingest_all(handle.raw_mut(), &opts)) {
+    if let Some(progress) = &progress {
+        progress.set_task("scanning sessions");
+    }
+    let opts = match &progress {
+        Some(progress) => progress.ingest_options(globals.ledger_path.clone()),
+        None => TaskProgress::quiet_ingest_options(globals.ledger_path.clone()),
+    };
+    let result = rt.block_on(ingest_all(handle.raw_mut(), &opts));
+    if let Some(progress) = &progress {
+        progress.finish_and_clear();
+    }
+    match result {
         Ok(report) => {
             // In hook mode we keep stderr quiet by default; only log
             // when work was actually done so a per-tool-call hook

--- a/crates/relayburn-cli/src/commands/overhead.rs
+++ b/crates/relayburn-cli/src/commands/overhead.rs
@@ -16,10 +16,13 @@ use relayburn_sdk::{
 
 use crate::cli::{GlobalArgs, OverheadAction, OverheadArgs};
 use crate::render::error::report_error;
+use crate::render::progress::TaskProgress;
 
 pub fn run(globals: &GlobalArgs, args: OverheadArgs) -> i32 {
     match args.action {
-        Some(OverheadAction::Trim(trim)) => run_trim(globals, args.project, args.since, args.kind, trim.top),
+        Some(OverheadAction::Trim(trim)) => {
+            run_trim(globals, args.project, args.since, args.kind, trim.top)
+        }
         None => run_report(globals, args.project, args.since, args.kind),
     }
 }
@@ -37,10 +40,16 @@ fn run_report(
         kind: kind.map(Into::into),
         ledger_home: globals.ledger_path.clone(),
     };
+    let progress = TaskProgress::new(globals, "overhead");
+    progress.set_task("analyzing overhead files");
     let result = match sdk_overhead(opts) {
         Ok(r) => r,
-        Err(err) => return report_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_error(&err, globals);
+        }
     };
+    progress.finish_and_clear();
 
     if result.files.is_empty() {
         let msg = match kind {
@@ -87,10 +96,16 @@ fn run_trim(
         top,
         include_diff: None,
     };
+    let progress = TaskProgress::new(globals, "overhead");
+    progress.set_task("finding trim candidates");
     let result = match sdk_overhead_trim(opts) {
         Ok(r) => r,
-        Err(err) => return report_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_error(&err, globals);
+        }
     };
+    progress.finish_and_clear();
 
     if result.summary.files_analyzed == 0 {
         let msg = match kind {
@@ -278,7 +293,11 @@ fn push_file_block(
         "  Cost over {since_label}: {} across {} session{}",
         format_usd(attribution.total_cost),
         format_int(attribution.session_count),
-        if attribution.session_count == 1 { "" } else { "s" },
+        if attribution.session_count == 1 {
+            ""
+        } else {
+            "s"
+        },
     ));
     lines.push("  Sections ranked by cost:".to_string());
     if attribution.section_costs.is_empty() {
@@ -379,13 +398,17 @@ fn render_human_trim(result: &OverheadTrimResult) -> io::Result<()> {
     let mut handle = stdout.lock();
 
     if result.recommendations.is_empty() {
-        return handle.write_all("# no trim candidates — overhead files have no headed sections\n".as_bytes());
+        return handle.write_all(
+            "# no trim candidates — overhead files have no headed sections\n".as_bytes(),
+        );
     }
 
     // Group by `file` while preserving insertion order.
     let mut order: Vec<String> = Vec::new();
-    let mut groups: std::collections::HashMap<String, Vec<&relayburn_sdk::OverheadTrimRecommendation>> =
-        std::collections::HashMap::new();
+    let mut groups: std::collections::HashMap<
+        String,
+        Vec<&relayburn_sdk::OverheadTrimRecommendation>,
+    > = std::collections::HashMap::new();
     for rec in &result.recommendations {
         groups
             .entry(rec.file.clone())
@@ -566,6 +589,9 @@ mod tests {
         let inner = serde_json::Number::from_f64(7.0).expect("finite");
         let mut v = serde_json::json!({ "outer": [serde_json::Value::Number(inner)] });
         coerce_integer_floats(&mut v);
-        assert_eq!(serde_json::to_string(&v).expect("serialize"), r#"{"outer":[7]}"#);
+        assert_eq!(
+            serde_json::to_string(&v).expect("serialize"),
+            r#"{"outer":[7]}"#
+        );
     }
 }

--- a/crates/relayburn-cli/src/commands/state.rs
+++ b/crates/relayburn-cli/src/commands/state.rs
@@ -18,8 +18,7 @@
 //! `state-status*` invocations carry the 2.0 shape.
 
 use relayburn_sdk::{
-    ingest_all, Ledger, LedgerHandle, LedgerOpenOptions, RawIngestOptions, ResetSummary,
-    StateStatus,
+    ingest_all, Ledger, LedgerHandle, LedgerOpenOptions, ResetSummary, StateStatus,
 };
 
 use crate::cli::{
@@ -27,6 +26,7 @@ use crate::cli::{
 };
 use crate::render::error::{report_advisory, report_error, report_ledger_error};
 use crate::render::json::render_json;
+use crate::render::progress::TaskProgress;
 
 pub fn run(globals: &GlobalArgs, args: StateArgs) -> i32 {
     let sub = args
@@ -45,18 +45,28 @@ pub fn run(globals: &GlobalArgs, args: StateArgs) -> i32 {
 // ---------------------------------------------------------------------------
 
 fn run_status(globals: &GlobalArgs) -> i32 {
+    let progress = TaskProgress::new(globals, "state");
     let opts = LedgerOpenOptions {
         home: globals.ledger_path.clone(),
         content_home: None,
     };
+    progress.set_task("opening ledger");
     let handle = match Ledger::open(opts) {
         Ok(h) => h,
-        Err(err) => return report_anyhow(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_anyhow(&err, globals);
+        }
     };
+    progress.set_task("reading derived state");
     let status = match handle.state_status() {
         Ok(s) => s,
-        Err(err) => return report_anyhow(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_anyhow(&err, globals);
+        }
     };
+    progress.finish_and_clear();
 
     if globals.json {
         if let Err(err) = render_json(&status) {
@@ -283,18 +293,28 @@ fn run_rebuild(globals: &GlobalArgs, args: StateRebuildArgs) -> i32 {
 }
 
 fn run_rebuild_derivable(globals: &GlobalArgs) -> i32 {
+    let progress = TaskProgress::new(globals, "state");
     let opts = LedgerOpenOptions {
         home: globals.ledger_path.clone(),
         content_home: None,
     };
+    progress.set_task("opening ledger");
     let mut handle = match Ledger::open(opts) {
         Ok(h) => h,
-        Err(err) => return report_anyhow(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_anyhow(&err, globals);
+        }
     };
+    progress.set_task("rebuilding derivable state");
     let summary = match handle.raw_mut().rebuild_derivable() {
         Ok(s) => s,
-        Err(err) => return report_ledger_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_ledger_error(&err, globals);
+        }
     };
+    progress.finish_and_clear();
     if globals.json {
         let payload = serde_json::json!({
             "rowsDropped": summary.rows_dropped,
@@ -323,19 +343,25 @@ fn run_rebuild_derivable(globals: &GlobalArgs) -> i32 {
 
 fn run_prune(globals: &GlobalArgs, args: crate::cli::StatePruneArgs) -> i32 {
     use relayburn_sdk::{load_config_with_home, Retention};
+    let progress = TaskProgress::new(globals, "state");
     // Load retention config from the same home the ledger will be
     // opened under below, so `--ledger-path /foo` reads
     // `/foo/config.json` instead of mixing in `$RELAYBURN_HOME`'s
     // retention against `/foo`'s DB. Mirrors the equivalent fix in
     // `state_status`.
+    progress.set_task("loading retention config");
     let cfg = match load_config_with_home(globals.ledger_path.as_deref()) {
         Ok(c) => c,
-        Err(err) => return report_ledger_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_ledger_error(&err, globals);
+        }
     };
     let retention = match args.days.as_deref() {
         Some(s) => match parse_retention(s) {
             Some(r) => r,
             None => {
+                progress.finish_and_clear();
                 let msg = format!(
                     "invalid --days value: {:?} (expected a number or \"forever\")",
                     s
@@ -354,6 +380,7 @@ fn run_prune(globals: &GlobalArgs, args: crate::cli::StatePruneArgs) -> i32 {
 
     let cutoff_ms = match retention {
         Retention::Forever => {
+            progress.finish_and_clear();
             if globals.json {
                 let payload =
                     serde_json::json!({ "rowsDeleted": 0, "bytesFreed": 0, "retention": "forever" });
@@ -366,6 +393,7 @@ fn run_prune(globals: &GlobalArgs, args: crate::cli::StatePruneArgs) -> i32 {
         Retention::Days(_) => match retention.as_millis() {
             Some(ms) => ms,
             None => {
+                progress.finish_and_clear();
                 if globals.json {
                     let payload = serde_json::json!({
                         "rowsDeleted": 0, "bytesFreed": 0, "retention": "forever"
@@ -398,14 +426,23 @@ fn run_prune(globals: &GlobalArgs, args: crate::cli::StatePruneArgs) -> i32 {
         home: globals.ledger_path.clone(),
         content_home: None,
     };
+    progress.set_task("opening ledger");
     let mut handle = match Ledger::open(opts) {
         Ok(h) => h,
-        Err(err) => return report_anyhow(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_anyhow(&err, globals);
+        }
     };
+    progress.set_task("pruning content rows");
     let stats = match handle.raw_mut().prune_content_older_than(&cutoff) {
         Ok(s) => s,
-        Err(err) => return report_ledger_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_ledger_error(&err, globals);
+        }
     };
+    progress.finish_and_clear();
 
     let _ = args.force; // 2.0 prune is purely TTL-based; --force is a no-op
                         // because there are no recoverable on-disk sidecars to
@@ -481,37 +518,55 @@ fn parse_retention(s: &str) -> Option<relayburn_sdk::Retention> {
 // same handle.
 
 fn run_reset(globals: &GlobalArgs, args: crate::cli::StateResetArgs) -> i32 {
+    let progress = TaskProgress::new(globals, "state");
     let opts = LedgerOpenOptions {
         home: globals.ledger_path.clone(),
         content_home: None,
     };
+    progress.set_task("opening ledger");
     let mut handle = match Ledger::open(opts) {
         Ok(h) => h,
-        Err(err) => return report_anyhow(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_anyhow(&err, globals);
+        }
     };
 
     if !args.force {
+        progress.set_task("counting reset targets");
         let summary = match handle.raw().count_reset_targets() {
             Ok(s) => s,
-            Err(err) => return report_ledger_error(&err, globals),
+            Err(err) => {
+                progress.finish_and_clear();
+                return report_ledger_error(&err, globals);
+            }
         };
+        progress.finish_and_clear();
         return print_reset_report(globals, &summary, /*executed=*/ false, None);
     }
 
+    progress.set_task("resetting derived state");
     let summary = match handle.raw_mut().reset() {
         Ok(s) => s,
-        Err(err) => return report_ledger_error(&err, globals),
+        Err(err) => {
+            progress.finish_and_clear();
+            return report_ledger_error(&err, globals);
+        }
     };
 
     let ingest_report = if args.reingest {
-        match run_reset_reingest(&mut handle, globals.ledger_path.clone()) {
+        match run_reset_reingest(&mut handle, globals.ledger_path.clone(), &progress) {
             Ok(r) => Some(r),
-            Err(err) => return report_error(&err, globals),
+            Err(err) => {
+                progress.finish_and_clear();
+                return report_error(&err, globals);
+            }
         }
     } else {
         None
     };
 
+    progress.finish_and_clear();
     print_reset_report(globals, &summary, /*executed=*/ true, ingest_report.as_ref())
 }
 
@@ -529,14 +584,13 @@ fn run_reset(globals: &GlobalArgs, args: crate::cli::StateResetArgs) -> i32 {
 fn run_reset_reingest(
     handle: &mut LedgerHandle,
     ledger_home: Option<std::path::PathBuf>,
+    progress: &TaskProgress,
 ) -> anyhow::Result<relayburn_sdk::IngestReport> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    let opts = RawIngestOptions {
-        ledger_home,
-        ..RawIngestOptions::default()
-    };
+    progress.set_task("re-ingesting sessions");
+    let opts = progress.ingest_options(ledger_home);
     rt.block_on(ingest_all(handle.raw_mut(), &opts))
 }
 
@@ -725,4 +779,3 @@ mod tests {
         assert_eq!(rel_to_home("/x/home/", "/x/home"), "${RELAYBURN_HOME}/");
     }
 }
-

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -12,8 +12,7 @@
 //! 2. Run [`relayburn_sdk::ingest_all`] against the same handle. The TS CLI
 //!    does this unconditionally so the summary block in human mode always
 //!    leads with `ingested N new sessions (+M turns)`. Output is captured
-//!    by reference (no progress spinner — that's a TTY-only concern that
-//!    breaks golden output).
+//!    by reference while TTY runs get a stderr spinner.
 //! 3. Lower CLI flags into [`relayburn_sdk::SummaryReportOptions`] and call
 //!    the SDK-owned `summary_report` verb.
 //! 4. Render the typed report as JSON or human output.
@@ -34,6 +33,7 @@ use serde_json::{json, Map, Value};
 use crate::cli::GlobalArgs;
 use crate::render::error::report_error;
 use crate::render::format::{coerce_whole_f64_to_int, format_uint, format_usd, render_table};
+use crate::render::progress::TaskProgress;
 
 /// Per-command flags for `burn summary`. Mirrors the TS surface in
 /// `packages/cli/src/commands/summary.ts` so a TS user can carry their
@@ -207,14 +207,16 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
     };
 
     let _archive_guard = ArchiveOverride::activate(args.no_archive);
+    let progress = TaskProgress::new(globals, "summary");
 
     let opts = match globals.ledger_path.as_deref() {
         Some(h) => LedgerOpenOptions::with_home(h),
         None => LedgerOpenOptions::default(),
     };
+    progress.set_task("opening ledger");
     let mut handle = Ledger::open(opts)?;
 
-    let ingest_report = run_ingest(&mut handle)?;
+    let ingest_report = run_ingest(&mut handle, &progress, globals.ledger_path.clone())?;
 
     let mode = if let Some(session_id) = subagent_tree_session_id {
         SummaryReportMode::SubagentTree { session_id }
@@ -232,6 +234,7 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         }
     };
 
+    progress.set_task("building summary");
     let report = handle.summary_report(SummaryReportOptions {
         session: args.session,
         project: args.project,
@@ -249,6 +252,7 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         include_quality: args.quality,
         ledger_home: None,
     })?;
+    progress.finish_and_clear();
 
     match report {
         SummaryReport::Grouped(report) => {
@@ -310,11 +314,16 @@ fn parse_tag_filters(tags: &[String]) -> anyhow::Result<BTreeMap<String, String>
 
 /// Run an ingest sweep on the open handle. Builds a current-thread tokio
 /// runtime so the otherwise-sync presenter can drive the async verb.
-fn run_ingest(handle: &mut LedgerHandle) -> anyhow::Result<relayburn_sdk::IngestReport> {
+fn run_ingest(
+    handle: &mut LedgerHandle,
+    progress: &TaskProgress,
+    ledger_home: Option<std::path::PathBuf>,
+) -> anyhow::Result<relayburn_sdk::IngestReport> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    let opts = relayburn_sdk::RawIngestOptions::default();
+    progress.set_task("refreshing ledger");
+    let opts = progress.ingest_options(ledger_home);
     rt.block_on(ingest_all(handle.raw_mut(), &opts))
 }
 

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -214,9 +214,16 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         None => LedgerOpenOptions::default(),
     };
     progress.set_task("opening ledger");
-    let mut handle = Ledger::open(opts)?;
+    let mut handle = Ledger::open(opts).map_err(|err| {
+        progress.finish_and_clear();
+        err
+    })?;
 
-    let ingest_report = run_ingest(&mut handle, &progress, globals.ledger_path.clone())?;
+    let ingest_report =
+        run_ingest(&mut handle, &progress, globals.ledger_path.clone()).map_err(|err| {
+            progress.finish_and_clear();
+            err
+        })?;
 
     let mode = if let Some(session_id) = subagent_tree_session_id {
         SummaryReportMode::SubagentTree { session_id }
@@ -251,6 +258,10 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         mode,
         include_quality: args.quality,
         ledger_home: None,
+    })
+    .map_err(|err| {
+        progress.finish_and_clear();
+        err
     })?;
     progress.finish_and_clear();
 
@@ -321,10 +332,18 @@ fn run_ingest(
 ) -> anyhow::Result<relayburn_sdk::IngestReport> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
-        .build()?;
+        .build()
+        .map_err(|err| {
+            progress.finish_and_clear();
+            err
+        })?;
     progress.set_task("refreshing ledger");
     let opts = progress.ingest_options(ledger_home);
     rt.block_on(ingest_all(handle.raw_mut(), &opts))
+        .map_err(|err| {
+            progress.finish_and_clear();
+            err
+        })
 }
 
 /// Drop-in for `RELAYBURN_ARCHIVE=0`. The Rust SDK is already SQLite-native,

--- a/crates/relayburn-cli/src/main.rs
+++ b/crates/relayburn-cli/src/main.rs
@@ -30,6 +30,13 @@ fn main() {
 /// calls.
 fn dispatch(args: Args) -> i32 {
     let globals = args.globals();
+    crate::render::logging::init(&globals);
+    tracing::debug!(
+        command = command_name(&args.command),
+        json = globals.json,
+        no_color = globals.no_color,
+        "dispatching command"
+    );
     match args.command {
         Command::Summary(sub) => commands::summary::run(&globals, sub),
         Command::Hotspots(sub) => commands::hotspots::run(&globals, sub),
@@ -38,5 +45,17 @@ fn dispatch(args: Args) -> i32 {
         Command::State(args) => commands::state::run(&globals, args),
         Command::Ingest(args) => commands::ingest::run(&globals, args),
         Command::McpServer(args) => commands::mcp_server::run(&globals, args),
+    }
+}
+
+fn command_name(command: &Command) -> &'static str {
+    match command {
+        Command::Summary(_) => "summary",
+        Command::Hotspots(_) => "hotspots",
+        Command::Overhead(_) => "overhead",
+        Command::Compare(_) => "compare",
+        Command::State(_) => "state",
+        Command::Ingest(_) => "ingest",
+        Command::McpServer(_) => "mcp-server",
     }
 }

--- a/crates/relayburn-cli/src/render/error.rs
+++ b/crates/relayburn-cli/src/render/error.rs
@@ -30,6 +30,7 @@ use std::io::{self, Write};
 use serde_json::json;
 
 use crate::cli::GlobalArgs;
+use crate::render::ux::{self, MessageKind};
 use relayburn_sdk::LedgerError;
 
 /// Exit code for a typed `LedgerError`. Distinct from generic-error
@@ -78,7 +79,7 @@ pub fn report_unimplemented(name: &str, globals: &GlobalArgs) -> i32 {
 /// stderr line is prefixed `burn: warning: ` so callers can grep for
 /// it.
 pub fn report_advisory(message: &str, _globals: &GlobalArgs) {
-    let _ = writeln!(io::stderr(), "burn: warning: {message}");
+    ux::print_warning(message, _globals);
 }
 
 /// Internal: do the actual stderr / JSON-envelope writing. Tolerates
@@ -89,7 +90,7 @@ fn report(globals: &GlobalArgs, message: &str, code: i32) -> i32 {
         let envelope = json!({ "error": message });
         let _ = write_json_envelope(&envelope);
     } else {
-        let _ = writeln!(io::stderr(), "burn: {message}");
+        ux::print_message(MessageKind::Error, message, globals);
     }
     code
 }
@@ -97,8 +98,7 @@ fn report(globals: &GlobalArgs, message: &str, code: i32) -> i32 {
 fn write_json_envelope(value: &serde_json::Value) -> io::Result<()> {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    serde_json::to_writer(&mut handle, value)
-        .map_err(io::Error::other)?;
+    serde_json::to_writer(&mut handle, value).map_err(io::Error::other)?;
     handle.write_all(b"\n")?;
     handle.flush()
 }

--- a/crates/relayburn-cli/src/render/logging.rs
+++ b/crates/relayburn-cli/src/render/logging.rs
@@ -1,0 +1,30 @@
+//! Structured logging bootstrap.
+//!
+//! `burn` keeps normal output quiet. Set `RELAYBURN_LOG=debug` (or `RUST_LOG`)
+//! to enable compact structured diagnostics on stderr.
+
+use std::io;
+
+use tracing_subscriber::EnvFilter;
+
+use crate::cli::GlobalArgs;
+use crate::render::ux;
+
+pub fn init(globals: &GlobalArgs) {
+    let has_filter =
+        std::env::var_os("RELAYBURN_LOG").is_some() || std::env::var_os("RUST_LOG").is_some();
+    if !has_filter {
+        return;
+    }
+
+    let filter = EnvFilter::try_from_env("RELAYBURN_LOG")
+        .or_else(|_| EnvFilter::try_from_default_env())
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_ansi(ux::colors_enabled(globals))
+        .with_writer(io::stderr)
+        .compact()
+        .try_init();
+}

--- a/crates/relayburn-cli/src/render/mod.rs
+++ b/crates/relayburn-cli/src/render/mod.rs
@@ -4,6 +4,10 @@
 //! - [`json`] — `--json`-aware structured output writer.
 //! - [`error`] — typed-error → stderr / exit-code mapping (with a
 //!   JSON-mode envelope for `--json`).
+//! - [`logging`] — opt-in structured diagnostics on stderr.
+//! - [`progress`] — TTY-only spinners and prettier warning rendering.
+//! - [`prompt`] — shared interactive prompt/select helpers.
+//! - [`ux`] — status messages, headings, and color policy.
 //!
 //! Wave 2 PRs add per-command rendering helpers next to their command
 //! file, but anything reusable across two or more commands belongs
@@ -12,4 +16,8 @@
 pub mod error;
 pub mod format;
 pub mod json;
+pub mod logging;
+pub mod progress;
+pub mod prompt;
 pub mod table;
+pub mod ux;

--- a/crates/relayburn-cli/src/render/progress.rs
+++ b/crates/relayburn-cli/src/render/progress.rs
@@ -71,7 +71,7 @@ impl TaskProgress {
             if self.inner.pretty_warnings {
                 eprintln!("{}", format_warning(body, self.inner.color));
             } else {
-                eprintln!("⚠ {body}");
+                eprintln!("burn: warning: {body}");
             }
         });
     }

--- a/crates/relayburn-cli/src/render/progress.rs
+++ b/crates/relayburn-cli/src/render/progress.rs
@@ -1,0 +1,192 @@
+//! TTY-only progress and warning helpers.
+//!
+//! Human runs get a stderr spinner while long-running work is in flight.
+//! JSON mode and redirected stderr keep the old quiet/scriptable behavior.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use console::style;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use relayburn_sdk::RawIngestOptions;
+
+use crate::cli::GlobalArgs;
+use crate::render::ux;
+
+#[derive(Clone)]
+pub struct TaskProgress {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    bar: Option<ProgressBar>,
+    color: bool,
+    pretty_warnings: bool,
+}
+
+impl TaskProgress {
+    pub fn new(globals: &GlobalArgs, label: impl Into<String>) -> Self {
+        let color = ux::colors_enabled(globals);
+        let pretty = ux::stderr_is_pretty(globals);
+        let bar = pretty.then(|| spinner(label.into(), color));
+        Self {
+            inner: Arc::new(Inner {
+                bar,
+                color,
+                pretty_warnings: pretty,
+            }),
+        }
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.inner.bar.is_some()
+    }
+
+    pub fn set_task(&self, message: impl Into<String>) {
+        if let Some(bar) = &self.inner.bar {
+            bar.set_message(message.into());
+        }
+    }
+
+    pub fn finish_and_clear(&self) {
+        if let Some(bar) = &self.inner.bar {
+            bar.finish_and_clear();
+        }
+    }
+
+    pub fn suspend<F>(&self, f: F)
+    where
+        F: FnOnce(),
+    {
+        if let Some(bar) = &self.inner.bar {
+            bar.suspend(f);
+        } else {
+            f();
+        }
+    }
+
+    pub fn warn(&self, body: &str) {
+        self.suspend(|| {
+            if self.inner.pretty_warnings {
+                eprintln!("{}", format_warning(body, self.inner.color));
+            } else {
+                eprintln!("⚠ {body}");
+            }
+        });
+    }
+
+    pub fn ingest_options(&self, ledger_home: Option<PathBuf>) -> RawIngestOptions {
+        let on_progress = self.is_visible().then(|| {
+            let progress = self.clone();
+            Box::new(move |message: &str| {
+                progress.set_task(message.to_string());
+            }) as Box<dyn Fn(&str) + Send + Sync>
+        });
+        let on_warn = {
+            let progress = self.clone();
+            Some(Box::new(move |body: &str| {
+                progress.warn(body);
+            }) as Box<dyn Fn(&str) + Send + Sync>)
+        };
+
+        RawIngestOptions {
+            on_progress,
+            on_warn,
+            ledger_home,
+            ..RawIngestOptions::default()
+        }
+    }
+
+    pub fn quiet_ingest_options(ledger_home: Option<PathBuf>) -> RawIngestOptions {
+        RawIngestOptions {
+            on_warn: Some(Box::new(ignore_warning) as Box<dyn Fn(&str) + Send + Sync>),
+            ledger_home,
+            ..RawIngestOptions::default()
+        }
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        if let Some(bar) = &self.bar {
+            bar.finish_and_clear();
+        }
+    }
+}
+
+fn spinner(label: String, color: bool) -> ProgressBar {
+    let bar = ProgressBar::new_spinner();
+    bar.set_draw_target(ProgressDrawTarget::stderr_with_hz(20));
+    let template = if color {
+        "{spinner:.magenta} {prefix:.cyan} {msg}"
+    } else {
+        "{spinner} {prefix} {msg}"
+    };
+    let style = ProgressStyle::with_template(template)
+        .unwrap_or_else(|_| ProgressStyle::default_spinner())
+        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
+    bar.set_style(style);
+    bar.set_prefix(label);
+    bar.enable_steady_tick(Duration::from_millis(80));
+    bar
+}
+
+fn ignore_warning(_: &str) {}
+
+fn format_warning(body: &str, color: bool) -> String {
+    let mut lines = body.lines();
+    let first = lines.next().unwrap_or(body).trim();
+    let (scope, detail) = first.split_once(':').unwrap_or(("burn", first));
+    let scope = scope.trim();
+    let detail = detail.trim();
+
+    let icon = paint("⚠", color, |s| style(s).yellow().bold().to_string());
+    let title = paint(format!("{scope} ingest warning"), color, |s| {
+        style(s).yellow().bold().to_string()
+    });
+    let rail = paint("│", color, |s| style(s).yellow().dim().to_string());
+
+    let mut out = format!("{icon} {title}");
+    if !detail.is_empty() {
+        out.push('\n');
+        out.push_str(&format!("  {rail} {detail}"));
+    }
+    for line in lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        out.push('\n');
+        out.push_str(&format!("  {rail} {line}"));
+    }
+    out
+}
+
+fn paint<S, F>(value: S, color: bool, apply: F) -> String
+where
+    S: ToString,
+    F: FnOnce(String) -> String,
+{
+    let value = value.to_string();
+    if color {
+        apply(value)
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_warning;
+
+    #[test]
+    fn warning_formatter_reframes_gap_warning() {
+        let body = "claude: 7 sessions logged tool calls without any observed tool_result content (381 tool calls).\n  Likely cause: still running.\n  Counts decay later.";
+        let rendered = format_warning(body, false);
+        assert_eq!(
+            rendered,
+            "⚠ claude ingest warning\n  │ 7 sessions logged tool calls without any observed tool_result content (381 tool calls).\n  │ Likely cause: still running.\n  │ Counts decay later."
+        );
+    }
+}

--- a/crates/relayburn-cli/src/render/prompt.rs
+++ b/crates/relayburn-cli/src/render/prompt.rs
@@ -1,0 +1,73 @@
+//! Interactive prompt wrappers.
+//!
+//! Current commands remain flag-driven for automation. These helpers make future
+//! interactive flows consistent and keep dialoguer details out of command code.
+
+#![allow(dead_code)]
+
+use std::io::{self, IsTerminal};
+
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Confirm, Input, Select};
+
+use crate::cli::GlobalArgs;
+use crate::render::ux;
+
+pub fn confirm(globals: &GlobalArgs, prompt: &str, default: bool) -> io::Result<bool> {
+    if !interactive(globals) {
+        return Ok(default);
+    }
+    Confirm::with_theme(&theme(globals))
+        .with_prompt(prompt)
+        .default(default)
+        .interact()
+        .map_err(io::Error::other)
+}
+
+pub fn input(globals: &GlobalArgs, prompt: &str, default: Option<&str>) -> io::Result<String> {
+    if !interactive(globals) {
+        return Ok(default.unwrap_or_default().to_string());
+    }
+
+    let theme = theme(globals);
+    let mut input = Input::<String>::with_theme(&theme).with_prompt(prompt);
+    if let Some(default) = default {
+        input = input.default(default.to_string());
+    }
+    input.interact_text().map_err(io::Error::other)
+}
+
+pub fn select(
+    globals: &GlobalArgs,
+    prompt: &str,
+    items: &[impl AsRef<str>],
+    default: Option<usize>,
+) -> io::Result<Option<usize>> {
+    if items.is_empty() {
+        return Ok(None);
+    }
+    if !interactive(globals) {
+        return Ok(default);
+    }
+
+    let labels: Vec<&str> = items.iter().map(|item| item.as_ref()).collect();
+    let theme = theme(globals);
+    let mut select = Select::with_theme(&theme)
+        .with_prompt(prompt)
+        .items(&labels);
+    if let Some(default) = default {
+        select = select.default(default.min(items.len() - 1));
+    }
+    select.interact_opt().map_err(io::Error::other)
+}
+
+fn interactive(globals: &GlobalArgs) -> bool {
+    !globals.json
+        && std::io::stdin().is_terminal()
+        && std::io::stderr().is_terminal()
+        && !ux::term_is_dumb()
+}
+
+fn theme(_globals: &GlobalArgs) -> ColorfulTheme {
+    ColorfulTheme::default()
+}

--- a/crates/relayburn-cli/src/render/table.rs
+++ b/crates/relayburn-cli/src/render/table.rs
@@ -21,6 +21,7 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::{ContentArrangement, Table};
 
 use crate::cli::GlobalArgs;
+use crate::render::ux;
 
 /// Render a table to a `String`. Caller decides whether to write it to
 /// stdout, embed it in a larger envelope, or capture it in a test.
@@ -36,7 +37,7 @@ pub fn render_table(globals: &GlobalArgs, headers: &[&str], rows: &[Vec<String>]
         .load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic);
 
-    if globals.no_color {
+    if !ux::colors_enabled(globals) {
         // `comfy-table`'s built-in no-tty mode disables cell styling /
         // ANSI emission at the source — much safer than post-hoc
         // stripping (which is a UTF-8 minefield: the box-drawing
@@ -68,11 +69,7 @@ pub fn render_table(globals: &GlobalArgs, headers: &[&str], rows: &[Vec<String>]
 /// failures via `render::error::report_error`. Mirrors the shape of
 /// [`crate::render::json::render_json`] so all rendering helpers
 /// uniformly bubble I/O errors up to the dispatcher.
-pub fn print_table(
-    globals: &GlobalArgs,
-    headers: &[&str],
-    rows: &[Vec<String>],
-) -> io::Result<()> {
+pub fn print_table(globals: &GlobalArgs, headers: &[&str], rows: &[Vec<String>]) -> io::Result<()> {
     let rendered = render_table(globals, headers, rows);
     let stdout = io::stdout();
     let mut handle = stdout.lock();
@@ -196,11 +193,7 @@ mod tests {
         // verbatim. If callers need to hand off pre-styled content, the
         // sanitization belongs upstream (in the cell builder) where the
         // input type is known.
-        let rendered = render_table(
-            &no_color_globals(),
-            &["k"],
-            &[vec!["plain".into()]],
-        );
+        let rendered = render_table(&no_color_globals(), &["k"], &[vec!["plain".into()]]);
         assert!(!rendered.contains('\u{1b}'));
     }
 }

--- a/crates/relayburn-cli/src/render/ux.rs
+++ b/crates/relayburn-cli/src/render/ux.rs
@@ -1,0 +1,172 @@
+//! Small CLI design-system helpers.
+//!
+//! Keep these helpers conservative: they style human TTY output, but fall back
+//! to the historic script-friendly strings for JSON, pipes, and dumb terminals.
+
+#![allow(dead_code)]
+
+use std::io::{self, IsTerminal, Write};
+
+use console::style;
+
+use crate::cli::GlobalArgs;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageKind {
+    Success,
+    Error,
+    Warning,
+    Info,
+}
+
+impl MessageKind {
+    fn icon(self) -> &'static str {
+        match self {
+            Self::Success => "✓",
+            Self::Error => "✕",
+            Self::Warning => "⚠",
+            Self::Info => "ℹ",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+            Self::Warning => "warning",
+            Self::Info => "info",
+        }
+    }
+}
+
+pub fn colors_enabled(globals: &GlobalArgs) -> bool {
+    !globals.no_color
+        && std::env::var_os("NO_COLOR").is_none()
+        && std::env::var("CLICOLOR").map(|v| v != "0").unwrap_or(true)
+        && !term_is_dumb()
+}
+
+pub fn stderr_is_pretty(globals: &GlobalArgs) -> bool {
+    !globals.json && io::stderr().is_terminal() && !term_is_dumb()
+}
+
+pub fn term_is_dumb() -> bool {
+    std::env::var("TERM")
+        .map(|term| term.eq_ignore_ascii_case("dumb"))
+        .unwrap_or(false)
+}
+
+pub fn format_message(kind: MessageKind, message: &str, globals: &GlobalArgs) -> String {
+    if !stderr_is_pretty(globals) {
+        return match kind {
+            MessageKind::Warning => format!("burn: warning: {message}"),
+            MessageKind::Error => format!("burn: {message}"),
+            MessageKind::Success | MessageKind::Info => message.to_string(),
+        };
+    }
+
+    let color = colors_enabled(globals);
+    let icon = paint_kind(kind, kind.icon(), color, true);
+    let label = paint_kind(kind, kind.label(), color, true);
+    let rail = paint_kind(kind, "│", color, false);
+    let mut lines = message.lines();
+    let first = lines.next().unwrap_or(message).trim();
+
+    let mut out = format!("{icon} {label}");
+    if !first.is_empty() {
+        out.push('\n');
+        out.push_str(&format!("  {rail} {first}"));
+    }
+    for line in lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        out.push('\n');
+        out.push_str(&format!("  {rail} {line}"));
+    }
+    out
+}
+
+pub fn print_message(kind: MessageKind, message: &str, globals: &GlobalArgs) {
+    let _ = writeln!(io::stderr(), "{}", format_message(kind, message, globals));
+}
+
+pub fn print_success(message: &str, globals: &GlobalArgs) {
+    print_message(MessageKind::Success, message, globals);
+}
+
+pub fn print_error(message: &str, globals: &GlobalArgs) {
+    print_message(MessageKind::Error, message, globals);
+}
+
+pub fn print_warning(message: &str, globals: &GlobalArgs) {
+    print_message(MessageKind::Warning, message, globals);
+}
+
+pub fn print_info(message: &str, globals: &GlobalArgs) {
+    print_message(MessageKind::Info, message, globals);
+}
+
+pub fn section(title: &str, globals: &GlobalArgs) -> String {
+    if !colors_enabled(globals) {
+        return title.to_string();
+    }
+    style(title).bold().cyan().to_string()
+}
+
+pub fn dim(value: impl ToString, globals: &GlobalArgs) -> String {
+    let value = value.to_string();
+    if colors_enabled(globals) {
+        style(value).dim().to_string()
+    } else {
+        value
+    }
+}
+
+fn paint_kind(kind: MessageKind, value: &str, color: bool, bold: bool) -> String {
+    if !color {
+        return value.to_string();
+    }
+    let styled = style(value.to_string());
+    let styled = match kind {
+        MessageKind::Success => styled.green(),
+        MessageKind::Error => styled.red(),
+        MessageKind::Warning => styled.yellow(),
+        MessageKind::Info => styled.cyan(),
+    };
+    if bold {
+        styled.bold().to_string()
+    } else {
+        styled.dim().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn piped_globals() -> GlobalArgs {
+        GlobalArgs {
+            json: false,
+            ledger_path: None,
+            no_color: false,
+        }
+    }
+
+    #[test]
+    fn non_tty_warning_keeps_scriptable_prefix() {
+        assert_eq!(
+            format_message(MessageKind::Warning, "heads up", &piped_globals()),
+            "burn: warning: heads up"
+        );
+    }
+
+    #[test]
+    fn non_tty_error_keeps_scriptable_prefix() {
+        assert_eq!(
+            format_message(MessageKind::Error, "boom", &piped_globals()),
+            "burn: boom"
+        );
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,17 +24,17 @@ importers:
   packages/relayburn:
     optionalDependencies:
       '@relayburn/cli-darwin-arm64':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
       '@relayburn/cli-darwin-x64':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
       '@relayburn/cli-linux-arm64-gnu':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
       '@relayburn/cli-linux-x64-gnu':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
 
   packages/relayburn/npm/darwin-arm64: {}
 
@@ -54,17 +54,17 @@ importers:
         version: 0.25.12
     optionalDependencies:
       '@relayburn/sdk-darwin-arm64':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
       '@relayburn/sdk-darwin-x64':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
       '@relayburn/sdk-linux-arm64-gnu':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
       '@relayburn/sdk-linux-x64-gnu':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.5.1
+        version: 2.5.1
 
   packages/sdk-node/npm/darwin-arm64: {}
 
@@ -237,54 +237,54 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@relayburn/cli-darwin-arm64@2.5.0':
-    resolution: {integrity: sha512-kP5zZPiCXAaeGuqCZfw2F3Oqui1BiA7bg8O+EEVFdiGMDaisb601n83E6KjcCYuTpjlCarHOEDByokVqYT2F2A==}
+  '@relayburn/cli-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-hnqBUYVGfF1IMjONHlJssrZ27KDrEWIzElwBdL1ngI+YU/3S81gH1PLdFCGWqdcyydqaTL6uBiVqZbvvHgrdqA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-darwin-x64@2.5.0':
-    resolution: {integrity: sha512-T4YkfjLqHXGR51e4AqU7ezZfScddMNRcS5h5EjMYnD0BQXnw+qsmS9aesNP8AjSuCk8s0GMeKzfk66k/ExGCpw==}
+  '@relayburn/cli-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-7Bd2sgh91ErSI4ZV8mdzv+KEldTZXidi9UFHw9Q81mmyDS+Y9Q4EO+Bras3IvTgFjFRPC6EUYe3pR2rmQ6MQtg==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.5.0':
-    resolution: {integrity: sha512-JazhfSWL9KQFM7Wg6BRjuzMWRIhxbUOq82hQU0avX8cCnlMIOplqSZ4KLfbW9tr3S1ofYh2sPUXa6PQRdNeTYg==}
+  '@relayburn/cli-linux-arm64-gnu@2.5.1':
+    resolution: {integrity: sha512-N5kv+pjPyC/PVVKcwg1pZLLX2yb5ObShb7FyCLcSfk2sJMEEOgaaXgsrikwUkUXb2j1BY0a7kvtf1ZkbT1hvDw==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/cli-linux-x64-gnu@2.5.0':
-    resolution: {integrity: sha512-3mxHT6f8ZQitifSQpmcjxrPcJHl3zCFgj4jwGxM3TfIybSvM2yKIccbJkO4X8wMNxHjF2L1bsYjrlGfnWTDCBA==}
+  '@relayburn/cli-linux-x64-gnu@2.5.1':
+    resolution: {integrity: sha512-RRuaXAAmOa8gsAWi9DA90j+qecqW4gILOpfpk2iEVTS9Tf6yswfKHGCSoNFU+mDAq4mDI64Tg3rlRL9finTw6A==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/sdk-darwin-arm64@2.5.0':
-    resolution: {integrity: sha512-F2wHBaLxmxb9e16hnMS8DftuXtvlbRWx36G3FeMAX9tLVTDAHfRRIRTKIZxinaPpRSw5wN/sXVG+Oka3mq6OIw==}
+  '@relayburn/sdk-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-Gxps0cY+BXmF/hDMd+betjd3or3gle7kBQeQ/AM+hkVUfYaRV/DuCpLNXvOXyP8kLJGU1bd3fRX+HT1nvaAqrA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@relayburn/sdk-darwin-x64@2.5.0':
-    resolution: {integrity: sha512-KHGULt2zGjuEqnsVkM7QlPLACGMkji6paVm2LT/Hj1BUI1MmxvURBtnoymRl/BuYgWJCvsknmuj/K79vRyMyKA==}
+  '@relayburn/sdk-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-zxBj9FhdmJahMlpMKBzn5ZGwo4L2UWoMpkqsRdcR5VfRrMebKQlK8TzaGpRAai4NxkRX1r5a+dVHgE2O57aDEA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@relayburn/sdk-linux-arm64-gnu@2.5.0':
-    resolution: {integrity: sha512-klFIZcUu4i9OmlrPl/g58aXaUi77i5NxgIy9y7d3+xrjonN8kBP7kGF2AL6s+LtRk4YsXUNKHQCKwjBVwuhhvA==}
+  '@relayburn/sdk-linux-arm64-gnu@2.5.1':
+    resolution: {integrity: sha512-Gylb9ZXNlkHA+ABIX8qX0k1JCrwcpxVoh8xbZRGf7o5HcfTG73SMRWG2piU8XsadNjqUtnJSvYPBpxaJpXIymw==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@relayburn/sdk-linux-x64-gnu@2.5.0':
-    resolution: {integrity: sha512-PUd0ihsjK3jsZ5/J5qVjPQHGE+ketX4K8LfMKZef8YMo/oW6j2rOZ7N9A/oN5TSZzHCchouZOJQiXI9j/gskSQ==}
+  '@relayburn/sdk-linux-x64-gnu@2.5.1':
+    resolution: {integrity: sha512-E/+8BzoIWQCp3c+CpOLueNFuzhh6FCFkvvoo7oIqXe3+BqKLAdAX8wf5ShetteKhbYznfYVkMHiKBWh1upK1zw==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
@@ -387,28 +387,28 @@ snapshots:
 
   '@napi-rs/cli@2.18.4': {}
 
-  '@relayburn/cli-darwin-arm64@2.5.0':
+  '@relayburn/cli-darwin-arm64@2.5.1':
     optional: true
 
-  '@relayburn/cli-darwin-x64@2.5.0':
+  '@relayburn/cli-darwin-x64@2.5.1':
     optional: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.5.0':
+  '@relayburn/cli-linux-arm64-gnu@2.5.1':
     optional: true
 
-  '@relayburn/cli-linux-x64-gnu@2.5.0':
+  '@relayburn/cli-linux-x64-gnu@2.5.1':
     optional: true
 
-  '@relayburn/sdk-darwin-arm64@2.5.0':
+  '@relayburn/sdk-darwin-arm64@2.5.1':
     optional: true
 
-  '@relayburn/sdk-darwin-x64@2.5.0':
+  '@relayburn/sdk-darwin-x64@2.5.1':
     optional: true
 
-  '@relayburn/sdk-linux-arm64-gnu@2.5.0':
+  '@relayburn/sdk-linux-arm64-gnu@2.5.1':
     optional: true
 
-  '@relayburn/sdk-linux-x64-gnu@2.5.0':
+  '@relayburn/sdk-linux-x64-gnu@2.5.1':
     optional: true
 
   '@types/node@22.19.18':


### PR DESCRIPTION
## Summary
- add a shared CLI UX layer for status messages, TTY-only spinners, styled warnings, prompt wrappers, and opt-in structured logging
- wire progress indicators into ingest, summary, hotspots, compare, overhead, and state maintenance flows
- preserve script-friendly behavior for JSON output, pipes, dumb terminals, and --no-color

## Testing
- cargo test -p relayburn-cli
- cargo test --workspace