### PR TITLE
Clarify summary partial coverage footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Changed
+
+- `relayburn-cli`: `burn summary` partial-coverage footers now name the
+  token field with the largest gap and clarify that totals still include all
+  matched turns.
+
 ## [2.6.0] - 2026-05-08
 
 ### Added

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -398,6 +398,16 @@ fn cell_is_partial(c: &relayburn_sdk::FieldCoverage) -> bool {
 const PARTIAL_MARK: &str = "*";
 const DASH: &str = "—";
 
+fn coverage_field_label(field: CoverageField) -> &'static str {
+    match field {
+        CoverageField::Input => "input",
+        CoverageField::Output => "output",
+        CoverageField::Reasoning => "reasoning",
+        CoverageField::CacheRead => "cacheRead",
+        CoverageField::CacheCreate => "cacheCreate",
+    }
+}
+
 /// Render one token-field cell. Three cases:
 ///   - every contributing turn reported the field → numeric value, no marker
 ///   - some turns reported, some didn't           → numeric value + `*`
@@ -1084,29 +1094,40 @@ fn format_replacement_savings_line(s: &relayburn_sdk::ReplacementSavingsSummary)
     )
 }
 
-/// Footer note explaining the `*` marker. Numerator is the worst-covered
-/// axis: for each coverage field, sum its `missing` across every row, then
-/// take the max. Denominator is the cross-row sum of `known + missing` for
-/// `input` (the canonical token field; if a record has any per-turn
-/// coverage at all, it carries input).
+/// Footer note explaining the `*` marker. Numerator is the token field with
+/// the largest missing count: for each coverage field, sum its `missing`
+/// across every row, then take the max. Denominator is the cross-row sum of
+/// `known + missing` for `input` (the canonical token field; if a record has
+/// any per-turn coverage at all, it carries input).
 fn format_partial_footer(rows: &[UsageCostAggregateRow]) -> String {
     let mut total: u64 = 0;
     for r in rows {
         total += r.coverage.input.known + r.coverage.input.missing;
     }
     let mut missing: u64 = 0;
+    let mut fields: Vec<&'static str> = Vec::new();
     for f in COVERAGE_FIELDS {
         let mut field_missing: u64 = 0;
         for r in rows {
             field_missing += r.coverage.field(f).missing;
         }
-        if field_missing > missing {
-            missing = field_missing;
+        match field_missing.cmp(&missing) {
+            std::cmp::Ordering::Greater => {
+                missing = field_missing;
+                fields.clear();
+                fields.push(coverage_field_label(f));
+            }
+            std::cmp::Ordering::Equal if field_missing > 0 => {
+                fields.push(coverage_field_label(f));
+            }
+            _ => {}
         }
     }
+    let field = fields.join("/");
     format!(
-        "{} partial coverage: {} of {} turns omitted per-turn token data",
+        "{} partial token coverage: largest gap is {} (missing on {} of {} turns); totals still include all turns",
         PARTIAL_MARK,
+        field,
         format_uint(missing),
         format_uint(total),
     )
@@ -1213,6 +1234,45 @@ mod tests {
         let value = grouped_json_value(&report, &relayburn_sdk::IngestReport::empty());
 
         assert_eq!(value["quality"], json!({"outcomes": [], "oneShot": []}));
+    }
+
+    #[test]
+    fn partial_footer_names_gap_and_says_totals_include_all_turns() {
+        fn row(label: &str, coverage: relayburn_sdk::RowCoverage) -> UsageCostAggregateRow {
+            UsageCostAggregateRow {
+                label: label.to_string(),
+                turns: 0,
+                usage: relayburn_sdk::Usage::default(),
+                cost: CostBreakdown {
+                    model: String::new().into(),
+                    total: 0.0,
+                    input: 0.0,
+                    output: 0.0,
+                    reasoning: 0.0,
+                    cache_read: 0.0,
+                    cache_create: 0.0,
+                },
+                coverage,
+            }
+        }
+
+        let mut claude_coverage = relayburn_sdk::RowCoverage::default();
+        claude_coverage.input.known = 3;
+        claude_coverage.output.known = 3;
+        claude_coverage.reasoning.missing = 3;
+
+        let mut codex_coverage = relayburn_sdk::RowCoverage::default();
+        codex_coverage.input.known = 1;
+        codex_coverage.output.known = 1;
+        codex_coverage.reasoning.known = 1;
+
+        assert_eq!(
+            format_partial_footer(&[
+                row("claude-sonnet-4-6", claude_coverage),
+                row("gpt-5-codex", codex_coverage),
+            ]),
+            "* partial token coverage: largest gap is reasoning (missing on 3 of 4 turns); totals still include all turns",
+        );
     }
 
     #[test]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,17 +24,17 @@ importers:
   packages/relayburn:
     optionalDependencies:
       '@relayburn/cli-darwin-arm64':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
       '@relayburn/cli-darwin-x64':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
       '@relayburn/cli-linux-arm64-gnu':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
       '@relayburn/cli-linux-x64-gnu':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
 
   packages/relayburn/npm/darwin-arm64: {}
 
@@ -54,17 +54,17 @@ importers:
         version: 0.25.12
     optionalDependencies:
       '@relayburn/sdk-darwin-arm64':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
       '@relayburn/sdk-darwin-x64':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
       '@relayburn/sdk-linux-arm64-gnu':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
       '@relayburn/sdk-linux-x64-gnu':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.6.0
+        version: 2.6.0
 
   packages/sdk-node/npm/darwin-arm64: {}
 
@@ -237,54 +237,54 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@relayburn/cli-darwin-arm64@2.5.2':
-    resolution: {integrity: sha512-BQAtBDdxcCi65LjWwJks1rWzZZP7+RYcO5LX3KlpXo1Hqo1ibo4zGBUZ6FSSRiUlNyUuKyfwJ2Vwf/nuqXNjPA==}
+  '@relayburn/cli-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-suU3ZDEyI5zZucXL1PJ3prEqB0yfTOqvR7scTwMx7vavol0MtruHGdtWo3BYckTpAp5ZZif3wM4UrGXELtGHCA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-darwin-x64@2.5.2':
-    resolution: {integrity: sha512-MGdC7SJs0S3mFkjbcfQut6Til045BuaUnWguHRHpbn70jGYryyqitz6q7AImEhsvZZUEpEciw+MSE5IIXq0FyA==}
+  '@relayburn/cli-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-/q69kaCIHWO7C/AO7bt3EoxielxxaqS26DS7j/1LTy0j03yGfhZs2ysBtDFqI/ptOh8Ky0dY16VOyzBaloEqPg==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.5.2':
-    resolution: {integrity: sha512-LGyZwnhW24DhQXo4iYMs/Lym/UAESxJoZv62wiP3sDaiZV7nnN13Y5CKbVtUvFpTV9hGae9y99ZRF8WDXrrwEA==}
+  '@relayburn/cli-linux-arm64-gnu@2.6.0':
+    resolution: {integrity: sha512-xMiljFrTK8BTJh/DlFKniCYee8CPR3vkHysI0q6NmgsZIWoKRuWwk+AFxwLJhcfqEJ38kjQKCC9XHVzuREb5Jg==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/cli-linux-x64-gnu@2.5.2':
-    resolution: {integrity: sha512-qepni4L0G+HtqtoG1BwHQkaQR54txKuPPmkVAAFrWa+3ThB2CvXxMymlHUanWD/Tq08WxVdcPMTNIN9gzLYISw==}
+  '@relayburn/cli-linux-x64-gnu@2.6.0':
+    resolution: {integrity: sha512-rFC4/XyVv+PukTmyR0/ua6xlGMBzFRbKoPL3ndGDWccprt+r3uOZW1pEnG0snNNq3Etf+hY+ZpauhmT6ChHo7w==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/sdk-darwin-arm64@2.5.2':
-    resolution: {integrity: sha512-OSoUGplSTaoDgfM46r0u198IHEvZFPSvDDfv+FMOXy+TEaloqK/M1iDOy9sY/TWjNCRY/gvILp5fcFwYcuCdIg==}
+  '@relayburn/sdk-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-YLf9Xt33UJHGua07aQLbl8l8KlHWI4PtIixBEMJdiuYHpbf803gK1cxVP1JmFGp2xBQXvcluDQt7IAQRkjxHtA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@relayburn/sdk-darwin-x64@2.5.2':
-    resolution: {integrity: sha512-/I7LPeBTYzqL0pvZxTcF6siBZKeR6qgc/R8JhkdoxEpTGa27TprpJm17ilAkvaseWFmkzsr3uhLvRoDg/FBA5w==}
+  '@relayburn/sdk-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-KXEGQAckXrAhZqrQdaXCFUzLHuMki2gaNNU70GttIlXwxpn5ZBE+zat1LNNJeqFejlsTdzuJm0Ty45kAfo3FjA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@relayburn/sdk-linux-arm64-gnu@2.5.2':
-    resolution: {integrity: sha512-X62wiYsFO/rlTo6zl8mARasrqEdHE0ap2SwFrsVBMNavCj2HwWuQzC0F80qGGI9Vp3gZ9X0wpJFaw/d5ZWNqTQ==}
+  '@relayburn/sdk-linux-arm64-gnu@2.6.0':
+    resolution: {integrity: sha512-QEE+h+47rOw1gMTVaWBt+dQnwqf69Lrc8ddtKDu26P9if5+l33zS/qeA5rEnajcQqIySFsnr2TwChuPf5xYYEA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@relayburn/sdk-linux-x64-gnu@2.5.2':
-    resolution: {integrity: sha512-AuXsygyOGy2Vy+p/bcXVKwEMX91Ua8ayMdOF7nZfMe8aLW/EPkPYCgi2Wv+QIjYALljZd1DrdoHEEx3ceNBswg==}
+  '@relayburn/sdk-linux-x64-gnu@2.6.0':
+    resolution: {integrity: sha512-62ohzOuKxvqwI4IPQe/EO5WKta/RSGTfRiWgZI1Lqry9pZOwnDH0ABASpO7lpFhGjowakbEcLcHHtY4RzVQeAQ==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
@@ -387,28 +387,28 @@ snapshots:
 
   '@napi-rs/cli@2.18.4': {}
 
-  '@relayburn/cli-darwin-arm64@2.5.2':
+  '@relayburn/cli-darwin-arm64@2.6.0':
     optional: true
 
-  '@relayburn/cli-darwin-x64@2.5.2':
+  '@relayburn/cli-darwin-x64@2.6.0':
     optional: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.5.2':
+  '@relayburn/cli-linux-arm64-gnu@2.6.0':
     optional: true
 
-  '@relayburn/cli-linux-x64-gnu@2.5.2':
+  '@relayburn/cli-linux-x64-gnu@2.6.0':
     optional: true
 
-  '@relayburn/sdk-darwin-arm64@2.5.2':
+  '@relayburn/sdk-darwin-arm64@2.6.0':
     optional: true
 
-  '@relayburn/sdk-darwin-x64@2.5.2':
+  '@relayburn/sdk-darwin-x64@2.6.0':
     optional: true
 
-  '@relayburn/sdk-linux-arm64-gnu@2.5.2':
+  '@relayburn/sdk-linux-arm64-gnu@2.6.0':
     optional: true
 
-  '@relayburn/sdk-linux-x64-gnu@2.5.2':
+  '@relayburn/sdk-linux-x64-gnu@2.6.0':
     optional: true
 
   '@types/node@22.19.18':


### PR DESCRIPTION
## Summary
- Name the token field with the largest partial-coverage gap in burn summary footers.
- Clarify that summary totals still include all matched turns.
- Add a focused unit test and changelog note.

## Tests
- cargo test -p relayburn-cli