### PR TITLE
feat(cli): self-update via `burn update` + on-launch offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Added
+
+- `burn update`: upgrade to the latest release through whichever package manager installed the binary (npm or cargo); `--check` reports availability without installing.
+- On-launch update check: interactive `burn` invocations offer to install a newer release and restart, throttled to one network probe per 24h and suppressed once a version is declined.
+- `burn update toggle-auto-update [--on|--off]`: enable or disable the on-launch update check (state stored in `$RELAYBURN_HOME/update.json`).
+
 ## [3.0.0] - 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +116,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -254,6 +266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +422,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +445,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fsevent-sys"
@@ -445,6 +496,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -506,10 +568,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -646,6 +811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +851,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -852,6 +1033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +1097,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1050,6 +1246,7 @@ dependencies = [
  "phf",
  "predicates",
  "relayburn-sdk",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",
@@ -1057,6 +1254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "uuid",
 ]
 
@@ -1098,6 +1296,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1334,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1238,6 +1485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,10 +1509,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1273,13 +1538,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1369,6 +1645,16 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1489,6 +1775,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,7 +1828,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1656,6 +1984,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +2037,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1943,6 +2298,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,10 +2347,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/relayburn-cli/Cargo.toml
+++ b/crates/relayburn-cli/Cargo.toml
@@ -95,6 +95,19 @@ tokio = { workspace = true, features = ["sync", "rt", "signal"] }
 # `Map`-backed implementation does. Mirrors the SDK's own dependency.
 indexmap = { version = "2", features = ["serde"] }
 
+# `ureq` is the blocking HTTP client behind `burn update` / the on-launch
+# update check (`src/selfupdate.rs`). Picked over `reqwest` because the
+# self-update path is sync and one-shot — a tiny GET against the npm /
+# crates.io registry — so the async runtime + heavier dep tree reqwest
+# pulls in would be pure overhead. Default features bring rustls so we
+# don't take a system-OpenSSL build dependency in the CI release matrix.
+ureq = { version = "2", features = ["json"] }
+
+# Semver comparison for the update check: parse `CARGO_PKG_VERSION` and the
+# registry's reported latest, then compare. Already in the lockfile as a
+# transitive dep, so declaring it direct adds no new build cost.
+semver = "1"
+
 [dev-dependencies]
 # `assert_cmd` drives the binary in the smoke test under `tests/`.
 # `predicates` provides the matchers `assert_cmd` wants.

