### PR TITLE
refactor(cli): consolidate codex+opencode adapters, drop WatcherController

### DIFF
--- a/crates/relayburn-cli/src/harnesses/claude.rs
+++ b/crates/relayburn-cli/src/harnesses/claude.rs
@@ -34,6 +34,7 @@ use relayburn_sdk::{
 };
 
 use super::{HarnessAdapter, PlanCtx, SpawnPlan};
+use crate::util::home::home_dir;
 use crate::util::time::iso_now;
 
 /// Public unit-struct adapter for `claude`. Held as `&'static
@@ -47,10 +48,7 @@ pub static CLAUDE_ADAPTER: ClaudeAdapter = ClaudeAdapter;
 
 /// Default Claude session-store root: `$HOME/.claude/projects`.
 fn claude_projects_root() -> PathBuf {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."));
-    home.join(".claude").join("projects")
+    home_dir().join(".claude").join("projects")
 }
 
 /// Mint a v4 UUID using the current SystemTime + process id as a weak

--- a/crates/relayburn-cli/src/harnesses/codex.rs
+++ b/crates/relayburn-cli/src/harnesses/codex.rs
@@ -1,105 +1,54 @@
 //! Codex `HarnessAdapter` — Rust port of `packages/cli/src/harnesses/codex.ts`.
 //!
 //! Codex shares the pending-stamp + watch-loop shape with OpenCode, so the
-//! adapter is constructed via [`super::pending_stamp::adapter_static`]
+//! adapter is constructed via [`super::pending_stamp::session_store_adapter`]
 //! instead of re-implementing the trait. The only codex-specific bits are:
 //!
 //! * `name = "codex"` — the dispatch key and log-line label.
 //! * `session_root` — `$HOME/.codex/sessions`, resolved lazily so tests
 //!   that override `$HOME` see the override.
-//! * `ingest_sessions` — opens a fresh ledger handle and runs
-//!   [`relayburn_sdk::ingest_codex_sessions`] (the codex-only ingest pass).
-//!   The TS sibling calls `ingestCodexSessions()` directly here; the Rust
-//!   SDK function takes `&mut Ledger`, so the closure opens a handle each
-//!   call. That mirrors the TS lock-then-write-then-close shape, and the
-//!   per-tick open is cheap (SQLite WAL, no DDL after first open).
-//!
-//! The factory's [`super::pending_stamp::adapter_static`] does the
-//! `Box::leak` so the registry can store the result as
-//! `&'static dyn HarnessAdapter`. See the factory module for the leak
-//! rationale (codex/opencode are the only two callers; runtime cost is
-//! a few dozen bytes per process).
+//! * `ingest_sessions` — defers to [`relayburn_sdk::ingest_codex_sessions`],
+//!   the codex-only ingest pass. The factory opens a fresh ledger handle
+//!   per call (mirrors the TS lock-then-write-then-close shape; SQLite WAL
+//!   keeps the per-tick open cheap).
 
+use std::future::Future;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::pin::Pin;
 
-use relayburn_sdk::{ingest_codex_sessions, Ledger, LedgerOpenOptions, RawIngestOptions};
+use relayburn_sdk::{ingest_codex_sessions, IngestReport, RawIngestOptions, RawLedger};
 
-use super::pending_stamp::{self, IngestSessionsFn, PendingStampAdapter};
+use super::pending_stamp;
 use super::HarnessAdapter;
+use crate::util::home::home_dir;
 
-/// Resolve the codex session-store root. Mirrors the TS sibling
+/// `$HOME/.codex/sessions`. Mirrors the TS sibling
 /// (`path.join(homedir(), '.codex', 'sessions')`) and the SDK's internal
-/// `codex_sessions_dir` default. Resolved on every call so tests that
-/// flip `$HOME` between runs see the override.
+/// `codex_sessions_dir` default.
 fn codex_sessions_dir() -> PathBuf {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."));
-    home.join(".codex").join("sessions")
+    home_dir().join(".codex").join("sessions")
 }
 
