### PR TITLE
perf: read verbs skip ingest on read; index bounded ts windows (all reads <100ms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+- `burn summary` and `burn hotspots` no longer run a pre-query ingest sweep by default — both return in well under 100ms instead of seconds on large ledgers (`hotspots` was ~3s). Pass `--ingest` for a one-off freshen; keep the ledger current out of band with `burn ingest --watch` or the Claude Stop hook.
+- Faster reads on large ledgers: time-windowed turn queries (`--since`/`--until` without a `--session`) now seek the `ts` index instead of scanning the whole `turns` table, cutting `summary`/`hotspots`/`overhead`/`compare` query time by roughly 3-4x. Output is unchanged.
+
 ## [3.2.2] - 2026-06-10
 
 - `burn summary` now reports turns whose model has no pricing entry (`unpricedTurns`/`unpricedModels` in JSON output, warning footer in human output) instead of silently counting them at $0.

--- a/crates/relayburn-cli/src/commands/hotspots.rs
+++ b/crates/relayburn-cli/src/commands/hotspots.rs
@@ -102,6 +102,15 @@ pub struct HotspotsArgs {
     /// pick their own sort.
     #[arg(long = "rank-by", value_name = "DIM", value_enum, default_value_t = RankBy::Cost)]
     pub rank_by: RankBy,
+
+    /// Run a pre-query ingest sweep so hotspots reflects freshly appended
+    /// sessions. Off by default: `hotspots` is a read verb, and a full-store
+    /// sweep re-stats every session file under every harness store — seconds
+    /// on a large ledger. Keep the ledger current out of band with
+    /// `burn ingest --watch` (or the Claude Stop hook); pass `--ingest` only
+    /// for a one-off freshen. Mirrors `burn summary --ingest`.
+    #[arg(long = "ingest")]
+    pub ingest: bool,
 }
 
 /// Sort dimension for the per-tool human-mode tables. Mirrors `--rank-by`.
@@ -246,9 +255,15 @@ fn run_inner(globals: &GlobalArgs, args: HotspotsArgs) -> anyhow::Result<i32> {
     progress.set_task("opening ledger");
     let mut handle = Ledger::open(opts)?;
 
-    progress.set_task("refreshing ledger");
-    let raw_opts = progress.ingest_options(ledger_home.clone());
-    ingest_all(handle.raw_mut(), &raw_opts)?;
+    // Read-verb default: skip the pre-query sweep (see `burn summary` /
+    // `burn compare`). `--ingest` opts back into a one-off freshen; otherwise
+    // go straight to the query and let `burn ingest --watch` / the Claude Stop
+    // hook keep the ledger current out of band.
+    if args.ingest {
+        progress.set_task("refreshing ledger");
+        let raw_opts = progress.ingest_options(ledger_home.clone());
+        ingest_all(handle.raw_mut(), &raw_opts)?;
+    }
     drop(handle);
 
     let session_filter = match args.session.as_deref() {

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -9,10 +9,18 @@
 //!
 //! 1. Open a [`relayburn_sdk::LedgerHandle`] honoring `--ledger-path` /
 //!    `RELAYBURN_HOME`.
-//! 2. Run [`relayburn_sdk::ingest_all`] against the same handle. The TS CLI
-//!    does this unconditionally so the summary block in human mode always
-//!    leads with `ingested N new sessions (+M turns)`. Output is captured
-//!    by reference while TTY runs get a stderr spinner.
+//! 2. Optionally run [`relayburn_sdk::ingest_all`] against the same handle,
+//!    gated on `--ingest`. `summary` is a read verb, and a pre-query sweep
+//!    re-stats every session file under every harness store — seconds on a
+//!    large OpenCode store (tens of thousands of sessions) — so it is
+//!    **off by default**. The steady-state setup keeps the ledger fresh out
+//!    of band: `burn ingest --watch` once per host, or the Claude Stop hook
+//!    (`burn ingest --hook claude`) firing each turn. Pass `--ingest` for a
+//!    one-off freshen; the human banner then leads with
+//!    `ingested N new sessions (+M turns)` and a TTY gets a stderr spinner.
+//!    When the sweep is skipped, an empty [`relayburn_sdk::IngestReport`]
+//!    keeps the banner / JSON `ingest` block byte-identical to a no-op sweep
+//!    (`ingested 0 new sessions`). See `burn compare` for the same decision.
 //! 3. Lower CLI flags into [`relayburn_sdk::SummaryReportOptions`] and call
 //!    the SDK-owned `summary_report` verb.
 //! 4. Render the typed report as JSON or human output.
@@ -109,6 +117,15 @@ pub struct SummaryArgs {
     /// which is SQLite-native and has no archive layer to bypass.
     #[arg(long = "no-archive")]
     pub no_archive: bool,
+
+    /// Run a pre-query ingest sweep so the summary leads with freshly
+    /// appended sessions. Off by default: `summary` is a read verb, and a
+    /// full-store sweep re-stats every session file under every harness
+    /// store — seconds on a large ledger. Keep the ledger current out of
+    /// band with `burn ingest --watch` (or the Claude Stop hook); pass
+    /// `--ingest` only for a one-off freshen.
+    #[arg(long = "ingest")]
+    pub ingest: bool,
 }
 
 pub fn run(globals: &GlobalArgs, args: SummaryArgs) -> i32 {
@@ -220,10 +237,17 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         progress.finish_and_clear();
     })?;
 
-    let ingest_report = run_ingest(&mut handle, &progress, globals.ledger_path.clone())
-        .inspect_err(|_| {
+    // Read-verb default: skip the pre-query sweep (see the module doc and
+    // `burn compare`). `--ingest` opts back into a one-off freshen; otherwise
+    // an empty report keeps the banner / JSON `ingest` block identical to a
+    // no-op sweep without paying for the full-store stat walk.
+    let ingest_report = if args.ingest {
+        run_ingest(&mut handle, &progress, globals.ledger_path.clone()).inspect_err(|_| {
             progress.finish_and_clear();
-        })?;
+        })?
+    } else {
+        relayburn_sdk::IngestReport::empty()
+    };
 
     let mode = if let Some(session_id) = subagent_tree_session_id {
         SummaryReportMode::SubagentTree { session_id }

--- a/crates/relayburn-cli/tests/smoke.rs
+++ b/crates/relayburn-cli/tests/smoke.rs
@@ -688,3 +688,120 @@ fn ingest_watch_and_hook_are_mutually_exclusive() {
         .code(2)
         .stderr(predicate::str::contains("mutually exclusive"));
 }
+
+/// Resolve a checked-in fixture path relative to the repo root (this
+/// crate's manifest dir is `crates/relayburn-cli`).
+fn fixture_path(rel: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root is two levels above the crate manifest")
+        .join(rel)
+}
+
+/// `burn summary` is a read verb: by default it must NOT run a pre-query
+/// ingest sweep (which re-stats every session file under every harness
+/// store and costs seconds on a large ledger — see
+/// `plans/009-summary-sub-100ms.md`). A Claude transcript sitting in
+/// `$HOME/.claude/projects` must therefore be invisible to a default
+/// `summary` against an empty ledger: the banner reports
+/// `ingested 0 new sessions` and no turns are analyzed.
+#[test]
+fn summary_does_not_ingest_by_default() {
+    let home = tempfile::TempDir::new().expect("tmp HOME");
+    let project_dir = home.path().join(".claude/projects/proj");
+    std::fs::create_dir_all(&project_dir).expect("create claude project dir");
+    std::fs::copy(
+        fixture_path("tests/fixtures/claude/multi-block-turn.jsonl"),
+        project_dir.join("sess.jsonl"),
+    )
+    .expect("seed a Claude transcript that ingest *would* pick up");
+    let ledger = home.path().join("ledger");
+
+    burn()
+        .arg("summary")
+        .env("RELAYBURN_HOME", &ledger)
+        .env("HOME", home.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ingested 0 new sessions"))
+        .stdout(predicate::str::contains("turns analyzed: 0"));
+}
+
+/// `burn summary --ingest` opts back into the one-off sweep: the same
+/// seeded transcript is now ingested (`ingested 1 new session`) and its
+/// turn shows up in the report. Guards the flag so the read-verb default
+/// can't silently swallow the explicit freshen path.
+#[test]
+fn summary_ingest_flag_runs_the_sweep() {
+    let home = tempfile::TempDir::new().expect("tmp HOME");
+    let project_dir = home.path().join(".claude/projects/proj");
+    std::fs::create_dir_all(&project_dir).expect("create claude project dir");
+    std::fs::copy(
+        fixture_path("tests/fixtures/claude/multi-block-turn.jsonl"),
+        project_dir.join("sess.jsonl"),
+    )
+    .expect("seed a Claude transcript");
+    let ledger = home.path().join("ledger");
+
+    burn()
+        .args(["summary", "--ingest"])
+        .env("RELAYBURN_HOME", &ledger)
+        .env("HOME", home.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ingested 1 new session"))
+        .stdout(predicate::str::contains("turns analyzed: 1"));
+}
+
+/// `burn hotspots` is a read verb with the same default as `summary`: no
+/// pre-query ingest sweep. A seeded Claude transcript must be invisible to a
+/// default `hotspots` against an empty ledger. See
+/// `plans/009-summary-sub-100ms.md`.
+#[test]
+fn hotspots_does_not_ingest_by_default() {
+    let home = tempfile::TempDir::new().expect("tmp HOME");
+    let project_dir = home.path().join(".claude/projects/proj");
+    std::fs::create_dir_all(&project_dir).expect("create claude project dir");
+    std::fs::copy(
+        fixture_path("tests/fixtures/claude/multi-block-turn.jsonl"),
+        project_dir.join("sess.jsonl"),
+    )
+    .expect("seed a Claude transcript that ingest *would* pick up");
+    let ledger = home.path().join("ledger");
+
+    burn()
+        .arg("hotspots")
+        .env("RELAYBURN_HOME", &ledger)
+        .env("HOME", home.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("turns analyzed: 0"));
+}
+
+/// `burn hotspots --ingest` opts back into the one-off sweep, mirroring
+/// `summary --ingest`.
+#[test]
+fn hotspots_ingest_flag_runs_the_sweep() {
+    let home = tempfile::TempDir::new().expect("tmp HOME");
+    let project_dir = home.path().join(".claude/projects/proj");
+    std::fs::create_dir_all(&project_dir).expect("create claude project dir");
+    std::fs::copy(
+        fixture_path("tests/fixtures/claude/multi-block-turn.jsonl"),
+        project_dir.join("sess.jsonl"),
+    )
+    .expect("seed a Claude transcript");
+    let ledger = home.path().join("ledger");
+
+    burn()
+        .args(["hotspots", "--ingest"])
+        .env("RELAYBURN_HOME", &ledger)
+        .env("HOME", home.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("turns analyzed: 1"));
+}

--- a/crates/relayburn-sdk/src/ledger/reader.rs
+++ b/crates/relayburn-sdk/src/ledger/reader.rs
@@ -39,6 +39,7 @@ pub(crate) fn query_turns(conn: &Connection, q: &Query) -> Result<Vec<EnrichedTu
             ts_nullable: false,
             session_id_or_related: false,
             project_columns: true,
+            prefer_ts_index: true,
         },
     );
     let mut stmt = conn.prepare_cached(&sql)?;
@@ -92,6 +93,9 @@ pub(crate) fn query_turns_in_sessions(
             ts_nullable: false,
             session_id_or_related: false,
             project_columns: true,
+            // This path targets specific sessions via the injected IN clause
+            // below, which rides idx_turns_session — do not force the ts index.
+            prefer_ts_index: false,
         },
     );
 
@@ -145,6 +149,7 @@ pub(crate) fn query_compactions(conn: &Connection, q: &Query) -> Result<Vec<Comp
             ts_nullable: false,
             session_id_or_related: false,
             project_columns: false,
+            prefer_ts_index: false,
         },
     )
 }
