### PR TITLE
Fix hotspots findings groupBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Fixed
+
+- `@relayburn/sdk` `hotspots({ groupBy: "findings" })` now returns the exported findings result instead of rejecting the option.
+
 ## [3.1.1] - 2026-05-31
 
 ### Changed

--- a/crates/relayburn-sdk-node/src/lib.rs
+++ b/crates/relayburn-sdk-node/src/lib.rs
@@ -990,8 +990,8 @@ pub fn overhead_trim(opts: Option<OverheadTrimOptions>) -> Result<BigIntPromotin
 
 /// Mirror of `sdk::HotspotsGroupBy`. Wire values match
 /// The Node facade's
-/// `'attribution' | 'bash' | 'bash-verb' | 'file' | 'subagent'` literal
-/// union.
+/// `'attribution' | 'bash' | 'bash-verb' | 'file' | 'subagent' |
+/// 'findings'` literal union.
 #[napi(string_enum = "kebab-case")]
 pub enum HotspotsGroupBy {
     Attribution,
@@ -999,6 +999,7 @@ pub enum HotspotsGroupBy {
     BashVerb,
     File,
     Subagent,
+    Findings,
 }
 
 impl From<HotspotsGroupBy> for sdk::HotspotsGroupBy {
@@ -1009,6 +1010,7 @@ impl From<HotspotsGroupBy> for sdk::HotspotsGroupBy {
             HotspotsGroupBy::BashVerb => sdk::HotspotsGroupBy::BashVerb,
             HotspotsGroupBy::File => sdk::HotspotsGroupBy::File,
             HotspotsGroupBy::Subagent => sdk::HotspotsGroupBy::Subagent,
+            HotspotsGroupBy::Findings => sdk::HotspotsGroupBy::Findings,
         }
     }
 }

--- a/crates/relayburn-sdk/src/query_verbs.rs
+++ b/crates/relayburn-sdk/src/query_verbs.rs
@@ -2977,6 +2977,29 @@ pub enum HotspotsGroupBy {
     BashVerb,
     File,
     Subagent,
+    Findings,
+}
+
+const DEFAULT_HOTSPOTS_FINDING_KINDS: &[&str] = &[
+    "retry-loop",
+    "failure-run",
+    "cancellation-run",
+    "compaction-loss",
+    "edit-revert",
+    "edit-heavy",
+    "skill-recall-dup",
+    "skill-pruning-protection",
+    "system-prompt-tax",
+    "ghost-surface",
+    "tool-output-bloat",
+    "tool-call-pattern",
+];
+
+fn default_hotspots_finding_kinds() -> Vec<String> {
+    DEFAULT_HOTSPOTS_FINDING_KINDS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -3151,6 +3174,13 @@ impl LedgerHandle {
         }
         let pricing = load_pricing(None);
 
+        if matches!(opts.group_by, Some(HotspotsGroupBy::Findings)) {
+            let patterns = match opts.patterns {
+                Some(patterns) if !patterns.is_empty() => patterns,
+                _ => default_hotspots_finding_kinds(),
+            };
+            return run_hotspots_findings(self, &turns, &pricing, patterns, &q);
+        }
         if using_patterns {
             return run_hotspots_findings(
                 self,
@@ -3267,6 +3297,7 @@ fn run_hotspots_attribution(
                 refusal_reason: None,
             });
         }
+        HotspotsGroupBy::Findings => unreachable!("findings is handled before attribution"),
         HotspotsGroupBy::Attribution => {}
     }
 
