### PR TITLE
Fix burn subprocess leak in BurnLedger.capture

### DIFF
--- a/apps/macos/Sources/Burn/BurnLedger.swift
+++ b/apps/macos/Sources/Burn/BurnLedger.swift
@@ -164,19 +164,29 @@ actor BurnLedger {
         } catch {
             return nil
         }
-        // Drain stdout on a background queue so a full pipe buffer can't deadlock
-        // against waitUntilExit, then bound the wait with a timeout.
-        let dataQueue = DispatchQueue(label: "burn-ledger.capture")
+        // Read stdout to EOF (which arrives when the process exits) and reap it
+        // on a background queue; bound the wait with a timeout. This blocks the
+        // BurnLedger actor until the process truly finishes or is killed — which,
+        // because the actor serializes calls, guarantees only one `burn`
+        // subprocess can ever be alive at a time (no pile-up). Avoids the
+        // `terminationHandler` race that could let capture() return while the
+        // child kept running.
+        let group = DispatchGroup()
+        group.enter()
         var output = Data()
-        dataQueue.async { output = stdout.fileHandleForReading.readDataToEndOfFile() }
-
-        let finished = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in finished.signal() }
-        if finished.wait(timeout: .now() + timeout) == .timedOut {
-            process.terminate()
+        DispatchQueue.global(qos: .utility).async {
+            output = stdout.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            group.leave()
+        }
+        if group.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()                       // SIGTERM…
+            usleep(200_000)
+            if process.isRunning {                    // …then SIGKILL if it ignores it
+                kill(process.processIdentifier, SIGKILL)
+            }
             return nil
         }
-        dataQueue.sync {} // ensure the drain finished
         guard process.terminationStatus == 0 else { return nil }
         return String(data: output, encoding: .utf8)
     }


### PR DESCRIPTION
## Summary

The macOS app's live-burn tab was leaking `burn summary` subprocesses — dozens accumulated (one per ~1.5s poll, none exiting), which hammered the machine. This fix landed on the #480 branch *after* #480 was squash-merged, so it didn't reach main; this PR brings it in.

## Root cause

`BurnLedger` is an actor, so `capture()` calls are serialized — the only way `burn` processes pile up is if `capture()` returns while the child is still alive. The previous implementation used a `terminationHandler` + semaphore (which has a race: if the process exits before the handler is wired, the wait misbehaves) and only sent **SIGTERM** on timeout, which a busy `burn` can ignore. So each poll's subprocess got orphaned and the next spawned on top.

## Fix

Rewrite `capture()` to read stdout to EOF + `waitUntilExit` on a background queue, bounded by the timeout, and **SIGKILL** (not just SIGTERM) on timeout. It now blocks the actor until the process truly exits or is killed, so the actor's serialization guarantees **at most one `burn` subprocess alive at a time** — no pile-up possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/burn/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