-/// Build the [`PendingStampAdapter`] config for codex. Exposed as a
-/// constructor function (rather than a `static`) because the closure
-/// captures and the `Arc<dyn Fn>`s inside don't fit a const initializer.
-/// The registry calls this once and feeds the result to
-/// [`pending_stamp::adapter_static`].
-pub fn config() -> PendingStampAdapter {
-    let session_root: Arc<dyn Fn() -> PathBuf + Send + Sync> = Arc::new(codex_sessions_dir);
-    let ingest_sessions: IngestSessionsFn = Arc::new(|ledger_home| {
-        Box::pin(async move {
-            // Open a fresh ledger handle per tick. The TS sibling's
-            // `ingestCodexSessions` does the same via `withLock('ledger', …)`;
-            // SQLite WAL keeps the per-call open cheap. Use the same typed
-            // ledger home the pending-stamp writer used so explicit
-            // `--ledger-path` runs keep manifest writes and resolution scoped
-            // to one home.
-            let ledger_opts = match ledger_home.as_deref() {
-                Some(home) => LedgerOpenOptions::with_home(home),
-                None => LedgerOpenOptions::default(),
-            };
-            let mut handle = Ledger::open(ledger_opts)?;
-            let opts = RawIngestOptions {
-                ledger_home,
-                ..RawIngestOptions::default()
-            };
-            ingest_codex_sessions(handle.raw_mut(), &opts).await
-        })
-    });
-    PendingStampAdapter::new("codex", session_root, ingest_sessions)
+/// Box-pin the SDK's `async fn ingest_codex_sessions` into a fn pointer
+/// the [`pending_stamp::SessionIngestor`] type alias accepts.
+fn codex_ingest<'a>(
+    ledger: &'a mut RawLedger,
+    opts: &'a RawIngestOptions,
+) -> Pin<Box<dyn Future<Output = anyhow::Result<IngestReport>> + Send + 'a>> {
+    Box::pin(ingest_codex_sessions(ledger, opts))
 }
 
-/// Convenience: hand out a `&'static dyn HarnessAdapter` for the codex
-/// adapter. The registry calls this once at lazy-init time. See
-/// [`pending_stamp::adapter_static`] for the leak semantics — codex is
-/// one of two callers and the leaked footprint is bytes, not megabytes.
+/// Hand out a `&'static dyn HarnessAdapter` for codex. The registry calls
+/// this once at lazy-init time. See
+/// [`pending_stamp::session_store_adapter`] for the leak semantics.
 pub fn adapter() -> &'static dyn HarnessAdapter {
-    pending_stamp::adapter_static(config())
+    pending_stamp::session_store_adapter("codex", codex_sessions_dir, codex_ingest)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::harnesses::test_env::with_test_home;
-
-    /// `config()` returns a `PendingStampAdapter` named `codex` with the
-    /// standard 1s tick interval. Sanity check that the constructor wires
-    /// the name through the factory contract.
-    #[test]
-    fn config_has_codex_name() {
-        let cfg = config();
-        assert_eq!(cfg.name, "codex");
-        // session_root closure resolves to `$HOME/.codex/sessions`. Use a
-        // controlled $HOME so the assertion doesn't depend on the
-        // developer's actual home dir; restored after via `with_test_home`.
-        with_test_home("/tmp/burn-codex-test-home", || {
-            let resolved = (cfg.session_root)();
-            assert_eq!(
-                resolved,
-                PathBuf::from("/tmp/burn-codex-test-home/.codex/sessions")
-            );
-        });
-    }
 
     /// `adapter()` round-trips through the trait surface — name, session
     /// root, and the `&'static` lifetime the registry requires. Mirrors

--- a/crates/relayburn-cli/src/harnesses/mod.rs
+++ b/crates/relayburn-cli/src/harnesses/mod.rs
@@ -11,11 +11,12 @@
 //! 2. **`before_spawn`** — fire any pre-spawn side effect: stamp now if the
 //!    session id is known up front (claude path), or drop a pending-stamp
 //!    manifest the post-spawn ingest pass will resolve (codex / opencode).
-//! 3. **`start_watcher`** *(optional)* — return a [`WatchController`] that
-//!    drains a session-store directory while the child runs. Adapters that
-//!    ingest a single pre-known session file (claude) return `None` here;
-//!    adapters that share the pending-stamp shape (codex, opencode) wire
-//!    the watch loop through [`pending_stamp::adapter`].
+//! 3. **`start_watcher`** *(optional)* — return a [`WatchController`]
+//!    (re-exported from `relayburn_sdk`) that drains a session-store
+//!    directory while the child runs. Adapters that ingest a single
+//!    pre-known session file (claude) return `None` here; adapters that
+//!    share the pending-stamp shape (codex, opencode) wire the watch loop
+//!    through [`pending_stamp::adapter`].
 //! 4. **`after_exit`** — run a final ingest pass after the child exits and
 //!    return an [`IngestReport`] for the launcher to report.
 //! 5. The launcher itself owns step zero — collecting `cwd`, passthrough
