### PR TITLE
ci(publish): refresh pnpm-lock.yaml during release bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -434,6 +434,15 @@ jobs:
           # Refresh Cargo.lock to reflect the new workspace version.
           cargo update --workspace
 
+          # Refresh pnpm-lock.yaml so the workspace specifiers + optional
+          # platform dep versions match the bumped package.json files. Without
+          # this, the lock file lags one release behind every publish run
+          # (e.g. 2.7.0 ships, but the lock still pins 2.6.1 for
+          # `@relayburn/{cli,sdk}-<short>`), and the next `pnpm install
+          # --frozen-lockfile` on `main` fails. `--lockfile-only` skips
+          # node_modules churn — we already installed dependencies above.
+          pnpm install --lockfile-only
+
       # Belt-and-suspenders alongside the precursor's heal: even if the
       # local→npm baseline was in sync there, the computed release
       # version might collide with an existing version (e.g. someone
@@ -783,6 +792,7 @@ jobs:
                   packages/relayburn/npm/*/package.json \
                   packages/sdk-node/npm/*/package.json \
                   CHANGELOG.md \
+                  pnpm-lock.yaml \
                   Cargo.toml Cargo.lock \
                   crates/relayburn-cli/Cargo.toml crates/relayburn-sdk-node/Cargo.toml
           if git diff --cached --quiet; then

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,17 +24,17 @@ importers:
   packages/relayburn:
     optionalDependencies:
       '@relayburn/cli-darwin-arm64':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
       '@relayburn/cli-darwin-x64':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
       '@relayburn/cli-linux-arm64-gnu':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
       '@relayburn/cli-linux-x64-gnu':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
 
   packages/relayburn/npm/darwin-arm64: {}
 
@@ -54,17 +54,17 @@ importers:
         version: 0.25.12
     optionalDependencies:
       '@relayburn/sdk-darwin-arm64':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
       '@relayburn/sdk-darwin-x64':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
       '@relayburn/sdk-linux-arm64-gnu':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
       '@relayburn/sdk-linux-x64-gnu':
-        specifier: 2.6.1
-        version: 2.6.1
+        specifier: 2.7.0
+        version: 2.7.0
 
   packages/sdk-node/npm/darwin-arm64: {}
 
