### PR TITLE
perf(ingest): no-op fast path gated on a source fingerprint (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
   `session_span_trees(session_id)` verbs project `TurnRecord` +
   `tool_result_event` rows + Claude subagent sidecars into an
   OTel-style `TurnSpanTree { Turn -> { UserPrompt, Inference -> ToolUse ->
-  { ToolResult, Subagent } } }`. Pure projection — no schema change,
+{ ToolResult, Subagent } } }`. Pure projection — no schema change,
   no caching. Orphan subagents surface as sibling `Subagent` spans
   with `unattached=true`. Locked attribute keys (`tokens.*`, `model`,
   `request_id`, `tool_use_id`, `agent_id`, `stop_reason`) for
@@ -99,10 +99,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
   `Option<StopReason>` enum (kebab-case wire form); deserialization is
   lenient so pre-3.0 ledgers replay cleanly. (#437)
 - `relayburn-sdk` ledger schema bumps to v3: `turns` gains a `stop_reason
-  TEXT` column (#437) and `tool_result_events` gains nullable `output_bytes`
+TEXT` column (#437) and `tool_result_events` gains nullable `output_bytes`
   / `output_truncated` columns (#436). Both are migrated in place on
   `Ledger::open`; existing rows leave the new columns `NULL`. Run `burn
-  state rebuild` to backfill an older ledger.
+state rebuild` to backfill an older ledger.
 - `relayburn-sdk` ledger schema bumps to v5: adds the `inferences`
   derived table for per-API-call aggregates. Created idempotently on
   open; rebuilt by `burn state rebuild`. Pre-v5 ledgers stay empty
@@ -233,7 +233,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 - `relayburn-cli`: dropped the no-op flags `burn state prune --force`,
   `burn state rebuild archive --full`/`--vacuum` (and the legacy
   `vacuum` positional), `burn state rebuild all --force`, and `burn
-  state rebuild classify --force`. They had no effect against the
+state rebuild classify --force`. They had no effect against the
   SQLite layout; passing them now fails at parse time.
 
 ## [2.6.1] - 2026-05-09
@@ -259,9 +259,9 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
   project), `--limit` (defaults to 20), and the global `--json`. Pipes
   cleanly into `burn summary --session <id>` for drill-down.
 - `relayburn-sdk`: new `sessions_list` query verb (`LedgerHandle::sessions_list`
-  + free-function form) returning `SessionsListResult { sessions, limit,
-  truncated }`. Derived from the `turns` table so older ledgers with an
-  empty `sessions` table still enumerate correctly.
+  - free-function form) returning `SessionsListResult { sessions, limit,
+truncated }`. Derived from the `turns` table so older ledgers with an
+    empty `sessions` table still enumerate correctly.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+### Changed
+
+- `ingest()` short-circuits when nothing upstream changed: a stat-only source fingerprint is compared against the last sweep's value, so a no-op ingest skips the cursor load and per-file deserialize and returns `{ ingested: 0 }` in roughly the cost of walking the source dirs instead of ~0.7s. Adds `archive_state.source_fingerprint` (schema v6, auto-migrated). (#468)
+
 ## [3.1.1] - 2026-05-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ### Changed
 
-- `ingest()` short-circuits when nothing upstream changed: a stat-only source fingerprint is compared against the last sweep's value, so a no-op ingest skips the cursor load and per-file deserialize and returns `{ ingested: 0 }` in roughly the cost of walking the source dirs instead of ~0.7s. Adds `archive_state.source_fingerprint` (schema v6, auto-migrated). (#468)
+- `ingest()` is near-instant when nothing upstream changed: a no-op sweep returns `{ ingested: 0 }` in roughly source-walk time (~0.2s) instead of ~0.7s. Adds `archive_state.source_fingerprint` (schema v6, auto-migrated).
 
 ## [3.1.1] - 2026-05-31
 

--- a/crates/relayburn-cli/src/commands/ingest.rs
+++ b/crates/relayburn-cli/src/commands/ingest.rs
@@ -48,7 +48,8 @@ use std::time::Duration;
 
 use relayburn_sdk::{
     default_session_roots, ingest_all, ingest_claude_transcript_path, start_watch_loop,
-    IngestReport, IngestRoots, Ledger, LedgerHandle, LedgerOpenOptions, StartWatchLoopOptions,
+    IngestReport, IngestRoots, Ledger, LedgerHandle, LedgerOpenOptions, RawIngestOptions,
+    StartWatchLoopOptions,
 };
 
 use crate::cli::{GlobalArgs, IngestArgs};