@@ -42,7 +43,7 @@ pub mod pending_stamp;
 pub mod registry;
 
 #[cfg(test)]
-mod test_env;
+pub(crate) mod test_env;
 
 pub use registry::{list_harness_names, lookup};
 
@@ -144,7 +145,7 @@ pub trait HarnessAdapter: Send + Sync {
         Ok(())
     }
 
-    /// Optional. Return a [`WatcherController`] from
+    /// Optional. Return a [`WatchController`] from
     /// [`relayburn_sdk::start_watch_loop`] to drain a session store
     /// while the child runs; return `None` for adapters that ingest a
     /// single pre-known file at exit.
@@ -156,49 +157,13 @@ pub trait HarnessAdapter: Send + Sync {
         &self,
         _ctx: &PlanCtx,
         _on_report: relayburn_sdk::ReportSink,
-    ) -> Option<WatcherController> {
+    ) -> Option<WatchController> {
         None
     }
 
     /// Final ingest pass after the child exits. Returns an
     /// [`IngestReport`] the driver folds into its summary line.
     async fn after_exit(&self, ctx: &PlanCtx, plan: &SpawnPlan) -> anyhow::Result<IngestReport>;
-}
-
-/// Wrapper around the SDK's [`WatchController`]. Today this is just a
-/// newtype so callers don't have to import `relayburn_sdk` directly to
-/// construct or stop a watcher; tomorrow it gives us a stable boundary
-/// to attach harness-side observability (e.g. a `name`, a per-adapter
-/// metric counter) without leaking through to the SDK.
-pub struct WatcherController {
-    inner: WatchController,
-}
-
-impl WatcherController {
-    /// Wrap a raw SDK controller. `pending_stamp::adapter` is the
-    /// canonical caller; bespoke adapters that build their own watch
-    /// loop also funnel through here.
-    pub fn new(inner: WatchController) -> Self {
-        Self { inner }
-    }
-
-    /// Run a single tick on demand. Forwards to
-    /// [`WatchController::tick`].
-    pub async fn tick(&self) {
-        self.inner.tick().await;
-    }
-
-    /// Stop the periodic loop and await any in-flight tick. Idempotent.
-    /// Call this once the spawned child exits.
-    pub async fn stop(&self) {
-        self.inner.stop().await;
-    }
-
-    /// Borrow the wrapped controller for callers that need the raw
-    /// SDK type (e.g. integration tests parking on `tick_done`).
-    pub fn raw(&self) -> &WatchController {
-        &self.inner
-    }
 }
 
 #[cfg(test)]

--- a/crates/relayburn-cli/src/harnesses/opencode.rs
+++ b/crates/relayburn-cli/src/harnesses/opencode.rs
@@ -1,7 +1,7 @@
 //! OpenCode `HarnessAdapter` — Rust port of `packages/cli/src/harnesses/opencode.ts`.
 //!
 //! OpenCode shares the pending-stamp + watch-loop shape with codex, so the
-//! adapter is constructed via [`super::pending_stamp::adapter_static`]
+//! adapter is constructed via [`super::pending_stamp::session_store_adapter`]
 //! instead of re-implementing the trait. The only opencode-specific bits are:
 //!
 //! * `name = "opencode"` — the dispatch key and log-line label.
@@ -9,109 +9,53 @@
 //!   resolved lazily so tests that override `$HOME` see the override.
 //!   Mirrors the TS sibling's `path.join(homedir(), '.local', 'share',
 //!   'opencode', 'storage', 'session')` exactly.
-//! * `ingest_sessions` — opens a fresh ledger handle and runs
-//!   [`relayburn_sdk::ingest_opencode_sessions`] (the opencode-only ingest
-//!   pass). The TS sibling calls `ingestOpencodeSessions()` directly here;
-//!   the Rust SDK function takes `&mut Ledger`, so the closure opens a
-//!   handle each call. That mirrors the TS lock-then-write-then-close
-//!   shape, and the per-tick open is cheap (SQLite WAL, no DDL after first
-//!   open).
-//!
-//! The factory's [`super::pending_stamp::adapter_static`] does the
-//! `Box::leak` so the registry can store the result as
-//! `&'static dyn HarnessAdapter`. See the factory module for the leak
-//! rationale (codex/opencode are the only two callers; runtime cost is
-//! a few dozen bytes per process).
+//! * `ingest_sessions` — defers to
+//!   [`relayburn_sdk::ingest_opencode_sessions`], the opencode-only ingest
+//!   pass. The factory opens a fresh ledger handle per call (mirrors the
+//!   TS lock-then-write-then-close shape; SQLite WAL keeps the per-tick
+//!   open cheap).
 
