### PR TITLE
ci(publish): repair lockfile and verify --frozen-lockfile after refresh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1165,6 +1165,23 @@ jobs:
           git add pnpm-lock.yaml
           git commit --amend --no-edit
 
+      # Sanity-check the refreshed lockfile before pushing. `pnpm install
+      # --lockfile-only` has a known regression where it can silently drop
+      # the host-platform optionalDependency entry for an umbrella that
+      # has a same-named workspace package (e.g. the linux-x64-gnu leg
+      # was dropped from `@relayburn/sdk`'s importer in the 2.7.3 release,
+      # breaking the next `pnpm install --frozen-lockfile` on main and
+      # blocking the napi-build job in the following publish run). Running
+      # `--frozen-lockfile` here surfaces that regression while we still
+      # control the refs — the amended release commit hasn't been pushed
+      # yet, so failing here aborts the tag push and keeps a broken
+      # lockfile off `main`. The npm packages are already published at
+      # this point, but that's recoverable; a broken lockfile on main
+      # blocks every downstream PR.
+      - name: Verify refreshed lockfile is consistent
+        if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.version != 'none' || github.event.inputs.custom_version != '') }}
+        run: pnpm install --frozen-lockfile
+
       # Annotated tags (-a) so `git push --follow-tags` actually pushes them;
       # lightweight tags are skipped by --follow-tags.
       #

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1180,7 +1180,28 @@ jobs:
       # blocks every downstream PR.
       - name: Verify refreshed lockfile is consistent
         if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.version != 'none' || github.event.inputs.custom_version != '') }}
-        run: pnpm install --frozen-lockfile
+        # pnpm's `--frozen-lockfile` first does the deterministic local check
+        # we care about (lockfile vs package.json specifiers), then proceeds
+        # to actually install the deps. The install half hits the npm
+        # registry, which can flake transiently right after we just pushed
+        # 11 packages to it — retry a handful of times with backoff before
+        # treating the failure as a real lockfile regression. Mirrors the
+        # sparse-index wait loop earlier in this job.
+        run: |
+          set -euo pipefail
+          attempts=6
+          for i in $(seq 1 "$attempts"); do
+            if pnpm install --frozen-lockfile; then
+              echo "frozen-lockfile check passed (attempt $i/$attempts)"
+              exit 0
+            fi
+            if [ "$i" -eq "$attempts" ]; then
+              echo "::error title=Frozen lockfile verification failed::pnpm install --frozen-lockfile failed after $attempts attempts."
+              exit 1
+            fi
+            echo "frozen-lockfile attempt $i/$attempts failed, retrying in 10s..."
+            sleep 10
+          done
 
       # Annotated tags (-a) so `git push --follow-tags` actually pushes them;
       # lightweight tags are skipped by --follow-tags.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@relayburn/sdk-linux-arm64-gnu':
         specifier: 2.7.3
         version: 2.7.3
+      '@relayburn/sdk-linux-x64-gnu':
+        specifier: 2.7.3
+        version: 2.7.3
 
   packages/sdk-node/npm/darwin-arm64: {}
 
@@ -280,6 +283,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@relayburn/sdk-linux-x64-gnu@2.7.3':
+    resolution: {integrity: sha512-Yl68EskC7ce0BVStJRpSkuvSjPDQ2kheuuoIMivyChqSVPhPDP/gy8jBKrRMNI7wN528hg8uB93LKjig3ZSnqw==}
+    engines: {node: '>=22'}
+    cpu: [x64]
+    os: [linux]
+
   '@types/node@22.19.18':
     resolution: {integrity: sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==}
 
@@ -397,6 +406,9 @@ snapshots:
     optional: true
 
   '@relayburn/sdk-linux-arm64-gnu@2.7.3':
+    optional: true
+
+  '@relayburn/sdk-linux-x64-gnu@2.7.3':
     optional: true
 
   '@types/node@22.19.18':


### PR DESCRIPTION
## Summary

The 2.7.3 release commit (`081f3cd`) silently dropped `@relayburn/sdk-linux-x64-gnu` from the `@relayburn/sdk` importer entry in `pnpm-lock.yaml`. The other three SDK platform legs and all four CLI legs were bumped cleanly to 2.7.3, but the linux-x64-gnu SDK entry was removed entirely instead of bumped — leaving the lockfile out of sync with `packages/sdk-node/package.json`'s `optionalDependencies`.

That breaks `pnpm install --frozen-lockfile` on `main`, which in turn breaks the `napi-build` matrix the next publish run gates on. All four `Build SDK napi bindings` legs of [run 25621569797](https://github.com/AgentWorkforce/burn/actions/runs/25621569797) failed at the `Install workspace deps` step with:

```
ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/packages/sdk-node/package.json

  specifiers in the lockfile don't match specifiers in package.json:
* 1 dependencies were added: @relayburn/sdk-linux-x64-gnu@2.7.3
```

This PR:

- Refreshes `pnpm-lock.yaml` against the published versions, restoring the missing `@relayburn/sdk-linux-x64-gnu@2.7.3` entry. Verified locally with `pnpm install --frozen-lockfile`.
- Adds a follow-up `pnpm install --frozen-lockfile` step after the publish workflow's lockfile refresh + amend, so if `pnpm install --lockfile-only` ever drops an importer entry again, the workflow fails before `git push --follow-tags`. The npm packages will already have shipped at that point, but the broken lockfile won't reach `main`, where it would otherwise block every subsequent CI run and the next publish.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds locally on this branch.
- [ ] PR `napi build` matrix passes (was failing on `main` for the reason above).
- [ ] PR `cli build` matrix passes.
- [ ] Other CI checks pass.

https://claude.ai/code/session_01N1uPm9zmHpdGsKgNVJDmAd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcS18xampfHPDfCNHPivrz)_