### PR TITLE
fix(cli): stop calling unsafe std::env::set_var in compare/summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `relayburn-cli`: `burn summary` partial-coverage footers now name the
   token field with the largest gap and clarify that totals still include all
   matched turns.
+- `relayburn-cli`: drop the `RELAYBURN_ARCHIVE` env mutation in `burn compare`
+  and `burn summary`. The Rust SDK never read the variable, and `set_var` is
+  unsafe under Rust 1.84+. `--no-archive` is now an explicit no-op.
 
 ## [2.6.0] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `relayburn-cli`: `burn summary` partial-coverage footers now name the
   token field with the largest gap and clarify that totals still include all
   matched turns.
-- `relayburn-cli`: drop the `RELAYBURN_ARCHIVE` env mutation in `burn compare`
-  and `burn summary`. The Rust SDK never read the variable, and `set_var` is
-  unsafe under Rust 1.84+. `--no-archive` is now an explicit no-op.
+- `relayburn-cli`: `--no-archive` on `burn compare` and `burn summary` is now
+  an explicit no-op (accepted for TS CLI flag parity).
 
 ## [2.6.0] - 2026-05-08
 

--- a/crates/relayburn-cli/src/cli.rs
+++ b/crates/relayburn-cli/src/cli.rs
@@ -244,8 +244,8 @@ pub struct CompareArgs {
     #[arg(long)]
     pub csv: bool,
 
-    /// Bypass the SQLite archive and stream the ledger directly.
-    /// Honored when env `RELAYBURN_ARCHIVE=0`.
+    /// Accepted for TS CLI flag parity; a no-op against the Rust SDK,
+    /// which is SQLite-native and has no archive layer to bypass.
     #[arg(long = "no-archive")]
     pub no_archive: bool,
 }

--- a/crates/relayburn-cli/src/commands/compare.rs
+++ b/crates/relayburn-cli/src/commands/compare.rs
@@ -128,11 +128,9 @@ fn run_inner(globals: &GlobalArgs, args: CompareArgs) -> Result<i32> {
         return Err(anyhow!("invalid --min-sample: {min_sample}"));
     }
 
-    // 6. Honor --no-archive by exporting RELAYBURN_ARCHIVE=0 for the
-    //    duration of this call. The Rust SDK doesn't read RELAYBURN_ARCHIVE
-    //    today (it's SQLite-only), but we set the env so any future archive
-    //    layer behaves identically to the TS CLI's `--no-archive`.
-    let _archive_guard = ArchiveOverride::activate(args.no_archive);
+    // 6. `--no-archive` is accepted for TS CLI flag parity but is a no-op:
+    //    the Rust SDK is SQLite-native and has no archive layer to bypass.
+    let _ = args.no_archive;
 
     // 7. Build the Query.
     let mut q = Query::default();
