### PR TITLE
docs(comments): drop cross-project attribution in task-notification doc block

### DIFF
--- a/crates/relayburn-sdk/src/reader/classifier.rs
+++ b/crates/relayburn-sdk/src/reader/classifier.rs
@@ -1005,12 +1005,9 @@ pub fn count_retries(tool_calls: &[ToolCall]) -> u64 {
 // finishes. They share the envelope shape of queued user prompts, so a
 // text-prefix-only filter (just checking for `<task-notification>` in
 // content) would false-positive on a real user prompt that legitimately
-// types that string. Port of agent-profiler's `isTaskNotification` from
-// `lib/claude-code/trace-filters.js` — each clause AND-checks shape AND
-// purpose so legitimate prompts with the same shape but a different
-// `commandMode` / `origin.kind` survive.
-//
-// See AgentWorkforce/burn#439.
+// types that string. Each clause AND-checks shape AND purpose so
+// legitimate prompts with the same shape but a different `commandMode` /
+// `origin.kind` survive.
 // ---------------------------------------------------------------------------
 
 /// True when a raw JSONL row represents a harness-injected


### PR DESCRIPTION
Follow-up to merged PR #442.

## Summary

Strip cross-project attribution from the doc-block above `is_task_notification` in `classifier.rs`. The original text leaned on "Port of agent-profiler's `isTaskNotification` from `lib/claude-code/trace-filters.js`" — the rest of the block already explains *why* shape-AND-purpose matching matters (false-positive guard for user prompts that literally type `<task-notification>`), so the attribution sentence adds nothing a future reader needs. Also drops the trailing `See AgentWorkforce/burn#439` issue ref, since issue refs belong in PR descriptions, not source code.

Comment-only change. Zero behavior change.

## Test plan

- [x] `git grep` confirms zero remaining `agent-profiler` / `DevonPeroutky` references in `crates/` or `packages/` on this branch.
- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` — 783 passed, 0 failed, 4 ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEpNZbWEYNwxzqQjTN5LCY)_