### PR TITLE
ci(publish): link umbrella optionalDeps to workspace during lockfile refresh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1149,8 +1149,19 @@ jobs:
           fi
 
           # The "Commit version bumps" step runs under the same condition
-          # as this step, so a release commit is guaranteed to exist at
-          # HEAD when we get here. Amend the lockfile into it.
+          # as this step, but it no-ops if `git diff --cached --quiet` is
+          # true (e.g. the heal step already brought every package to the
+          # release version, so `npm version --allow-same-version` rewrote
+          # the files identically). In that case HEAD is some unrelated
+          # prior commit, and amending the lockfile into it would rewrite
+          # someone else's history. Guard by requiring the HEAD subject to
+          # match the release commit format ("chore(release):") that the
+          # version commit step produces; bail out cleanly otherwise.
+          HEAD_SUBJECT=$(git log -1 --format=%s)
+          if [[ "$HEAD_SUBJECT" != chore\(release\):* ]]; then
+            echo "::warning title=Skipped lockfile amend::HEAD is not a release commit (\"$HEAD_SUBJECT\") — the version bump produced no diff to commit, so there is nothing to amend the lockfile into. Skipping."
+            exit 0
+          fi
           git add pnpm-lock.yaml
           git commit --amend --no-edit
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -434,14 +434,15 @@ jobs:
           # Refresh Cargo.lock to reflect the new workspace version.
           cargo update --workspace
 
-          # Refresh pnpm-lock.yaml so the workspace specifiers + optional
-          # platform dep versions match the bumped package.json files. Without
-          # this, the lock file lags one release behind every publish run
-          # (e.g. 2.7.0 ships, but the lock still pins 2.6.1 for
-          # `@relayburn/{cli,sdk}-<short>`), and the next `pnpm install
-          # --frozen-lockfile` on `main` fails. `--lockfile-only` skips
-          # node_modules churn — we already installed dependencies above.
-          pnpm install --lockfile-only
+          # Note: pnpm-lock.yaml is refreshed AFTER the npm publish loop
+          # below — see the "Refresh pnpm-lock.yaml" step. Doing it here
+          # would fail because the umbrella optionalDeps pin exact
+          # RELEASE_VER specs against `@relayburn/{cli,sdk}-<short>`, but
+          # those versions don't exist on the npm registry yet (the
+          # "Verify new versions are not yet published" step right below
+          # explicitly asserts that). pnpm 10's default
+          # `link-workspace-packages=false` means it would try to fetch
+          # those unpublished versions from the registry and abort.
 
       # Belt-and-suspenders alongside the precursor's heal: even if the
       # local→npm baseline was in sync there, the computed release
@@ -1111,6 +1112,47 @@ jobs:
             echo "==> Publishing $TARBALL $COMMON_FLAGS"
             npm publish "$TARBALL" $COMMON_FLAGS
           done
+
+      # Refresh pnpm-lock.yaml AFTER the publish loop so the umbrella
+      # `optionalDependencies` (`@relayburn/{cli,sdk}-<short>`) resolve
+      # against the now-published RELEASE_VER tarballs on the npm
+      # registry. Doing this before publish would fail under pnpm 10's
+      # default `link-workspace-packages=false` because the new versions
+      # don't exist on the registry yet (see the comment in the "Apply
+      # release version" step above).
+      #
+      # Without this refresh, the lock file lags one release behind every
+      # publish run (e.g. 2.7.0 ships, but the lock still pins 2.6.1 for
+      # `@relayburn/{cli,sdk}-<short>`), and the next
+      # `pnpm install --frozen-lockfile` on `main` fails.
+      #
+      # The lockfile change is amended into the version commit created by
+      # the "Commit version bumps" step earlier so the release is one
+      # atomic commit on `main`. The amend is safe because nothing has
+      # been pushed yet (the "Tag + push" step below pushes both the
+      # amended commit and the tags created against it).
+      #
+      # `--lockfile-only` skips node_modules churn — we already installed
+      # dependencies near the top of the job. On dry runs there's nothing
+      # to amend (the version commit step is skipped) and there are no
+      # newly-published versions on the registry, so we skip the refresh
+      # entirely.
+      - name: Refresh pnpm-lock.yaml against published versions
+        if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.version != 'none' || github.event.inputs.custom_version != '') }}
+        run: |
+          set -euo pipefail
+          pnpm install --lockfile-only
+
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "pnpm-lock.yaml unchanged after refresh — nothing to amend."
+            exit 0
+          fi
+
+          # The "Commit version bumps" step runs under the same condition
+          # as this step, so a release commit is guaranteed to exist at
+          # HEAD when we get here. Amend the lockfile into it.
+          git add pnpm-lock.yaml
+          git commit --amend --no-edit
 
       # Annotated tags (-a) so `git push --follow-tags` actually pushes them;
       # lightweight tags are skipped by --follow-tags.


### PR DESCRIPTION
## Summary

PR #403 added `pnpm install --lockfile-only` immediately after the bump step. Under pnpm 10's default `link-workspace-packages=false`, that install tries to resolve the `relayburn` and `@relayburn/sdk` umbrellas' per-platform `optionalDependencies` (`@relayburn/{cli,sdk}-<short>`) at the new `RELEASE_VER` from the npm registry — but those versions don't exist yet. The publish loop that creates them runs later in the same job, and the "Verify new versions are not yet published" step explicitly asserts the unpublished state. The lockfile refresh therefore failed before any release could go out, blocking all real publishes.

## Fix

Move the `pnpm install --lockfile-only` to a new step that runs **after** the npm publish loop, when the new versions are live on the registry and resolve cleanly under the default `link-workspace-packages=false`. Amend the resulting lockfile diff into the version commit created earlier so the release stays one atomic commit on `main`. The amend is safe because nothing has been pushed yet — `Tag + push` runs immediately after and pushes both the amended commit and the tags created against it.

Skipped on dry runs and on `version: none` re-publishes (no release commit exists to amend, and there are no newly-published versions to resolve).

## Why not the simpler `link-workspace-packages=true` approach

A previous push on this branch tried setting `link-workspace-packages=true` in `.npmrc` so pnpm would resolve the umbrella optionalDeps to the local workspace packages and the lockfile-only step could succeed before publish. That made the publish workflow happy but broke local + CI installs: pnpm symlinked the empty workspace platform packages under `node_modules/`, which don't contain the prebuilt napi `.node` binary (that's only built and staged inside the publish workflow), so `@relayburn/sdk` failed to load its native binding and MCP tests broke. Codex Review caught the same regression independently. Reverted; this PR is now workflow-only — `.npmrc` and `pnpm-lock.yaml` are untouched.

## Test plan

- [ ] CI green on this PR (workspace install + tests should pass — change is workflow-only and doesn't affect dev/CI installs)
- [ ] On the next `Publish Packages` workflow run, the new `Refresh pnpm-lock.yaml against published versions` step succeeds after the publish loop and the resulting lockfile is amended into the release commit
- [ ] Post-merge `main` HEAD has a release commit that includes both the version bumps and a lockfile pointing at the just-published `@relayburn/{cli,sdk}-<short>@<RELEASE_VER>`
- [ ] Subsequent `pnpm install --frozen-lockfile` runs on `main` succeed (no version drift between package.json and pnpm-lock.yaml)
- [ ] Dry run of the publish workflow still passes (the new step is gated on `dry_run != 'true'`)

https://claude.ai/code/session_01U68Cv49ey4EiLvCR2cikdE