@@ -488,42 +486,6 @@ fn days_to_ymd(days_from_epoch: i64) -> (i64, u32, u32) {
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = if m <= 2 { y + 1 } else { y };
     (year, m as u32, d as u32)
-}
-
-/// Drop-in for `RELAYBURN_ARCHIVE=0`. Restores the previous value on
-/// drop so a panic part-way through doesn't leak the override.
-struct ArchiveOverride {
-    previous: Option<String>,
-    activated: bool,
-}
-
-impl ArchiveOverride {
-    fn activate(no_archive: bool) -> Self {
-        if !no_archive {
-            return Self {
-                previous: None,
-                activated: false,
-            };
-        }
-        let previous = std::env::var("RELAYBURN_ARCHIVE").ok();
-        std::env::set_var("RELAYBURN_ARCHIVE", "0");
-        Self {
-            previous,
-            activated: true,
-        }
-    }
-}
-
-impl Drop for ArchiveOverride {
-    fn drop(&mut self) {
-        if !self.activated {
-            return;
-        }
-        match self.previous.take() {
-            Some(v) => std::env::set_var("RELAYBURN_ARCHIVE", v),
-            None => std::env::remove_var("RELAYBURN_ARCHIVE"),
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -104,9 +104,8 @@ pub struct SummaryArgs {
     #[arg(long)]
     pub quality: bool,
 
-    /// Bypass the archive sidecar and stream the ledger. Kept for parity
-    /// with the TS CLI and as an escape hatch for archive-corruption
-    /// debugging.
+    /// Accepted for TS CLI flag parity; a no-op against the Rust SDK,
+    /// which is SQLite-native and has no archive layer to bypass.
     #[arg(long = "no-archive")]
     pub no_archive: bool,
 }

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -206,7 +206,9 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         None
     };
 
-    let _archive_guard = ArchiveOverride::activate(args.no_archive);
+    // `--no-archive` is accepted for TS CLI flag parity but is a no-op:
+    // the Rust SDK is SQLite-native and has no archive layer to bypass.
+    let _ = args.no_archive;
     let progress = TaskProgress::new(globals, "summary");
 
     let opts = match globals.ledger_path.as_deref() {
@@ -344,43 +346,6 @@ fn run_ingest(
             progress.finish_and_clear();
             err
         })
-}
-
-/// Drop-in for `RELAYBURN_ARCHIVE=0`. The Rust SDK is already SQLite-native,
-/// but this preserves the TS CLI flag contract for any lower layer that checks
-/// the env escape hatch.
-struct ArchiveOverride {
-    previous: Option<String>,
-    activated: bool,
-}
-
-impl ArchiveOverride {
-    fn activate(no_archive: bool) -> Self {
-        if !no_archive {
-            return Self {
-                previous: None,
-                activated: false,
-            };
-        }
-        let previous = std::env::var("RELAYBURN_ARCHIVE").ok();
-        std::env::set_var("RELAYBURN_ARCHIVE", "0");
-        Self {
-            previous,
-            activated: true,
-        }
-    }
-}
-
-impl Drop for ArchiveOverride {
-    fn drop(&mut self) {
-        if !self.activated {
-            return;
-        }
-        match self.previous.take() {
-            Some(v) => std::env::set_var("RELAYBURN_ARCHIVE", v),
-            None => std::env::remove_var("RELAYBURN_ARCHIVE"),
-        }
-    }
 }
 
 const COVERAGE_FIELDS: [CoverageField; 5] = [


### PR DESCRIPTION
## Summary

Closes #335.

The `ArchiveOverride` guard in `burn compare` / `burn summary` mutated `RELAYBURN_ARCHIVE` for the duration of each call, but the Rust SDK never reads that variable — its own comment admits it was a no-op preserved "for any future archive layer." Under Rust 1.84+ `std::env::set_var` is `unsafe` because it can race with concurrent reads in the same process, so this is a footgun for parallel test runs and embedders with no upside.

- Drop `ArchiveOverride` from `compare.rs` and `summary.rs` entirely.
- `--no-archive` stays on the CLI for TS-CLI flag parity but is now an explicit no-op (which it effectively was anyway, just plus a process-global env mutation).
- Fix the `cli.rs` doc comment so it stops promising env-var honoring that never existed in the Rust SDK.

The other site flagged in the issue (`run.rs` mutating `RELAYBURN_HOME`) no longer exists in `main` — the harness adapters now resolve their ledger handle through `LedgerOpenOptions` directly without touching process env. So that half of #335 is already done.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — all suites pass (no deltas vs. main: 24 / 65 / 5 / 19 / 644 / 2 / 13 in cli + sdk)
- [x] `cargo clippy -p relayburn-cli --all-targets` — same warning count as `main` (no new lints introduced; the 21 pre-existing SDK warnings are unrelated)
- [x] Golden + smoke suites still pass (they pin `RELAYBURN_ARCHIVE=0` themselves via `Command::env`, which is fine)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TwQ65iFtjvvbiqjx25m49c)_