@@ -3372,6 +3403,10 @@ fn refused_for_group(
             rows: Vec::new(),
             refused: Some(true),
             refusal_reason: Some(refusal),
+        },
+        HotspotsGroupBy::Findings => HotspotsResult::Findings {
+            findings: Vec::new(),
+            summary: summary_value,
         },
         HotspotsGroupBy::Attribution => {
             HotspotsResult::Attribution(Box::new(HotspotsAttributionResult {
@@ -5548,6 +5583,43 @@ mod tests {
             HotspotsResult::Findings { findings, summary } => {
                 // No retries in fixture, so findings is empty — but the
                 // kind:findings shape and summary block should still ship.
+                assert!(findings.is_empty());
+                assert!(summary.is_object());
+            }
+            other => panic!("expected findings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hotspots_group_by_findings_returns_findings_kind() {
+        let (_dir, handle) = fixture_handle();
+        let r = handle
+            .hotspots(HotspotsOptions {
+                group_by: Some(HotspotsGroupBy::Findings),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match r {
+            HotspotsResult::Findings { findings, summary } => {
+                assert!(findings.iter().all(|f| !f.kind.is_empty()));
+                assert!(summary.is_object());
+            }
+            other => panic!("expected findings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hotspots_group_by_findings_honors_patterns_filter() {
+        let (_dir, handle) = fixture_handle();
+        let r = handle
+            .hotspots(HotspotsOptions {
+                group_by: Some(HotspotsGroupBy::Findings),
+                patterns: Some(vec!["retry-loop".into()]),
+                ..HotspotsOptions::default()
+            })
+            .unwrap();
+        match r {
+            HotspotsResult::Findings { findings, summary } => {
                 assert!(findings.is_empty());
                 assert!(summary.is_object());
             }

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `hotspots({ groupBy: "findings" })` now returns the exported findings result instead of rejecting the option.
+
 ## [3.0.0] - 2026-05-26
 
 ### Added

--- a/packages/sdk-node/src/index.d.ts
+++ b/packages/sdk-node/src/index.d.ts
@@ -249,7 +249,13 @@ export interface OverheadTrimResult {
 /** Trim recommendations for high-cost overhead-file sections. Powers `burn overhead trim`. */
 export declare function overheadTrim(opts?: OverheadTrimOptions): Promise<OverheadTrimResult>
 
-export type HotspotsGroupBy = 'attribution' | 'bash' | 'bash-verb' | 'file' | 'subagent';
+export type HotspotsGroupBy =
+  | 'attribution'
+  | 'bash'
+  | 'bash-verb'
+  | 'file'
+  | 'subagent'
+  | 'findings';
 
 export interface HotspotsOptions {
   session?: string;
@@ -525,4 +531,5 @@ export declare const HotspotsGroupBy: {
   readonly BashVerb: 'bash-verb';
   readonly File: 'file';
   readonly Subagent: 'subagent';
+  readonly Findings: 'findings';
 };

--- a/packages/sdk-node/test/conformance.test.js
+++ b/packages/sdk-node/test/conformance.test.js
@@ -121,6 +121,14 @@ test('read verbs return stable shapes against the fixture ledger', async (t) => 
     const hotspots = await sdk.hotspots({ ledgerHome });
     assert.equal(typeof hotspots.kind, 'string');
 
+    assert.equal(sdk.HotspotsGroupBy.Findings, 'findings');
+    const hotspotFindings = await sdk.hotspots({
+      ledgerHome,
+      groupBy: sdk.HotspotsGroupBy.Findings,
+    });
+    assert.equal(hotspotFindings.kind, 'findings');
+    assert.ok(Array.isArray(hotspotFindings.findings));
+
     const compare = await sdk.compare({
       ledgerHome,
       models: ['claude-sonnet-4-5', 'claude-opus-4-7'],


### PR DESCRIPTION
## **User description**
Fixes #467

## Summary
- Accept `findings` as a `HotspotsGroupBy` value in the Rust SDK and napi binding.
- Route `hotspots({ groupBy: "findings" })` through the existing findings analyzer, using all detector kinds by default and honoring explicit `patterns` filters.
- Update `@relayburn/sdk` typings, enum constants, conformance coverage, and changelogs.

## Verification
- `cargo test -p relayburn-sdk hotspots_group_by_findings`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm --filter @relayburn/sdk test`
- Direct native smoke: rebuilt local napi artifact and called `hotspots({ ledgerHome: "tests/fixtures/cli-golden/ledger", groupBy: "findings" })` against `packages/sdk-node/src/index.darwin-arm64.node`


___

## **CodeAnt-AI Description**
Allow `hotspots` to return findings results for `groupBy: "findings"`

### What Changed
- `hotspots({ groupBy: "findings" })` now returns the findings result instead of rejecting the option
- When no patterns are provided, findings uses the built-in default set of finding kinds
- Existing pattern filters still apply when they are provided
- The Node SDK types and exported `HotspotsGroupBy` values now include `findings`

### Impact
`✅ Fewer hotspots option errors`
`✅ Clearer findings reports`
`✅ Safer findings grouping in SDK apps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
