### PR TITLE
perf(sdk): push ledger Query filters into SQL + adopt prepare_cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `relayburn-cli`: `burn summary` partial-coverage footers now name the
   token field with the largest gap and clarify that totals still include all
   matched turns.
+- `relayburn-sdk`: ledger query verbs (`query_turns`, `query_compactions`,
+  `query_relationships`, `query_tool_result_events`, `query_user_turns`)
+  now push `since` / `until` / `session_id` / `source` / `project` filters
+  into SQL and reuse compiled statements via `prepare_cached`. Cuts the
+  per-call cost of `burn ingest --watch` and any verb that drives a
+  filtered query against a multi-month ledger.
 
 ## [2.6.0] - 2026-05-08
 

--- a/crates/relayburn-sdk/src/ledger/reader.rs
+++ b/crates/relayburn-sdk/src/ledger/reader.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, params_from_iter};
 use serde::{Deserialize, Serialize};
 
 use crate::reader::{
@@ -31,9 +31,20 @@ pub struct EnrichedTurn {
 
 pub(crate) fn query_turns(conn: &Connection, q: &Query) -> Result<Vec<EnrichedTurn>> {
     let stamps = collect_stamps(conn)?;
-    let mut stmt = conn.prepare("SELECT record_json FROM turns ORDER BY rowid")?;
+    let (sql, bound) = build_select_sql(
+        "turns",
+        q,
+        TableFilters {
+            ts_nullable: false,
+            session_id_or_related: false,
+            project_columns: true,
+        },
+    );
+    let mut stmt = conn.prepare_cached(&sql)?;
     let rows = stmt
-        .query_map([], |row| row.get::<_, String>(0))?
+        .query_map(params_from_iter(bound.iter()), |row| {
+            row.get::<_, String>(0)
+        })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     let mut out = Vec::new();
     for json in rows {
@@ -42,7 +53,7 @@ pub(crate) fn query_turns(conn: &Connection, q: &Query) -> Result<Vec<EnrichedTu
             Err(_) => continue,
         };
         let enrichment = fold_stamps(&turn, &stamps);
-        if !turn_passes(&turn, q, &enrichment) {
+        if !enrichment_filter_passes(&enrichment, q) {
             continue;
         }
         out.push(EnrichedTurn { turn, enrichment });
@@ -51,33 +62,61 @@ pub(crate) fn query_turns(conn: &Connection, q: &Query) -> Result<Vec<EnrichedTu
 }
 
 pub(crate) fn query_compactions(conn: &Connection, q: &Query) -> Result<Vec<CompactionEvent>> {
-    select_records(conn, "compactions", |r: CompactionEvent| {
-        compaction_passes(&r, q).then_some(r)
-    })
+    select_filtered_records(
+        conn,
+        "compactions",
+        q,
+        TableFilters {
+            ts_nullable: false,
+            session_id_or_related: false,
+            project_columns: false,
+        },
+    )
 }
 
 pub(crate) fn query_relationships(
     conn: &Connection,
     q: &Query,
 ) -> Result<Vec<SessionRelationshipRecord>> {
-    select_records(conn, "relationships", |r: SessionRelationshipRecord| {
-        relationship_passes(&r, q).then_some(r)
-    })
+    select_filtered_records(
+        conn,
+        "relationships",
+        q,
+        TableFilters {
+            ts_nullable: true,
+            session_id_or_related: true,
+            project_columns: false,
+        },
+    )
 }
 
 pub(crate) fn query_tool_result_events(
     conn: &Connection,
     q: &Query,
 ) -> Result<Vec<ToolResultEventRecord>> {
-    select_records(conn, "tool_result_events", |r: ToolResultEventRecord| {
-        tool_result_event_passes(&r, q).then_some(r)
-    })
+    select_filtered_records(
+        conn,
+        "tool_result_events",
+        q,
+        TableFilters {
+            ts_nullable: true,
+            session_id_or_related: false,
+            project_columns: false,
+        },
+    )
 }
 
 pub(crate) fn query_user_turns(conn: &Connection, q: &Query) -> Result<Vec<UserTurnRecord>> {
-    select_records(conn, "user_turns", |r: UserTurnRecord| {
-        user_turn_passes(&r, q).then_some(r)
-    })
+    select_filtered_records(
+        conn,
+        "user_turns",
+        q,
+        TableFilters {
+            ts_nullable: false,
+            session_id_or_related: false,
+            project_columns: false,
+        },
+    )
 }
 
 pub(crate) fn list_stamps(conn: &Connection) -> Result<Vec<Stamp>> {
@@ -96,7 +135,7 @@ pub(crate) fn list_stamps(conn: &Connection) -> Result<Vec<Stamp>> {
 /// session_id should never reach us, but the extra guard keeps the
 /// surface symmetric.
 pub(crate) fn list_user_turn_session_ids(conn: &Connection) -> Result<HashSet<String>> {
-    let mut stmt = conn.prepare("SELECT DISTINCT session_id FROM user_turns")?;
+    let mut stmt = conn.prepare_cached("SELECT DISTINCT session_id FROM user_turns")?;
     let mut rows = stmt.query([])?;
     let mut out = HashSet::new();
     while let Some(row) = rows.next()? {
@@ -110,31 +149,107 @@ pub(crate) fn list_user_turn_session_ids(conn: &Connection) -> Result<HashSet<St
     Ok(out)
 }
 
-fn select_records<T, F>(conn: &Connection, table: &str, mut filter: F) -> Result<Vec<T>>
+/// Per-table column shape used to build the SQL `WHERE` clause from a
+/// [`Query`]. Each table has the same logical filters, but their column
+/// shapes differ:
+///
+/// - `ts_nullable`: relationships and tool_result_events store `ts` as
+///   nullable, and the historical Rust filter passed rows whose `ts` was
+///   `NULL` regardless of `since`/`until`. Mirror that with
+///   `(ts IS NULL OR ts >= ?)`.
+/// - `session_id_or_related`: relationships match the filter against
+///   either `session_id` or `related_session_id`.
+/// - `project_columns`: only `turns` carries the `project` /
+///   `project_key` columns surfaced via `Query::project`.
+#[derive(Clone, Copy)]
+struct TableFilters {
+    ts_nullable: bool,
+    session_id_or_related: bool,
+    project_columns: bool,
+}
+
+/// Build a `SELECT record_json FROM <table> WHERE … ORDER BY rowid`
+/// statement that pushes every supported [`Query`] predicate into SQL,
+/// alongside the parameter list to bind. Generates a stable SQL string
+/// per filter combination so [`Connection::prepare_cached`] can reuse the
+/// compiled statement across calls.
+fn build_select_sql(table: &str, q: &Query, shape: TableFilters) -> (String, Vec<String>) {
+    let mut sql = format!("SELECT record_json FROM {table}");
+    let mut clauses: Vec<&'static str> = Vec::new();
+    let mut bound: Vec<String> = Vec::new();
+
+    if let Some(since) = &q.since {
+        if shape.ts_nullable {
+            clauses.push("(ts IS NULL OR ts >= ?)");
+        } else {
+            clauses.push("ts >= ?");
+        }
+        bound.push(since.clone());
+    }
+    if let Some(until) = &q.until {
+        if shape.ts_nullable {
+            clauses.push("(ts IS NULL OR ts <= ?)");
+        } else {
+            clauses.push("ts <= ?");
+        }
+        bound.push(until.clone());
+    }
+    if let Some(sid) = &q.session_id {
+        if shape.session_id_or_related {
+            clauses.push("(session_id = ? OR related_session_id = ?)");
+            bound.push(sid.clone());
+            bound.push(sid.clone());
+        } else {
+            clauses.push("session_id = ?");
+            bound.push(sid.clone());
+        }
+    }
+    if let Some(source) = q.source {
+        clauses.push("source = ?");
+        bound.push(source.wire_str().to_string());
+    }
+    if shape.project_columns {
+        if let Some(project) = &q.project {
+            clauses.push("(project = ? OR project_key = ?)");
+            bound.push(project.clone());
+            bound.push(project.clone());
+        }
+    }
+
+    if !clauses.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+    sql.push_str(" ORDER BY rowid");
+    (sql, bound)
+}
+
+fn select_filtered_records<T>(
+    conn: &Connection,
+    table: &str,
+    q: &Query,
+    shape: TableFilters,
+) -> Result<Vec<T>>
 where
     T: for<'de> Deserialize<'de>,
-    F: FnMut(T) -> Option<T>,
 {
-    let sql = format!("SELECT record_json FROM {table} ORDER BY rowid");
-    let mut stmt = conn.prepare(&sql)?;
+    let (sql, bound) = build_select_sql(table, q, shape);
+    let mut stmt = conn.prepare_cached(&sql)?;
     let rows = stmt
-        .query_map([], |r| r.get::<_, String>(0))?
+        .query_map(params_from_iter(bound.iter()), |r| r.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     let mut out = Vec::new();
     for json in rows {
-        let record: T = match serde_json::from_str(&json) {
-            Ok(r) => r,
+        match serde_json::from_str::<T>(&json) {
+            Ok(record) => out.push(record),
             Err(_) => continue,
-        };
-        if let Some(kept) = filter(record) {
-            out.push(kept);
         }
     }
     Ok(out)
 }
 
 fn collect_stamps(conn: &Connection) -> Result<Vec<Stamp>> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "SELECT ts, selector_json, enrichment_json
          FROM stamps
          ORDER BY ts, written_at",
@@ -179,144 +294,17 @@ fn fold_stamps(turn: &TurnRecord, stamps: &[Stamp]) -> Enrichment {
     out
 }
 
-fn turn_passes(turn: &TurnRecord, q: &Query, enrichment: &Enrichment) -> bool {
-    if let Some(ref since) = q.since {
-        if &turn.ts < since {
-            return false;
-        }
-    }
-    if let Some(ref until) = q.until {
-        if &turn.ts > until {
-            return false;
-        }
-    }
-    if let Some(ref project) = q.project {
-        let matches_project = turn.project.as_deref() == Some(project)
-            || turn.project_key.as_deref() == Some(project);
-        if !matches_project {
-            return false;
-        }
-    }
-    if let Some(ref sid) = q.session_id {
-        if &turn.session_id != sid {
-            return false;
-        }
-    }
-    if let Some(source) = q.source {
-        if turn.source != source {
-            return false;
-        }
-    }
-    if let Some(ref wanted) = q.enrichment {
-        for (key, value) in wanted {
-            if enrichment.get(key) != Some(value) {
-                return false;
-            }
-        }
-    }
-    true
-}
-
-fn compaction_passes(e: &CompactionEvent, q: &Query) -> bool {
-    if let Some(ref since) = q.since {
-        if &e.ts < since {
-            return false;
-        }
-    }
-    if let Some(ref until) = q.until {
-        if &e.ts > until {
-            return false;
-        }
-    }
-    if let Some(ref sid) = q.session_id {
-        if &e.session_id != sid {
-            return false;
-        }
-    }
-    if let Some(source) = q.source {
-        if e.source != source {
-            return false;
-        }
-    }
-    true
-}
-
-fn relationship_passes(r: &SessionRelationshipRecord, q: &Query) -> bool {
-    if let (Some(ref since), Some(ref ts)) = (&q.since, &r.ts) {
-        if ts < since {
-            return false;
-        }
-    }
-    if let (Some(ref until), Some(ref ts)) = (&q.until, &r.ts) {
-        if ts > until {
-            return false;
-        }
-    }
-    if let Some(ref sid) = q.session_id {
-        if &r.session_id != sid && r.related_session_id.as_ref() != Some(sid) {
-            return false;
-        }
-    }
-    if let Some(source) = q.source {
-        // `Query.source` is a `SourceKind` (the harness identity);
-        // `r.source` is a `RelationshipSourceKind` (a superset that
-        // also covers `spawn-env`, `native-claude`, etc.). Compare via
-        // their kebab-case wire labels so a `source = "claude-code"`
-        // filter matches both enums identically — same semantics as the
-        // TS adapter, which compared the raw strings.
-        if source.wire_str() != r.source.wire_str() {
-            return false;
-        }
-    }
-    true
-}
-
-fn tool_result_event_passes(r: &ToolResultEventRecord, q: &Query) -> bool {
-    if let (Some(ref since), Some(ref ts)) = (&q.since, &r.ts) {
-        if ts < since {
-            return false;
-        }
-    }
-    if let (Some(ref until), Some(ref ts)) = (&q.until, &r.ts) {
-        if ts > until {
-            return false;
-        }
-    }
-    if let Some(ref sid) = q.session_id {
-        if &r.session_id != sid {
-            return false;
-        }
-    }
-    if let Some(source) = q.source {
-        if r.source != source {
-            return false;
-        }
-    }
-    true
-}
-
-fn user_turn_passes(r: &UserTurnRecord, q: &Query) -> bool {
-    if let Some(ref since) = q.since {
-        if &r.ts < since {
-            return false;
-        }
-    }
-    if let Some(ref until) = q.until {
-        if &r.ts > until {
-            return false;
-        }
-    }
-    if let Some(ref sid) = q.session_id {
-        if &r.session_id != sid {
-            return false;
-        }
-    }
-    if let Some(source) = q.source {
-        if r.source != source {
-            return false;
-        }
-    }
-    true
+/// Folded-stamp enrichment is the only [`Query`] predicate that can't be
+/// pushed into SQL — stamps live in their own table and the match logic
+/// runs in Rust. SQL handles `since` / `until` / `session_id` / `source`
+/// / `project` for us, so this is the last gate before yielding a turn.
+fn enrichment_filter_passes(enrichment: &Enrichment, q: &Query) -> bool {
+    let Some(ref wanted) = q.enrichment else {
+        return true;
+    };
+    wanted
+        .iter()
+        .all(|(key, value)| enrichment.get(key) == Some(value))
 }
 
 /// Tables `count_table` and `raw_record_jsons` are allowed to address.
@@ -354,7 +342,7 @@ pub(crate) fn count_table(conn: &Connection, table: &str) -> Result<i64> {
 pub(crate) fn raw_record_jsons(conn: &Connection, table: &str) -> Result<Vec<String>> {
     validate_table(table)?;
     let sql = format!("SELECT record_json FROM {table} ORDER BY rowid");
-    let mut stmt = conn.prepare(&sql)?;
+    let mut stmt = conn.prepare_cached(&sql)?;
     let rows = stmt
         .query_map([], |r| r.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;

--- a/crates/relayburn-sdk/src/ledger/tests.rs
+++ b/crates/relayburn-sdk/src/ledger/tests.rs
@@ -939,3 +939,175 @@ fn pruning_content_does_not_lock_events_db() {
     }
     prune_thread.join().unwrap();
 }
+
+#[test]
+fn query_turns_filters_pushed_to_sql_match_legacy_semantics() {
+    // Regression: #324 pushed `since` / `until` / `session_id` /
+    // `source` / `project` from a Rust post-filter into the SQL
+    // `WHERE` clause. Pin the result-set parity against a hand-built
+    // matrix so a future SQL change can't silently regress.
+    let tmp = TempDir::new().unwrap();
+    let mut l = open_in(&tmp);
+
+    let mut t_a = make_turn("s1", "m1", "2025-01-01T00:00:00Z", 10);
+    t_a.project = Some("burn".into());
+    t_a.project_key = Some("burn".into());
+    let mut t_b = make_turn("s1", "m2", "2025-01-02T00:00:00Z", 20);
+    t_b.project = Some("burn".into());
+    t_b.project_key = Some("burn".into());
+    let mut t_c = make_turn("s2", "m3", "2025-01-03T00:00:00Z", 30);
+    t_c.source = SourceKind::Codex;
+    t_c.project = Some("other".into());
+    t_c.project_key = Some("other".into());
+    l.append_turns(&[t_a, t_b, t_c]).unwrap();
+
+    // since: drops 2025-01-01, keeps later two.
+    let r = l
+        .query_turns(&Query {
+            since: Some("2025-01-02T00:00:00Z".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(r.len(), 2);
+
+    // until: drops 2025-01-03, keeps earlier two.
+    let r = l
+        .query_turns(&Query {
+            until: Some("2025-01-02T00:00:00Z".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(r.len(), 2);
+
+    // session_id: only s1's two turns.
+    let r = l.query_turns(&Query::for_session("s1")).unwrap();
+    assert_eq!(r.len(), 2);
+    assert!(r.iter().all(|et| et.turn.session_id == "s1"));
+
+    // source: only the codex row.
+    let r = l
+        .query_turns(&Query {
+            source: Some(SourceKind::Codex),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(r.len(), 1);
+    assert_eq!(r[0].turn.source, SourceKind::Codex);
+
+    // project: matches against project OR project_key.
+    let r = l
+        .query_turns(&Query {
+            project: Some("burn".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(r.len(), 2);
+
+    // Combined since+source: AND-composed.
+    let r = l
+        .query_turns(&Query {
+            since: Some("2025-01-02T00:00:00Z".into()),
+            source: Some(SourceKind::ClaudeCode),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(r.len(), 1);
+    assert_eq!(r[0].turn.message_id, "m2");
+}
+
+#[test]
+fn query_relationships_session_filter_matches_either_endpoint() {
+    // The `session_id` filter on relationships must match either
+    // `session_id` or `related_session_id` — same semantics the Rust
+    // post-filter implemented and the SQL clause now upholds.
+    let tmp = TempDir::new().unwrap();
+    let mut l = open_in(&tmp);
+
+    let parent_edge = SessionRelationshipRecord {
+        v: 1,
+        source: RelationshipSourceKind::ClaudeCode,
+        session_id: "child".into(),
+        related_session_id: Some("parent".into()),
+        relationship_type: RelationshipType::Continuation,
+        ts: Some("2025-01-01T00:00:00Z".into()),
+        source_session_id: None,
+        source_version: None,
+        parent_tool_use_id: None,
+        agent_id: None,
+        subagent_type: None,
+        description: None,
+    };
+    let unrelated = SessionRelationshipRecord {
+        v: 1,
+        source: RelationshipSourceKind::ClaudeCode,
+        session_id: "other".into(),
+        related_session_id: Some("third".into()),
+        relationship_type: RelationshipType::Continuation,
+        ts: Some("2025-01-02T00:00:00Z".into()),
+        source_session_id: None,
+        source_version: None,
+        parent_tool_use_id: None,
+        agent_id: None,
+        subagent_type: None,
+        description: None,
+    };
+    l.append_relationships(&[parent_edge, unrelated]).unwrap();
+
+    let by_child = l
+        .query_relationships(&Query::for_session("child"))
+        .unwrap();
+    assert_eq!(by_child.len(), 1);
+
+    let by_parent = l
+        .query_relationships(&Query::for_session("parent"))
+        .unwrap();
+    assert_eq!(by_parent.len(), 1, "filter matches related_session_id too");
+}
+
+#[test]
+fn query_tool_result_events_keeps_null_ts_rows_under_since_filter() {
+    // tool_result_events.ts is nullable, and the legacy Rust filter
+    // skipped the since/until check entirely when ts was None. The
+    // SQL pushdown mirrors that with `(ts IS NULL OR ts >= ?)` so a
+    // null-ts row still surfaces under a filtered query.
+    use crate::reader::{ToolResultEventRecord, ToolResultEventSource, ToolResultStatus};
+
+    let tmp = TempDir::new().unwrap();
+    let mut l = open_in(&tmp);
+
+    let make = |tool_use_id: &str, event_index: u64, ts: Option<&str>| ToolResultEventRecord {
+        v: 1,
+        source: SourceKind::ClaudeCode,
+        session_id: "s1".into(),
+        message_id: None,
+        tool_use_id: tool_use_id.into(),
+        call_index: None,
+        event_index,
+        ts: ts.map(Into::into),
+        status: ToolResultStatus::Completed,
+        event_source: ToolResultEventSource::ToolResult,
+        content_length: None,
+        content_hash: None,
+        is_error: None,
+        usage: None,
+        usage_attribution: None,
+        subagent_session_id: None,
+        agent_id: None,
+        replaced_tools: None,
+        collapsed_calls: None,
+    };
+    let with_ts = make("tu1", 0, Some("2025-01-01T00:00:00Z"));
+    let null_ts = make("tu2", 1, None);
+    l.append_tool_result_events(&[with_ts, null_ts]).unwrap();
+
+    let r = l
+        .query_tool_result_events(&Query {
+            since: Some("2030-01-01T00:00:00Z".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    // The dated row is excluded by the `since` bound; the null-ts row
+    // survives because it carries no timestamp to compare against.
+    assert_eq!(r.len(), 1);
+    assert!(r[0].ts.is_none());
+}

--- a/crates/relayburn-sdk/src/ledger/tests.rs
+++ b/crates/relayburn-sdk/src/ledger/tests.rs
@@ -949,11 +949,13 @@ fn query_turns_filters_pushed_to_sql_match_legacy_semantics() {
     let tmp = TempDir::new().unwrap();
     let mut l = open_in(&tmp);
 
+    // Asymmetric project / project_key seeding so the regression
+    // catches a SQL change that only checks one of the two columns.
     let mut t_a = make_turn("s1", "m1", "2025-01-01T00:00:00Z", 10);
     t_a.project = Some("burn".into());
-    t_a.project_key = Some("burn".into());
+    t_a.project_key = None;
     let mut t_b = make_turn("s1", "m2", "2025-01-02T00:00:00Z", 20);
-    t_b.project = Some("burn".into());
+    t_b.project = None;
     t_b.project_key = Some("burn".into());
     let mut t_c = make_turn("s2", "m3", "2025-01-03T00:00:00Z", 30);
     t_c.source = SourceKind::Codex;


### PR DESCRIPTION
Closes #324.

## Summary

`crates/relayburn-sdk/src/ledger/reader.rs` was loading every row of the target table into a `Vec<String>` and then filtering in Rust. Pure SQL predicates (`since`, `until`, `session_id`, `source`, `project`) now ride into a generated `WHERE` clause so the existing indexes (`idx_turns_ts`, `idx_turns_session`, etc.) actually do work, and the hot SELECTs use `Connection::prepare_cached` so `burn ingest --watch`'s once-a-second `ingest_all` read no longer pays full prepare/teardown.

- All five query verbs share a `build_select_sql` helper that emits a stable SQL string per filter combination — `prepare_cached` reuses the compiled statement.
- Per-table column shape (nullable `ts`, OR-on-`related_session_id`, project columns) is encoded in a small `TableFilters` struct so the helper stays declarative.
- Folded-stamp enrichment is the only `Query` predicate still evaluated in Rust — stamps live in their own table — so `query_turns` keeps a post-filter for that one case.
- `collect_stamps`, `list_user_turn_session_ids`, and `raw_record_jsons` also moved to `prepare_cached`.

## Test plan

- [x] `cargo test --workspace` (647 tests in `relayburn-sdk` + 89 across cli/ingest helpers, all green)
- [x] New regression tests pin the SQL semantics:
  - combined `since` / `source` / `project` filters on `turns`
  - relationships `session_id` matching either endpoint (`session_id` OR `related_session_id`)
  - `tool_result_events` rows with null `ts` surviving a `since` bound
- [x] `cargo build --workspace`

https://claude.ai/code/session_01MzV5fYE85XC1JwNn6deQ8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzV5fYE85XC1JwNn6deQ8R)_