@@ -161,6 +166,7 @@ pub(crate) fn query_relationships(
             ts_nullable: true,
             session_id_or_related: true,
             project_columns: false,
+            prefer_ts_index: false,
         },
     )
 }
@@ -177,6 +183,7 @@ pub(crate) fn query_tool_result_events(
             ts_nullable: true,
             session_id_or_related: false,
             project_columns: false,
+            prefer_ts_index: false,
         },
     )
 }
@@ -190,6 +197,7 @@ pub(crate) fn query_user_turns(conn: &Connection, q: &Query) -> Result<Vec<UserT
             ts_nullable: false,
             session_id_or_related: false,
             project_columns: false,
+            prefer_ts_index: false,
         },
     )
 }
@@ -299,6 +307,12 @@ struct TableFilters {
     ts_nullable: bool,
     session_id_or_related: bool,
     project_columns: bool,
+    /// Force `idx_turns_ts` for a bounded `ts` window (see the access-path
+    /// note in [`build_select_sql`]). Set only by the full-window
+    /// [`query_turns`] read against the `turns` table; left `false` for the
+    /// session-IN path (which rides `idx_turns_session`) and every non-`turns`
+    /// table (which has no such index).
+    prefer_ts_index: bool,
 }
 
 /// Build a `SELECT record_json FROM <table> WHERE … ORDER BY rowid`