--- a/crates/relayburn-cli/src/cli.rs
+++ b/crates/relayburn-cli/src/cli.rs
@@ -134,7 +134,7 @@ pub enum Command {
 #[derive(Debug, Clone, ClapArgs)]
 pub struct UpdateArgs {
     /// Report whether a newer release exists, but install nothing.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "force")]
     pub check: bool,
 
     /// Reinstall the latest release even if already up to date.

--- a/crates/relayburn-cli/src/cli.rs
+++ b/crates/relayburn-cli/src/cli.rs
@@ -120,6 +120,50 @@ pub enum Command {
     /// in-session self-query.
     #[command(name = "mcp-server")]
     McpServer(McpServerArgs),
+
+    /// Check for, install, or configure `burn` self-updates.
+    Update(UpdateArgs),
+}
+
+/// Per-command flags for `burn update`.
+///
+/// Bare `burn update` upgrades to the latest published release through
+/// whichever package manager installed the binary (npm or cargo). The
+/// `toggle-auto-update` subcommand flips the on-launch update check that
+/// every other command runs.
+#[derive(Debug, Clone, ClapArgs)]
+pub struct UpdateArgs {
+    /// Report whether a newer release exists, but install nothing.
+    #[arg(long)]
+    pub check: bool,
+
+    /// Reinstall the latest release even if already up to date.
+    #[arg(long)]
+    pub force: bool,
+
+    #[command(subcommand)]
+    pub action: Option<UpdateAction>,
+}
+
+/// Nested subcommand for `burn update`.
+#[derive(Debug, Clone, Subcommand)]
+pub enum UpdateAction {
+    /// Turn the on-launch update check on or off (bare form flips it).
+    #[command(name = "toggle-auto-update")]
+    ToggleAutoUpdate(ToggleAutoUpdateArgs),
+}
+
+/// `burn update toggle-auto-update` flags. With neither `--on` nor
+/// `--off`, the current setting is flipped.
+#[derive(Debug, Clone, ClapArgs)]
+pub struct ToggleAutoUpdateArgs {
+    /// Force the on-launch check on.
+    #[arg(long, conflicts_with = "off")]
+    pub on: bool,
+
+    /// Force the on-launch check off.
+    #[arg(long)]
+    pub off: bool,
 }
 
 /// Per-command flags for `burn ingest`. Mirrors the TS surface in

--- a/crates/relayburn-cli/src/commands/mod.rs
+++ b/crates/relayburn-cli/src/commands/mod.rs
@@ -28,3 +28,4 @@ pub mod sessions;
 pub mod stamps;
 pub mod state;
 pub mod summary;
+pub mod update;

--- a/crates/relayburn-cli/src/commands/update.rs
+++ b/crates/relayburn-cli/src/commands/update.rs
@@ -47,6 +47,14 @@ fn run_update(globals: &GlobalArgs, check_only: bool, force: bool) -> i32 {
     let channel = selfupdate::detect_channel();
     let current = selfupdate::current_version();
 
+    // Without a known install channel we can neither pick a registry to
+    // query nor an installer to run, so bail before the network probe with
+    // the manual commands rather than a cryptic request error. Covers both
+    // `--check` and the install path.
+    if channel == Channel::Unknown {
+        return report_error(&unknown_channel_error(), globals);
+    }
+
     let latest = match selfupdate::fetch_latest(channel, MANUAL_TIMEOUT) {
         Ok(v) => v,
         Err(err) => return report_error(&err, globals),
@@ -83,16 +91,6 @@ fn run_update(globals: &GlobalArgs, check_only: bool, force: bool) -> i32 {
     if !available && !force {
         ux::print_success(&format!("burn is already up to date ({current})."), globals);
         return 0;
-    }
-
-    if channel == Channel::Unknown {
-        return report_error(
-            &anyhow::anyhow!(
-                "can't tell how `burn` was installed; upgrade manually with \
-                 `npm install -g relayburn@latest` or `cargo install relayburn-cli --force`"
-            ),
-            globals,
-        );
     }
 
     match selfupdate::perform_install(globals, channel) {
@@ -138,6 +136,15 @@ fn run_toggle(globals: &GlobalArgs, toggle: ToggleAutoUpdateArgs) -> i32 {
         );
     }
     0
+}
+
+/// Shared "we don't know how this was installed" guidance for the
+/// `Channel::Unknown` path.
+fn unknown_channel_error() -> anyhow::Error {
+    anyhow::anyhow!(
+        "can't tell how `burn` was installed; upgrade manually with \
+         `npm install -g relayburn@latest` or `cargo install relayburn-cli --force`"
+    )
 }
 
 fn print_json(value: &serde_json::Value) -> std::io::Result<()> {

--- a/crates/relayburn-cli/src/commands/update.rs
+++ b/crates/relayburn-cli/src/commands/update.rs
@@ -24,9 +24,22 @@ use crate::selfupdate::{self, Channel, UpdateState};
 const MANUAL_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub fn run(globals: &GlobalArgs, args: UpdateArgs) -> i32 {
-    match args.action {
+    let UpdateArgs {
+        check,
+        force,
+        action,
+    } = args;
+
+    match action {
+        Some(_) if check || force => report_error(
+            &anyhow::anyhow!(
+                "`burn update --check` and `burn update --force` cannot be combined \
+                 with a subcommand"
+            ),
+            globals,
+        ),
         Some(UpdateAction::ToggleAutoUpdate(toggle)) => run_toggle(globals, toggle),
-        None => run_update(globals, args.check, args.force),
+        None => run_update(globals, check, force),
     }
 }
 

--- a/crates/relayburn-cli/src/commands/update.rs
+++ b/crates/relayburn-cli/src/commands/update.rs
@@ -1,0 +1,142 @@
+//! `burn update` — manual upgrade + auto-update toggle.
+//!
+//! Three shapes, all thin presenters over [`crate::selfupdate`]:
+//!
+//! - `burn update`                     — upgrade to the latest release.
+//! - `burn update --check`             — report availability, install nothing.
+//! - `burn update toggle-auto-update`  — flip the on-launch check on/off.
+//!
+//! The heavy lifting (channel detection, registry query, package-manager
+//! shell-out, on-disk state) lives in [`crate::selfupdate`]; this file
+//! only maps CLI flags onto those calls and renders the result.
+
+use std::time::Duration;
+
+use serde_json::json;
+
+use crate::cli::{GlobalArgs, ToggleAutoUpdateArgs, UpdateAction, UpdateArgs};
+use crate::render::error::report_error;
+use crate::render::ux;
+use crate::selfupdate::{self, Channel, UpdateState};
+
+/// Network budget for the manual path. Longer than the on-launch probe —
+/// the user explicitly asked, so it's fine to wait a beat.
+const MANUAL_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn run(globals: &GlobalArgs, args: UpdateArgs) -> i32 {
+    match args.action {
+        Some(UpdateAction::ToggleAutoUpdate(toggle)) => run_toggle(globals, toggle),
+        None => run_update(globals, args.check, args.force),
+    }
+}
+
+fn run_update(globals: &GlobalArgs, check_only: bool, force: bool) -> i32 {
+    let channel = selfupdate::detect_channel();
+    let current = selfupdate::current_version();
+
+    let latest = match selfupdate::fetch_latest(channel, MANUAL_TIMEOUT) {
+        Ok(v) => v,
+        Err(err) => return report_error(&err, globals),
+    };
+
+    // Refresh cached state so the on-launch path benefits from this probe.
+    let home = selfupdate::home_dir(globals);
+    let mut state = UpdateState::load(&home);
+    state.last_check = now_unix();
+    state.latest_known = Some(latest.to_string());
+    let _ = state.save(&home);
+
+    let available = latest > current;
+
+    if check_only {
+        if globals.json {
+            let _ = print_json(&json!({
+                "current": current.to_string(),
+                "latest": latest.to_string(),
+                "updateAvailable": available,
+                "channel": channel.label(),
+            }));
+        } else if available {
+            ux::print_info(
+                &format!("Update available: {current} → {latest} (install with `burn update`)."),
+                globals,
+            );
+        } else {
+            ux::print_success(&format!("burn is up to date ({current})."), globals);
+        }
+        return 0;
+    }
+
+    if !available && !force {
+        ux::print_success(&format!("burn is already up to date ({current})."), globals);
+        return 0;
+    }
+
+    if channel == Channel::Unknown {
+        return report_error(
+            &anyhow::anyhow!(
+                "can't tell how `burn` was installed; upgrade manually with \
+                 `npm install -g relayburn@latest` or `cargo install relayburn-cli --force`"
+            ),
+            globals,
+        );
+    }
+
+    match selfupdate::perform_install(globals, channel) {
+        Ok(()) => {
+            // Clear any earlier on-launch decline now that we're current.
+            state.declined_version = None;
+            let _ = state.save(&home);
+            ux::print_success(&format!("Updated to burn {latest}."), globals);
+            0
+        }
+        Err(err) => report_error(&err, globals),
+    }
+}
+
+fn run_toggle(globals: &GlobalArgs, toggle: ToggleAutoUpdateArgs) -> i32 {
+    let home = selfupdate::home_dir(globals);
+    let mut state = UpdateState::load(&home);
+
+    // `--on` / `--off` set explicitly; bare `toggle-auto-update` flips.
+    state.auto_update = if toggle.on {
+        true
+    } else if toggle.off {
+        false
+    } else {
+        !state.auto_update
+    };
+
+    if let Err(err) = state.save(&home) {
+        return report_error(&err, globals);
+    }
+
+    if globals.json {
+        let _ = print_json(&json!({ "autoUpdate": state.auto_update }));
+    } else if state.auto_update {
+        ux::print_success(
+            "Auto-update is ON. burn will offer to upgrade itself on launch.",
+            globals,
+        );
+    } else {
+        ux::print_success(
+            "Auto-update is OFF. Run `burn update` to upgrade manually.",
+            globals,
+        );
+    }
+    0
+}
+
+fn print_json(value: &serde_json::Value) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut out = std::io::stdout().lock();
+    serde_json::to_writer(&mut out, value).map_err(std::io::Error::other)?;
+    out.write_all(b"\n")
+}
+
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/crates/relayburn-cli/src/main.rs
+++ b/crates/relayburn-cli/src/main.rs
@@ -13,6 +13,7 @@
 mod cli;
 mod commands;
 mod render;
+mod selfupdate;
 
 use clap::Parser;
 
@@ -37,6 +38,15 @@ fn dispatch(args: Args) -> i32 {
         no_color = globals.no_color,
         "dispatching command"
     );
+    // On-launch self-update offer. Skipped for `update` itself (it owns
+    // the upgrade flow) and `mcp-server` (a stdio protocol channel that a
+    // prompt would corrupt). The check is otherwise best-effort and
+    // silently no-ops in non-interactive / `--json` / disabled cases — see
+    // `selfupdate::maybe_offer_update`. On accept it installs and re-execs,
+    // so it may not return.
+    if offer_update_for(&args.command) {
+        selfupdate::maybe_offer_update(&globals);
+    }
     match args.command {
         Command::Summary(sub) => commands::summary::run(&globals, sub),
         Command::Hotspots(sub) => commands::hotspots::run(&globals, sub),
@@ -48,7 +58,15 @@ fn dispatch(args: Args) -> i32 {
         Command::Stamps(args) => commands::stamps::run(&globals, args),
         Command::Ingest(args) => commands::ingest::run(&globals, args),
         Command::McpServer(args) => commands::mcp_server::run(&globals, args),
+        Command::Update(args) => commands::update::run(&globals, args),
     }
+}
+
+/// Whether the on-launch update check should run for this command. The
+/// `update` command drives upgrades itself, and `mcp-server` speaks a
+/// machine protocol on stdio where an interactive prompt has no place.
+fn offer_update_for(command: &Command) -> bool {
+    !matches!(command, Command::Update(_) | Command::McpServer(_))
 }
 
 fn command_name(command: &Command) -> &'static str {
@@ -63,5 +81,6 @@ fn command_name(command: &Command) -> &'static str {
         Command::Stamps(_) => "stamps",
         Command::Ingest(_) => "ingest",
         Command::McpServer(_) => "mcp-server",
+        Command::Update(_) => "update",
     }
 }

--- a/crates/relayburn-cli/src/selfupdate.rs
+++ b/crates/relayburn-cli/src/selfupdate.rs
@@ -188,7 +188,16 @@ pub fn detect_channel() -> Channel {
         }
     }
     match std::env::current_exe() {
-        Ok(exe) => channel_from_path(&exe.to_string_lossy()),
+        Ok(exe) => {
+            // A custom `$CARGO_HOME` relocates cargo-installed binaries out
+            // of `~/.cargo/bin`, which the path heuristic below would miss.
+            if let Ok(cargo_home) = std::env::var("CARGO_HOME") {
+                if !cargo_home.is_empty() && exe.starts_with(&cargo_home) {
+                    return Channel::Cargo;
+                }
+            }
+            channel_from_path(&exe.to_string_lossy())
+        }
         Err(_) => Channel::Unknown,
     }
 }
@@ -291,10 +300,13 @@ pub fn maybe_offer_update(globals: &GlobalArgs) {
     if std::env::var_os(SKIP_ENV).is_some() {
         return;
     }
-    // No prompts in machine-readable mode or when not attached to a
-    // terminal we can both read from and draw on.
+    // No prompts in machine-readable mode or when any of our standard
+    // streams isn't a terminal: a piped stdout (`burn summary | cat`) means
+    // the user isn't watching an interactive session, so we must not block
+    // on a prompt.
     if globals.json
         || !io::stdin().is_terminal()
+        || !io::stdout().is_terminal()
         || !io::stderr().is_terminal()
         || ux::term_is_dumb()
     {
@@ -375,7 +387,11 @@ pub fn maybe_offer_update(globals: &GlobalArgs) {
 /// any state change. Returns `None` when nothing usable is known.
 fn resolve_latest(channel: Channel, home: &Path, state: &mut UpdateState) -> Option<Version> {
     let now = now_unix();
-    if now - state.last_check < CHECK_INTERVAL_SECS {
+    // Clock skew or a hand-edited `last_check` in the future would
+    // otherwise suppress probes until wall-clock time caught up; treat a
+    // future stamp as "due now".
+    let within_window = state.last_check <= now && now - state.last_check < CHECK_INTERVAL_SECS;
+    if within_window {
         return state
             .latest_known
             .as_deref()
@@ -399,11 +415,10 @@ fn resolve_latest(channel: Channel, home: &Path, state: &mut UpdateState) -> Opt
 
 /// Re-launch the (now updated) binary with the original arguments,
 /// replacing the current process on Unix. Only returns on failure.
-fn reexec() -> io::Error {
-    let exe = match std::env::current_exe() {
-        Ok(e) => e,
-        Err(e) => return e,
-    };
+///
+/// `exe` must be resolved *before* the installer runs — see
+/// [`maybe_offer_update`] for why.
+fn reexec(exe: PathBuf) -> io::Error {
     let args: Vec<OsString> = std::env::args_os().skip(1).collect();
 
     #[cfg(unix)]

--- a/crates/relayburn-cli/src/selfupdate.rs
+++ b/crates/relayburn-cli/src/selfupdate.rs
@@ -322,8 +322,9 @@ pub fn maybe_offer_update(globals: &GlobalArgs) {
     if latest <= current {
         return;
     }
+    let latest_label = latest.to_string();
     // Already said no to exactly this version — wait for the next release.
-    if state.declined_version.as_deref() == Some(latest.to_string().as_str()) {
+    if state.declined_version.as_deref() == Some(latest_label.as_str()) {
         return;
     }
 
@@ -332,7 +333,7 @@ pub fn maybe_offer_update(globals: &GlobalArgs) {
     match prompt::confirm(globals, &question, true) {
         Ok(true) => {}
         Ok(false) => {
-            state.declined_version = Some(latest.to_string());
+            state.declined_version = Some(latest_label.clone());
             let _ = state.save(&home);
             ux::print_info(
                 "Staying on the current version. I'll ask again on the next release — or run `burn update` anytime.",
@@ -347,7 +348,7 @@ pub fn maybe_offer_update(globals: &GlobalArgs) {
 
     match perform_install(globals, channel) {
         Ok(()) => {
-            state.latest_known = Some(latest.to_string());
+            state.latest_known = Some(latest_label);
             state.declined_version = None;
             let _ = state.save(&home);
             ux::print_success(&format!("Updated to burn {latest}. Restarting…"), globals);

--- a/crates/relayburn-cli/src/selfupdate.rs
+++ b/crates/relayburn-cli/src/selfupdate.rs
@@ -358,15 +358,25 @@ pub fn maybe_offer_update(globals: &GlobalArgs) {
         Err(_) => return,
     }
 
+    // Resolve our own path BEFORE the installer runs. npm/cargo replace the
+    // binary by unlinking + rewriting at the same path; afterwards Linux can
+    // resolve `current_exe()` to the now-deleted inode (a `…/burn (deleted)`
+    // path), which would make the restart fail even though the new binary is
+    // sitting right there.
+    let exe = std::env::current_exe();
+
     match perform_install(globals, channel) {
         Ok(()) => {
             state.latest_known = Some(latest_label);
             state.declined_version = None;
             let _ = state.save(&home);
             ux::print_success(&format!("Updated to burn {latest}. Restarting…"), globals);
-            // On success this replaces the process and never returns; if
-            // it does return, the re-exec failed and we fall through.
-            let err = reexec();
+            // On success the re-exec replaces the process and never returns;
+            // if it does return, the restart failed and we fall through.
+            let err = match exe {
+                Ok(exe) => reexec(exe),
+                Err(e) => e,
+            };
             ux::print_warning(
                 &format!(
                     "Couldn't restart automatically ({err}). Re-run your command to use {latest}."

--- a/crates/relayburn-cli/src/selfupdate.rs
+++ b/crates/relayburn-cli/src/selfupdate.rs
@@ -1,0 +1,528 @@
+//! Self-update for the `burn` binary.
+//!
+//! Two entry points:
+//!
+//! - [`maybe_offer_update`] — the on-launch check. Called from
+//!   `main::dispatch` for every interactive command except `update`
+//!   itself and `mcp-server`. Throttled to one network probe per
+//!   [`CHECK_INTERVAL_SECS`]; when a newer release exists it prompts the
+//!   user to install + restart, and remembers a declined version so it
+//!   doesn't nag again until the next release.
+//! - the helpers under `burn update` ([`fetch_latest`], [`perform_install`],
+//!   [`UpdateState`], [`detect_channel`]) — the manual upgrade path.
+//!
+//! `burn` ships through two channels (see `CLAUDE.md`): prebuilt npm
+//! platform packages (`@relayburn/cli-<platform>`, driven by the
+//! `relayburn` umbrella) and `cargo install relayburn-cli` from
+//! crates.io. The installer shells out to whichever package manager owns
+//! the running binary so npm's / cargo's bookkeeping stays consistent —
+//! we never blind-overwrite a binary another tool manages. When the
+//! channel can't be determined (a hand-copied binary, a dev build) the
+//! update path declines to act and points the user at the manual
+//! commands instead.
+//!
+//! All update state lives in `$RELAYBURN_HOME/update.json`, separate from
+//! the SDK's `config.json`, so the SDK's on-disk config schema doesn't
+//! grow a CLI-only concern.
+
+#![allow(dead_code)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, IsTerminal};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::cli::GlobalArgs;
+use crate::render::{prompt, ux};
+
+/// Minimum gap between network probes for the on-launch check. The
+/// manual `burn update` path ignores this and always hits the network.
+const CHECK_INTERVAL_SECS: i64 = 24 * 60 * 60;
+
+/// User-Agent sent with registry requests. crates.io rejects requests
+/// without one, and it gives both registries a way to attribute traffic.
+const USER_AGENT: &str = concat!(
+    "relayburn-cli/",
+    env!("CARGO_PKG_VERSION"),
+    " (+https://github.com/AgentWorkforce/burn)"
+);
+
+/// Set on a re-exec'd process so the freshly-installed binary doesn't run
+/// the on-launch check again and risk an update loop.
+const SKIP_ENV: &str = "RELAYBURN_SKIP_UPDATE_CHECK";
+
+/// Explicit channel hint. The npm wrapper (`packages/relayburn/bin/burn.js`)
+/// sets this to `npm` before exec'ing the binary; everything else falls
+/// back to path-based detection.
+const CHANNEL_ENV: &str = "RELAYBURN_INSTALL_CHANNEL";
+
+/// How the running `burn` was installed — determines which package
+/// manager `perform_install` drives and which registry `fetch_latest`
+/// queries for the latest version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    /// Installed via `npm i -g relayburn` (prebuilt platform package).
+    Npm,
+    /// Installed via `cargo install relayburn-cli`.
+    Cargo,
+    /// Hand-copied binary / dev build — no owning package manager.
+    Unknown,
+}
+
+impl Channel {
+    pub fn label(self) -> &'static str {
+        match self {
+            Channel::Npm => "npm",
+            Channel::Cargo => "cargo",
+            Channel::Unknown => "unknown",
+        }
+    }
+
+    /// The command a user would run to upgrade by hand on this channel.
+    fn manual_hint(self) -> &'static str {
+        match self {
+            Channel::Npm => "npm install -g relayburn@latest",
+            Channel::Cargo => "cargo install relayburn-cli --force",
+            Channel::Unknown => {
+                "reinstall from your package manager (npm i -g relayburn@latest, or cargo install relayburn-cli --force)"
+            }
+        }
+    }
+}
+
+/// Persisted update state at `$RELAYBURN_HOME/update.json`.
+///
+/// Every field is optional / defaulted so a missing or partially-written
+/// file degrades to "auto-update on, never checked" rather than erroring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateState {
+    /// Whether the on-launch check runs. Toggled by
+    /// `burn update toggle-auto-update`. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub auto_update: bool,
+    /// Unix seconds of the last network probe (throttling anchor).
+    #[serde(default)]
+    pub last_check: i64,
+    /// Latest version seen at `last_check`, cached so checks inside the
+    /// throttle window don't re-hit the network.
+    #[serde(default)]
+    pub latest_known: Option<String>,
+    /// Version the user said "no" to on launch. Suppresses re-prompting
+    /// until a newer release supersedes it.
+    #[serde(default)]
+    pub declined_version: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for UpdateState {
+    fn default() -> Self {
+        Self {
+            auto_update: true,
+            last_check: 0,
+            latest_known: None,
+            declined_version: None,
+        }
+    }
+}
+
+impl UpdateState {
+    /// Load state from `<home>/update.json`. A missing or unparseable
+    /// file yields [`UpdateState::default`] — the update path is
+    /// best-effort and never blocks a command over its own state file.
+    pub fn load(home: &Path) -> Self {
+        let path = state_path(home);
+        match fs::read_to_string(&path) {
+            Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Persist state to `<home>/update.json`, creating the home dir if
+    /// needed.
+    pub fn save(&self, home: &Path) -> io::Result<()> {
+        fs::create_dir_all(home)?;
+        let path = state_path(home);
+        let body = serde_json::to_string_pretty(self).map_err(io::Error::other)?;
+        fs::write(path, body)
+    }
+}
+
+fn state_path(home: &Path) -> PathBuf {
+    home.join("update.json")
+}
+
+/// Resolve the relayburn home dir, honoring the global `--ledger-path`
+/// override and otherwise deferring to the SDK's env / default resolution.
+pub fn home_dir(globals: &GlobalArgs) -> PathBuf {
+    globals
+        .ledger_path
+        .clone()
+        .unwrap_or_else(relayburn_sdk::ledger_home)
+}
+
+/// The compiled-in version of the running binary.
+pub fn current_version() -> Version {
+    // CARGO_PKG_VERSION is always valid semver — a parse failure here
+    // would be a build-time bug, so an explicit panic message is clearer
+    // than a soft fallback that would silently disable updates.
+    Version::parse(env!("CARGO_PKG_VERSION")).expect("CARGO_PKG_VERSION is valid semver")
+}
+
+/// Determine the install channel. Prefers the explicit [`CHANNEL_ENV`]
+/// hint (set by the npm wrapper), then falls back to inspecting the
+/// running executable's path.
+pub fn detect_channel() -> Channel {
+    if let Ok(hint) = std::env::var(CHANNEL_ENV) {
+        match hint.as_str() {
+            "npm" => return Channel::Npm,
+            "cargo" => return Channel::Cargo,
+            _ => {}
+        }
+    }
+    match std::env::current_exe() {
+        Ok(exe) => channel_from_path(&exe.to_string_lossy()),
+        Err(_) => Channel::Unknown,
+    }
+}
+
+/// Path-based channel heuristic, split out for testability.
+fn channel_from_path(path: &str) -> Channel {
+    // npm global installs land the platform binary under a
+    // `@relayburn/cli-<platform>` package inside a `node_modules` tree.
+    if path.contains("node_modules") && path.contains("@relayburn") {
+        return Channel::Npm;
+    }
+    // `cargo install` drops binaries in `$CARGO_HOME/bin` (default
+    // `~/.cargo/bin`).
+    if path.contains(".cargo") {
+        return Channel::Cargo;
+    }
+    Channel::Unknown
+}
+
+/// Fetch the latest published version from the registry that backs
+/// `channel`. Short timeouts keep the on-launch path from ever hanging
+/// the user's actual command.
+pub fn fetch_latest(channel: Channel, read_timeout: Duration) -> anyhow::Result<Version> {
+    let url = match channel {
+        Channel::Npm => "https://registry.npmjs.org/relayburn/latest",
+        Channel::Cargo => "https://crates.io/api/v1/crates/relayburn-cli",
+        Channel::Unknown => anyhow::bail!("cannot determine how `burn` was installed"),
+    };
+
+    let agent = ureq::builder()
+        .timeout_connect(Duration::from_secs(3))
+        .timeout_read(read_timeout)
+        .user_agent(USER_AGENT)
+        .build();
+
+    let body: serde_json::Value = agent
+        .get(url)
+        .call()
+        .map_err(|e| anyhow::anyhow!("update check request failed: {e}"))?
+        .into_json()
+        .map_err(|e| anyhow::anyhow!("update check response was not valid JSON: {e}"))?;
+
+    extract_version(channel, &body)
+}
+
+/// Pull the version string out of a registry response and parse it.
+/// Separated from the network call so it can be unit-tested with canned
+/// JSON.
+fn extract_version(channel: Channel, body: &serde_json::Value) -> anyhow::Result<Version> {
+    let raw = match channel {
+        // npm `/<pkg>/latest` returns the latest manifest with a
+        // top-level `version`.
+        Channel::Npm => body.get("version").and_then(|v| v.as_str()),
+        // crates.io returns `{ "crate": { "max_stable_version": ... } }`.
+        Channel::Cargo => body
+            .get("crate")
+            .and_then(|c| c.get("max_stable_version"))
+            .and_then(|v| v.as_str()),
+        Channel::Unknown => None,
+    };
+    let raw =
+        raw.ok_or_else(|| anyhow::anyhow!("registry response was missing a version field"))?;
+    Version::parse(raw.trim())
+        .map_err(|e| anyhow::anyhow!("registry returned an unparseable version `{raw}`: {e}"))
+}
+
+/// Run the package-manager command that upgrades `burn` in place. Inherits
+/// stdio so the user sees npm/cargo progress. Returns an error (rather
+/// than panicking) so callers can fall back to manual instructions.
+pub fn perform_install(globals: &GlobalArgs, channel: Channel) -> anyhow::Result<()> {
+    let (program, args): (&str, &[&str]) = match channel {
+        Channel::Npm => ("npm", &["install", "-g", "relayburn@latest"]),
+        Channel::Cargo => ("cargo", &["install", "relayburn-cli", "--force"]),
+        Channel::Unknown => {
+            anyhow::bail!(
+                "can't tell how `burn` was installed; upgrade manually: {}",
+                Channel::Unknown.manual_hint()
+            )
+        }
+    };
+
+    ux::print_info(&format!("Running `{program} {}`…", args.join(" ")), globals);
+
+    let status = Command::new(program)
+        .args(args)
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to launch `{program}` (is it on your PATH?): {e}"))?;
+
+    if !status.success() {
+        anyhow::bail!("`{program}` exited with {status}");
+    }
+    Ok(())
+}
+
+/// The on-launch update check. Best-effort and silent on every failure
+/// path — it must never get in the way of the command the user actually
+/// typed.
+pub fn maybe_offer_update(globals: &GlobalArgs) {
+    // Re-exec guard: a freshly-installed binary skips the check.
+    if std::env::var_os(SKIP_ENV).is_some() {
+        return;
+    }
+    // No prompts in machine-readable mode or when not attached to a
+    // terminal we can both read from and draw on.
+    if globals.json
+        || !io::stdin().is_terminal()
+        || !io::stderr().is_terminal()
+        || ux::term_is_dumb()
+    {
+        return;
+    }
+
+    let channel = detect_channel();
+    // Nothing we can offer to install — don't probe or prompt.
+    if channel == Channel::Unknown {
+        return;
+    }
+
+    let home = home_dir(globals);
+    let mut state = UpdateState::load(&home);
+    if !state.auto_update {
+        return;
+    }
+
+    let current = current_version();
+    let latest = match resolve_latest(channel, &home, &mut state) {
+        Some(v) => v,
+        None => return,
+    };
+
+    if latest <= current {
+        return;
+    }
+    // Already said no to exactly this version — wait for the next release.
+    if state.declined_version.as_deref() == Some(latest.to_string().as_str()) {
+        return;
+    }
+
+    let question =
+        format!("A new burn is available: {current} → {latest}. Update and restart now?");
+    match prompt::confirm(globals, &question, true) {
+        Ok(true) => {}
+        Ok(false) => {
+            state.declined_version = Some(latest.to_string());
+            let _ = state.save(&home);
+            ux::print_info(
+                "Staying on the current version. I'll ask again on the next release — or run `burn update` anytime.",
+                globals,
+            );
+            return;
+        }
+        // Interrupted (Ctrl-C) or prompt I/O error: don't record a
+        // decline, just continue — we'll ask again next launch.
+        Err(_) => return,
+    }
+
+    match perform_install(globals, channel) {
+        Ok(()) => {
+            state.latest_known = Some(latest.to_string());
+            state.declined_version = None;
+            let _ = state.save(&home);
+            ux::print_success(&format!("Updated to burn {latest}. Restarting…"), globals);
+            // On success this replaces the process and never returns; if
+            // it does return, the re-exec failed and we fall through.
+            let err = reexec();
+            ux::print_warning(
+                &format!(
+                    "Couldn't restart automatically ({err}). Re-run your command to use {latest}."
+                ),
+                globals,
+            );
+        }
+        Err(e) => {
+            ux::print_error(&format!("Update failed: {e}"), globals);
+        }
+    }
+}
+
+/// Resolve the latest version for the on-launch path, honoring the
+/// throttle window. Inside the window we trust the cached `latest_known`;
+/// outside it we probe the network and update `last_check` (even on
+/// failure, so a flaky network doesn't probe on every launch). Persists
+/// any state change. Returns `None` when nothing usable is known.
+fn resolve_latest(channel: Channel, home: &Path, state: &mut UpdateState) -> Option<Version> {
+    let now = now_unix();
+    if now - state.last_check < CHECK_INTERVAL_SECS {
+        return state
+            .latest_known
+            .as_deref()
+            .and_then(|s| Version::parse(s).ok());
+    }
+
+    match fetch_latest(channel, Duration::from_secs(4)) {
+        Ok(v) => {
+            state.last_check = now;
+            state.latest_known = Some(v.to_string());
+            let _ = state.save(home);
+            Some(v)
+        }
+        Err(_) => {
+            state.last_check = now;
+            let _ = state.save(home);
+            None
+        }
+    }
+}
+
+/// Re-launch the (now updated) binary with the original arguments,
+/// replacing the current process on Unix. Only returns on failure.
+fn reexec() -> io::Error {
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(e) => return e,
+    };
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // `exec` only returns if it fails to replace the image.
+        Command::new(exe).args(args).env(SKIP_ENV, "1").exec()
+    }
+
+    #[cfg(not(unix))]
+    {
+        match Command::new(exe).args(args).env(SKIP_ENV, "1").status() {
+            Ok(status) => std::process::exit(status.code().unwrap_or(0)),
+            Err(e) => e,
+        }
+    }
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn channel_from_path_recognizes_npm() {
+        assert_eq!(
+            channel_from_path("/usr/local/lib/node_modules/@relayburn/cli-darwin-arm64/bin/burn"),
+            Channel::Npm
+        );
+    }
+
+    #[test]
+    fn channel_from_path_recognizes_cargo() {
+        assert_eq!(
+            channel_from_path("/Users/dev/.cargo/bin/burn"),
+            Channel::Cargo
+        );
+    }
+
+    #[test]
+    fn channel_from_path_unknown_for_handcopied() {
+        assert_eq!(channel_from_path("/usr/local/bin/burn"), Channel::Unknown);
+    }
+
+    #[test]
+    fn extract_version_reads_npm_shape() {
+        let body = serde_json::json!({ "name": "relayburn", "version": "3.1.2" });
+        assert_eq!(
+            extract_version(Channel::Npm, &body).unwrap(),
+            Version::parse("3.1.2").unwrap()
+        );
+    }
+
+    #[test]
+    fn extract_version_reads_crates_shape() {
+        let body = serde_json::json!({
+            "crate": { "max_stable_version": "3.1.2", "newest_version": "3.2.0-next.1" }
+        });
+        assert_eq!(
+            extract_version(Channel::Cargo, &body).unwrap(),
+            Version::parse("3.1.2").unwrap()
+        );
+    }
+
+    #[test]
+    fn extract_version_errors_on_missing_field() {
+        let body = serde_json::json!({ "nope": true });
+        assert!(extract_version(Channel::Npm, &body).is_err());
+        assert!(extract_version(Channel::Cargo, &body).is_err());
+    }
+
+    #[test]
+    fn state_roundtrips_and_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+
+        // Missing file → defaults (auto-update on).
+        let loaded = UpdateState::load(home);
+        assert!(loaded.auto_update);
+        assert_eq!(loaded.last_check, 0);
+        assert!(loaded.latest_known.is_none());
+
+        let state = UpdateState {
+            auto_update: false,
+            last_check: 1234,
+            latest_known: Some("3.1.0".into()),
+            declined_version: Some("3.1.0".into()),
+        };
+        state.save(home).unwrap();
+
+        let reloaded = UpdateState::load(home);
+        assert!(!reloaded.auto_update);
+        assert_eq!(reloaded.last_check, 1234);
+        assert_eq!(reloaded.latest_known.as_deref(), Some("3.1.0"));
+        assert_eq!(reloaded.declined_version.as_deref(), Some("3.1.0"));
+    }
+
+    #[test]
+    fn malformed_state_falls_back_to_default() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(state_path(tmp.path()), "{ not json").unwrap();
+        let loaded = UpdateState::load(tmp.path());
+        assert!(loaded.auto_update);
+    }
+
+    #[test]
+    fn partial_state_keeps_auto_update_default_on() {
+        // A file that only sets last_check should still default
+        // auto_update to true rather than false.
+        let tmp = TempDir::new().unwrap();
+        fs::write(state_path(tmp.path()), r#"{"last_check":42}"#).unwrap();
+        let loaded = UpdateState::load(tmp.path());
+        assert!(loaded.auto_update);
+        assert_eq!(loaded.last_check, 42);
+    }
+}

--- a/crates/relayburn-cli/tests/smoke.rs
+++ b/crates/relayburn-cli/tests/smoke.rs
@@ -168,7 +168,9 @@ fn update_parent_flags_do_not_apply_to_toggle_subcommand() {
         .args(["--json", "update", "--check", "toggle-auto-update"])
         .assert()
         .code(2)
-        .stdout(predicate::str::contains("cannot be combined with a subcommand"));
+        .stdout(predicate::str::contains(
+            "cannot be combined with a subcommand",
+        ));
 }
 
 #[test]

--- a/crates/relayburn-cli/tests/smoke.rs
+++ b/crates/relayburn-cli/tests/smoke.rs
@@ -151,8 +151,13 @@ fn update_toggle_auto_update_json_writes_state_without_network() {
     let state_path = home.path().join("update.json");
     let state = std::fs::read_to_string(&state_path)
         .unwrap_or_else(|err| panic!("failed to read {}: {err}", state_path.display()));
-    assert!(
-        state.contains("\"auto_update\": false"),
+    // Parse rather than substring-match so the assertion survives a switch
+    // between pretty and compact serde output.
+    let persisted: serde_json::Value =
+        serde_json::from_str(&state).expect("update.json is valid JSON");
+    assert_eq!(
+        persisted["auto_update"],
+        serde_json::Value::Bool(false),
         "expected persisted auto_update=false, got:\n{state}",
     );
 }

--- a/crates/relayburn-cli/tests/smoke.rs
+++ b/crates/relayburn-cli/tests/smoke.rs
@@ -34,6 +34,7 @@ const SUBCOMMANDS: &[&str] = &[
     "flow",
     "ingest",
     "mcp-server",
+    "update",
 ];
 
 /// Subcommands that still print "not yet implemented" when invoked
@@ -106,6 +107,72 @@ fn overhead_trim_help_exits_zero_with_non_empty_stdout() {
         !stdout.is_empty(),
         "`overhead trim --help` should emit non-empty stdout; got empty",
     );
+}
+
+#[test]
+fn update_toggle_auto_update_help_exits_zero_with_non_empty_stdout() {
+    let output = burn()
+        .args(["update", "toggle-auto-update", "--help"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).expect("help should be valid UTF-8");
+    assert!(
+        !stdout.is_empty(),
+        "`update toggle-auto-update --help` should emit non-empty stdout; got empty",
+    );
+}
+
+#[test]
+fn update_toggle_auto_update_json_writes_state_without_network() {
+    let home = tempfile::TempDir::new().expect("tmp RELAYBURN_HOME");
+
+    let output = burn()
+        .args([
+            "--json",
+            "--ledger-path",
+            home.path().to_str().expect("tmp path is utf-8"),
+            "update",
+            "toggle-auto-update",
+            "--off",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("--json output is valid JSON");
+    assert_eq!(value["autoUpdate"], serde_json::Value::Bool(false));
+
+    let state_path = home.path().join("update.json");
+    let state = std::fs::read_to_string(&state_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", state_path.display()));
+    assert!(
+        state.contains("\"auto_update\": false"),
+        "expected persisted auto_update=false, got:\n{state}",
+    );
+}
+
+#[test]
+fn update_parent_flags_do_not_apply_to_toggle_subcommand() {
+    burn()
+        .args(["--json", "update", "--check", "toggle-auto-update"])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("cannot be combined with a subcommand"));
+}
+
+#[test]
+fn update_check_and_force_are_mutually_exclusive() {
+    burn()
+        .args(["update", "--check", "--force"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
 }
 
 #[test]

--- a/packages/relayburn/CHANGELOG.md
+++ b/packages/relayburn/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `relayburn`.
 
 ## [Unreleased]
 
+- Set `RELAYBURN_INSTALL_CHANNEL=npm` when launching the binary so `burn update` upgrades via `npm install -g relayburn@latest` instead of guessing the install channel.
+
 ## [2.4.0] - 2026-05-08
 
 ### Removed

--- a/packages/relayburn/CHANGELOG.md
+++ b/packages/relayburn/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `relayburn`.
 
 ## [Unreleased]
 
-- Set `RELAYBURN_INSTALL_CHANNEL=npm` when launching the binary so `burn update` upgrades via `npm install -g relayburn@latest` instead of guessing the install channel.
+- `burn update` now upgrades npm installs through `npm install -g relayburn@latest`: the launcher tags the install channel so the binary picks the right package manager.
 
 ## [2.4.0] - 2026-05-08
 

--- a/packages/relayburn/bin/burn.js
+++ b/packages/relayburn/bin/burn.js
@@ -105,6 +105,10 @@ if (!command) {
 const child = spawnSync(command, passthroughArgs, {
   stdio: 'inherit',
   windowsHide: false,
+  // Tell the binary it was installed via npm so `burn update` / the
+  // on-launch update check drive `npm install -g relayburn@latest`
+  // rather than guessing from the executable path.
+  env: { ...process.env, RELAYBURN_INSTALL_CHANNEL: 'npm' },
 });
 
 if (child.error) {


### PR DESCRIPTION
## What

Adds a self-update path to the `burn` binary, backed by a new `crates/relayburn-cli/src/selfupdate.rs` module, across three surfaces:

### 1. On-launch auto-update offer
Interactive `burn` invocations now check for a newer release and prompt:

> A new burn is available: 3.0.0 → 3.1.0. Update and restart now?

On **yes** it installs and re-execs your original command; on **no** it records the declined version and waits for the next release. It is strictly best-effort:

- Silent no-op in `--json` mode, non-TTY / piped contexts, dumb terminals, and when the install channel is unknown.
- Network probes throttled to once per 24h (cached in `update.json`), so repeated invocations don't slow down.
- Skipped for `update` itself and `mcp-server` (stdio protocol channel).

### 2. `burn update`
Manual upgrade through whichever package manager owns the binary, rather than blind-overwriting:

- npm install → `npm install -g relayburn@latest`
- cargo install → `cargo install relayburn-cli --force`
- unknown channel → declines with manual instructions

`--check` reports availability (human or `--json`) without installing; `--force` reinstalls even when current.

### 3. `burn update toggle-auto-update [--on|--off]`
Flips (or sets) the on-launch check; persisted as `auto_update` in `$RELAYBURN_HOME/update.json`. Bare form flips the current value.

## How

- **Channel detection** prefers `RELAYBURN_INSTALL_CHANNEL` (now set to `npm` by `packages/relayburn/bin/burn.js`), falling back to executable-path heuristics for cargo.
- **Latest-version lookup** queries the matching registry — npm `registry.npmjs.org/relayburn/latest` or crates.io `max_stable_version` — with short timeouts and a User-Agent.
- **State** lives in `$RELAYBURN_HOME/update.json`, separate from the SDK's `config.json`, so the SDK's on-disk schema doesn't grow a CLI-only concern.
- New deps: `ureq` (blocking HTTP, rustls) and `semver`.

## Testing

- `cargo build` / `clippy` / `fmt` clean; `cargo test -p relayburn-cli` green (8 new unit tests covering channel detection, registry-response parsing, and state round-trip/defaults).
- Verified live: help text, toggle on/off/flip (+ JSON), and `--check` against **both** real registries (correctly reports 3.0.0 up-to-date on npm and cargo channels).

⚠️ **Not yet exercised end-to-end:** the actual binary-replace + re-exec on a genuinely-newer release. I confirmed `--force` correctly *invokes* the package-manager command but interrupted it rather than run a real install. Worth a manual smoke test from an npm/cargo install once 3.0.1+ is published. The re-exec relies on the package manager overwriting the binary in place (true for both `npm i -g` and `cargo install --force`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)