### PR TITLE
chore(classifier): drop stale READ_ONLY_TOOLS reference comment

### DIFF
--- a/crates/relayburn-sdk/src/reader/classifier.rs
+++ b/crates/relayburn-sdk/src/reader/classifier.rs
@@ -46,12 +46,6 @@ static EDIT_TOOLS: phf::Set<&'static str> = phf_set! {
 
 static DELEGATION_TOOLS: phf::Set<&'static str> = phf_set! { "Agent", "Task" };
 
-// READ_ONLY_TOOLS lived in the TS classifier as commentary on the priority-6
-// branch, but both arms of that branch return `exploration` (see
-// `pick_category` priority 6 below), so the set is unreferenced. Tracked in
-// AgentWorkforce/burn#254 — keeping it out of the Rust port avoids a dead-code
-// warning while preserving identical behavior.
-
 /// Harness-specific tool names mapped to the canonical (Claude Code) names the
 /// rule tables are written against. Adding a new harness is a one-line change
 /// here.


### PR DESCRIPTION
## Summary

Resolves #254.

The issue asked which of three interpretations applies to the dead `READ_ONLY_TOOLS` check in the (now-removed) `packages/reader/src/classifier.ts` priority-6 branch:

1. Latent bug
2. Deliberate scaffolding
3. Truly dead

Since the entire TypeScript reader package has been removed (CLAUDE.md: "the old TypeScript 1.x implementation packages have been removed; `crates/` is the source of truth"), interpretation **(3)** is the de facto answer — the set is gone everywhere, and the Rust port at `crates/relayburn-sdk/src/reader/classifier.rs` never carried it.

This PR just removes the stale 5-line comment that referenced #254 and explained why the set was omitted from the port. With the TS gone, the comment no longer pays for itself.

No behavior change. `cargo build -p relayburn-sdk` is clean.

## Test plan

- [x] `cargo build -p relayburn-sdk` succeeds
- [ ] CI green

https://claude.ai/code/session_01Kj22tayE46FxVUCXiy3mC8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj22tayE46FxVUCXiy3mC8)_