### PR TITLE
relayburn-sdk: drop reintroduced let _ block in parse_codex_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `relayburn-cli`: `burn sessions list` human output now keeps full session ids,
   shows a single human-readable last-seen date column, and truncates long
   project paths from the beginning.
-- `relayburn-sdk`: drop the `let _ = (...)` warning-silencing block at the tail
-  of `parse_codex_buffer` (re-introduced by the JSONL streaming refactor). The
-  `committed_*` snapshots are read by either the resume state or the emitted
-  records, and modern rustc no longer flags the live mirrors.
+- `relayburn-sdk`: `parse_codex_buffer` no longer carries a trailing
+  warning-silencing `let _ = (...)` tail block.
 
 ## [2.7.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `relayburn-cli`: `burn sessions list` human output now keeps full session ids,
   shows a single human-readable last-seen date column, and truncates long
   project paths from the beginning.
+- `relayburn-sdk`: drop the `let _ = (...)` warning-silencing block at the tail
+  of `parse_codex_buffer` (re-introduced by the JSONL streaming refactor). The
+  `committed_*` snapshots are read by either the resume state or the emitted
+  records, and modern rustc no longer flags the live mirrors.
 
 ## [2.7.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `relayburn-cli`: `burn sessions list` human output now keeps full session ids,
   shows a single human-readable last-seen date column, and truncates long
   project paths from the beginning.
-- `relayburn-sdk`: `parse_codex_buffer` no longer carries a trailing
-  warning-silencing `let _ = (...)` tail block.
 
 ## [2.7.0] - 2026-05-09
 

--- a/crates/relayburn-sdk/src/reader/codex.rs
+++ b/crates/relayburn-sdk/src/reader/codex.rs
@@ -1192,18 +1192,6 @@ fn parse_codex_buffer<R: BufRead>(
         }
     }
 
-    // Silence unused-mutable warnings for snapshot mirrors that are written
-    // but only read indirectly.
-    let _ = (
-        cumulative,
-        session_id,
-        session_cwd,
-        turn_contexts,
-        seen_session_meta_keys,
-        root_session_emitted,
-        last_completed_turn,
-    );
-
     Ok(ParseCodexIncrementalResult {
         turns,
         content: content_out,


### PR DESCRIPTION
## Summary

Drops the `let _ = (cumulative, session_id, …)` warning-silencer at the
tail of `parse_codex_buffer`. PR #371 had removed both `let _` blocks in
this function, but #372 (the JSONL streaming refactor) reintroduced the
larger one when it restructured the parse loop.

Audit notes (per item 3 of #346):

- Each `committed_*` mirror **is** read post-loop, either by the
  emitted records (`turns`, `events_out`, `relationships_out`,
  `tool_events_out`, `user_turns_out`) or by the `CodexResumeState`
  built for the next incremental call. The live values at function exit
  are genuinely dead.
- Modern rustc does **not** raise `unused_assignments`/`unused_mut`
  diagnostics for the live mirrors after this removal — `cargo build`
  and `cargo clippy` are both clean on `relayburn-sdk`.

Status of the other items in #346: items 2, 4, 5, 6 were resolved in
#352, and the codex/opencode parts of item 1 plus the smaller `let _`
block of item 3 were resolved in #371. The claude.rs duplicate-parser
piece of item 1 remains and is intentionally out of scope here.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all 644 sdk lib tests + workspace tests pass)
- [x] `cargo clippy -p relayburn-sdk --all-targets` produces no new warnings tied to this change

Closes part of #346.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuKouEW6rEfmDB6Ya1SdpS)_