@@ -237,54 +237,54 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@relayburn/cli-darwin-arm64@2.6.1':
-    resolution: {integrity: sha512-ocfjJa1J3M+fD50ysDFCN+f7aVM7dMSpN2WvpzmjOGkB61z+u9dzsvuszoJIvHa8ybJ1EKp6u/MKzSg+iUC5iw==}
+  '@relayburn/cli-darwin-arm64@2.7.0':
+    resolution: {integrity: sha512-1sV8hKl1uhYhVWRCBWGJmbULgdOI4+3cidTKQaXZuoVrd4QFCul7jY4dTkO130gjmmhJD8J/HKgivvTfQ5pfeQ==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-darwin-x64@2.6.1':
-    resolution: {integrity: sha512-zcnKosgN+bweP3EZKXxqoA2V4eQll968uTdF4zDAM12BNUHOWmMYiLeS9PROj6a9BLqNin0/axFxb7L9ckfTyg==}
+  '@relayburn/cli-darwin-x64@2.7.0':
+    resolution: {integrity: sha512-qZj2ukqOtPW42iHYQpQLvo0KH8OmOfg8USdpE1DPn6YgrKM+tMDN+xjgCAKHDsyRUhLcLmINApT1z3EnGjrOew==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.6.1':
-    resolution: {integrity: sha512-CBT+DpzvZEKt0/t85xGijloxvtFIwc/lIWdFVBVX21Idul1bBpXWwfuNH14B2Sf8IO7zPZ7eSz/FU8TdavbNAw==}
+  '@relayburn/cli-linux-arm64-gnu@2.7.0':
+    resolution: {integrity: sha512-2jGLTdk0hixZ6mxNYX04nRM6KltxcSyrhocLRKAXU7X+V0IQI4wwklra9Us9iosMx7/DQf1sQi91njZ5/JCnNg==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/cli-linux-x64-gnu@2.6.1':
-    resolution: {integrity: sha512-zZtfuFifX08VR2NPd+qsa0r4uCoggkB6ClhA3eiRqxe5bO3piLybtU40WzVSiUk0z+Bw6WaHMjOzXjBjoKxHSg==}
+  '@relayburn/cli-linux-x64-gnu@2.7.0':
+    resolution: {integrity: sha512-fMml1dhBd7g9KZYoru1Un4/zqkoGYynBICJpZYZ6lXO/OlGQ+YBS0Y18G3cRJDmodG4xXsV3KoQyIbuPl+H0Eg==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@relayburn/sdk-darwin-arm64@2.6.1':
-    resolution: {integrity: sha512-8cFHGhJfZhC1zaVJDBFdLdr0FMY6xx9nrrUzbRKWb/ZCGzgsjgize+Pac7H8hRJ1OZmvZOJxac0hh/oI1tj88Q==}
+  '@relayburn/sdk-darwin-arm64@2.7.0':
+    resolution: {integrity: sha512-EBSx4vpDJDCukU6CUhOMaLPbP1rmokX5NvS6sCjwt75UbD9Kmgbp3hu39D/5YgcO02ToA6maILLGnDCPSeefPw==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@relayburn/sdk-darwin-x64@2.6.1':
-    resolution: {integrity: sha512-E3e9D70F7vIJdywKX6aq/H9IKLIMmJZB07L2DTvr//wtktBPKjpR6xWQvFIl12T8YJUc53spPDjAYQkyGb3Ucw==}
+  '@relayburn/sdk-darwin-x64@2.7.0':
+    resolution: {integrity: sha512-lEleM4JjwKilDLD0gNk3H0KYASlfb1k48JqtkOxzw2qHi9XJnUE6S4TFcXsXi0ndgOHOJQtqjzCxwRgcJL3JdA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@relayburn/sdk-linux-arm64-gnu@2.6.1':
-    resolution: {integrity: sha512-xAJMT9O6QD3qejzMTPMjd1ziJfn+vdFAuQaflCR/HKXmH+2wgNUHeKe6rLF0rLIwwwF65LkrmTvGFHIcZfQF0A==}
+  '@relayburn/sdk-linux-arm64-gnu@2.7.0':
+    resolution: {integrity: sha512-2kNBgBGAThIxRNEIxjIOaUszkcrYm4QRjkQoU62I+hAzz6GLczu7IwkH+ohRbkA6djRE/NVBxEXNNTmRyRo+UA==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@relayburn/sdk-linux-x64-gnu@2.6.1':
-    resolution: {integrity: sha512-e9xqwwPVA6yMtue3GjBuAWjCvZb47xrPRLstCVhlWwYwKH1YSv0V7t2I+6wyqfA8SjdcKS3NyZ5BZcYMvIchkg==}
+  '@relayburn/sdk-linux-x64-gnu@2.7.0':
+    resolution: {integrity: sha512-xXXUdkAM0adJvLXHovUyt2GONgTtz9r78Uf+6618XQAdE7ZZJmMpCGaFDaXmMB28bMsltPAlgcV6dJmkcJX6Hg==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
@@ -387,28 +387,28 @@ snapshots:
 
   '@napi-rs/cli@2.18.4': {}
 
-  '@relayburn/cli-darwin-arm64@2.6.1':
+  '@relayburn/cli-darwin-arm64@2.7.0':
     optional: true
 
-  '@relayburn/cli-darwin-x64@2.6.1':
+  '@relayburn/cli-darwin-x64@2.7.0':
     optional: true
 
-  '@relayburn/cli-linux-arm64-gnu@2.6.1':
+  '@relayburn/cli-linux-arm64-gnu@2.7.0':
     optional: true
 
-  '@relayburn/cli-linux-x64-gnu@2.6.1':
+  '@relayburn/cli-linux-x64-gnu@2.7.0':
     optional: true
 
-  '@relayburn/sdk-darwin-arm64@2.6.1':
+  '@relayburn/sdk-darwin-arm64@2.7.0':
     optional: true
 
-  '@relayburn/sdk-darwin-x64@2.6.1':
+  '@relayburn/sdk-darwin-x64@2.7.0':
     optional: true
 
-  '@relayburn/sdk-linux-arm64-gnu@2.6.1':
+  '@relayburn/sdk-linux-arm64-gnu@2.7.0':
     optional: true
 
-  '@relayburn/sdk-linux-x64-gnu@2.6.1':
+  '@relayburn/sdk-linux-x64-gnu@2.7.0':
     optional: true
 
   '@types/node@22.19.18':


### PR DESCRIPTION
## Summary

- The publish workflow bumps every `package.json` to the lockstep release version and refreshes `Cargo.lock`, but never touched `pnpm-lock.yaml`. Since the `relayburn` and `@relayburn/sdk` umbrellas pin their per-platform `optionalDependencies` to an exact version, the lock file lagged one release behind every publish (current state: `pnpm-lock.yaml` still pinned `2.6.1` after `2.7.0` shipped).
- Add `pnpm install --lockfile-only` at the end of the "Apply release version to all packages" step (right after `cargo update --workspace`), and stage `pnpm-lock.yaml` in the release commit.
- Commit the currently-stale `pnpm-lock.yaml` (`2.6.1` → `2.7.0`) so `main` is back in agreement with the latest release and `pnpm install --frozen-lockfile` in CI stops diverging from `package.json`.

## Test plan

- [ ] CI on this branch is green (`pnpm install --frozen-lockfile` no longer drifts).
- [ ] Next dry-run publish shows `pnpm-lock.yaml` in the staged release commit's diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNJpjzCf3kNjLdrzgX4Ab6)_