### PR TITLE
feat(cli): add 'sessions list' subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Added
+
+- `relayburn-cli`: new `burn sessions list` subcommand that enumerates
+  recent sessions (most-recent first) so callers can find a session id
+  without dropping into raw SQLite. Flags: `--since` (defaults to `7d`),
+  `--project`, `--grep` (case-insensitive substring against session id +
+  project), `--limit` (defaults to 20), and the global `--json`. Pipes
+  cleanly into `burn summary --session <id>` for drill-down.
+- `relayburn-sdk`: new `sessions_list` query verb (`LedgerHandle::sessions_list`
+  + free-function form) returning `SessionsListResult { sessions, limit,
+  truncated }`. Derived from the `turns` table so older ledgers with an
+  empty `sessions` table still enumerate correctly.
+
 ## [2.5.1] - 2026-05-08
 
 ### Changed

--- a/crates/relayburn-cli/src/cli.rs
+++ b/crates/relayburn-cli/src/cli.rs
@@ -104,6 +104,9 @@ pub enum Command {
     /// Inspect or rebuild derived state under `~/.agentworkforce/burn`.
     State(StateArgs),
 
+    /// Enumerate sessions in the ledger.
+    Sessions(SessionsArgs),
+
     /// Scan harness session stores and append new turns to the ledger.
     Ingest(IngestArgs),
 
@@ -443,4 +446,56 @@ pub struct StateResetArgs {
     /// `--reingest` on its own so a typo can't silently no-op.
     #[arg(long, requires = "force")]
     pub reingest: bool,
+}
+
+// ---------------------------------------------------------------------------
+// `burn sessions` — typed args + nested subcommand
+// ---------------------------------------------------------------------------
+
+/// `burn sessions [...]` — session enumeration verbs.
+///
+/// Today the only nested verb is `list`, which prints recent sessions
+/// most-recent first so callers can find a session id to feed into
+/// `burn summary --session <id>` / `burn hotspots --session <id>`.
+/// The args struct exists so future verbs (`show`, `tag`, …) can land
+/// without churning the dispatcher.
+#[derive(Debug, Clone, ClapArgs)]
+pub struct SessionsArgs {
+    #[command(subcommand)]
+    pub command: SessionsSubcommand,
+}
+
+/// Nested subcommand for `burn sessions`. Required (no positional default)
+/// — the subcommand surface is small enough that `burn sessions` on its
+/// own is more confusing than `burn sessions list` would be helpful.
+#[derive(Debug, Clone, Subcommand)]
+pub enum SessionsSubcommand {
+    /// Print a table of recent sessions (most-recent first).
+    List(SessionsListArgs),
+}
+
+/// `burn sessions list` — flags. `--json`, `--ledger-path`, `--no-color`
+/// are inherited via [`Args`].
+#[derive(Debug, Clone, ClapArgs)]
+pub struct SessionsListArgs {
+    /// Slice the ledger to events at or after `<since>`. Accepts either an
+    /// ISO timestamp or a relative range (`24h`, `7d`, `4w`, `2m`).
+    /// Defaults to `7d` so the table is bounded for a typical "what did
+    /// I run recently" lookup; pass an explicit value (e.g. `--since 30d`)
+    /// to widen the window.
+    #[arg(long, value_name = "WHEN")]
+    pub since: Option<String>,
+
+    /// Restrict to a single project (matches `project` or `projectKey`).
+    #[arg(long, value_name = "PROJECT")]
+    pub project: Option<String>,
+
+    /// Case-insensitive substring filter. Matched against `session_id` and
+    /// the resolved project label.
+    #[arg(long, value_name = "PATTERN")]
+    pub grep: Option<String>,
+
+    /// Row cap. Defaults to 20.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<u64>,
 }

--- a/crates/relayburn-cli/src/commands/mod.rs
+++ b/crates/relayburn-cli/src/commands/mod.rs
@@ -23,5 +23,6 @@ pub mod hotspots;
 pub mod ingest;
 pub mod mcp_server;
 pub mod overhead;
+pub mod sessions;
 pub mod state;
 pub mod summary;

--- a/crates/relayburn-cli/src/commands/sessions.rs
+++ b/crates/relayburn-cli/src/commands/sessions.rs
@@ -1,0 +1,219 @@
+//! `burn sessions list` — enumerate sessions in the ledger.
+//!
+//! Thin presenter over `relayburn_sdk::sessions_list`. Today the
+//! `sessions` parent verb only carries `list`; the args struct keeps
+//! room for follow-up nested verbs (`show`, `tag`, …) without churning
+//! the dispatcher.
+//!
+//! ## Wiring
+//!
+//! 1. Open a [`LedgerHandle`] honoring the global `--ledger-path`.
+//! 2. Lower CLI flags into [`SessionsListOptions`] (defaulting `since`
+//!    to `7d` so a no-flag invocation is bounded for the common
+//!    "what did I run recently" lookup).
+//! 3. Render the typed `SessionsListResult` as JSON or a plain table.
+//!
+//! Cost is included — `cost_for_turn` is the same helper `summary` and
+//! `session_cost` already use, so no new attribution code lives here.
+//! Models with no pricing entry contribute zero, mirroring the rest of
+//! the read-path verbs.
+
+use relayburn_sdk::{
+    Ledger, LedgerHandle, LedgerOpenOptions, SessionListEntry, SessionsListOptions,
+    SessionsListResult,
+};
+use serde_json::{json, Value};
+
+use crate::cli::{GlobalArgs, SessionsArgs, SessionsListArgs, SessionsSubcommand};
+use crate::render::error::report_error;
+use crate::render::format::{coerce_whole_f64_to_int, format_uint, format_usd, render_table};
+use crate::render::progress::TaskProgress;
+
+const DEFAULT_SINCE: &str = "7d";
+const SESSION_ID_DISPLAY_WIDTH: usize = 12;
+
+pub fn run(globals: &GlobalArgs, args: SessionsArgs) -> i32 {
+    match args.command {
+        SessionsSubcommand::List(list_args) => run_list(globals, list_args),
+    }
+}
+
+fn run_list(globals: &GlobalArgs, args: SessionsListArgs) -> i32 {
+    match run_list_inner(globals, args) {
+        Ok(code) => code,
+        Err(err) => report_error(&err, globals),
+    }
+}
+
+fn run_list_inner(globals: &GlobalArgs, args: SessionsListArgs) -> anyhow::Result<i32> {
+    let progress = TaskProgress::new(globals, "sessions");
+
+    let opts = LedgerOpenOptions {
+        home: globals.ledger_path.clone(),
+        content_home: None,
+    };
+    progress.set_task("opening ledger");
+    let handle = Ledger::open(opts).inspect_err(|_| {
+        progress.finish_and_clear();
+    })?;
+
+    let since = args
+        .since
+        .clone()
+        .unwrap_or_else(|| DEFAULT_SINCE.to_string());
+    let sdk_opts = SessionsListOptions {
+        since: Some(since.clone()),
+        project: args.project.clone(),
+        grep: args.grep.clone(),
+        limit: args.limit,
+        ledger_home: None,
+    };
+
+    progress.set_task("scanning sessions");
+    let result = handle.sessions_list(sdk_opts).inspect_err(|_| {
+        progress.finish_and_clear();
+    })?;
+    progress.finish_and_clear();
+
+    if globals.json {
+        emit_json(
+            &result,
+            &since,
+            args.project.as_deref(),
+            args.grep.as_deref(),
+        );
+    } else {
+        emit_human(&result, &since, args.grep.as_deref(), &handle);
+    }
+    Ok(0)
+}
+
+fn emit_json(result: &SessionsListResult, since: &str, project: Option<&str>, grep: Option<&str>) {
+    let mut filters = json!({ "since": since });
+    if let Some(p) = project {
+        filters
+            .as_object_mut()
+            .unwrap()
+            .insert("project".into(), Value::String(p.to_string()));
+    }
+    if let Some(g) = grep {
+        filters
+            .as_object_mut()
+            .unwrap()
+            .insert("grep".into(), Value::String(g.to_string()));
+    }
+
+    let mut payload = json!({
+        "filters": filters,
+        "limit": result.limit,
+        "truncated": result.truncated,
+        "sessions": result.sessions,
+    });
+    coerce_whole_f64_to_int(&mut payload);
+    let mut out = serde_json::to_string_pretty(&payload).unwrap_or_default();
+    out.push('\n');
+    print!("{}", out);
+}
+
+fn emit_human(
+    result: &SessionsListResult,
+    since: &str,
+    grep: Option<&str>,
+    _handle: &LedgerHandle,
+) {
+    let mut lines: Vec<String> = Vec::new();
+    lines.push(String::new());
+
+    if result.sessions.is_empty() {
+        lines.push(format!(
+            "no sessions found (since {since}{}).",
+            grep.map(|g| format!(", grep \"{g}\"")).unwrap_or_default(),
+        ));
+        let mut out = lines.join("\n");
+        out.push('\n');
+        print!("{}", out);
+        return;
+    }
+
+    let mut rows: Vec<Vec<String>> = vec![vec![
+        "session".into(),
+        "project".into(),
+        "started".into(),
+        "last seen".into(),
+        "turns".into(),
+        "cost".into(),
+    ]];
+    for entry in &result.sessions {
+        rows.push(vec![
+            short_session_id(&entry.session_id),
+            display_project(entry),
+            entry.started_at.clone(),
+            entry.last_seen.clone(),
+            format_uint(entry.turn_count),
+            format_usd(entry.total_cost_usd),
+        ]);
+    }
+    lines.push(render_table(&rows));
+    lines.push(String::new());
+    lines.push(format!(
+        "showing {} session{} (since {since}, limit {}){}",
+        format_uint(result.sessions.len() as u64),
+        if result.sessions.len() == 1 { "" } else { "s" },
+        format_uint(result.limit),
+        if result.truncated {
+            "; more available — re-run with --limit to widen".to_string()
+        } else {
+            String::new()
+        },
+    ));
+    lines.push("(pass the full session id to `burn summary --session <id>` for details)".into());
+    lines.push(String::new());
+    print!("{}", lines.join("\n"));
+}
+
+/// Truncate the session id for human display. Wide enough to disambiguate
+/// the on-disk layout (the per-harness session-id schemes all carry their
+/// entropy in the first 12 chars) without dominating the row width. JSON
+/// output keeps the full id so scripts pipe through unaffected.
+fn short_session_id(id: &str) -> String {
+    if id.chars().count() <= SESSION_ID_DISPLAY_WIDTH {
+        return id.to_string();
+    }
+    let prefix: String = id.chars().take(SESSION_ID_DISPLAY_WIDTH).collect();
+    format!("{prefix}…")
+}
+
+fn display_project(entry: &SessionListEntry) -> String {
+    entry.project.clone().unwrap_or_else(|| "—".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_session_id_truncates_long_ids() {
+        let id = "abcdef1234567890abcdef";
+        assert_eq!(short_session_id(id), "abcdef123456…");
+    }
+
+    #[test]
+    fn short_session_id_passes_short_ids_through() {
+        let id = "sess-old";
+        assert_eq!(short_session_id(id), "sess-old");
+    }
+
+    #[test]
+    fn display_project_falls_back_to_dash_when_missing() {
+        let entry = SessionListEntry {
+            session_id: "abc".into(),
+            project: None,
+            started_at: "2026-04-23T00:00:00.000Z".into(),
+            last_seen: "2026-04-23T00:00:00.000Z".into(),
+            turn_count: 1,
+            total_cost_usd: 0.0,
+            models: vec![],
+        };
+        assert_eq!(display_project(&entry), "—");
+    }
+}

--- a/crates/relayburn-cli/src/main.rs
+++ b/crates/relayburn-cli/src/main.rs
@@ -43,6 +43,7 @@ fn dispatch(args: Args) -> i32 {
         Command::Overhead(args) => commands::overhead::run(&globals, args),
         Command::Compare(args) => commands::compare::run(&globals, args),
         Command::State(args) => commands::state::run(&globals, args),
+        Command::Sessions(args) => commands::sessions::run(&globals, args),
         Command::Ingest(args) => commands::ingest::run(&globals, args),
         Command::McpServer(args) => commands::mcp_server::run(&globals, args),
     }
@@ -55,6 +56,7 @@ fn command_name(command: &Command) -> &'static str {
         Command::Overhead(_) => "overhead",
         Command::Compare(_) => "compare",
         Command::State(_) => "state",
+        Command::Sessions(_) => "sessions",
         Command::Ingest(_) => "ingest",
         Command::McpServer(_) => "mcp-server",
     }

--- a/crates/relayburn-cli/tests/smoke.rs
+++ b/crates/relayburn-cli/tests/smoke.rs
@@ -29,6 +29,7 @@ const SUBCOMMANDS: &[&str] = &[
     "overhead",
     "compare",
     "state",
+    "sessions",
     "ingest",
     "mcp-server",
 ];
@@ -223,13 +224,7 @@ fn hotspots_unknown_pattern_value_is_rejected() {
 #[test]
 fn hotspots_group_by_and_patterns_are_mutually_exclusive() {
     burn()
-        .args([
-            "hotspots",
-            "--group-by",
-            "file",
-            "--patterns",
-            "retry-loop",
-        ])
+        .args(["hotspots", "--group-by", "file", "--patterns", "retry-loop"])
         .assert()
         .code(2)
         .stderr(predicate::str::contains("mutually exclusive"));
@@ -303,4 +298,63 @@ fn state_reset_reingest_requires_force() {
         .args(["state", "reset", "--reingest"])
         .assert()
         .failure();
+}
+
+/// `burn sessions` is a parent verb that requires a nested subcommand;
+/// invoking it bare should fail (clap's required-subcommand check) so a
+/// future PR adding a sibling verb can't accidentally regress to a
+/// silent no-op default.
+#[test]
+fn sessions_without_subcommand_fails() {
+    burn().arg("sessions").assert().failure();
+}
+
+/// `burn sessions list` against an empty isolated ledger should open
+/// cleanly, scan zero turns, and report "no sessions found" with exit 0.
+/// Pins the empty-ledger path so a future regression in the SDK verb
+/// can't silently start erroring on a fresh install.
+#[test]
+fn sessions_list_against_empty_ledger_reports_no_sessions() {
+    let home = tempfile::TempDir::new().expect("tmp RELAYBURN_HOME");
+
+    burn()
+        .args(["sessions", "list"])
+        .env("RELAYBURN_HOME", home.path())
+        .env("HOME", home.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no sessions found"));
+}
+
+/// `burn sessions list --json` against an empty isolated ledger should
+/// emit a valid JSON envelope with an empty `sessions` array and the
+/// resolved filters echoed back. Asserting on `--json` separately from
+/// the human form keeps the structured contract under test even if the
+/// human format gets stylistically tweaked later.
+#[test]
+fn sessions_list_json_envelope_shape() {
+    let home = tempfile::TempDir::new().expect("tmp RELAYBURN_HOME");
+
+    let output = burn()
+        .args(["--json", "sessions", "list", "--limit", "5"])
+        .env("RELAYBURN_HOME", home.path())
+        .env("HOME", home.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("--json output is valid JSON");
+    assert_eq!(value["limit"], serde_json::Value::from(5));
+    assert_eq!(value["truncated"], serde_json::Value::Bool(false));
+    assert_eq!(
+        value["sessions"],
+        serde_json::Value::Array(Vec::new()),
+        "expected empty sessions array against fresh ledger"
+    );
+    assert_eq!(value["filters"]["since"], serde_json::Value::from("7d"));
 }

--- a/crates/relayburn-sdk/src/query_verbs.rs
+++ b/crates/relayburn-sdk/src/query_verbs.rs
@@ -2046,6 +2046,174 @@ pub fn session_cost(opts: SessionCostOptions) -> Result<SessionCostResult> {
 }
 
 // ---------------------------------------------------------------------------
+// sessions_list
+// ---------------------------------------------------------------------------
+
+/// Default row cap when `SessionsListOptions::limit` is `None`. Picked to
+/// match the "find a session to review" scroll budget — a tighter cap than
+/// the typical agent's recent-session count, with `--limit` for callers
+/// that want more.
+pub const SESSIONS_LIST_DEFAULT_LIMIT: u64 = 20;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsListOptions {
+    /// Slice the ledger to events at or after this point. Same parser as
+    /// every other verb's `since` (relative `24h`/`7d`/`4w`/`2m` or ISO).
+    pub since: Option<String>,
+    /// Restrict to a single project (matches `project` or `projectKey`).
+    pub project: Option<String>,
+    /// Case-insensitive substring filter against `session_id` and the
+    /// resolved project label. Kept simple — FTS5 is not consulted here.
+    pub grep: Option<String>,
+    /// Row cap. Defaults to [`SESSIONS_LIST_DEFAULT_LIMIT`] when `None`.
+    pub limit: Option<u64>,
+    pub ledger_home: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListEntry {
+    /// Full session id. Renderers may truncate for human display.
+    pub session_id: String,
+    /// Project label (`project` if present, falling back to `projectKey`).
+    /// `None` when neither field was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    /// ISO timestamp of the earliest turn within the filter window.
+    pub started_at: String,
+    /// ISO timestamp of the latest turn within the filter window.
+    pub last_seen: String,
+    pub turn_count: u64,
+    #[serde(rename = "totalCostUSD")]
+    pub total_cost_usd: f64,
+    /// Distinct models observed in the session, sorted lexicographically.
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsListResult {
+    /// Sessions ordered by `last_seen` descending — most-recent first.
+    pub sessions: Vec<SessionListEntry>,
+    /// Effective row cap used for the response (the `limit` flag, defaulted).
+    pub limit: u64,
+    /// `true` when the underlying turn scan was truncated by `limit`. Lets
+    /// callers tell "no more sessions" apart from "more exist; widen the
+    /// cap to see them".
+    pub truncated: bool,
+}
+
+impl LedgerHandle {
+    /// Enumerate sessions in the ledger most-recent first. Derived from the
+    /// `turns` table rather than `sessions` because the latter may be empty
+    /// in older ledgers (the canonical source of truth is the per-turn rows
+    /// every other read verb already trusts).
+    pub fn sessions_list(&self, opts: SessionsListOptions) -> Result<SessionsListResult> {
+        let limit = opts.limit.unwrap_or(SESSIONS_LIST_DEFAULT_LIMIT);
+        let q = build_query(None, opts.project.as_deref(), opts.since.as_deref())?;
+        let turns = collect_turns(self, &q)?;
+
+        let pricing = load_pricing(None);
+        // Aggregate per-session in a single pass over the turn stream.
+        let mut acc: BTreeMap<String, SessionAccumulator> = BTreeMap::new();
+        for turn in &turns {
+            let entry = acc.entry(turn.session_id.clone()).or_default();
+            entry.add_turn(turn, &pricing);
+        }
+
+        let needle = opts.grep.as_ref().map(|s| s.to_lowercase());
+        let mut entries: Vec<SessionListEntry> = acc
+            .into_iter()
+            .map(|(session_id, acc)| acc.into_entry(session_id))
+            .filter(|entry| match needle.as_deref() {
+                None => true,
+                Some(needle) => {
+                    let project_match = entry
+                        .project
+                        .as_deref()
+                        .map(|p| p.to_lowercase().contains(needle))
+                        .unwrap_or(false);
+                    project_match || entry.session_id.to_lowercase().contains(needle)
+                }
+            })
+            .collect();
+
+        // Most-recent first; tie-break on session_id for stable ordering when
+        // two sessions share a last_seen ts (mostly tests, but worth pinning).
+        entries.sort_by(|a, b| {
+            b.last_seen
+                .cmp(&a.last_seen)
+                .then_with(|| a.session_id.cmp(&b.session_id))
+        });
+
+        let truncated = entries.len() as u64 > limit;
+        entries.truncate(limit as usize);
+
+        Ok(SessionsListResult {
+            sessions: entries,
+            limit,
+            truncated,
+        })
+    }
+}
+
+pub fn sessions_list(opts: SessionsListOptions) -> Result<SessionsListResult> {
+    let handle = open_with(opts.ledger_home.as_deref())?;
+    handle.sessions_list(SessionsListOptions {
+        ledger_home: None,
+        ..opts
+    })
+}
+
+#[derive(Default)]
+struct SessionAccumulator {
+    started_at: Option<String>,
+    last_seen: Option<String>,
+    turn_count: u64,
+    cost_total: f64,
+    project: Option<String>,
+    models: BTreeSet<String>,
+}
+
+impl SessionAccumulator {
+    fn add_turn(&mut self, turn: &TurnRecord, pricing: &PricingTable) {
+        self.turn_count += 1;
+        match self.started_at.as_ref() {
+            Some(cur) if cur.as_str() <= turn.ts.as_str() => {}
+            _ => self.started_at = Some(turn.ts.clone()),
+        }
+        match self.last_seen.as_ref() {
+            Some(cur) if cur.as_str() >= turn.ts.as_str() => {}
+            _ => self.last_seen = Some(turn.ts.clone()),
+        }
+        if self.project.is_none() {
+            // Mirror the resolution `Query.project` filters on so the rendered
+            // column matches the value users would pass to `--project`.
+            self.project = turn.project.clone().or_else(|| turn.project_key.clone());
+        }
+        self.models.insert(turn.model.clone());
+        if let Some(c) = cost_for_turn(turn, pricing) {
+            self.cost_total += c.total;
+        }
+    }
+
+    fn into_entry(self, session_id: String) -> SessionListEntry {
+        SessionListEntry {
+            session_id,
+            project: self.project,
+            started_at: self.started_at.unwrap_or_default(),
+            last_seen: self.last_seen.unwrap_or_default(),
+            turn_count: self.turn_count,
+            // Round to 6 decimals — same precision contract `session_cost`
+            // uses, so the two surfaces are byte-comparable.
+            total_cost_usd: (self.cost_total * 1_000_000.0).round() / 1_000_000.0,
+            models: self.models.into_iter().collect(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // overhead + overhead_trim — share `gather_overhead`
 // ---------------------------------------------------------------------------
 
@@ -4635,5 +4803,199 @@ mod tests {
         let pricing = load_pricing(None);
         let result = compute_summary(&turns, &pricing);
         assert!(result.replacement_savings.is_none());
+    }
+
+    fn multi_session_handle() -> (TempDir, LedgerHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let opts = LedgerOpenOptions::with_home(dir.path());
+        let mut handle = Ledger::open(opts).expect("open ledger");
+
+        let mk = |session: &str,
+                  project: Option<&str>,
+                  ts: &str,
+                  message_id: &str,
+                  model: &str|
+         -> TurnRecord {
+            TurnRecord {
+                v: 1,
+                source: SourceKind::ClaudeCode,
+                session_id: session.into(),
+                session_path: None,
+                message_id: message_id.into(),
+                turn_index: 0,
+                ts: ts.into(),
+                model: model.into(),
+                project: project.map(|s| s.into()),
+                project_key: None,
+                usage: Usage {
+                    input: 100,
+                    output: 50,
+                    reasoning: 0,
+                    cache_read: 0,
+                    cache_create_5m: 0,
+                    cache_create_1h: 0,
+                },
+                tool_calls: vec![],
+                files_touched: None,
+                subagent: None,
+                stop_reason: None,
+                activity: None,
+                retries: None,
+                has_edits: None,
+                fidelity: None,
+            }
+        };
+
+        // sess-old: oldest session, two turns, project /tmp/proj-a
+        // sess-mid: middle session, one turn, project /tmp/proj-b
+        // sess-new: newest session, one turn, project /tmp/proj-a
+        handle
+            .raw_mut()
+            .append_turns(&[
+                mk(
+                    "sess-old",
+                    Some("/tmp/proj-a"),
+                    "2026-04-20T10:00:00.000Z",
+                    "m-1",
+                    "claude-sonnet-4-6",
+                ),
+                mk(
+                    "sess-old",
+                    Some("/tmp/proj-a"),
+                    "2026-04-20T10:05:00.000Z",
+                    "m-2",
+                    "claude-sonnet-4-6",
+                ),
+                mk(
+                    "sess-mid",
+                    Some("/tmp/proj-b"),
+                    "2026-04-22T08:00:00.000Z",
+                    "m-3",
+                    "claude-sonnet-4-6",
+                ),
+                mk(
+                    "sess-new",
+                    Some("/tmp/proj-a"),
+                    "2026-04-23T12:00:00.000Z",
+                    "m-4",
+                    "claude-sonnet-4-6",
+                ),
+            ])
+            .expect("append turns");
+        (dir, handle)
+    }
+
+    #[test]
+    fn sessions_list_orders_most_recent_first_with_aggregates() {
+        let (_dir, handle) = multi_session_handle();
+        let result = handle
+            .sessions_list(SessionsListOptions::default())
+            .expect("sessions_list");
+        assert_eq!(result.limit, SESSIONS_LIST_DEFAULT_LIMIT);
+        assert!(!result.truncated);
+        let ids: Vec<&str> = result
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["sess-new", "sess-mid", "sess-old"]);
+
+        let old = result
+            .sessions
+            .iter()
+            .find(|s| s.session_id == "sess-old")
+            .unwrap();
+        assert_eq!(old.turn_count, 2);
+        assert_eq!(old.started_at, "2026-04-20T10:00:00.000Z");
+        assert_eq!(old.last_seen, "2026-04-20T10:05:00.000Z");
+        assert_eq!(old.project.as_deref(), Some("/tmp/proj-a"));
+        assert_eq!(old.models, vec!["claude-sonnet-4-6"]);
+        assert!(old.total_cost_usd > 0.0);
+    }
+
+    #[test]
+    fn sessions_list_project_filter_narrows_to_match() {
+        let (_dir, handle) = multi_session_handle();
+        let result = handle
+            .sessions_list(SessionsListOptions {
+                project: Some("/tmp/proj-b".into()),
+                ..SessionsListOptions::default()
+            })
+            .expect("sessions_list");
+        let ids: Vec<&str> = result
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["sess-mid"]);
+    }
+
+    #[test]
+    fn sessions_list_grep_matches_session_id_or_project_case_insensitive() {
+        let (_dir, handle) = multi_session_handle();
+
+        // session_id substring
+        let by_id = handle
+            .sessions_list(SessionsListOptions {
+                grep: Some("OLD".into()),
+                ..SessionsListOptions::default()
+            })
+            .expect("sessions_list");
+        let ids: Vec<&str> = by_id
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["sess-old"]);
+
+        // project substring (matches sess-old + sess-new, both /tmp/proj-a)
+        let by_project = handle
+            .sessions_list(SessionsListOptions {
+                grep: Some("proj-a".into()),
+                ..SessionsListOptions::default()
+            })
+            .expect("sessions_list");
+        let ids: Vec<&str> = by_project
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["sess-new", "sess-old"]);
+    }
+
+    #[test]
+    fn sessions_list_limit_truncates_and_reports_truncation() {
+        let (_dir, handle) = multi_session_handle();
+        let result = handle
+            .sessions_list(SessionsListOptions {
+                limit: Some(2),
+                ..SessionsListOptions::default()
+            })
+            .expect("sessions_list");
+        assert_eq!(result.limit, 2);
+        assert!(result.truncated);
+        let ids: Vec<&str> = result
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["sess-new", "sess-mid"]);
+    }
+
+    #[test]
+    fn sessions_list_since_drops_sessions_outside_window() {
+        let (_dir, handle) = multi_session_handle();
+        let result = handle
+            .sessions_list(SessionsListOptions {
+                since: Some("2026-04-22T00:00:00.000Z".into()),
+                ..SessionsListOptions::default()
+            })
+            .expect("sessions_list");
+        let ids: Vec<&str> = result
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["sess-new", "sess-mid"]);
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,17 +24,17 @@ importers:
   packages/relayburn:
     optionalDependencies:
       '@relayburn/cli-darwin-arm64':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
       '@relayburn/cli-darwin-x64':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
       '@relayburn/cli-linux-arm64-gnu':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
       '@relayburn/cli-linux-x64-gnu':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
 
   packages/relayburn/npm/darwin-arm64: {}
 
@@ -54,17 +54,17 @@ importers:
         version: 0.25.12
     optionalDependencies:
       '@relayburn/sdk-darwin-arm64':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
       '@relayburn/sdk-darwin-x64':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
       '@relayburn/sdk-linux-arm64-gnu':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
       '@relayburn/sdk-linux-x64-gnu':
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 2.5.2
+        version: 2.5.2
 
   packages/sdk-node/npm/darwin-arm64: {}
 
@@ -237,54 +237,54 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@relayburn/cli-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-hnqBUYVGfF1IMjONHlJssrZ27KDrEWIzElwBdL1ngI+YU/3S81gH1PLdFCGWqdcyydqaTL6uBiVqZbvvHgrdqA==}
+  '@relayburn/cli-darwin-arm64@2.5.2':
+    resolution: {integrity: sha512-BQAtBDdxcCi65LjWwJks1rWzZZP7+RYcO5LX3KlpXo1Hqo1ibo4zGBUZ6FSSRiUlNyUuKyfwJ2Vwf/nuqXNjPA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-7Bd2sgh91ErSI4ZV8mdzv+KEldTZXidi9UFHw9Q81mmyDS+Y9Q4EO+Bras3IvTgFjFRPC6EUYe3pR2rmQ6MQtg==}
+  '@relayburn/cli-darwin-x64@2.5.2':
+    resolution: {integrity: sha512-MGdC7SJs0S3mFkjbcfQut6Til045BuaUnWguHRHpbn70jGYryyqitz6q7AImEhsvZZUEpEciw+MSE5IIXq0FyA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.5.1':
-    resolution: {integrity: sha512-N5kv+pjPyC/PVVKcwg1pZLLX2yb5ObShb7FyCLcSfk2sJMEEOgaaXgsrikwUkUXb2j1BY0a7kvtf1ZkbT1hvDw==}
+  '@relayburn/cli-linux-arm64-gnu@2.5.2':
+    resolution: {integrity: sha512-LGyZwnhW24DhQXo4iYMs/Lym/UAESxJoZv62wiP3sDaiZV7nnN13Y5CKbVtUvFpTV9hGae9y99ZRF8WDXrrwEA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/cli-linux-x64-gnu@2.5.1':
-    resolution: {integrity: sha512-RRuaXAAmOa8gsAWi9DA90j+qecqW4gILOpfpk2iEVTS9Tf6yswfKHGCSoNFU+mDAq4mDI64Tg3rlRL9finTw6A==}
+  '@relayburn/cli-linux-x64-gnu@2.5.2':
+    resolution: {integrity: sha512-qepni4L0G+HtqtoG1BwHQkaQR54txKuPPmkVAAFrWa+3ThB2CvXxMymlHUanWD/Tq08WxVdcPMTNIN9gzLYISw==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/sdk-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-Gxps0cY+BXmF/hDMd+betjd3or3gle7kBQeQ/AM+hkVUfYaRV/DuCpLNXvOXyP8kLJGU1bd3fRX+HT1nvaAqrA==}
+  '@relayburn/sdk-darwin-arm64@2.5.2':
+    resolution: {integrity: sha512-OSoUGplSTaoDgfM46r0u198IHEvZFPSvDDfv+FMOXy+TEaloqK/M1iDOy9sY/TWjNCRY/gvILp5fcFwYcuCdIg==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@relayburn/sdk-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-zxBj9FhdmJahMlpMKBzn5ZGwo4L2UWoMpkqsRdcR5VfRrMebKQlK8TzaGpRAai4NxkRX1r5a+dVHgE2O57aDEA==}
+  '@relayburn/sdk-darwin-x64@2.5.2':
+    resolution: {integrity: sha512-/I7LPeBTYzqL0pvZxTcF6siBZKeR6qgc/R8JhkdoxEpTGa27TprpJm17ilAkvaseWFmkzsr3uhLvRoDg/FBA5w==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@relayburn/sdk-linux-arm64-gnu@2.5.1':
-    resolution: {integrity: sha512-Gylb9ZXNlkHA+ABIX8qX0k1JCrwcpxVoh8xbZRGf7o5HcfTG73SMRWG2piU8XsadNjqUtnJSvYPBpxaJpXIymw==}
+  '@relayburn/sdk-linux-arm64-gnu@2.5.2':
+    resolution: {integrity: sha512-X62wiYsFO/rlTo6zl8mARasrqEdHE0ap2SwFrsVBMNavCj2HwWuQzC0F80qGGI9Vp3gZ9X0wpJFaw/d5ZWNqTQ==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@relayburn/sdk-linux-x64-gnu@2.5.1':
-    resolution: {integrity: sha512-E/+8BzoIWQCp3c+CpOLueNFuzhh6FCFkvvoo7oIqXe3+BqKLAdAX8wf5ShetteKhbYznfYVkMHiKBWh1upK1zw==}
+  '@relayburn/sdk-linux-x64-gnu@2.5.2':
+    resolution: {integrity: sha512-AuXsygyOGy2Vy+p/bcXVKwEMX91Ua8ayMdOF7nZfMe8aLW/EPkPYCgi2Wv+QIjYALljZd1DrdoHEEx3ceNBswg==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
@@ -387,28 +387,28 @@ snapshots:
 
   '@napi-rs/cli@2.18.4': {}
 
-  '@relayburn/cli-darwin-arm64@2.5.1':
+  '@relayburn/cli-darwin-arm64@2.5.2':
     optional: true
 
-  '@relayburn/cli-darwin-x64@2.5.1':
+  '@relayburn/cli-darwin-x64@2.5.2':
     optional: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.5.1':
+  '@relayburn/cli-linux-arm64-gnu@2.5.2':
     optional: true
 
-  '@relayburn/cli-linux-x64-gnu@2.5.1':
+  '@relayburn/cli-linux-x64-gnu@2.5.2':
     optional: true
 
-  '@relayburn/sdk-darwin-arm64@2.5.1':
+  '@relayburn/sdk-darwin-arm64@2.5.2':
     optional: true
 
-  '@relayburn/sdk-darwin-x64@2.5.1':
+  '@relayburn/sdk-darwin-x64@2.5.2':
     optional: true
 
-  '@relayburn/sdk-linux-arm64-gnu@2.5.1':
+  '@relayburn/sdk-linux-arm64-gnu@2.5.2':
     optional: true
 
-  '@relayburn/sdk-linux-x64-gnu@2.5.1':
+  '@relayburn/sdk-linux-x64-gnu@2.5.2':
     optional: true
 
   '@types/node@22.19.18':


### PR DESCRIPTION
## Summary

`burn`'s subcommands today (`summary | hotspots | overhead | compare | state | ingest | mcp-server`) are all aggregators — none enumerate sessions. Finding a session id to feed into `burn summary --session <id>` currently means dropping into raw SQLite against `~/.agentworkforce/burn/burn.sqlite`. This PR closes that gap.

- New `burn sessions list` CLI subcommand.
- New `relayburn-sdk::sessions_list` verb (`LedgerHandle::sessions_list` + free function), derived from the `turns` table so older ledgers with an empty `sessions` table still enumerate correctly.
- Defaults to the last 7 days, capped at 20 rows, sorted most-recent-first.

## Surface

```
burn sessions list [--since WHEN] [--project PROJECT] [--grep PATTERN] [--limit N] [--json]
```

Columns (human mode): session id (truncated to 12 chars + `…`), project, started, last seen, turns, cost. JSON mode preserves the full session id and adds `filters`, `limit`, and `truncated` envelope fields so scripts can tell "no more sessions" from "more available — widen --limit".

`--grep` is a case-insensitive substring against both the session id and the resolved project label. Kept simple (no FTS5) — that surface stays reserved for content search.

## Example

```
$ burn sessions list --since 24h --limit 5
session        project                            started                   last seen                 turns  cost
019e0898-82a…  /Users/will/.agent-workforce/...   2026-05-08T17:17:54.168Z  2026-05-08T17:22:49.621Z  6      $0.00
6f9e1a24-28f…  /Users/will/Projects/workforce     2026-05-08T16:58:00.643Z  2026-05-08T17:22:16.297Z  55     $3.11
…

showing 5 sessions (since 24h, limit 5); more available — re-run with --limit to widen
(pass the full session id to `burn summary --session <id>` for details)
```

`burn sessions list --json --since 24h | jq '.sessions[] | {sessionId, totalCostUSD}'` works as a pipeline source.

## Implementation notes

- SDK verb walks the turn stream once (same path `summary` already trusts), groups by `session_id`, sums per-turn cost via the existing `cost_for_turn` helper, then applies grep + sort + limit.
- `total_cost_usd` is rounded to 6 decimals to match the precision contract `session_cost` already documents — the two surfaces are byte-comparable for a single session.
- `burn sessions` is a parent verb that requires a nested subcommand. Today only `list` exists; the args struct keeps room for follow-up verbs (`show`, `tag`, …) without churning the dispatcher.

## Test plan

- [x] `cargo build -p relayburn-cli -p relayburn-sdk` clean
- [x] 5 new SDK unit tests in `query_verbs::tests` cover sort order, project / grep / since filters, and limit/truncation
- [x] 3 new CLI tests cover `sessions` parent verb fails without subcommand, `sessions list` against an empty isolated ledger reports "no sessions found", and `--json` envelope shape
- [x] Smoke against the real ledger (~39k sessions): tried `--since 24h`, `--json`, `--grep workforce`, `--project /Users/will/Projects/workforce`, `--limit 5`; all behave as expected
- [x] `cargo clippy` clean for the changed files
- [x] `cargo fmt` applied to changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)