### PR TITLE
Fix CLI release SDK dependency lockstep

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -106,10 +106,10 @@ jobs:
       - name: Lockstep Cargo.toml to release version
         # When invoked via the publish workflow, sed the workspace
         # `[workspace.package].version` (and the path-dep `version = "X.Y"`
-        # pin in `crates/relayburn-cli/Cargo.toml`) so the `burn` binary
-        # built below carries the post-bump `CARGO_PKG_VERSION`. Without
-        # this, clap's `version,` directive bakes the pre-bump version
-        # into the binary and `burn --version` reports the previous
+        # pins in crates that depend on `relayburn-sdk`) so the `burn`
+        # binary built below carries the post-bump `CARGO_PKG_VERSION`.
+        # Without this, clap's `version,` directive bakes the pre-bump
+        # version into the binary and `burn --version` reports the previous
         # release. Mirrors the regex used in publish.yml's "Lockstep the
         # Rust workspace" step that runs against the published commit.
         #
@@ -122,8 +122,10 @@ jobs:
           RUST_MINOR=$(echo "$RUST_VER" | awk -F. '{print $1"."$2}')
           echo "Rust workspace lockstep: $RUST_VER (minor pin: $RUST_MINOR)"
           sed -i.bak -E "s/^version = \"[^\"]+\"$/version = \"$RUST_VER\"/" Cargo.toml
-          sed -i.bak -E "s|(relayburn-sdk = \\{ path = \"\\.\\./relayburn-sdk\", version = \")[^\"]+(\" \\})|\\1$RUST_MINOR\\2|" crates/relayburn-cli/Cargo.toml
-          rm -f Cargo.toml.bak crates/relayburn-cli/Cargo.toml.bak
+          for crate in relayburn-cli relayburn-sdk-node; do
+            sed -i.bak -E "s|(relayburn-sdk = \\{ path = \"\\.\\./relayburn-sdk\", version = \")[^\"]+(\" \\})|\\1$RUST_MINOR\\2|" "crates/$crate/Cargo.toml"
+          done
+          rm -f Cargo.toml.bak crates/relayburn-cli/Cargo.toml.bak crates/relayburn-sdk-node/Cargo.toml.bak
 
       - name: Build burn binary for ${{ matrix.target }}
         # The binary name is `burn` (the `[[bin]]` rename in


### PR DESCRIPTION
## Summary
- update cli-build release lockstep to rewrite both Rust crates that path-depend on relayburn-sdk
- keep the cli-build workflow aligned with publish.yml so release_version builds resolve the workspace at major bumps

## Verification
- simulated the failing 3.0.0 lockstep rewrite, then ran cargo check -p relayburn-cli --bin burn
- cargo check -p relayburn-cli --bin burn