@@ -307,7 +321,31 @@ struct TableFilters {
 /// per filter combination so [`Connection::prepare_cached`] can reuse the
 /// compiled statement across calls.
 fn build_select_sql(table: &str, q: &Query, shape: TableFilters) -> (String, Vec<String>) {
-    let mut sql = format!("SELECT record_json FROM {table}");
+    // Access-path hint: a bounded `ts` window on `turns` should seek the
+    // matching tail via `idx_turns_ts` instead of scanning every row. Because
+    // the statement ends in `ORDER BY rowid`, SQLite otherwise prefers a full
+    // rowid `SCAN` (no sort needed) and reads the entire table — ~85ms / ~97k
+    // rows on a large ledger even when the window matches ~1% of turns. Forcing
+    // the index turns that into an index range-seek plus an in-memory sort of
+    // just the matched rows; output stays byte-identical (same rows, same
+    // `ORDER BY rowid`). Applied only when:
+    //   (a) the table is `turns` (the only one carrying `idx_turns_ts`),
+    //   (b) there is a `ts` bound to seek on, and
+    //   (c) no `session_id` filter — session-scoped reads ride
+    //       `idx_turns_session` and are already cheap; forcing the ts index
+    //       there would pessimize them.
+    // Trade-off: a window covering most of the table pays an index seek + a
+    // large sort instead of a plain scan, but such unbounded reads are already
+    // aggregation-bound (well over any interactive budget), so the common
+    // recent-window path is the one worth optimizing.
+    let use_ts_index =
+        shape.prefer_ts_index && q.session_id.is_none() && (q.since.is_some() || q.until.is_some());
+    let from = if use_ts_index {
+        std::borrow::Cow::Owned(format!("{table} INDEXED BY idx_turns_ts"))
+    } else {
+        std::borrow::Cow::Borrowed(table)
+    };
+    let mut sql = format!("SELECT record_json FROM {from}");
     let mut clauses: Vec<&'static str> = Vec::new();
     let mut bound: Vec<String> = Vec::new();
 
@@ -481,4 +519,72 @@ pub(crate) fn raw_record_jsons(conn: &Connection, table: &str) -> Result<Vec<Str
         .query_map([], |r| r.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
+}
+
+#[cfg(test)]
+mod build_select_sql_tests {
+    use super::*;
+
+    fn turns_shape(prefer_ts_index: bool) -> TableFilters {
+        TableFilters {
+            ts_nullable: false,
+            session_id_or_related: false,
+            project_columns: true,
+            prefer_ts_index,
+        }
+    }
+
+    /// The `query_turns` full-window path forces `idx_turns_ts` for a bounded
+    /// `ts` filter — that's the access-path fix that keeps `summary` /
+    /// `hotspots` / `overhead` / `compare` off a full table scan. Ordering
+    /// stays `ORDER BY rowid`, so rows (and golden output) are unchanged.
+    #[test]
+    fn ts_window_forces_index_and_keeps_rowid_order() {
+        let q = Query {
+            since: Some("2026-06-16T00:00:00.000Z".into()),
+            ..Query::default()
+        };
+        let (sql, bound) = build_select_sql("turns", &q, turns_shape(true));
+        assert!(
+            sql.contains("FROM turns INDEXED BY idx_turns_ts"),
+            "bounded ts window must seek the ts index, got: {sql}"
+        );
+        assert!(sql.trim_end().ends_with("ORDER BY rowid"), "got: {sql}");
+        assert_eq!(bound, vec!["2026-06-16T00:00:00.000Z".to_string()]);
+    }
+
+    /// A `session_id` filter rides `idx_turns_session` and is already cheap;
+    /// forcing the ts index there would pessimize it, so the hint is dropped
+    /// even though `prefer_ts_index` is set.
+    #[test]
+    fn session_filter_does_not_force_ts_index() {
+        let q = Query {
+            since: Some("2026-06-16T00:00:00.000Z".into()),
+            session_id: Some("abc".into()),
+            ..Query::default()
+        };
+        let (sql, _) = build_select_sql("turns", &q, turns_shape(true));
+        assert!(!sql.contains("INDEXED BY"), "got: {sql}");
+    }
+
+    /// No `ts` bound → nothing to seek on → no hint (forcing the index with no
+    /// `ts` predicate would be invalid).
+    #[test]
+    fn no_ts_bound_does_not_force_index() {
+        let q = Query::default();
+        let (sql, _) = build_select_sql("turns", &q, turns_shape(true));
+        assert!(!sql.contains("INDEXED BY"), "got: {sql}");
+    }
+
+    /// Callers that don't opt in (`prefer_ts_index: false`, e.g. the
+    /// session-IN path and every non-`turns` table) never get the hint.
+    #[test]
+    fn opt_out_never_forces_index() {
+        let q = Query {
+            since: Some("2026-06-16T00:00:00.000Z".into()),
+            ..Query::default()
+        };
+        let (sql, _) = build_select_sql("turns", &q, turns_shape(false));
+        assert!(!sql.contains("INDEXED BY"), "got: {sql}");
+    }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "pnpm --filter @relayburn/sdk test && pnpm --filter @relayburn/mcp test",
     "test:bundle": "pnpm --filter @relayburn/sdk test:bundle",
     "pricing:update": "node scripts/update-pricing.mjs",
+    "bench:summary": "python3 scripts/bench-summary.py",
     "verify": "cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && pnpm -r --if-present run build && pnpm run test"
   },
   "devDependencies": {

--- a/scripts/bench-summary.py
+++ b/scripts/bench-summary.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Time `burn summary` against a real ledger and check it against a budget.
+
+This is the timing eval for the "summary sub-100ms" goal (see
+`plans/009-summary-sub-100ms.md`). It runs the *release* binary end-to-end —
+process startup + ingest sweep + query + render — against a live ledger, which
+is the number a user actually feels at the prompt.
+
+Usage:
+    python3 scripts/bench-summary.py                 # default: live ledger, 20 runs, 100ms budget
+    python3 scripts/bench-summary.py --runs 40
+    python3 scripts/bench-summary.py --budget-ms 100 --metric p95
+    python3 scripts/bench-summary.py --breakdown     # attribute ingest vs query
+    python3 scripts/bench-summary.py --json          # machine-readable summary
+
+Exit status is non-zero when the chosen metric exceeds the budget, so this
+doubles as a regression gate once the goal is met.
+
+Notes:
+  - Defaults to the release binary at target/release/burn and the binary's own
+    default ledger ($RELAYBURN_HOME or ~/.agentworkforce/burn). Pass --home to
+    point at a different ledger, or --bin to time a different binary.
+  - Build first: `cargo build --release -p relayburn-cli` (or pass --build).
+  - Measurements are wall-clock around the subprocess, including process spawn.
+    stdout/stderr are discarded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BIN = REPO_ROOT / "target" / "release" / "burn"
+
+
+def percentile(values: list[float], pct: float) -> float:
+    """Nearest-rank percentile (pct in 0..100). values need not be sorted."""
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = max(1, min(len(ordered), round(pct / 100.0 * len(ordered))))
+    return ordered[rank - 1]
+
+
+def time_command(argv: list[str], env: dict[str, str]) -> float:
+    """Return wall-clock seconds for one run of argv, discarding output."""
+    start = time.perf_counter()
+    subprocess.run(
+        argv,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+        check=False,
+    )
+    return time.perf_counter() - start
+
+
+def run_samples(argv: list[str], env: dict[str, str], warmup: int, runs: int) -> list[float]:
+    for _ in range(warmup):
+        time_command(argv, env)
+    return [time_command(argv, env) * 1000.0 for _ in range(runs)]
+
+
+def summarize(name: str, samples_ms: list[float]) -> dict:
+    return {
+        "label": name,
+        "runs": len(samples_ms),
+        "min_ms": min(samples_ms),
+        "median_ms": statistics.median(samples_ms),
+        "mean_ms": statistics.fmean(samples_ms),
+        "p95_ms": percentile(samples_ms, 95),
+        "max_ms": max(samples_ms),
+    }
+
+
+def fmt_row(stats: dict) -> str:
+    return (
+        f"{stats['label']:<22} "
+        f"min {stats['min_ms']:8.1f}  "
+        f"median {stats['median_ms']:8.1f}  "
+        f"p95 {stats['p95_ms']:8.1f}  "
+        f"mean {stats['mean_ms']:8.1f}  "
+        f"max {stats['max_ms']:8.1f}   (ms)"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bin", default=str(DEFAULT_BIN), help="path to the burn binary")
+    ap.add_argument("--home", default=None, help="ledger home (default: binary default / $RELAYBURN_HOME)")
+    ap.add_argument("--summary-args", default="summary --since 24h",
+                    help='argv after the binary for the summary run (default: "summary --since 24h")')
+    ap.add_argument("--runs", type=int, default=20, help="timed runs (default 20)")
+    ap.add_argument("--warmup", type=int, default=3, help="discarded warmup runs (default 3)")
+    ap.add_argument("--budget-ms", type=float, default=100.0, help="budget the metric is checked against (default 100)")
+    ap.add_argument("--metric", choices=["median", "p95", "min", "mean"], default="median",
+                    help="which metric the budget gate uses (default median)")
+    ap.add_argument("--breakdown", action="store_true",
+                    help="also time `ingest` alone to attribute ingest vs query cost")
+    ap.add_argument("--build", action="store_true", help="run `cargo build --release -p relayburn-cli` first")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = ap.parse_args()
+
+    if args.build:
+        subprocess.run(["cargo", "build", "--release", "-p", "relayburn-cli"], cwd=REPO_ROOT, check=True)
+
+    bin_path = Path(args.bin)
+    if not bin_path.exists():
+        print(f"error: binary not found at {bin_path}\n"
+              f"build it: cargo build --release -p relayburn-cli  (or pass --build)", file=sys.stderr)
+        return 2
+
+    env = dict(os.environ)
+    if args.home:
+        env["RELAYBURN_HOME"] = args.home
+    home_display = args.home or env.get("RELAYBURN_HOME") or "~/.agentworkforce/burn (default)"
+
+    summary_argv = [str(bin_path)] + shlex.split(args.summary_args)
+
+    if not args.json:
+        print(f"binary:  {bin_path}")
+        print(f"ledger:  {home_display}")
+        print(f"command: {' '.join(shlex.quote(a) for a in summary_argv)}")
+        print(f"runs:    {args.runs} timed ({args.warmup} warmup)\n")
+
+    summary_stats = summarize("summary", run_samples(summary_argv, env, args.warmup, args.runs))
+
+    results = {"summary": summary_stats}
+    if args.breakdown:
+        ingest_argv = [str(bin_path), "ingest"]
+        ingest_stats = summarize("ingest (alone)", run_samples(ingest_argv, env, args.warmup, args.runs))
+        results["ingest"] = ingest_stats
+        # Query cost is summary minus ingest at the median; a coarse attribution.
+        results["query_estimate_ms"] = max(0.0, summary_stats["median_ms"] - ingest_stats["median_ms"])
+
+    metric_key = f"{args.metric}_ms"
+    observed = summary_stats[metric_key]
+    passed = observed <= args.budget_ms
+
+    if args.json:
+        print(json.dumps({
+            "budget_ms": args.budget_ms,
+            "metric": args.metric,
+            "observed_ms": observed,
+            "passed": passed,
+            "results": results,
+        }, indent=2))
+    else:
+        print(fmt_row(summary_stats))
+        if args.breakdown:
+            print(fmt_row(results["ingest"]))
+            print(f"\n~query cost (summary median - ingest median): {results['query_estimate_ms']:.1f} ms")
+        verdict = "PASS" if passed else "FAIL"
+        print(f"\n[{verdict}] summary {args.metric} = {observed:.1f} ms  (budget {args.budget_ms:.0f} ms)")
+        if not passed:
+            over = observed / args.budget_ms
+            print(f"        {over:.1f}x over budget — see plans/009-summary-sub-100ms.md")
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Every `burn` read command now returns in **under 100ms** on a large ledger. Two independent costs were dominating, both addressed here.

### 1. Read verbs ran a synchronous full-store ingest sweep
`summary` and `hotspots` called `ingest_all` before querying. That sweep re-stats **every** session file under every harness store (~44k+ OpenCode session files on the test ledger) on each invocation — seconds of wall-clock, ~99% of the command's time.

**Fix:** both verbs are read-only by default with an opt-in `--ingest` flag, matching the existing `burn compare` precedent. Freshness stays the job of `burn ingest --watch` (FS-event driven) or the Claude Stop hook. When the sweep is skipped, an empty `IngestReport` keeps the banner / JSON `ingest` block byte-identical to a no-op sweep.

### 2. Windowed turn queries full-scanned the table
`query_turns` runs `SELECT record_json FROM turns WHERE ts >= ? ORDER BY rowid`. The ledger has `idx_turns_ts`, but `ORDER BY rowid` made the planner pick a full `SCAN turns` — reading all ~97k rows to return the ~1,123 in a 24h window (`EXPLAIN QUERY PLAN` confirmed).

**Fix:** force `INDEXED BY idx_turns_ts` for a bounded `ts` window when no `session_id` filter is present (new `TableFilters.prefer_ts_index`, set only by the full-window `query_turns`; the session-IN path rides `idx_turns_session` and opts out, as do non-`turns` tables). The matched set is sorted by rowid in memory, so **output is byte-identical** (same rows, same order).

## Results

Median, release binary, live ~614MB `burn.sqlite`, `--since 24h`:

| Command | Before | After |
|---|---|---|
| `hotspots` | 3088 ms | **76 ms** |
| `summary` | 3298 ms | **62 ms** |
| `compare` | 50 ms | **16 ms** |
| `overhead` | 49 ms | **13 ms** |
| `state status` | 62 ms | 65 ms |
| `sessions` / `stamps` / `flow` | ~4–5 ms | ~4–5 ms |

## Correctness

- All `BURN_GOLDEN` command snapshots still pass **byte-for-byte** (summary, hotspots, overhead, compare, flow) — the index change only alters the access path.
- New tests: 4 smoke tests (`summary`/`hotspots` ingest gate) + `reader.rs::build_select_sql_tests` (index-hint conditions).
- `cargo fmt`/`clippy -D warnings` clean; full workspace suite green.
- Pre-existing, **unrelated** drift noted: the `BURN_GOLDEN`-gated `state`/`state-json` snapshots pin `schema version: 5` while `SCHEMA_VERSION` is `6` — worth a separate snapshot refresh.

## Tooling

Adds `scripts/bench-summary.py` (`pnpm run bench:summary`) — times the release binary end-to-end against a live ledger and exits non-zero over a budget, so it doubles as a regression gate.

## Behavior change to flag

`summary`/`hotspots` no longer auto-freshen on read. Consumers that relied on that (e.g. polling `summary --json`) should run `burn ingest --watch` or pass `--ingest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/burn/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