+use std::future::Future;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::pin::Pin;
 
-use relayburn_sdk::{ingest_opencode_sessions, Ledger, LedgerOpenOptions, RawIngestOptions};
+use relayburn_sdk::{ingest_opencode_sessions, IngestReport, RawIngestOptions, RawLedger};
 
-use super::pending_stamp::{self, IngestSessionsFn, PendingStampAdapter};
+use super::pending_stamp;
 use super::HarnessAdapter;
+use crate::util::home::home_dir;
 
-/// Resolve the opencode session-store root. Mirrors the TS sibling
-/// (`path.join(homedir(), '.local', 'share', 'opencode', 'storage',
-/// 'session')`) and the SDK's internal `opencode_sessions_dir` default.
-/// Resolved on every call so tests that flip `$HOME` between runs see
-/// the override.
+/// `$HOME/.local/share/opencode/storage/session`. Mirrors the TS sibling
+/// and the SDK's internal `opencode_sessions_dir` default.
 fn opencode_sessions_dir() -> PathBuf {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."));
-    home.join(".local")
+    home_dir()
+        .join(".local")
         .join("share")
         .join("opencode")
         .join("storage")
         .join("session")
 }
 
-/// Build the [`PendingStampAdapter`] config for opencode. Exposed as a
-/// constructor function (rather than a `static`) because the closure
-/// captures and the `Arc<dyn Fn>`s inside don't fit a const initializer.
-/// The registry calls this once and feeds the result to
-/// [`pending_stamp::adapter_static`].
-pub fn config() -> PendingStampAdapter {
-    let session_root: Arc<dyn Fn() -> PathBuf + Send + Sync> = Arc::new(opencode_sessions_dir);
-    let ingest_sessions: IngestSessionsFn = Arc::new(|ledger_home| {
-        Box::pin(async move {
-            // Open a fresh ledger handle per tick. The TS sibling's
-            // `ingestOpencodeSessions` does the same via `withLock('ledger', …)`;
-            // SQLite WAL keeps the per-call open cheap. Use the same typed
-            // ledger home the pending-stamp writer used so explicit
-            // `--ledger-path` runs keep manifest writes and resolution scoped
-            // to one home.
-            let ledger_opts = match ledger_home.as_deref() {
-                Some(home) => LedgerOpenOptions::with_home(home),
-                None => LedgerOpenOptions::default(),
-            };
-            let mut handle = Ledger::open(ledger_opts)?;
-            let opts = RawIngestOptions {
-                ledger_home,
-                ..RawIngestOptions::default()
-            };
-            ingest_opencode_sessions(handle.raw_mut(), &opts).await
-        })
-    });
-    PendingStampAdapter::new("opencode", session_root, ingest_sessions)
+/// Box-pin the SDK's `async fn ingest_opencode_sessions` into a fn
+/// pointer the [`pending_stamp::SessionIngestor`] type alias accepts.
+fn opencode_ingest<'a>(
+    ledger: &'a mut RawLedger,
+    opts: &'a RawIngestOptions,
+) -> Pin<Box<dyn Future<Output = anyhow::Result<IngestReport>> + Send + 'a>> {
+    Box::pin(ingest_opencode_sessions(ledger, opts))
 }
 
-/// Convenience: hand out a `&'static dyn HarnessAdapter` for the opencode
-/// adapter. The registry calls this once at lazy-init time. See
-/// [`pending_stamp::adapter_static`] for the leak semantics — opencode is
-/// one of two callers and the leaked footprint is bytes, not megabytes.
+/// Hand out a `&'static dyn HarnessAdapter` for opencode. The registry
+/// calls this once at lazy-init time. See
+/// [`pending_stamp::session_store_adapter`] for the leak semantics.
 pub fn adapter() -> &'static dyn HarnessAdapter {