@@ -210,7 +211,7 @@ fn run_watch(globals: &GlobalArgs, args: &IngestArgs) -> i32 {
         let handle_for_ingest = handle_arc.clone();
         let progress_for_ingest = progress_for_loop.clone();
         let watch_message_for_ingest = watch_message.clone();
-        let ingest_fn: relayburn_sdk::IngestFn = Arc::new(move || {
+        let ingest_fn: relayburn_sdk::IngestFn = Arc::new(move |force: bool| {
             let h = handle_for_ingest.clone();
             let progress = progress_for_ingest.clone();
             let ledger_home = ledger_home.clone();
@@ -220,9 +221,16 @@ fn run_watch(globals: &GlobalArgs, args: &IngestArgs) -> i32 {
                     p.set_task("scanning sessions");
                 }
                 let mut guard = h.lock().await;
+                // `force` is set by the FS-event driver: a `notify` event can
+                // beat the write's flush, so force a full sweep rather than
+                // trust the stat-only source fingerprint for that tick.
                 let opts = match &progress {
                     Some(p) => p.ingest_options(ledger_home),
                     None => TaskProgress::quiet_ingest_options(ledger_home),
+                };
+                let opts = RawIngestOptions {
+                    force_scan: force,
+                    ..opts
                 };
                 let result = ingest_all(guard.raw_mut(), &opts);
                 if let Some(p) = &progress {

--- a/crates/relayburn-cli/src/harnesses/pending_stamp.rs
+++ b/crates/relayburn-cli/src/harnesses/pending_stamp.rs
@@ -222,7 +222,10 @@ impl PendingStampAdapterImpl {
     /// same path `after_exit` does.
     fn ingest_fn(&self, ledger_home: Option<PathBuf>) -> IngestFn {
         let ingest_sessions = self.ingest_sessions.clone();
-        Arc::new(move || {
+        // `_force` is ignored here: the pending-stamp watcher runs its own
+        // caller-supplied ingest closure (not `ingest_all` directly), so the
+        // FS-event force-scan signal isn't plumbed through this path.
+        Arc::new(move |_force: bool| {
             let f = ingest_sessions.clone();
             let ledger_home = ledger_home.clone();
             Box::pin(async move { f(ledger_home).await })

--- a/crates/relayburn-sdk/src/ingest/ingest.rs
+++ b/crates/relayburn-sdk/src/ingest/ingest.rs
@@ -96,6 +96,16 @@ pub struct IngestOptions {
     /// per-harness home dirs (`~/.claude/projects`, `~/.codex/sessions`,
     /// `~/.local/share/opencode/storage`).
     pub roots: IngestRoots,
+    /// Bypass the no-op fast path and always run a full cursor-based sweep.
+    /// The watch loop sets this for FS-event-driven ticks: a real `notify`
+    /// event can fire while a write is still in flight (file opened, bytes
+    /// not yet flushed), so `fs::metadata` — and therefore the stat-only
+    /// [`source_fingerprint`] — can still read pre-write size/mtime and
+    /// collide with the stored value. Forcing the sweep on an FS event lets
+    /// the per-file cursors observe whatever has flushed instead of trusting
+    /// the aggregate. The fingerprint is still recorded afterwards, so the
+    /// slow polling backstop (which leaves this `false`) keeps the fast path.
+    pub force_scan: bool,
 }
 
 /// Per-harness root paths. `None` means "use the OS default for this harness".
@@ -194,8 +204,22 @@ const FINGERPRINT_HASH_PRIME: u64 = 0x100000001b3;
 /// Computed from `fs::metadata` only — no cursor deserialization and no
 /// parse — so it is far cheaper than a full sweep while still detecting
 /// in-place appends to existing JSONL files (which directory mtimes miss).
-/// For OpenCode it folds in each session's message-dir mtime, the same
-/// signal [`ingest_opencode_into`] watches for new message files.
+///
+/// For OpenCode, appends land as *new files* in `message/<session>/` rather
+/// than as growth of the session json, so we fold in both the message-dir
+/// mtime (the signal [`ingest_opencode_into`] keys on) AND the dir's child
+/// count. The count is the load-bearing one: on filesystems with coarse
+/// mtime granularity a new message file can land inside the same tick as the
+/// recorded fingerprint, leaving the dir mtime unmoved — but adding the file
+/// always bumps the entry count, so the gate still re-opens. (Without the
+/// count, the fast path would make that blind spot sticky: it would block the
+/// whole sweep until some unrelated change moved the fingerprint.)
+///
+/// This is a change *detector*, not a content hash: two distinct source
+/// states could in principle collide. For append-only session logs within a
+/// single inter-sweep window that is not a practical concern, and the worst
+/// case is one skipped no-op sweep, never lost data — the per-file cursors
+/// still catch up on the next fingerprint change.
 fn source_fingerprint(roots: &IngestRoots) -> String {
     let mut count: u64 = 0;
     let mut total_bytes: u64 = 0;
@@ -206,7 +230,7 @@ fn source_fingerprint(roots: &IngestRoots) -> String {
     for project_dir in list_dirs(&projects_root) {
         for file in list_jsonl_files(&project_dir) {
             if let Ok(meta) = fs::metadata(&file) {
-                count += 1;
+                count = count.wrapping_add(1);
                 total_bytes = total_bytes.wrapping_add(meta.len());
                 hash_sum = hash_sum.wrapping_add(fingerprint_entry_hash("claude", &file, &meta));
             }
@@ -216,19 +240,19 @@ fn source_fingerprint(roots: &IngestRoots) -> String {
     // Codex: ~/.codex/sessions/**/*.jsonl
     for file in walk_jsonl(codex_sessions_dir(roots)) {
         if let Ok(meta) = fs::metadata(&file) {
-            count += 1;
+            count = count.wrapping_add(1);
             total_bytes = total_bytes.wrapping_add(meta.len());
             hash_sum = hash_sum.wrapping_add(fingerprint_entry_hash("codex", &file, &meta));
         }
     }
 
-    // OpenCode: ses_*.json plus the per-session message-dir mtime, which is
-    // what the adapter watches for new message files (appends land as new
-    // files in that dir, not as growth of the session json).
+    // OpenCode: ses_*.json plus, per session, the message-dir mtime and its
+    // child count. The count closes the coarse-mtime new-file window (see the
+    // doc comment); the adapter watches the same dir for new message files.
     let message_root = opencode_message_root(roots);
     for file in walk_opencode_sessions(opencode_session_root(roots)) {
         if let Ok(meta) = fs::metadata(&file) {
-            count += 1;
+            count = count.wrapping_add(1);
             total_bytes = total_bytes.wrapping_add(meta.len());
             hash_sum = hash_sum.wrapping_add(fingerprint_entry_hash("opencode", &file, &meta));
         }
@@ -240,6 +264,7 @@ fn source_fingerprint(roots: &IngestRoots) -> String {
                     &message_dir,
                     t,
                 ));
+                count = count.wrapping_add(dir_entry_count(&message_dir));
             }
         }
     }
@@ -286,15 +311,22 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
 
     progress(opts, "checking for source changes");
     let current_fp = source_fingerprint(&opts.roots);
-    match ledger.read_source_fingerprint() {
-        Ok(stored) if !stored.is_empty() && stored == current_fp => {
-            // Nothing upstream changed since the last sweep — skip the
-            // cursor load + per-file deserialize entirely.
-            return Ok(IngestReport::empty());
+    // `force_scan` (set by the watch loop on an FS-event tick) skips the gate:
+    // a `notify` event can land before the write is flushed, so the stat-only
+    // fingerprint may still match the stored value even though new bytes are
+    // coming. A forced full sweep lets the per-file cursors catch up; an
+    // unforced tick (slow polling backstop, manual ingest) keeps the fast path.
+    if !opts.force_scan {
+        match ledger.read_source_fingerprint() {
+            Ok(stored) if !stored.is_empty() && stored == current_fp => {
+                // Nothing upstream changed since the last sweep — skip the
+                // cursor load + per-file deserialize entirely.
+                return Ok(IngestReport::empty());
+            }
+            Ok(_) => {}
+            // A read failure shouldn't wedge ingest; fall through to a full sweep.
+            Err(_) => {}
         }
-        Ok(_) => {}
-        // A read failure shouldn't wedge ingest; fall through to a full sweep.
-        Err(_) => {}
     }
 
     progress(opts, "loading ingest cursors");
@@ -306,6 +338,15 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
     let content_mode = resolve_content_mode(opts.ledger_home.as_deref());
     let on_warn: Option<&dyn Fn(&str)> = opts.on_warn.as_ref().map(|f| f.as_ref() as &dyn Fn(&str));
 
+    // Set by any per-harness loop that statted a source file but couldn't read
+    // or parse it. Such a file was already folded into `current_fp`, so caching
+    // the fingerprint would let a transient failure (e.g. a `PermissionDenied`
+    // read later fixed with `chmod`, which moves ctime but not size/mtime) stay
+    // sticky: the next sweep would match the stored fingerprint and short-
+    // circuit before retrying. When set, we leave the stored fingerprint
+    // untouched so the next ingest re-walks and retries the skipped source.
+    let mut had_skips = false;
+
     // Emit per-adapter, immediately after each scan, so a later adapter
     // returning Err does not swallow a gap the earlier adapter already
     // recorded against work that was already appended.
@@ -316,6 +357,7 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
         &opts.roots,
         content_mode,
         opts.ledger_home.as_deref(),
+        &mut had_skips,
     )?;
     report.merge(&r);
     emit_gap_warning(AdapterName::Claude, content_mode, on_warn);
@@ -327,6 +369,7 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
         &opts.roots,
         content_mode,
         opts.ledger_home.as_deref(),
+        &mut had_skips,
     )?;
     report.merge(&r);
     emit_gap_warning(AdapterName::Codex, content_mode, on_warn);
@@ -338,6 +381,7 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
         &opts.roots,
         content_mode,
         opts.ledger_home.as_deref(),
+        &mut had_skips,
     )?;
     report.merge(&r);
     emit_gap_warning(AdapterName::Opencode, content_mode, on_warn);
@@ -349,9 +393,25 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
     // conservative: any file that changed mid-sweep yields a different
     // fingerprint next time, forcing a re-scan (cheap, since per-file
     // cursors then skip the already-read bytes).
-    ledger
-        .write_source_fingerprint(&current_fp)
-        .map_err(|e| anyhow::anyhow!(e))?;
+    //
+    // Ordering is deliberate: cursors are saved first, fingerprint last and
+    // in a separate statement. A crash between them leaves cursors advanced
+    // but the fingerprint stale/blank, which only forces one extra full scan
+    // (cursors then find nothing new) — never a missed append. We must never
+    // store a fingerprint *ahead* of the cursors, so the fingerprint write
+    // stays after the cursor save.
+    //
+    // Skip the write entirely when a source file was counted into `current_fp`
+    // but couldn't be read/parsed: caching would make that skip sticky (see
+    // `had_skips` above). Leaving the stored fingerprint stale costs at most a
+    // full re-scan next time — a persistently-broken file keeps the fast path
+    // off until it parses, which is the conservative trade (never a lost append
+    // over a perf win).
+    if !had_skips {
+        ledger
+            .write_source_fingerprint(&current_fp)
+            .map_err(|e| anyhow::anyhow!(e))?;
+    }
     Ok(report)
 }
 
@@ -394,6 +454,7 @@ where
         &IngestRoots,
         ContentStoreMode,
         Option<&Path>,
+        &mut bool,
     ) -> anyhow::Result<IngestReport>,
 {
     progress(opts, "cleaning pending spawn stamps");
@@ -401,12 +462,16 @@ where
     let before = load_cursors(ledger).map_err(|e| anyhow::anyhow!(e))?;
     let mut after = before.clone();
     let content_mode = resolve_content_mode(opts.ledger_home.as_deref());
+    // The single-harness verbs don't gate on the source fingerprint, so the
+    // skip flag is only consumed by `ingest_all`; capture and ignore it here.
+    let mut had_skips = false;
     let report = body(
         ledger,
         &mut after,
         &opts.roots,
         content_mode,
         opts.ledger_home.as_deref(),
+        &mut had_skips,
     )?;
     let on_warn: Option<&dyn Fn(&str)> = opts.on_warn.as_ref().map(|f| f.as_ref() as &dyn Fn(&str));
     emit_gap_warning(adapter, content_mode, on_warn);
@@ -534,6 +599,7 @@ fn ingest_claude_into(
     roots: &IngestRoots,
     content_mode: ContentStoreMode,
     ledger_home: Option<&Path>,
+    had_skips: &mut bool,
 ) -> anyhow::Result<IngestReport> {
     let mut report = IngestReport::empty();
     let projects_root = claude_projects_dir(roots);
@@ -550,6 +616,7 @@ fn ingest_claude_into(
                 Ok(m) => m,
                 Err(err) => {
                     eprintln!("[burn] skipping {}: {}", file.display(), err);
+                    *had_skips = true;
                     continue;
                 }
             };
@@ -598,6 +665,7 @@ fn ingest_claude_into(
                 Ok(r) => r,
                 Err(err) => {
                     eprintln!("[burn] skipping {}: {}", file.display(), err);
+                    *had_skips = true;
                     continue;
                 }
             };
@@ -674,6 +742,7 @@ fn ingest_codex_into(
     roots: &IngestRoots,
     content_mode: ContentStoreMode,
     ledger_home: Option<&Path>,
+    had_skips: &mut bool,
 ) -> anyhow::Result<IngestReport> {
     let mut report = IngestReport::empty();
     let sessions_root = codex_sessions_dir(roots);
@@ -684,6 +753,7 @@ fn ingest_codex_into(
             Ok(m) => m,
             Err(err) => {
                 eprintln!("[burn] skipping {}: {}", file.display(), err);
+                *had_skips = true;
                 continue;
             }
         };
@@ -729,6 +799,7 @@ fn ingest_codex_into(
             Ok(r) => r,
             Err(err) => {
                 eprintln!("[burn] skipping {}: {}", file.display(), err);
+                *had_skips = true;
                 continue;
             }
         };
@@ -808,6 +879,7 @@ fn ingest_opencode_into(
     roots: &IngestRoots,
     content_mode: ContentStoreMode,
     ledger_home: Option<&Path>,
+    had_skips: &mut bool,
 ) -> anyhow::Result<IngestReport> {
     let mut report = IngestReport::empty();
     let session_root = opencode_session_root(roots);
@@ -828,6 +900,7 @@ fn ingest_opencode_into(
             Ok(m) => m,
             Err(err) => {
                 eprintln!("[burn] skipping {}: {}", file.display(), err);
+                *had_skips = true;
                 continue;
             }
         };
@@ -867,6 +940,7 @@ fn ingest_opencode_into(
             Ok(r) => r,
             Err(err) => {
                 eprintln!("[burn] skipping {}: {}", file.display(), err);
+                *had_skips = true;
                 continue;
             }
         };
@@ -1243,6 +1317,17 @@ fn dir_mtime(dir: &Path) -> Option<i64> {
     Some(mtime_ms(&meta))
 }
 
+/// Number of direct entries in `dir`, or `0` if it can't be read. Used by the
+/// source fingerprint to detect a new OpenCode message file even when the
+/// directory mtime granularity is too coarse to register the add within the
+/// same tick.
+fn dir_entry_count(dir: &Path) -> u64 {
+    match fs::read_dir(dir) {
+        Ok(entries) => entries.filter(|e| e.is_ok()).count() as u64,
+        Err(_) => 0,
+    }
+}
+
 fn mtime_ms(meta: &fs::Metadata) -> i64 {
     meta.modified()
         .ok()
@@ -1338,6 +1423,49 @@ mod tests {
         assert_ne!(
             appended, with_file,
             "appending bytes must move the fingerprint"
+        );
+
+        // Deleting the file (count drops) must move it back toward empty.
+        fs::remove_file(&file).unwrap();
+        let deleted = source_fingerprint(&roots);
+        assert_ne!(
+            deleted, appended,
+            "deleting a file must move the fingerprint"
+        );
+        assert_eq!(deleted, empty, "back to zero files == empty fingerprint");
+    }
+
+    #[test]
+    fn source_fingerprint_moves_on_new_opencode_message_file() {
+        // M1 regression: an OpenCode append lands as a NEW file under
+        // message/<session>/, not as growth of the ses_*.json. Folding the
+        // message-dir child count into the fingerprint guarantees the gate
+        // re-opens even if the dir mtime granularity is too coarse to move.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let storage = tmp.path().join("opencode");
+        let roots = IngestRoots {
+            claude_projects_dir: Some(tmp.path().join("claude")),
+            codex_sessions_dir: Some(tmp.path().join("codex")),
+            opencode_storage_dir: Some(storage.clone()),
+        };
+
+        let session_dir = storage.join("session");
+        fs::create_dir_all(&session_dir).unwrap();
+        let session_file = session_dir.join("ses_abc.json");
+        fs::write(&session_file, "{}").unwrap();
+
+        let message_dir = storage.join("message").join("ses_abc");
+        fs::create_dir_all(&message_dir).unwrap();
+        fs::write(message_dir.join("msg_1.json"), "{}").unwrap();
+        let before = source_fingerprint(&roots);
+
+        // Add a second message file WITHOUT touching ses_abc.json. The session
+        // file size/mtime are unchanged; only the message-dir child count moves.
+        fs::write(message_dir.join("msg_2.json"), "{}").unwrap();
+        let after = source_fingerprint(&roots);
+        assert_ne!(
+            after, before,
+            "a new message file must move the fingerprint via the dir child count"
         );
     }
 }

--- a/crates/relayburn-sdk/src/ingest/ingest.rs
+++ b/crates/relayburn-sdk/src/ingest/ingest.rs
@@ -183,10 +183,88 @@ fn resolve_content_mode(ledger_home: Option<&Path>) -> ContentStoreMode {
         .unwrap_or(ContentStoreMode::Full)
 }
 
+/// Cheap aggregate over the source session files `ingest_all` scans:
+/// `"count:totalBytes:mtimeSum"`. Any file added, removed, appended,
+/// truncated, or touched changes at least one component, so an unchanged
+/// fingerprint means there is nothing new to ingest.
+///
+/// Computed from `fs::metadata` only — no cursor deserialization and no
+/// parse — so it is far cheaper than a full sweep while still detecting
+/// in-place appends to existing JSONL files (which directory mtimes miss).
+/// For OpenCode it folds in each session's message-dir mtime, the same
+/// signal [`ingest_opencode_into`] watches for new message files.
+///
+/// `mtime_sum` is a wrapping `i128` accumulation: order-independent and
+/// sensitive to any single file's mtime moving in either direction, so a
+/// clock going backwards still registers as a change.
+fn source_fingerprint(roots: &IngestRoots) -> String {
+    let mut count: u64 = 0;
+    let mut total_bytes: u64 = 0;
+    let mut mtime_sum: i128 = 0;
+
+    // Claude: ~/.claude/projects/<project>/<session>.jsonl
+    let projects_root = claude_projects_dir(roots);
+    for project_dir in list_dirs(&projects_root) {
+        for file in list_jsonl_files(&project_dir) {
+            if let Ok(meta) = fs::metadata(&file) {
+                count += 1;
+                total_bytes = total_bytes.wrapping_add(meta.len());
+                mtime_sum = mtime_sum.wrapping_add(mtime_ms(&meta) as i128);
+            }
+        }
+    }
+
+    // Codex: ~/.codex/sessions/**/*.jsonl
+    for file in walk_jsonl(codex_sessions_dir(roots)) {
+        if let Ok(meta) = fs::metadata(&file) {
+            count += 1;
+            total_bytes = total_bytes.wrapping_add(meta.len());
+            mtime_sum = mtime_sum.wrapping_add(mtime_ms(&meta) as i128);
+        }
+    }
+
+    // OpenCode: ses_*.json plus the per-session message-dir mtime, which is
+    // what the adapter watches for new message files (appends land as new
+    // files in that dir, not as growth of the session json).
+    let message_root = opencode_message_root(roots);
+    for file in walk_opencode_sessions(opencode_session_root(roots)) {
+        if let Ok(meta) = fs::metadata(&file) {
+            count += 1;
+            total_bytes = total_bytes.wrapping_add(meta.len());
+            mtime_sum = mtime_sum.wrapping_add(mtime_ms(&meta) as i128);
+        }
+        if let Some(session_id) = file.file_stem().and_then(|s| s.to_str()) {
+            if let Some(t) = dir_mtime(&message_root.join(session_id)) {
+                mtime_sum = mtime_sum.wrapping_add(t as i128);
+            }
+        }
+    }
+
+    format!("{count}:{total_bytes}:{mtime_sum}")
+}
+
 /// Ingest every known session store once. Cleans stale pending stamps,
 /// loads cursors, walks Claude/Codex/OpenCode in turn, then persists any
 /// cursor mutations. Returns the merged report.
+///
+/// Fast path: a stat-only [`source_fingerprint`] is compared against the
+/// value the last sweep recorded. When they match, nothing upstream has
+/// moved and the call returns an empty report without loading cursors or
+/// touching any session file beyond the fingerprint walk. See #468.
 pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<IngestReport> {
+    progress(opts, "checking for source changes");
+    let current_fp = source_fingerprint(&opts.roots);
+    match ledger.read_source_fingerprint() {
+        Ok(stored) if !stored.is_empty() && stored == current_fp => {
+            // Nothing upstream changed since the last sweep — skip the
+            // cursor load + per-file deserialize entirely.
+            return Ok(IngestReport::empty());
+        }
+        Ok(_) => {}
+        // A read failure shouldn't wedge ingest; fall through to a full sweep.
+        Err(_) => {}
+    }
+
     progress(opts, "cleaning pending spawn stamps");
     cleanup_stale_pending_stamps_in(opts.ledger_home.as_deref())?;
     progress(opts, "loading ingest cursors");
@@ -236,6 +314,14 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
 
     progress(opts, "saving ingest cursors");
     save_cursors_if_changed(ledger, &before, &after).map_err(|e| anyhow::anyhow!(e))?;
+    // Record the source fingerprint captured at the start of this sweep so
+    // the next call can short-circuit. Storing the *start* value is
+    // conservative: any file that changed mid-sweep yields a different
+    // fingerprint next time, forcing a re-scan (cheap, since per-file
+    // cursors then skip the already-read bytes).
+    ledger
+        .write_source_fingerprint(&current_fp)
+        .map_err(|e| anyhow::anyhow!(e))?;
     Ok(report)
 }
 
@@ -1194,5 +1280,34 @@ mod tests {
         assert_eq!(claude_projects_dir(&roots), PathBuf::from("/x/claude"));
         assert_eq!(codex_sessions_dir(&roots), PathBuf::from("/x/codex"));
         assert_eq!(opencode_storage_dir(&roots), PathBuf::from("/x/oc"));
+    }
+
+    #[test]
+    fn source_fingerprint_is_stable_and_moves_on_change() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let roots = IngestRoots {
+            claude_projects_dir: Some(tmp.path().join("claude")),
+            codex_sessions_dir: Some(tmp.path().join("codex")),
+            opencode_storage_dir: Some(tmp.path().join("opencode")),
+        };
+        // Empty roots: well-formed, stable, and identical across calls.
+        let empty = source_fingerprint(&roots);
+        assert_eq!(empty, source_fingerprint(&roots));
+        assert_eq!(empty, "0:0:0");
+
+        let project = roots.claude_projects_dir.as_ref().unwrap().join("proj");
+        fs::create_dir_all(&project).unwrap();
+        let file = project.join("s1.jsonl");
+        fs::write(&file, "a\n").unwrap();
+        let with_file = source_fingerprint(&roots);
+        assert_ne!(with_file, empty, "adding a file must move the fingerprint");
+
+        // Growing the file (size + mtime) must move it again.
+        fs::write(&file, "a\nbb\n").unwrap();
+        let appended = source_fingerprint(&roots);
+        assert_ne!(
+            appended, with_file,
+            "appending bytes must move the fingerprint"
+        );
     }
 }

--- a/crates/relayburn-sdk/src/ingest/ingest.rs
+++ b/crates/relayburn-sdk/src/ingest/ingest.rs
@@ -183,24 +183,23 @@ fn resolve_content_mode(ledger_home: Option<&Path>) -> ContentStoreMode {
         .unwrap_or(ContentStoreMode::Full)
 }
 
+const FINGERPRINT_HASH_OFFSET: u64 = 0xcbf29ce484222325;
+const FINGERPRINT_HASH_PRIME: u64 = 0x100000001b3;
+
 /// Cheap aggregate over the source session files `ingest_all` scans:
-/// `"count:totalBytes:mtimeSum"`. Any file added, removed, appended,
-/// truncated, or touched changes at least one component, so an unchanged
-/// fingerprint means there is nothing new to ingest.
+/// `"count:totalBytes:hash"`. The hash folds in each path, byte length,
+/// and mtime, so a file added, removed, appended, truncated, touched, or
+/// renamed changes the fingerprint in normal operation.
 ///
 /// Computed from `fs::metadata` only — no cursor deserialization and no
 /// parse — so it is far cheaper than a full sweep while still detecting
 /// in-place appends to existing JSONL files (which directory mtimes miss).
 /// For OpenCode it folds in each session's message-dir mtime, the same
 /// signal [`ingest_opencode_into`] watches for new message files.
-///
-/// `mtime_sum` is a wrapping `i128` accumulation: order-independent and
-/// sensitive to any single file's mtime moving in either direction, so a
-/// clock going backwards still registers as a change.
 fn source_fingerprint(roots: &IngestRoots) -> String {
     let mut count: u64 = 0;
     let mut total_bytes: u64 = 0;
-    let mut mtime_sum: i128 = 0;
+    let mut hash_sum: u64 = 0;
 
     // Claude: ~/.claude/projects/<project>/<session>.jsonl
     let projects_root = claude_projects_dir(roots);
@@ -209,7 +208,7 @@ fn source_fingerprint(roots: &IngestRoots) -> String {
             if let Ok(meta) = fs::metadata(&file) {
                 count += 1;
                 total_bytes = total_bytes.wrapping_add(meta.len());
-                mtime_sum = mtime_sum.wrapping_add(mtime_ms(&meta) as i128);
+                hash_sum = hash_sum.wrapping_add(fingerprint_entry_hash("claude", &file, &meta));
             }
         }
     }
@@ -219,7 +218,7 @@ fn source_fingerprint(roots: &IngestRoots) -> String {
         if let Ok(meta) = fs::metadata(&file) {
             count += 1;
             total_bytes = total_bytes.wrapping_add(meta.len());
-            mtime_sum = mtime_sum.wrapping_add(mtime_ms(&meta) as i128);
+            hash_sum = hash_sum.wrapping_add(fingerprint_entry_hash("codex", &file, &meta));
         }
     }
 
@@ -231,16 +230,46 @@ fn source_fingerprint(roots: &IngestRoots) -> String {
         if let Ok(meta) = fs::metadata(&file) {
             count += 1;
             total_bytes = total_bytes.wrapping_add(meta.len());
-            mtime_sum = mtime_sum.wrapping_add(mtime_ms(&meta) as i128);
+            hash_sum = hash_sum.wrapping_add(fingerprint_entry_hash("opencode", &file, &meta));
         }
         if let Some(session_id) = file.file_stem().and_then(|s| s.to_str()) {
-            if let Some(t) = dir_mtime(&message_root.join(session_id)) {
-                mtime_sum = mtime_sum.wrapping_add(t as i128);
+            let message_dir = message_root.join(session_id);
+            if let Some(t) = dir_mtime(&message_dir) {
+                hash_sum = hash_sum.wrapping_add(fingerprint_virtual_hash(
+                    "opencode-message",
+                    &message_dir,
+                    t,
+                ));
             }
         }
     }
 
-    format!("{count}:{total_bytes}:{mtime_sum}")
+    format!("{count}:{total_bytes}:{hash_sum:016x}")
+}
+
+fn fingerprint_entry_hash(kind: &str, path: &Path, meta: &fs::Metadata) -> u64 {
+    fingerprint_hash(kind, path, meta.len(), mtime_ms(meta))
+}
+
+fn fingerprint_virtual_hash(kind: &str, path: &Path, mtime_ms: i64) -> u64 {
+    fingerprint_hash(kind, path, 0, mtime_ms)
+}
+
+fn fingerprint_hash(kind: &str, path: &Path, len: u64, mtime_ms: i64) -> u64 {
+    let mut hash = FINGERPRINT_HASH_OFFSET;
+    fn feed(hash: &mut u64, bytes: &[u8]) {
+        for b in bytes {
+            *hash ^= u64::from(*b);
+            *hash = hash.wrapping_mul(FINGERPRINT_HASH_PRIME);
+        }
+    }
+    feed(&mut hash, kind.as_bytes());
+    feed(&mut hash, b"\0");
+    feed(&mut hash, path.to_string_lossy().as_bytes());
+    feed(&mut hash, b"\0");
+    feed(&mut hash, &len.to_le_bytes());
+    feed(&mut hash, &mtime_ms.to_le_bytes());
+    hash
 }
 
 /// Ingest every known session store once. Cleans stale pending stamps,
@@ -252,6 +281,9 @@ fn source_fingerprint(roots: &IngestRoots) -> String {
 /// moved and the call returns an empty report without loading cursors or
 /// touching any session file beyond the fingerprint walk. See #468.
 pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<IngestReport> {
+    progress(opts, "cleaning pending spawn stamps");
+    cleanup_stale_pending_stamps_in(opts.ledger_home.as_deref())?;
+
     progress(opts, "checking for source changes");
     let current_fp = source_fingerprint(&opts.roots);
     match ledger.read_source_fingerprint() {
@@ -265,8 +297,6 @@ pub fn ingest_all(ledger: &mut Ledger, opts: &IngestOptions) -> anyhow::Result<I
         Err(_) => {}
     }
 
-    progress(opts, "cleaning pending spawn stamps");
-    cleanup_stale_pending_stamps_in(opts.ledger_home.as_deref())?;
     progress(opts, "loading ingest cursors");
     let before = load_cursors(ledger).map_err(|e| anyhow::anyhow!(e))?;
     let mut after = before.clone();
@@ -1293,7 +1323,7 @@ mod tests {
         // Empty roots: well-formed, stable, and identical across calls.
         let empty = source_fingerprint(&roots);
         assert_eq!(empty, source_fingerprint(&roots));
-        assert_eq!(empty, "0:0:0");
+        assert_eq!(empty, "0:0:0000000000000000");
 
         let project = roots.claude_projects_dir.as_ref().unwrap().join("proj");
         fs::create_dir_all(&project).unwrap();

--- a/crates/relayburn-sdk/src/ingest/orchestration_tests.rs
+++ b/crates/relayburn-sdk/src/ingest/orchestration_tests.rs
@@ -26,6 +26,7 @@
 
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crate::ingest::cursors::{load_cursors, ClaudeCursor, FileCursor};
@@ -573,6 +574,63 @@ fn ingest_all_fast_path_still_cleans_stale_pending_stamps() {
     );
 }
 
+/// `force_scan` (set by the watch loop on an FS-event tick) must bypass the
+/// fingerprint gate even when the stat aggregate is unchanged — a `notify`
+/// event can land before the write flushes, so the fingerprint can't be
+/// trusted to prove "nothing changed" on that tick (#468 round 2). Without
+/// the bypass, a real event could be swallowed.
+#[test]
+fn ingest_all_force_scan_bypasses_unchanged_fingerprint() {
+    let tmp = TempDir::new().unwrap();
+    let _env = isolated_relayburn_home(&tmp);
+    let roots = pinned_roots(&tmp);
+
+    let project_dir = roots
+        .claude_projects_dir
+        .as_ref()
+        .unwrap()
+        .join("-tmp-project");
+    fs::create_dir_all(&project_dir).unwrap();
+    let sid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let session_file = project_dir.join(format!("{sid}.jsonl"));
+    fs::write(&session_file, claude_minimal_session(sid)).unwrap();
+
+    let mut ledger = open_ledger_in(&tmp);
+    let opts = IngestOptions {
+        roots: roots.clone(),
+        ..Default::default()
+    };
+    let forced_opts = IngestOptions {
+        roots,
+        force_scan: true,
+        ..Default::default()
+    };
+
+    // First sweep records the fingerprint.
+    assert!(ingest_all(&mut ledger, &opts).unwrap().scanned_sessions >= 1);
+
+    // Confirm the gate is armed: an unforced re-sweep short-circuits.
+    assert_eq!(
+        ingest_all(&mut ledger, &opts).unwrap().scanned_sessions,
+        0,
+        "unforced re-sweep with unchanged source should short-circuit"
+    );
+
+    // Forced sweep over the *same* unchanged source must still walk the file —
+    // this is the FS-event guarantee that a real event is never swallowed.
+    let forced = ingest_all(&mut ledger, &forced_opts).unwrap();
+    assert!(
+        forced.scanned_sessions >= 1,
+        "force_scan must bypass the fingerprint gate and re-walk the source"
+    );
+    // No new bytes on disk, so the per-file cursors still find nothing to
+    // append — force re-scans, it doesn't re-ingest already-seen turns.
+    assert_eq!(
+        forced.appended_turns, 0,
+        "a forced re-scan of unchanged bytes must not duplicate turns"
+    );
+}
+
 /// The fast path must not mask new data: appending to an existing session
 /// file changes its size + mtime, so the source fingerprint differs and the
 /// next `ingest_all` re-walks and picks up the new turns.
@@ -601,29 +659,196 @@ fn ingest_all_rescans_after_source_file_appended() {
 
     let r1 = ingest_all(&mut ledger, &opts).unwrap();
     assert!(r1.appended_turns >= 1);
+    let turns_before = ledger.query_turns(&Query::for_session(sid_a)).unwrap().len();
 
     // Confirm the gate is armed: an unchanged re-sweep short-circuits.
     assert_eq!(ingest_all(&mut ledger, &opts).unwrap().scanned_sessions, 0);
 
-    // Drop a brand-new session file — the fingerprint's file count, byte
-    // total, and path-aware metadata hash all move, so the gate must reopen.
-    // Give it a distinct timestamp/token shape so layer-2 content dedup
-    // doesn't collapse it onto session A's structurally-identical turn.
-    let sid_b = "cccccccc-cccc-cccc-cccc-cccccccccccc";
-    let file_b = project_dir.join(format!("{sid_b}.jsonl"));
-    fs::write(&file_b, claude_distinct_session(sid_b)).unwrap();
+    // Append new JSONL lines to the *existing* session file in place — the
+    // case directory mtimes miss but the stat-only fingerprint must still
+    // catch via the byte-total (and path-aware metadata hash) moving. Reuse
+    // the distinct-session turn shape (new uuids/message id + different
+    // text/timestamp) so layer-2 content dedup doesn't collapse it onto the
+    // first turn pair.
+    {
+        let extra = claude_distinct_session(sid_a);
+        let mut f = fs::OpenOptions::new().append(true).open(&file_a).unwrap();
+        f.write_all(extra.as_bytes()).unwrap();
+    }
 
     let r3 = ingest_all(&mut ledger, &opts).unwrap();
     assert!(
         r3.scanned_sessions >= 1,
-        "a new source file must defeat the fast path"
+        "an in-place append must defeat the fast path"
     );
     assert!(
         r3.appended_turns >= 1,
-        "the new session's turns must be ingested"
+        "the appended turns must be ingested"
     );
-    let turns_b = ledger.query_turns(&Query::for_session(sid_b)).unwrap();
-    assert!(!turns_b.is_empty(), "new session should be queryable");
+    let turns_after = ledger.query_turns(&Query::for_session(sid_a)).unwrap().len();
+    assert!(
+        turns_after > turns_before,
+        "appended turns must be queryable (before={turns_before}, after={turns_after})"
+    );
+}
+
+/// A source file that was statted (and so counted into the fingerprint) but
+/// couldn't be parsed must NOT arm the fast path: caching the fingerprint over
+/// a skip would make a transient read failure sticky — a later `chmod` that
+/// fixes the file (moving ctime, not size/mtime) would match the stored
+/// fingerprint and short-circuit before retrying, stranding the session. The
+/// next sweep must re-walk and pick the file up once it's readable.
+#[cfg(unix)]
+#[test]
+fn ingest_all_skipped_source_does_not_arm_fast_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let _env = isolated_relayburn_home(&tmp);
+    let roots = pinned_roots(&tmp);
+
+    let project_dir = roots
+        .claude_projects_dir
+        .as_ref()
+        .unwrap()
+        .join("-tmp-project");
+    fs::create_dir_all(&project_dir).unwrap();
+
+    // A readable session plus one we make unreadable so the parser errors.
+    let sid_ok = "11111111-2222-3333-4444-555555555555";
+    fs::write(
+        project_dir.join(format!("{sid_ok}.jsonl")),
+        claude_minimal_session(sid_ok),
+    )
+    .unwrap();
+    let sid_bad = "99999999-8888-7777-6666-555555555555";
+    let file_bad = project_dir.join(format!("{sid_bad}.jsonl"));
+    fs::write(&file_bad, claude_distinct_session(sid_bad)).unwrap();
+    fs::set_permissions(&file_bad, fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Running as root bypasses the permission bits, so the parser would read
+    // the file fine and there'd be no skip to assert on. Skip the test there.
+    if fs::File::open(&file_bad).is_ok() {
+        fs::set_permissions(&file_bad, fs::Permissions::from_mode(0o644)).unwrap();
+        return;
+    }
+
+    let mut ledger = open_ledger_in(&tmp);
+    let opts = IngestOptions {
+        roots,
+        ..Default::default()
+    };
+
+    // First sweep: the bad file is statted (counted into the fingerprint) but
+    // fails to parse, so the fingerprint must be left stale.
+    ingest_all(&mut ledger, &opts).unwrap();
+
+    // Because of the skip, an unchanged re-sweep must NOT short-circuit — it
+    // re-walks so the still-broken file gets another chance.
+    assert!(
+        ingest_all(&mut ledger, &opts).unwrap().scanned_sessions >= 1,
+        "a skipped source must keep the fast path off until it's processed"
+    );
+
+    // Fix the file's permissions (ctime moves, size/mtime don't) and confirm
+    // the next sweep finally ingests it — proving the gate never closed over it.
+    fs::set_permissions(&file_bad, fs::Permissions::from_mode(0o644)).unwrap();
+    let recovered = ingest_all(&mut ledger, &opts).unwrap();
+    assert!(
+        recovered.appended_turns >= 1,
+        "the recovered file's turns must be ingested once it's readable"
+    );
+    let turns_bad = ledger.query_turns(&Query::for_session(sid_bad)).unwrap();
+    assert!(
+        !turns_bad.is_empty(),
+        "previously-unreadable session should now be queryable"
+    );
+}
+
+/// The fingerprint lives in `archive_state`, so it must survive closing and
+/// reopening the ledger: a fresh `Ledger::open` against the same DB must still
+/// short-circuit an unchanged source. Guards against the gate accidentally
+/// keying on in-memory-only state.
+#[test]
+fn ingest_all_short_circuit_survives_ledger_reopen() {
+    let tmp = TempDir::new().unwrap();
+    let _env = isolated_relayburn_home(&tmp);
+    let roots = pinned_roots(&tmp);
+
+    let project_dir = roots
+        .claude_projects_dir
+        .as_ref()
+        .unwrap()
+        .join("-tmp-project");
+    fs::create_dir_all(&project_dir).unwrap();
+    let sid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let session_file = project_dir.join(format!("{sid}.jsonl"));
+    fs::write(&session_file, claude_minimal_session(sid)).unwrap();
+
+    let opts = IngestOptions {
+        roots,
+        ..Default::default()
+    };
+
+    {
+        let mut ledger = open_ledger_in(&tmp);
+        let r1 = ingest_all(&mut ledger, &opts).unwrap();
+        assert!(r1.scanned_sessions >= 1, "first sweep should walk the file");
+    }
+
+    // Reopen the same on-disk ledger. The persisted fingerprint must still
+    // gate the unchanged source.
+    let mut ledger = open_ledger_in(&tmp);
+    let r2 = ingest_all(&mut ledger, &opts).unwrap();
+    assert_eq!(
+        r2.scanned_sessions, 0,
+        "fingerprint persisted in archive_state should gate across a reopen"
+    );
+    assert_eq!(r2.appended_turns, 0);
+}
+
+/// `reset` blanks `source_fingerprint`, so the next `ingest_all` must re-walk
+/// from scratch even though nothing on disk changed. Proves the ledger-side
+/// blanking is wired end-to-end through the ingest gate (not just covered by
+/// the unit test on the SQL).
+#[test]
+fn ingest_all_rescans_after_reset_blanks_fingerprint() {
+    let tmp = TempDir::new().unwrap();
+    let _env = isolated_relayburn_home(&tmp);
+    let roots = pinned_roots(&tmp);
+
+    let project_dir = roots
+        .claude_projects_dir
+        .as_ref()
+        .unwrap()
+        .join("-tmp-project");
+    fs::create_dir_all(&project_dir).unwrap();
+    let sid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    let session_file = project_dir.join(format!("{sid}.jsonl"));
+    fs::write(&session_file, claude_minimal_session(sid)).unwrap();
+
+    let mut ledger = open_ledger_in(&tmp);
+    let opts = IngestOptions {
+        roots,
+        ..Default::default()
+    };
+
+    assert!(ingest_all(&mut ledger, &opts).unwrap().scanned_sessions >= 1);
+    // Gate is armed.
+    assert_eq!(ingest_all(&mut ledger, &opts).unwrap().scanned_sessions, 0);
+
+    // reset() blanks the fingerprint (and cursors), so ingest must re-walk
+    // and re-ingest the still-present source file.
+    ledger.reset().unwrap();
+    let r = ingest_all(&mut ledger, &opts).unwrap();
+    assert!(
+        r.scanned_sessions >= 1,
+        "reset must blank the fingerprint and force a re-walk"
+    );
+    assert!(
+        r.appended_turns >= 1,
+        "reset wiped derivable turns, so the re-walk must re-ingest them"
+    );
 }
 
 // --- helpers -------------------------------------------------------------

--- a/crates/relayburn-sdk/src/ingest/orchestration_tests.rs
+++ b/crates/relayburn-sdk/src/ingest/orchestration_tests.rs
@@ -522,6 +522,57 @@ fn ingest_all_short_circuits_when_source_unchanged() {
     assert_eq!(r2.appended_turns, 0);
 }
 
+#[test]
+fn ingest_all_fast_path_still_cleans_stale_pending_stamps() {
+    let tmp = TempDir::new().unwrap();
+    let _env = isolated_relayburn_home(&tmp);
+    let roots = pinned_roots(&tmp);
+
+    let project_dir = roots
+        .claude_projects_dir
+        .as_ref()
+        .unwrap()
+        .join("-tmp-project");
+    fs::create_dir_all(&project_dir).unwrap();
+    let sid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let session_file = project_dir.join(format!("{sid}.jsonl"));
+    fs::write(&session_file, claude_minimal_session(sid)).unwrap();
+
+    let mut ledger = open_ledger_in(&tmp);
+    let opts = IngestOptions {
+        roots,
+        ..Default::default()
+    };
+    assert!(ingest_all(&mut ledger, &opts).unwrap().appended_turns >= 1);
+
+    let pending_dir = tmp.path().join("relayburn").join("pending-stamps");
+    fs::create_dir_all(&pending_dir).unwrap();
+    let stale = pending_dir.join("claude-1-946684800000-stale.json");
+    fs::write(
+        &stale,
+        r#"{
+  "v": 1,
+  "harness": "claude",
+  "spawnerPid": 1,
+  "spawnStartTs": "2000-01-01T00:00:00.000Z",
+  "cwd": "/tmp/project",
+  "enrichment": {
+    "persona": "stale"
+  }
+}
+"#,
+    )
+    .unwrap();
+    assert!(stale.exists());
+
+    let r2 = ingest_all(&mut ledger, &opts).unwrap();
+    assert_eq!(r2.scanned_sessions, 0);
+    assert!(
+        !stale.exists(),
+        "fast-path ingest must still clean stale pending stamps"
+    );
+}
+
 /// The fast path must not mask new data: appending to an existing session
 /// file changes its size + mtime, so the source fingerprint differs and the
 /// next `ingest_all` re-walks and picks up the new turns.
@@ -554,10 +605,10 @@ fn ingest_all_rescans_after_source_file_appended() {
     // Confirm the gate is armed: an unchanged re-sweep short-circuits.
     assert_eq!(ingest_all(&mut ledger, &opts).unwrap().scanned_sessions, 0);
 
-    // Drop a brand-new session file — the fingerprint's file count + byte
-    // total + mtime sum all move, so the gate must reopen. Give it a
-    // distinct timestamp/token shape so layer-2 content dedup doesn't
-    // collapse it onto session A's structurally-identical turn.
+    // Drop a brand-new session file — the fingerprint's file count, byte
+    // total, and path-aware metadata hash all move, so the gate must reopen.
+    // Give it a distinct timestamp/token shape so layer-2 content dedup
+    // doesn't collapse it onto session A's structurally-identical turn.
     let sid_b = "cccccccc-cccc-cccc-cccc-cccccccccccc";
     let file_b = project_dir.join(format!("{sid_b}.jsonl"));
     fs::write(&file_b, claude_distinct_session(sid_b)).unwrap();

--- a/crates/relayburn-sdk/src/ingest/orchestration_tests.rs
+++ b/crates/relayburn-sdk/src/ingest/orchestration_tests.rs
@@ -479,7 +479,148 @@ fn ingest_claude_transcript_path_missing_file_is_empty_report() {
     assert_eq!(r.appended_turns, 0);
 }
 
+/// No-op fast path (#468): once a sweep records the source fingerprint, a
+/// follow-up `ingest_all` with no upstream change must short-circuit before
+/// it walks any session file. The earlier EOF-cursor test proves
+/// `appended_turns == 0`; this one proves the stronger property that the
+/// loops never ran at all (`scanned_sessions == 0`).
+#[test]
+fn ingest_all_short_circuits_when_source_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let _env = isolated_relayburn_home(&tmp);
+    let roots = pinned_roots(&tmp);
+
+    let project_dir = roots
+        .claude_projects_dir
+        .as_ref()
+        .unwrap()
+        .join("-tmp-project");
+    fs::create_dir_all(&project_dir).unwrap();
+    let sid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let session_file = project_dir.join(format!("{sid}.jsonl"));
+    fs::write(&session_file, claude_minimal_session(sid)).unwrap();
+
+    let mut ledger = open_ledger_in(&tmp);
+    let opts = IngestOptions {
+        roots,
+        ..Default::default()
+    };
+
+    let r1 = ingest_all(&mut ledger, &opts).unwrap();
+    assert!(r1.scanned_sessions >= 1, "first sweep should walk the file");
+    assert!(
+        r1.appended_turns >= 1,
+        "first sweep should ingest the turns"
+    );
+
+    // Nothing on disk moved — the second sweep must take the fast path.
+    let r2 = ingest_all(&mut ledger, &opts).unwrap();
+    assert_eq!(
+        r2.scanned_sessions, 0,
+        "unchanged source should short-circuit before walking any file"
+    );
+    assert_eq!(r2.appended_turns, 0);
+}
+
+/// The fast path must not mask new data: appending to an existing session
+/// file changes its size + mtime, so the source fingerprint differs and the
+/// next `ingest_all` re-walks and picks up the new turns.
+#[test]
+fn ingest_all_rescans_after_source_file_appended() {
+    let tmp = TempDir::new().unwrap();
+    let _env = isolated_relayburn_home(&tmp);
+    let roots = pinned_roots(&tmp);
+
+    let project_dir = roots
+        .claude_projects_dir
+        .as_ref()
+        .unwrap()
+        .join("-tmp-project");
+    fs::create_dir_all(&project_dir).unwrap();
+
+    let sid_a = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    let file_a = project_dir.join(format!("{sid_a}.jsonl"));
+    fs::write(&file_a, claude_minimal_session(sid_a)).unwrap();
+
+    let mut ledger = open_ledger_in(&tmp);
+    let opts = IngestOptions {
+        roots,
+        ..Default::default()
+    };
+
+    let r1 = ingest_all(&mut ledger, &opts).unwrap();
+    assert!(r1.appended_turns >= 1);
+
+    // Confirm the gate is armed: an unchanged re-sweep short-circuits.
+    assert_eq!(ingest_all(&mut ledger, &opts).unwrap().scanned_sessions, 0);
+
+    // Drop a brand-new session file — the fingerprint's file count + byte
+    // total + mtime sum all move, so the gate must reopen. Give it a
+    // distinct timestamp/token shape so layer-2 content dedup doesn't
+    // collapse it onto session A's structurally-identical turn.
+    let sid_b = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    let file_b = project_dir.join(format!("{sid_b}.jsonl"));
+    fs::write(&file_b, claude_distinct_session(sid_b)).unwrap();
+
+    let r3 = ingest_all(&mut ledger, &opts).unwrap();
+    assert!(
+        r3.scanned_sessions >= 1,
+        "a new source file must defeat the fast path"
+    );
+    assert!(
+        r3.appended_turns >= 1,
+        "the new session's turns must be ingested"
+    );
+    let turns_b = ledger.query_turns(&Query::for_session(sid_b)).unwrap();
+    assert!(!turns_b.is_empty(), "new session should be queryable");
+}
+
 // --- helpers -------------------------------------------------------------
+
+/// Like [`claude_minimal_session`] but with a distinct timestamp, message
+/// id, and token shape so its layer-2 content fingerprint differs from the
+/// minimal fixture — lets a test ingest two sessions without one being
+/// deduped onto the other.
+fn claude_distinct_session(session_id: &str) -> String {
+    let user = serde_json::json!({
+        "parentUuid": null,
+        "isSidechain": false,
+        "type": "user",
+        "message": {"role": "user", "content": "hello again"},
+        "uuid": "u-user-2",
+        "timestamp": "2026-05-01T12:00:00.000Z",
+        "cwd": "/tmp/project",
+        "sessionId": session_id,
+    });
+    let assistant = serde_json::json!({
+        "parentUuid": "u-user-2",
+        "isSidechain": false,
+        "message": {
+            "model": "claude-sonnet-4-6",
+            "id": "msg-asst-2",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "different reply"}],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 42,
+                "output_tokens": 99,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 0,
+                    "ephemeral_1h_input_tokens": 0
+                }
+            }
+        },
+        "type": "assistant",
+        "uuid": "u-asst-2",
+        "timestamp": "2026-05-01T12:00:01.000Z",
+        "cwd": "/tmp/project",
+        "sessionId": session_id,
+    });
+    format!("{}\n{}\n", user, assistant)
+}
 
 fn copy_dir_recursive(src: &Path, dst: &Path) {
     fs::create_dir_all(dst).unwrap();

--- a/crates/relayburn-sdk/src/ingest/watch_loop.rs
+++ b/crates/relayburn-sdk/src/ingest/watch_loop.rs
@@ -43,8 +43,15 @@ use tokio::task::JoinHandle;
 use crate::ingest::fs_events::FsBurst;
 use crate::ingest::ingest::IngestReport;
 
+/// Ingest callable driven by the loop. The `bool` argument is `force`: the
+/// FS-event driver passes `true` so the tick bypasses the no-op fast path
+/// (an FS event can fire before the write flushes, leaving the stat-only
+/// source fingerprint unchanged), while the polling backstop and the
+/// on-demand [`WatchController::tick`] pass `false` and keep the fast path.
 pub type IngestFn = Arc<
-    dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<IngestReport>> + Send>> + Send + Sync,
+    dyn Fn(bool) -> Pin<Box<dyn Future<Output = anyhow::Result<IngestReport>> + Send>>
+        + Send
+        + Sync,
 >;
 
 pub type ReportSink = Arc<dyn Fn(&IngestReport) + Send + Sync>;
@@ -190,11 +197,11 @@ impl WatchInner {
     /// The runner — whichever path holds the `in_flight` lock — owns the
     /// `tick_done` notify so a public `tick().await` parked via
     /// `run_tick_or_join` wakes regardless of which path drove the run.
-    async fn run_tick_skip_if_busy(self: &Arc<Self>) {
+    async fn run_tick_skip_if_busy(self: &Arc<Self>, force: bool) {
         let Ok(_guard) = self.in_flight.try_lock() else {
             return;
         };
-        self.run_locked().await;
+        self.run_locked(force).await;
     }
 
     /// Run-or-join variant used by the public `tick()`: if a tick is
@@ -202,7 +209,7 @@ impl WatchInner {
     /// silently skipping. Mirrors the TS `if (running) return running;`
     /// branch where overlapping callers share the in-flight promise — a
     /// `tick().await` is a real completion barrier rather than a no-op.
-    async fn run_tick_or_join(self: &Arc<Self>) {
+    async fn run_tick_or_join(self: &Arc<Self>, force: bool) {
         // Register interest BEFORE the try_lock peek. `Notified::enable`
         // (added in tokio 1.13) latches the waker on creation so a runner
         // that finishes between our peek and the await still wakes us;
@@ -213,7 +220,7 @@ impl WatchInner {
         notified.as_mut().enable();
 
         if let Ok(_guard) = self.in_flight.try_lock() {
-            self.run_locked().await;
+            self.run_locked(force).await;
         } else {
             notified.await;
         }
@@ -224,8 +231,8 @@ impl WatchInner {
     /// `run_tick_or_join` (public `tick`) funnel through here so any
     /// caller parked on `tick_done` wakes when the run finishes —
     /// regardless of which path the runner came from.
-    async fn run_locked(self: &Arc<Self>) {
-        let result = (self.ingest)().await;
+    async fn run_locked(self: &Arc<Self>, force: bool) {
+        let result = (self.ingest)(force).await;
         match result {
             Ok(report) => {
                 if let Some(sink) = &self.on_report {
@@ -249,7 +256,9 @@ impl WatchController {
     /// it and return when it completes — `tick().await` is a true
     /// completion barrier, matching the TS adapter's shared-promise shape.
     pub async fn tick(&self) {
-        self.inner.run_tick_or_join().await;
+        // On-demand ticks keep the fast path: a manual `tick()` isn't tied to
+        // an in-flight FS write, so the stat fingerprint is trustworthy.
+        self.inner.run_tick_or_join(false).await;
     }
 
     /// Stop the periodic task and await any in-flight tick. Idempotent.
@@ -313,7 +322,9 @@ pub fn start_watch_loop(opts: StartWatchLoopOptions) -> WatchController {
         };
 
         if immediate {
-            ticker.run_tick_skip_if_busy().await;
+            // Startup sweep: a fresh ledger has a blank fingerprint, so this
+            // always runs a full scan anyway; no need to force.
+            ticker.run_tick_skip_if_busy(false).await;
         }
 
         match burst {
@@ -361,7 +372,9 @@ async fn run_polling_driver(ticker: &Arc<WatchInner>, interval: Duration) {
         if ticker.stopped.load(Ordering::SeqCst) {
             break;
         }
-        ticker.run_tick_skip_if_busy().await;
+        // Pure-polling driver: no FS-event signal, so the stat fingerprint is
+        // the only change source — keep the fast path (force = false).
+        ticker.run_tick_skip_if_busy(false).await;
     }
 }
 
@@ -380,21 +393,27 @@ async fn run_fs_event_driver(
         if ticker.stopped.load(Ordering::SeqCst) {
             break;
         }
-        tokio::select! {
+        // `force` is true only when an FS event woke us: a `notify` event can
+        // arrive before the write is flushed, so the stat-only source
+        // fingerprint may still match the stored value. Forcing the sweep on an
+        // event makes the per-file cursors the source of truth for that tick.
+        // The slow backstop leaves `force` false so a quiet period still pays
+        // only the no-op fast path.
+        let force = tokio::select! {
             // `wait_for_burst` always resolves to `Some(())` once its
             // debounce window elapses; under sustained writes that's
             // every ~debounce, under bursts it coalesces. We don't
             // pattern-match the Option because the Notify-backed
             // channel can't close without dropping `_watcher`, which
             // would have already torn down this task.
-            _ = burst.wait_for_burst(debounce) => {}
-            _ = slow.tick() => {}
+            _ = burst.wait_for_burst(debounce) => true,
+            _ = slow.tick() => false,
             _ = ticker.stop_signal.notified() => break,
-        }
+        };
         if ticker.stopped.load(Ordering::SeqCst) {
             break;
         }
-        ticker.run_tick_skip_if_busy().await;
+        ticker.run_tick_skip_if_busy(force).await;
     }
 }
 
@@ -404,7 +423,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn ingest_counting(counter: Arc<AtomicUsize>) -> IngestFn {
-        Arc::new(move || {
+        Arc::new(move |_force: bool| {
             let counter = counter.clone();
             Box::pin(async move {
                 counter.fetch_add(1, Ordering::SeqCst);
@@ -502,7 +521,7 @@ mod tests {
         let in_flight_for_ingest = in_flight_count.clone();
         let max_for_ingest = max_concurrent.clone();
         let completed_for_ingest = completed.clone();
-        let ingest: IngestFn = Arc::new(move || {
+        let ingest: IngestFn = Arc::new(move |_force: bool| {
             let in_flight = in_flight_for_ingest.clone();
             let max = max_for_ingest.clone();
             let completed = completed_for_ingest.clone();
@@ -556,7 +575,8 @@ mod tests {
         use std::sync::Mutex as StdMutex;
         let captured: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
         let captured_clone = captured.clone();
-        let ingest: IngestFn = Arc::new(|| Box::pin(async move { Err(anyhow::anyhow!("boom")) }));
+        let ingest: IngestFn =
+            Arc::new(|_force: bool| Box::pin(async move { Err(anyhow::anyhow!("boom")) }));
         let on_error: ErrorSink = Arc::new(move |err| {
             captured_clone.lock().unwrap().push(err.to_string());
         });

--- a/crates/relayburn-sdk/src/ingest/watch_loop_tests.rs
+++ b/crates/relayburn-sdk/src/ingest/watch_loop_tests.rs
@@ -20,7 +20,7 @@ async fn watch_loop_drains_pending_work_within_two_ticks() {
 
     let pending_for_ingest = pending.clone();
     let drained_for_ingest = drained.clone();
-    let ingest: IngestFn = Arc::new(move || {
+    let ingest: IngestFn = Arc::new(move |_force: bool| {
         let pending = pending_for_ingest.clone();
         let drained = drained_for_ingest.clone();
         Box::pin(async move {
@@ -76,7 +76,7 @@ async fn manual_tick_joins_periodic_run() {
 
     let in_flight_for_ingest = in_flight.clone();
     let completed_for_ingest = completed.clone();
-    let ingest: IngestFn = Arc::new(move || {
+    let ingest: IngestFn = Arc::new(move |_force: bool| {
         let in_flight = in_flight_for_ingest.clone();
         let completed = completed_for_ingest.clone();
         Box::pin(async move {
@@ -131,7 +131,7 @@ async fn stop_awaits_in_flight_tick() {
 
     let in_flight_for_ingest = in_flight.clone();
     let completed_for_ingest = completed.clone();
-    let ingest: IngestFn = Arc::new(move || {
+    let ingest: IngestFn = Arc::new(move |_force: bool| {
         let in_flight = in_flight_for_ingest.clone();
         let completed = completed_for_ingest.clone();
         Box::pin(async move {
@@ -172,7 +172,7 @@ async fn stop_awaits_in_flight_tick() {
 async fn fs_events_fall_back_to_polling_when_no_path_exists() {
     let runs = Arc::new(AtomicUsize::new(0));
     let runs_for_ingest = runs.clone();
-    let ingest: IngestFn = Arc::new(move || {
+    let ingest: IngestFn = Arc::new(move |_force: bool| {
         let runs = runs_for_ingest.clone();
         Box::pin(async move {
             runs.fetch_add(1, Ordering::SeqCst);
@@ -218,7 +218,7 @@ async fn disable_fsevents_forces_polling_driver() {
     let dir = tempfile::tempdir().unwrap();
     let runs = Arc::new(AtomicUsize::new(0));
     let runs_for_ingest = runs.clone();
-    let ingest: IngestFn = Arc::new(move || {
+    let ingest: IngestFn = Arc::new(move |_force: bool| {
         let runs = runs_for_ingest.clone();
         Box::pin(async move {
             runs.fetch_add(1, Ordering::SeqCst);
@@ -257,11 +257,17 @@ async fn disable_fsevents_forces_polling_driver() {
 async fn burst_writes_coalesce_into_one_tick() {
     let dir = tempfile::tempdir().unwrap();
     let runs = Arc::new(AtomicUsize::new(0));
+    let forced_runs = Arc::new(AtomicUsize::new(0));
     let runs_for_ingest = runs.clone();
-    let ingest: IngestFn = Arc::new(move || {
+    let forced_for_ingest = forced_runs.clone();
+    let ingest: IngestFn = Arc::new(move |force: bool| {
         let runs = runs_for_ingest.clone();
+        let forced = forced_for_ingest.clone();
         Box::pin(async move {
             runs.fetch_add(1, Ordering::SeqCst);
+            if force {
+                forced.fetch_add(1, Ordering::SeqCst);
+            }
             Ok(IngestReport::default())
         })
     });
@@ -295,5 +301,13 @@ async fn burst_writes_coalesce_into_one_tick() {
     assert!(
         n >= 1,
         "100 burst writes should still wake the loop at least once, got {n}"
+    );
+    // The slow backstop is 60s and never fires in this window, so every tick
+    // here came from an FS event and must be forced — that is what defeats the
+    // fingerprint gate when a `notify` event beats the write's flush (#468 r2).
+    assert_eq!(
+        forced_runs.load(Ordering::SeqCst),
+        n,
+        "every FS-event-driven tick must pass force = true"
     );
 }

--- a/crates/relayburn-sdk/src/ingest_verb.rs
+++ b/crates/relayburn-sdk/src/ingest_verb.rs
@@ -54,6 +54,9 @@ impl IngestOptions {
             on_warn: self.on_warn,
             ledger_home: self.ledger_home,
             roots: self.roots,
+            // The public verb is never FS-event driven, so it always keeps the
+            // no-op fast path. `force_scan` is internal to the watch loop.
+            force_scan: false,
         }
     }
 }

--- a/crates/relayburn-sdk/src/ledger.rs
+++ b/crates/relayburn-sdk/src/ledger.rs
@@ -372,8 +372,13 @@ impl Ledger {
         }
 
         let now = writer::debug_now();
+        // Blank the source fingerprint so the ingest gate can't short-circuit
+        // a sweep against derived tables we just wiped. Cursors survive (the
+        // partial-progress contract for rebuild), so re-ingest stays cheap;
+        // this only forces the next ingest to re-examine source state rather
+        // than trusting a fingerprint recorded before the drop.
         self.conns.burn.execute(
-            "UPDATE archive_state SET last_rebuild_at = ? WHERE id = 1",
+            "UPDATE archive_state SET last_rebuild_at = ?, source_fingerprint = '' WHERE id = 1",
             params![now],
         )?;
 
@@ -443,6 +448,30 @@ impl Ledger {
                  last_built_at = ?
              WHERE id = 1",
             params![cursors_json, now],
+        )?;
+        Ok(())
+    }
+
+    /// Read the cheap source-change fingerprint recorded by the last
+    /// `ingest_all` sweep. Empty string means "never recorded" (fresh DB,
+    /// pre-v6 ledger, or post-reset) — which never matches a live
+    /// fingerprint, so ingest falls through to a full walk.
+    pub fn read_source_fingerprint(&self) -> Result<String> {
+        let fp: String = self.conns.burn.query_row(
+            "SELECT source_fingerprint FROM archive_state WHERE id = 1",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(fp)
+    }
+
+    /// Persist the source-change fingerprint. `ingest_all` calls this at the
+    /// end of a full sweep so the next call can short-circuit when nothing
+    /// upstream has moved.
+    pub fn write_source_fingerprint(&mut self, fingerprint: &str) -> Result<()> {
+        self.conns.burn.execute(
+            "UPDATE archive_state SET source_fingerprint = ? WHERE id = 1",
+            params![fingerprint],
         )?;
         Ok(())
     }
@@ -517,7 +546,8 @@ impl Ledger {
             "UPDATE archive_state \
              SET upstream_cursors_json = '{}', \
                  last_built_at = NULL, \
-                 last_rebuild_at = NULL \
+                 last_rebuild_at = NULL, \
+                 source_fingerprint = '' \
              WHERE id = 1",
             [],
         )?;

--- a/crates/relayburn-sdk/src/ledger/db.rs
+++ b/crates/relayburn-sdk/src/ledger/db.rs
@@ -220,6 +220,27 @@ fn migrate_burn_schema(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    if current_version < 6 {
+        // v5 → v6: add `archive_state.source_fingerprint` so `ingest_all`
+        // can short-circuit a no-op sweep. Same duplicate-column-only
+        // swallow pattern as the earlier steps; legacy rows default to ''
+        // which never matches a live fingerprint, so the first post-upgrade
+        // ingest walks normally and records the column. See #468.
+        match conn.execute(
+            "ALTER TABLE archive_state ADD COLUMN source_fingerprint TEXT NOT NULL DEFAULT ''",
+            [],
+        ) {
+            Ok(_) => {}
+            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
+                if msg.contains("duplicate column name") => {}
+            Err(e) => return Err(e.into()),
+        }
+        conn.execute(
+            "UPDATE archive_state SET schema_version = 6 WHERE id = 1",
+            [],
+        )?;
+    }
+
     // The `idx_turns_stop_reason` index is created here rather than in
     // the static DDL so a legacy v1 table (no `stop_reason` column yet)
     // doesn't fail the DDL pre-pass. By this point the column either

--- a/crates/relayburn-sdk/src/ledger/schema.rs
+++ b/crates/relayburn-sdk/src/ledger/schema.rs
@@ -57,7 +57,14 @@ pub const DERIVABLE_TABLES: &[&str] = &[
 ///   many inferences" don't conflate a single Claude API call's multiple
 ///   content-block rows. Derived at ingest from the parser's
 ///   `request_id_lookup`; rebuilt by `burn state rebuild`. (#434)
-pub const SCHEMA_VERSION: u32 = 5;
+/// - `6`: adds `archive_state.source_fingerprint TEXT` — a cheap aggregate
+///   (`count:totalBytes:mtimeSum`) over the source session files ingest
+///   scans. `ingest_all` records it after each sweep and short-circuits to
+///   an empty report when the live source fingerprint is unchanged, so a
+///   no-op ingest costs a stat-only walk instead of a full cursor load +
+///   per-file deserialize. Blanked by `state reset` so the next ingest
+///   re-walks from scratch. (#468)
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// DDL for `burn.sqlite`. Idempotent (`IF NOT EXISTS`) so re-applying on
 /// startup is a no-op once the tables exist.
@@ -221,11 +228,14 @@ CREATE TABLE IF NOT EXISTS archive_state (
     schema_version        INTEGER NOT NULL,
     upstream_cursors_json TEXT NOT NULL DEFAULT '{}',
     last_built_at         TEXT,
-    last_rebuild_at       TEXT
+    last_rebuild_at       TEXT,
+    -- Cheap source-side change gate: `count:totalBytes:mtimeSum` over the
+    -- session files ingest scans. Empty until the first ingest records it.
+    source_fingerprint    TEXT NOT NULL DEFAULT ''
 );
 
 INSERT INTO archive_state (id, schema_version)
-    VALUES (1, 5)
+    VALUES (1, 6)
     ON CONFLICT(id) DO NOTHING;
 "#;
 

--- a/crates/relayburn-sdk/src/ledger/schema.rs
+++ b/crates/relayburn-sdk/src/ledger/schema.rs
@@ -62,8 +62,9 @@ pub const DERIVABLE_TABLES: &[&str] = &[
 ///   `ingest_all` records it after each sweep and short-circuits to an
 ///   empty report when the live source fingerprint is unchanged, so a
 ///   no-op ingest costs a stat-only walk instead of a full cursor load +
-///   per-file deserialize. Blanked by `state reset` so the next ingest
-///   re-walks from scratch. (#468)
+///   per-file deserialize. Blanked by `state rebuild` / `state reset` so the
+///   next ingest does not trust source state captured before derived rows were
+///   wiped. (#468)
 pub const SCHEMA_VERSION: u32 = 6;
 
 /// DDL for `burn.sqlite`. Idempotent (`IF NOT EXISTS`) so re-applying on

--- a/crates/relayburn-sdk/src/ledger/schema.rs
+++ b/crates/relayburn-sdk/src/ledger/schema.rs
@@ -58,9 +58,9 @@ pub const DERIVABLE_TABLES: &[&str] = &[
 ///   content-block rows. Derived at ingest from the parser's
 ///   `request_id_lookup`; rebuilt by `burn state rebuild`. (#434)
 /// - `6`: adds `archive_state.source_fingerprint TEXT` — a cheap aggregate
-///   (`count:totalBytes:mtimeSum`) over the source session files ingest
-///   scans. `ingest_all` records it after each sweep and short-circuits to
-///   an empty report when the live source fingerprint is unchanged, so a
+///   (`count:totalBytes:hash`) over the source session files ingest scans.
+///   `ingest_all` records it after each sweep and short-circuits to an
+///   empty report when the live source fingerprint is unchanged, so a
 ///   no-op ingest costs a stat-only walk instead of a full cursor load +
 ///   per-file deserialize. Blanked by `state reset` so the next ingest
 ///   re-walks from scratch. (#468)
@@ -229,7 +229,7 @@ CREATE TABLE IF NOT EXISTS archive_state (
     upstream_cursors_json TEXT NOT NULL DEFAULT '{}',
     last_built_at         TEXT,
     last_rebuild_at       TEXT,
-    -- Cheap source-side change gate: `count:totalBytes:mtimeSum` over the
+    -- Cheap source-side change gate: `count:totalBytes:hash` over the
     -- session files ingest scans. Empty until the first ingest records it.
     source_fingerprint    TEXT NOT NULL DEFAULT ''
 );

--- a/crates/relayburn-sdk/src/ledger/tests.rs
+++ b/crates/relayburn-sdk/src/ledger/tests.rs
@@ -739,7 +739,8 @@ fn invalid_session_id_in_content_rejected() {
 /// column on `turns`, `archive_state.schema_version = 1`) opens cleanly
 /// against the 3.0 SDK, the column is back-added by the in-place
 /// migration, and the stored version bumps forward to the current
-/// `SCHEMA_VERSION` (5 after #436 + #435 + #434 chained on top of #437).
+/// `SCHEMA_VERSION` (6 after #436 + #435 + #434 + #468 chained on top of
+/// #437).
 /// Existing rows stay `NULL` for every back-added column until rewritten.
 #[test]
 fn legacy_v1_ledger_migrates_to_v2_on_open_and_adds_stop_reason_column() {
@@ -786,7 +787,7 @@ fn legacy_v1_ledger_migrates_to_v2_on_open_and_adds_stop_reason_column() {
     // Step 2: open through the SDK. The migration must:
     //   a) add `turns.stop_reason TEXT`,
     //   b) bump archive_state.schema_version forward to the current
-    //      `SCHEMA_VERSION` (chained v1 → v2 → v3 once #436 lands),
+    //      `SCHEMA_VERSION` (chained v1 → v2 → v3 → v4 → v5 → v6),
     //   c) leave the legacy row's stop_reason as NULL.
     let l = Ledger::open(&layout.burn, &layout.content).unwrap();
     let version: i64 = l

--- a/crates/relayburn-sdk/src/ledger/tests.rs
+++ b/crates/relayburn-sdk/src/ledger/tests.rs
@@ -798,12 +798,28 @@ fn legacy_v1_ledger_migrates_to_v2_on_open_and_adds_stop_reason_column() {
             |r| r.get(0),
         )
         .unwrap();
-    // Current `SCHEMA_VERSION` is 5 (chained #437 v2 + #436 v3 + #435
-    // v4 + #434 v5); the migration must walk every step in one open()
-    // call.
+    // Current `SCHEMA_VERSION` is 6 (chained #437 v2 + #436 v3 + #435
+    // v4 + #434 v5 + #468 v6); the migration must walk every step in one
+    // open() call.
     assert_eq!(
-        version, 5,
+        version, 6,
         "open must bump v1 forward to the current schema version"
+    );
+
+    // v5 → v6 must have added the `source_fingerprint` column to the
+    // legacy archive_state table (which predated it).
+    let archive_cols: Vec<String> = l
+        .conns
+        .burn
+        .prepare("PRAGMA table_info(archive_state)")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<std::result::Result<_, _>>()
+        .unwrap();
+    assert!(
+        archive_cols.iter().any(|c| c == "source_fingerprint"),
+        "v6 migration must add archive_state.source_fingerprint"
     );
 
     let column_names: Vec<String> = l

--- a/crates/relayburn-sdk/src/query_verbs.rs
+++ b/crates/relayburn-sdk/src/query_verbs.rs
@@ -6016,11 +6016,11 @@ mod tests {
         assert_eq!(s.burn.rows.stamps, 0);
         assert_eq!(s.burn.tracked_rows, 0);
         assert_eq!(s.content.rows, 0);
-        // v5 after #434 chained the `inferences` derived table onto
-        // #435's v4 (`turns.subagent_id`), #436's v3
-        // (`tool_result_events.output_bytes` / `output_truncated`) and
-        // #437's v2 (`turns.stop_reason`).
-        assert_eq!(s.archive.schema_version, 5);
+        // v6 (#468 `archive_state.source_fingerprint`) chained onto v5
+        // (#434 `inferences`), v4 (#435 `turns.subagent_id`), v3 (#436
+        // `tool_result_events.output_bytes` / `output_truncated`) and v2
+        // (#437 `turns.stop_reason`).
+        assert_eq!(s.archive.schema_version, 6);
         assert!(s.archive.last_built_at.is_none());
         assert!(s.archive.last_rebuild_at.is_none());
     }

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -88,7 +88,7 @@
   `HotspotsGroupBy` as 2.x extensions over the 1.x surface. (#247 part c)
 - Umbrella facade now coerces napi-rs `BigInt` return values to `Number`
   for safe-range integers (`[Number.MIN_SAFE_INTEGER,
-  Number.MAX_SAFE_INTEGER]`), matching the TS 1.x runtime shape; values
+Number.MAX_SAFE_INTEGER]`), matching the TS 1.x runtime shape; values
   outside that range stay `BigInt` to avoid silent precision loss.
 - Conformance suite is now wired into CI: `napi build` writes its outputs
   (`.node`, `binding.cjs`, `binding.d.ts`) into `src/` so the generated

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `ingest()` returns in roughly source-walk time (`{ ingested: 0 }`) when nothing upstream has changed, instead of paying the full ~0.7s cursor-load + per-file scan every call. Gated on a stat-only source fingerprint persisted in the ledger. (#468)
+- `ingest()` returns immediately with `{ ingested: 0 }` when nothing upstream has changed, avoiding the ~0.7s cursor load + per-file scan.
 
 ## [3.0.0] - 2026-05-26
 

--- a/packages/sdk-node/CHANGELOG.md
+++ b/packages/sdk-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `ingest()` returns in roughly source-walk time (`{ ingested: 0 }`) when nothing upstream has changed, instead of paying the full ~0.7s cursor-load + per-file scan every call. Gated on a stat-only source fingerprint persisted in the ledger. (#468)
+
 ## [3.0.0] - 2026-05-26
 
 ### Added


### PR DESCRIPTION
## **User description**
Fixes #468.

## Problem

`ingest()` cost ~0.7s on **every** call even when nothing upstream had changed. Profiling a 94k-turn / ~125 MB ledger showed a no-op sweep spends its time on work that produces zero new turns:

| phase | cost |
|---|---|
| `load_cursors` (parse the cursor blob) | ~58 ms |
| `clone` + `save`-compare of the cursor map | ~33 ms |
| per-file cursor deserialize (`get_typed`) | ~73 ms |
| source walk + `fs::metadata` per file | ~170 ms+ |
| per-file parse | only the rare changed files |

`fingerprint()` already detects "nothing changed" in ~47 ms, but it reflects the **post-ingest `turns` table**, so it can't gate ingest itself.

## Fix

Add a stat-only **source fingerprint** — `count:totalBytes:mtimeSum` over the Claude/Codex/OpenCode session files (folding in OpenCode's per-session message-dir mtime, the signal that adapter watches for new messages). `ingest_all` computes it up front and, when it matches the value the previous sweep recorded, returns an empty report **without** loading cursors, cloning, deserializing per-file cursors, or parsing.

- New `archive_state.source_fingerprint` column (schema **v6**, in-place `ALTER TABLE ADD COLUMN`, auto-migrated; legacy `''` never matches so the first post-upgrade ingest walks normally and records it).
- The fingerprint captured at the **start** of a sweep is stored after it completes — the conservative choice: any file that moves mid-sweep yields a different fingerprint next call, forcing a cheap re-scan that per-file cursors then skip. Storing the *end* value could miss bytes written after the walk passed a file.
- Blanked by `state reset` **and** `rebuild_derivable`, so a wiped/rebuilt ledger always re-walks.

Detects every relevant change: file add/remove (count + bytes), in-place append (bytes + mtime — which directory mtimes miss), truncate (bytes), and touch (mtime sum, sensitive in either direction so a backwards clock still registers).

## Impact

A no-op `burn ingest` on a live ledger dropped from **~0.74s → ~0.19s**. The residual is the unavoidable stat walk over the source trees — on this machine an atypically large OpenCode tree (138k message files); on Claude/Codex-dominant ledgers (the polling/refresh case the issue targets) it returns in tens of ms.

## Tests

- `source_fingerprint_is_stable_and_moves_on_change` — stable across calls; moves on file add and on append.
- `ingest_all_short_circuits_when_source_unchanged` — second sweep with unchanged source reports `scanned_sessions == 0` (proves the loops never ran, not just that nothing was appended).
- `ingest_all_rescans_after_source_file_appended` — a new source file defeats the gate and its turns are ingested + queryable.
- `legacy_v1_ledger_migrates_to_v2_on_open…` extended to assert the v6 `source_fingerprint` column is added on migration.

Full `cargo test --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Skip unchanged ingest sweeps, while still rescanning on real file events**

### What Changed
- `ingest()` now returns immediately when the source files match the last recorded fingerprint, so a no-op sweep no longer loads cursors or walks every session file
- Watch-driven ingest ticks still force a full rescan, so file updates from live edits are not skipped
- The saved fingerprint is cleared when state is reset or rebuilt, and it now survives closing and reopening the ledger
- Upgrading older ledgers adds the new fingerprint field automatically

### Impact
`✅ Faster no-op ingest`
`✅ Fewer unnecessary session scans`
`✅ Safer live file updates during watch mode`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