-    pending_stamp::adapter_static(config())
+    pending_stamp::session_store_adapter("opencode", opencode_sessions_dir, opencode_ingest)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::harnesses::test_env::with_test_home;
-
-    /// `config()` returns a `PendingStampAdapter` named `opencode` with
-    /// the standard 1s tick interval. Sanity check that the constructor
-    /// wires the name through the factory contract and that the
-    /// `session_root` closure resolves to the TS-mirrored path.
-    #[test]
-    fn config_has_opencode_name() {
-        let cfg = config();
-        assert_eq!(cfg.name, "opencode");
-        // session_root closure resolves to
-        // `$HOME/.local/share/opencode/storage/session`. Use a controlled
-        // $HOME so the assertion doesn't depend on the developer's actual
-        // home dir; restored after via `with_test_home`.
-        with_test_home("/tmp/burn-opencode-test-home", || {
-            let resolved = (cfg.session_root)();
-            assert_eq!(
-                resolved,
-                PathBuf::from(
-                    "/tmp/burn-opencode-test-home/.local/share/opencode/storage/session"
-                )
-            );
-        });
-    }
 
     /// `adapter()` round-trips through the trait surface — name, session
     /// root, and the `&'static` lifetime the registry requires. Mirrors
@@ -124,9 +68,7 @@ mod tests {
         with_test_home("/tmp/burn-opencode-test-home", || {
             assert_eq!(
                 a.session_root(),
-                PathBuf::from(
-                    "/tmp/burn-opencode-test-home/.local/share/opencode/storage/session"
-                )
+                PathBuf::from("/tmp/burn-opencode-test-home/.local/share/opencode/storage/session")
             );
         });
     }

--- a/crates/relayburn-cli/src/harnesses/pending_stamp.rs
+++ b/crates/relayburn-cli/src/harnesses/pending_stamp.rs
@@ -41,11 +41,12 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use relayburn_sdk::{
-    start_watch_loop, write_pending_stamp, IngestFn, IngestReport, PendingStampHarness,
-    PendingStampWriteOptions, ReportSink, StartWatchLoopOptions,
+    start_watch_loop, write_pending_stamp, IngestFn, IngestReport, Ledger, LedgerOpenOptions,
+    PendingStampHarness, PendingStampWriteOptions, RawIngestOptions, RawLedger, ReportSink,
+    StartWatchLoopOptions, WatchController,
 };
 
-use super::{HarnessAdapter, PlanCtx, SpawnPlan, WatcherController};
+use super::{HarnessAdapter, PlanCtx, SpawnPlan};
 
 /// Async ingest callback supplied by the caller. Returns the report the
 /// watch loop and `after_exit` hand back to the driver.
@@ -128,6 +129,55 @@ pub fn adapter(config: PendingStampAdapter) -> Box<dyn HarnessAdapter> {
 /// should use [`adapter`] instead.
 pub fn adapter_static(config: PendingStampAdapter) -> &'static dyn HarnessAdapter {
     Box::leak(Box::new(PendingStampAdapterImpl::new(config)))
+}
+
+/// Async fn pointer for an SDK session ingestor (`ingest_codex_sessions`,
+/// `ingest_opencode_sessions`). The shape matches both per-harness ingest
+/// passes verbatim — they live in `relayburn_sdk` as `async fn`, and the
+/// per-call `Box::pin` adaptation happens at the call site so the helper
+/// stays a fn pointer (no per-tick closure allocation).
+pub type SessionIngestor = for<'a> fn(
+    &'a mut RawLedger,
+    &'a RawIngestOptions,
+) -> Pin<Box<dyn Future<Output = anyhow::Result<IngestReport>> + Send + 'a>>;
+
+/// One-call factory for pending-stamp adapters whose only differences are
+/// the harness name, the session-root resolver, and which SDK ingest pass
+/// they call. Codex and OpenCode share the entire wrapper shape — opening
+/// a fresh ledger handle per tick, threading the active ledger home
+/// through `RawIngestOptions`, deferring to an SDK ingest function — so
+/// this helper folds that boilerplate behind a single line per harness.
+///
+/// Returns the same `&'static dyn HarnessAdapter` form as
+/// [`adapter_static`] so the result drops directly into the runtime
+/// registry. See [`adapter_static`] for the leak rationale; this helper
+/// has the same per-process bytes-not-megabytes footprint.
+pub fn session_store_adapter(
+    name: &'static str,
+    session_root: fn() -> PathBuf,
+    ingestor: SessionIngestor,
+) -> &'static dyn HarnessAdapter {
+    let session_root: Arc<dyn Fn() -> PathBuf + Send + Sync> = Arc::new(session_root);
+    let ingest_sessions: IngestSessionsFn = Arc::new(move |ledger_home| {
+        Box::pin(async move {
+            // Per-tick ledger open mirrors the TS sibling's
+            // `withLock('ledger', …)` pattern. SQLite WAL keeps the open
+            // cheap (no DDL after first open). Use the typed ledger home
+            // so explicit `--ledger-path` runs keep manifest writes and
+            // resolution scoped to the same home the writer used.
+            let ledger_opts = match ledger_home.as_deref() {
+                Some(home) => LedgerOpenOptions::with_home(home),
+                None => LedgerOpenOptions::default(),
+            };
+            let mut handle = Ledger::open(ledger_opts)?;
+            let opts = RawIngestOptions {
+                ledger_home,
+                ..RawIngestOptions::default()
+            };
+            ingestor(handle.raw_mut(), &opts).await
+        })
+    });
+    adapter_static(PendingStampAdapter::new(name, session_root, ingest_sessions))
 }
 
 /// `HarnessAdapter` implementation backing the [`adapter`] factory. Kept
@@ -227,7 +277,7 @@ impl HarnessAdapter for PendingStampAdapterImpl {
         &self,
         ctx: &PlanCtx,
         on_report: ReportSink,
-    ) -> Option<WatcherController> {
+    ) -> Option<WatchController> {
         // Match the TS adapter: do not run an immediate first tick. The
         // child has barely started; let the periodic interval drive the
         // first scan so we don't spawn an ingest pass that races the
@@ -236,7 +286,7 @@ impl HarnessAdapter for PendingStampAdapterImpl {
             .with_immediate(false)
             .with_interval(self.watch_interval)
             .with_on_report(on_report);
-        Some(WatcherController::new(start_watch_loop(opts)))
+        Some(start_watch_loop(opts))
     }
 
     async fn after_exit(&self, ctx: &PlanCtx, _plan: &SpawnPlan) -> anyhow::Result<IngestReport> {

--- a/crates/relayburn-cli/src/util/home.rs
+++ b/crates/relayburn-cli/src/util/home.rs
@@ -1,0 +1,16 @@
+//! Resolve the user's `$HOME` directory with a `.` fallback.
+//!
+//! Hoisted out of `harnesses/{claude,codex,opencode}.rs` per issue #328 —
+//! each adapter previously carried its own copy of this exact snippet.
+//! Resolved on every call so tests that flip `$HOME` between runs (see
+//! [`crate::harnesses::test_env::with_test_home`]) see the override.
+
+use std::path::PathBuf;
+
+/// Return `$HOME` as a `PathBuf`, falling back to `"."` when the env
+/// var is unset.
+pub fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}

--- a/crates/relayburn-cli/src/util/mod.rs
+++ b/crates/relayburn-cli/src/util/mod.rs
@@ -11,4 +11,5 @@
 // surface (`relayburn_cli::util::time::*`). The library crate is consumed
 // only by the in-repo binary + tests, so `pub` here is still effectively
 // crate-private from a published-API standpoint.
+pub mod home;
 pub mod time;


### PR DESCRIPTION
Closes #328.

## Summary

- Add `pending_stamp::session_store_adapter` factory that folds the session-root closure / per-tick ledger-open / `RawIngestOptions` wiring shared by codex and opencode. Each per-harness module now reduces to a session-dir resolver, a `Box::pin` adapter for the SDK `async fn` ingest, and a one-line `adapter()` constructor.
- Drop the `harnesses::WatcherController` newtype (was a pure pass-through wrapper around `relayburn_sdk::WatchController` with three forwarding methods plus an unused `raw()`); the `HarnessAdapter::start_watcher` trait method now returns `Option<WatchController>` directly.
- Hoist the triple-defined `$HOME` resolver out of `harnesses/{claude,codex,opencode}.rs` into a new `util::home::home_dir` helper.

Net: `+134 / -213` across 7 files. No behavior change — purely a structural cleanup matching the issue's proposed fix.

## Test plan

- [x] `cargo build -p relayburn-cli` (clean)
- [x] `cargo test -p relayburn-cli` (all suites pass: lib unit + golden + smoke)
- [x] `cargo clippy -p relayburn-cli --all-targets` (no new warnings on changed files; pre-existing warnings in `commands/summary.rs` untouched)
- [x] `runtime_adapter_names_match_runtime_adapters` parity test still green

https://claude.ai/code/session_016vpSmcq2sAeKUSb3tC1XY1

---
_Generated by [Claude Code](https://claude.ai/code/session_016vpSmcq2sAeKUSb3tC1XY1)_