### PR TITLE
Add --bucket time-series to summary and compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
+- `--bucket <DURATION>` on `burn summary` and `burn compare`: emit a per-bucket time-series across the `--since` window instead of a single total. JSON is `{ "bucketSeconds": N, "buckets": [ { "start", "end", ...the verb's report... } ] }`. Bucket grammar is the chart-axis form `30s` / `5m` (minutes) / `1h` / `12h` / `1d` / `7d` — note `m` is minutes here, unlike `--since` where `m` is months. Summary buckets are a pure per-turn fold, so per-bucket totals reconcile with the un-bucketed total; only the default grouped (`byModel` / `--by-provider`) summary supports `--bucket`. (`--bucket` on `hotspots` / `overhead` is not yet wired — their cross-turn attribution and window-amortized denominators need session-granular bucketing.)
+
 ## [3.3.0] - 2026-06-17
 
 - `burn summary` and `burn hotspots` no longer run a pre-query ingest sweep by default — both return in well under 100ms instead of seconds on large ledgers (`hotspots` was ~3s). Pass `--ingest` for a one-off freshen; keep the ledger current out of band with `burn ingest --watch` or the Claude Stop hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Cross-package release notes for relayburn. Package changelogs contain package-le
 
 ## [Unreleased]
 
-- `--bucket <DURATION>` on `burn summary` and `burn compare`: emit a per-bucket time-series across the `--since` window instead of a single total. JSON is `{ "bucketSeconds": N, "buckets": [ { "start", "end", ...the verb's report... } ] }`. Bucket grammar is the chart-axis form `30s` / `5m` (minutes) / `1h` / `12h` / `1d` / `7d` — note `m` is minutes here, unlike `--since` where `m` is months. Summary buckets are a pure per-turn fold, so per-bucket totals reconcile with the un-bucketed total; only the default grouped (`byModel` / `--by-provider`) summary supports `--bucket`. (`--bucket` on `hotspots` / `overhead` is not yet wired — their cross-turn attribution and window-amortized denominators need session-granular bucketing.)
+- `burn summary` and `burn compare` accept `--bucket <DURATION>` to emit a per-bucket time-series across the `--since` window instead of a single total (`{ "bucketSeconds": N, "buckets": [...] }` in JSON). Bucket units: `30s` / `5m` / `1h` / `12h` / `1d` / `7d` — note `m` is minutes here, unlike `--since` where `m` is months. `summary --bucket` supports only the default grouped (`byModel` / `--by-provider`) modes; `hotspots` / `overhead` are unchanged.
 
 ## [3.3.0] - 2026-06-17
 

--- a/crates/relayburn-cli/src/cli.rs
+++ b/crates/relayburn-cli/src/cli.rs
@@ -309,6 +309,13 @@ pub struct CompareArgs {
     /// which is SQLite-native and has no archive layer to bypass.
     #[arg(long = "no-archive")]
     pub no_archive: bool,
+
+    /// Emit a per-bucket time-series across the `--since` window instead of a
+    /// single comparison. Duration grammar: `30s`, `5m` (minutes), `1h`, `1d`,
+    /// `7d`. Note: small buckets thin each cell's sample, so `insufficientSample`
+    /// trips more often.
+    #[arg(long, value_name = "DURATION")]
+    pub bucket: Option<String>,
 }
 
 /// `burn overhead [trim]` argument set. The top-level form takes the

--- a/crates/relayburn-cli/src/commands/compare.rs
+++ b/crates/relayburn-cli/src/commands/compare.rs
@@ -180,6 +180,54 @@ fn run_inner(globals: &GlobalArgs, args: CompareArgs) -> Result<i32> {
     };
     progress.set_task("opening ledger");
     let handle = Ledger::open(ledger_opts)?;
+
+    // `--bucket` switches to a per-bucket time-series via the SDK verb.
+    if let Some(bucket_raw) = args.bucket.as_deref() {
+        let bucket_secs = match relayburn_sdk::parse_bucket(bucket_raw) {
+            Ok(secs) => secs,
+            Err(err) => {
+                progress.finish_and_clear();
+                eprintln!("burn: {err}");
+                return Ok(2);
+            }
+        };
+        let provider = provider_filter
+            .as_ref()
+            .map(|f| f.iter().cloned().collect::<Vec<_>>());
+        progress.set_task("building comparison time-series");
+        let series = handle
+            .compare_timeseries(
+                relayburn_sdk::CompareOptions {
+                    models: models.clone(),
+                    session: args.session.clone(),
+                    project: args.project.clone(),
+                    since: args.since.clone(),
+                    workflow: args.workflow.clone(),
+                    agent: args.agent.clone(),
+                    provider,
+                    min_sample: Some(min_sample),
+                    min_fidelity: Some(min_fidelity),
+                    ledger_home: None,
+                },
+                bucket_secs,
+            )
+            .inspect_err(|_| progress.finish_and_clear())?;
+        progress.finish_and_clear();
+        if globals.json {
+            render_json(&series)?;
+            return Ok(0);
+        }
+        for bucket in &series.buckets {
+            println!(
+                "{}  {:>5} turns  {} models",
+                bucket.start,
+                bucket.result.analyzed_turns,
+                bucket.result.models.len(),
+            );
+        }
+        return Ok(0);
+    }
+
     progress.set_task("loading turns");
     let queried_turns: Vec<EnrichedTurn> = handle.raw().query_turns(&q)?;
 

--- a/crates/relayburn-cli/src/commands/compare.rs
+++ b/crates/relayburn-cli/src/commands/compare.rs
@@ -131,6 +131,22 @@ fn run_inner(globals: &GlobalArgs, args: CompareArgs) -> Result<i32> {
         ));
     }
 
+    // `--bucket` opts into a per-bucket time-series. Parse it up front (before
+    // the ledger is opened) so a bad duration routes through the same error
+    // envelope as the other argument validations. CSV time-series rendering
+    // isn't implemented, so reject the combination rather than silently
+    // falling back to TTY output.
+    let bucket_secs = args
+        .bucket
+        .as_deref()
+        .map(relayburn_sdk::parse_bucket)
+        .transpose()?;
+    if bucket_secs.is_some() && args.csv {
+        return Err(anyhow!(
+            "--bucket and --csv are mutually exclusive; pick one."
+        ));
+    }
+
     // 4. Provider filter. Lower-cased CSV; turns whose effective provider
     //    (per `provider_for`) isn't in the set get dropped after the ledger
     //    query but before the fidelity gate, matching the TS pipeline order.
@@ -182,15 +198,8 @@ fn run_inner(globals: &GlobalArgs, args: CompareArgs) -> Result<i32> {
     let handle = Ledger::open(ledger_opts)?;
 
     // `--bucket` switches to a per-bucket time-series via the SDK verb.
-    if let Some(bucket_raw) = args.bucket.as_deref() {
-        let bucket_secs = match relayburn_sdk::parse_bucket(bucket_raw) {
-            Ok(secs) => secs,
-            Err(err) => {
-                progress.finish_and_clear();
-                eprintln!("burn: {err}");
-                return Ok(2);
-            }
-        };
+    // Parsing/validation already happened above, before the ledger was opened.
+    if let Some(bucket_secs) = bucket_secs {
         let provider = provider_filter
             .as_ref()
             .map(|f| f.iter().cloned().collect::<Vec<_>>());
@@ -215,6 +224,10 @@ fn run_inner(globals: &GlobalArgs, args: CompareArgs) -> Result<i32> {
         progress.finish_and_clear();
         if globals.json {
             render_json(&series)?;
+            return Ok(0);
+        }
+        if series.buckets.is_empty() {
+            println!("(no data in range)");
             return Ok(0);
         }
         for bucket in &series.buckets {

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -202,6 +202,36 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         }
     }
 
+    // `--bucket` opts into a per-bucket time-series. Parse and validate it
+    // (including the mode/flag combinations it supports) before opening the
+    // ledger or running ingest, so a bad invocation fails fast.
+    let bucket_secs = if let Some(bucket_raw) = args.bucket.as_deref() {
+        if args.by_tool
+            || args.by_subagent_type
+            || args.by_relationship.is_some()
+            || args.subagent_tree.is_some()
+            || args.group_by_tag.is_some()
+        {
+            eprintln!(
+                "burn: --bucket is only supported with the default grouped summary or --by-provider"
+            );
+            return Ok(2);
+        }
+        if args.quality {
+            eprintln!("burn: --bucket is not supported with --quality");
+            return Ok(2);
+        }
+        match relayburn_sdk::parse_bucket(bucket_raw) {
+            Ok(secs) => Some(secs),
+            Err(err) => {
+                eprintln!("burn: {err}");
+                return Ok(2);
+            }
+        }
+    } else {
+        None
+    };
+
     let provider_filter = match parse_provider_filter(args.provider.as_deref()) {
         Ok(filter) => filter,
         Err(msg) => {
@@ -291,15 +321,8 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
     };
 
     // `--bucket` switches to a per-bucket time-series of the grouped summary.
-    if let Some(bucket_raw) = args.bucket {
-        let bucket_secs = match relayburn_sdk::parse_bucket(&bucket_raw) {
-            Ok(secs) => secs,
-            Err(err) => {
-                progress.finish_and_clear();
-                eprintln!("burn: {err}");
-                return Ok(2);
-            }
-        };
+    // Parsing/validation already happened above, before the ledger was opened.
+    if let Some(bucket_secs) = bucket_secs {
         progress.set_task("building summary time-series");
         let series = handle
             .summary_timeseries(opts, bucket_secs)

--- a/crates/relayburn-cli/src/commands/summary.rs
+++ b/crates/relayburn-cli/src/commands/summary.rs
@@ -126,6 +126,13 @@ pub struct SummaryArgs {
     /// `--ingest` only for a one-off freshen.
     #[arg(long = "ingest")]
     pub ingest: bool,
+
+    /// Emit a time-series instead of a single total: bucket the `--since`
+    /// window into fixed-width windows and report per-bucket cost/usage.
+    /// Duration grammar: `30s`, `5m` (minutes), `1h`, `12h`, `1d`, `7d`.
+    /// Only valid for the default grouped (`byModel`/`--by-provider`) summary.
+    #[arg(long, value_name = "DURATION")]
+    pub bucket: Option<String>,
 }
 
 pub fn run(globals: &GlobalArgs, args: SummaryArgs) -> i32 {
@@ -265,28 +272,48 @@ fn run_inner(globals: &GlobalArgs, args: SummaryArgs) -> anyhow::Result<i32> {
         }
     };
 
+    let opts = SummaryReportOptions {
+        session: args.session,
+        project: args.project,
+        since: args.since,
+        workflow: args.workflow,
+        tags: if tag_filter.is_empty() {
+            None
+        } else {
+            Some(tag_filter)
+        },
+        group_by_tag: args.group_by_tag,
+        agent: args.agent,
+        providers: provider_filter.map(|providers| providers.into_iter().collect()),
+        mode,
+        include_quality: args.quality,
+        ledger_home: None,
+    };
+
+    // `--bucket` switches to a per-bucket time-series of the grouped summary.
+    if let Some(bucket_raw) = args.bucket {
+        let bucket_secs = match relayburn_sdk::parse_bucket(&bucket_raw) {
+            Ok(secs) => secs,
+            Err(err) => {
+                progress.finish_and_clear();
+                eprintln!("burn: {err}");
+                return Ok(2);
+            }
+        };
+        progress.set_task("building summary time-series");
+        let series = handle
+            .summary_timeseries(opts, bucket_secs)
+            .inspect_err(|_| {
+                progress.finish_and_clear();
+            })?;
+        progress.finish_and_clear();
+        return emit_summary_timeseries(globals, &series, &ingest_report);
+    }
+
     progress.set_task("building summary");
-    let report = handle
-        .summary_report(SummaryReportOptions {
-            session: args.session,
-            project: args.project,
-            since: args.since,
-            workflow: args.workflow,
-            tags: if tag_filter.is_empty() {
-                None
-            } else {
-                Some(tag_filter)
-            },
-            group_by_tag: args.group_by_tag,
-            agent: args.agent,
-            providers: provider_filter.map(|providers| providers.into_iter().collect()),
-            mode,
-            include_quality: args.quality,
-            ledger_home: None,
-        })
-        .inspect_err(|_| {
-            progress.finish_and_clear();
-        })?;
+    let report = handle.summary_report(opts).inspect_err(|_| {
+        progress.finish_and_clear();
+    })?;
     progress.finish_and_clear();
 
     match report {
@@ -442,6 +469,34 @@ fn emit_json(
 ) -> std::io::Result<()> {
     let value = grouped_json_value(report, ingest_report);
     render_json(&value)
+}
+
+/// Render a `--bucket` time-series. JSON emits `{ bucketSeconds, buckets: [...] }`
+/// (the consumer); human output is one line per bucket.
+fn emit_summary_timeseries(
+    globals: &GlobalArgs,
+    series: &relayburn_sdk::SummaryTimeseries,
+    ingest_report: &relayburn_sdk::IngestReport,
+) -> anyhow::Result<i32> {
+    if globals.json {
+        render_json(series)?;
+        return Ok(0);
+    }
+    emit_human_ingest_prelude(ingest_report);
+    if series.buckets.is_empty() {
+        println!("(no data in range)");
+        return Ok(0);
+    }
+    for bucket in &series.buckets {
+        println!(
+            "{}  {:>5} turns  {:>14} tok  {}",
+            bucket.start,
+            bucket.turn_count,
+            format_uint(bucket.total_tokens),
+            format_usd(bucket.total_cost.total),
+        );
+    }
+    Ok(0)
 }
 
 fn grouped_json_value(

--- a/crates/relayburn-sdk/src/query_verbs/compare.rs
+++ b/crates/relayburn-sdk/src/query_verbs/compare.rs
@@ -142,6 +142,131 @@ impl LedgerHandle {
             fidelity_summary,
         ))
     }
+
+    /// Time-bucketed [`compare`]: the same model comparison computed per
+    /// `bucket_secs`-wide window across the `--since` range (turn-level
+    /// partition; a clean per-turn fold). Note: small buckets thin each
+    /// model×category cell's sample, so `insufficientSample` trips far more
+    /// often than over the whole window.
+    pub fn compare_timeseries(
+        &self,
+        opts: CompareOptions,
+        bucket_secs: u64,
+    ) -> Result<CompareTimeseries> {
+        if opts.models.len() < 2 {
+            anyhow::bail!("compare: needs at least 2 models");
+        }
+        let min_fidelity = opts.min_fidelity.unwrap_or(FidelityClass::UsageOnly);
+        let models = opts.models.clone();
+        let min_sample = opts.min_sample;
+
+        let mut q = build_query(
+            opts.session.as_deref(),
+            opts.project.as_deref(),
+            opts.since.as_deref(),
+        )?;
+        let mut enrichment = BTreeMap::new();
+        if let Some(workflow) = opts.workflow {
+            enrichment.insert("workflowId".to_string(), workflow);
+        }
+        if let Some(agent) = opts.agent {
+            enrichment.insert("agentId".to_string(), agent);
+        }
+        if !enrichment.is_empty() {
+            q.enrichment = Some(enrichment);
+        }
+
+        let mut turns = self.inner.query_turns(&q)?;
+        if let Some(filter) = normalize_provider_filter(opts.provider) {
+            turns.retain(|t| {
+                let provider = crate::analyze::provider_for(&t.turn).provider;
+                filter.contains(&provider.to_ascii_lowercase())
+            });
+        }
+        let pricing = load_pricing(None);
+
+        let Some(anchor) = super::bucket_anchor_secs(
+            q.since.as_deref(),
+            turns
+                .iter()
+                .filter_map(|t| super::iso_z_to_epoch_secs(&t.turn.ts)),
+        ) else {
+            return Ok(CompareTimeseries {
+                bucket_secs,
+                buckets: Vec::new(),
+            });
+        };
+        let now = super::system_now_secs() as i64;
+        let anchor = super::clamp_bucket_anchor(anchor, now, bucket_secs);
+        let buckets = super::Buckets::new(anchor, now, bucket_secs);
+        let n = buckets.len();
+
+        let mut per_bucket: Vec<Vec<EnrichedTurn>> = (0..n).map(|_| Vec::new()).collect();
+        for t in turns {
+            let Some(ep) = super::iso_z_to_epoch_secs(&t.turn.ts) else {
+                continue;
+            };
+            if let Some(i) = buckets.index_for(ep) {
+                per_bucket[i].push(t);
+            }
+        }
+
+        let out = per_bucket
+            .into_iter()
+            .enumerate()
+            .map(|(i, mut bturns)| {
+                let fidelity_summary =
+                    summarize_fidelity_from_iter(bturns.iter().map(|t| t.turn.fidelity.as_ref()));
+                if min_fidelity != FidelityClass::Partial {
+                    bturns.retain(|t| has_minimum_fidelity(t.turn.fidelity.as_ref(), min_fidelity));
+                }
+                let table = build_compare_table(
+                    &bturns,
+                    &AnalyzeCompareOptions {
+                        pricing: &pricing,
+                        models: Some(models.clone()),
+                        min_sample,
+                    },
+                );
+                let result = shape_compare_result(
+                    table,
+                    bturns.len() as u64,
+                    min_fidelity,
+                    fidelity_summary,
+                );
+                CompareBucket {
+                    start: buckets.start_iso(i),
+                    end: buckets.end_iso(i),
+                    result,
+                }
+            })
+            .collect();
+
+        Ok(CompareTimeseries {
+            bucket_secs,
+            buckets: out,
+        })
+    }
+}
+
+/// One time bucket of a [`CompareTimeseries`] — the [`CompareResult`] for turns
+/// in `[start, end)`, flattened alongside the window bounds.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompareBucket {
+    pub start: String,
+    pub end: String,
+    #[serde(flatten)]
+    pub result: CompareResult,
+}
+
+/// A time-series of model comparisons, one [`CompareBucket`] per window.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompareTimeseries {
+    #[serde(rename = "bucketSeconds")]
+    pub bucket_secs: u64,
+    pub buckets: Vec<CompareBucket>,
 }
 
 pub fn compare(opts: CompareOptions) -> Result<CompareResult> {

--- a/crates/relayburn-sdk/src/query_verbs/compare.rs
+++ b/crates/relayburn-sdk/src/query_verbs/compare.rs
@@ -197,7 +197,7 @@ impl LedgerHandle {
             });
         };
         let now = super::system_now_secs() as i64;
-        let anchor = super::clamp_bucket_anchor(anchor, now, bucket_secs);
+        super::ensure_bucket_span(anchor, now, bucket_secs)?;
         let buckets = super::Buckets::new(anchor, now, bucket_secs);
         let n = buckets.len();
 

--- a/crates/relayburn-sdk/src/query_verbs/mod.rs
+++ b/crates/relayburn-sdk/src/query_verbs/mod.rs
@@ -305,11 +305,11 @@ pub fn parse_bucket(s: &str) -> Result<u64> {
 }
 
 fn bucket_secs_from_str(s: &str) -> Option<u64> {
-    if s.len() < 2 {
-        return None;
-    }
-    let unit = s.as_bytes()[s.len() - 1] as char;
-    let num = &s[..s.len() - 1];
+    // Split on the final char (not the final byte) so a trailing multi-byte
+    // UTF-8 unit can't land us on an invalid boundary and panic.
+    let mut chars = s.chars();
+    let unit = chars.next_back()?;
+    let num = chars.as_str();
     if num.is_empty() || !num.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
@@ -404,18 +404,21 @@ pub(crate) fn bucket_anchor_secs(
 }
 
 /// Upper bound on bucket count, so a tiny `--bucket` over an ancient `--since`
-/// can't allocate millions of windows. When the natural span would exceed it,
-/// the anchor moves forward to keep the most-recent `MAX_BUCKETS` windows.
+/// can't allocate millions of windows.
 pub(crate) const MAX_BUCKETS: i64 = 10_000;
 
-/// Clamp the anchor so `[anchor, end)` spans at most [`MAX_BUCKETS`] buckets.
-pub(crate) fn clamp_bucket_anchor(anchor: i64, end: i64, bucket_secs: u64) -> i64 {
+/// Reject a window that would span more than [`MAX_BUCKETS`] buckets. We fail
+/// fast rather than silently moving the anchor forward: truncating the lower
+/// bound would drop already-queried turns and break the invariant that
+/// per-bucket totals reconcile with the un-bucketed `--since` total.
+pub(crate) fn ensure_bucket_span(anchor: i64, end: i64, bucket_secs: u64) -> Result<()> {
     let max_span = MAX_BUCKETS.saturating_mul(bucket_secs.max(1) as i64);
     if end.saturating_sub(anchor) > max_span {
-        end - max_span
-    } else {
-        anchor
+        anyhow::bail!(
+            "--bucket would create more than {MAX_BUCKETS} buckets; use a wider --bucket or a narrower --since"
+        );
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/relayburn-sdk/src/query_verbs/mod.rs
+++ b/crates/relayburn-sdk/src/query_verbs/mod.rs
@@ -289,6 +289,136 @@ fn days_to_ymd(days_from_epoch: i64) -> (i64, u32, u32) {
 }
 
 // ---------------------------------------------------------------------------
+// time-bucketing — shared by `--bucket` on summary / compare / hotspots / overhead
+// ---------------------------------------------------------------------------
+
+/// Parse a `--bucket` duration into seconds.
+///
+/// Note: unlike `--since` (where `m` means *month*), bucket sizes use the
+/// natural chart-axis grammar — `s`=seconds, `m`=minutes, `h`=hours, `d`=days,
+/// `w`=weeks. A month-sized bucket is meaningless for a burn time-series, and
+/// minute buckets (`5m`) are the common case (e.g. a "last 5 minutes" chart).
+pub fn parse_bucket(s: &str) -> Result<u64> {
+    bucket_secs_from_str(s).ok_or_else(|| {
+        anyhow::anyhow!("invalid bucket: {s} (expected a duration like 30s, 5m, 1h, 12h, 1d, 7d)")
+    })
+}
+
+fn bucket_secs_from_str(s: &str) -> Option<u64> {
+    if s.len() < 2 {
+        return None;
+    }
+    let unit = s.as_bytes()[s.len() - 1] as char;
+    let num = &s[..s.len() - 1];
+    if num.is_empty() || !num.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let n: u64 = num.parse().ok()?;
+    if n == 0 {
+        return None;
+    }
+    match unit {
+        's' => Some(n),
+        'm' => n.checked_mul(60),
+        'h' => n.checked_mul(3_600),
+        'd' => n.checked_mul(86_400),
+        'w' => n.checked_mul(7 * 86_400),
+        _ => None,
+    }
+}
+
+/// Parse the canonical ledger `ts` (`YYYY-MM-DDTHH:MM:SS(.mmm)Z`) into whole
+/// seconds since the Unix epoch. Sub-second precision is dropped (fine for
+/// bucket assignment). Returns `None` for malformed input.
+pub(crate) fn iso_z_to_epoch_secs(ts: &str) -> Option<i64> {
+    if ts.len() < 19 {
+        return None;
+    }
+    let year: i64 = ts.get(0..4)?.parse().ok()?;
+    let month: u32 = ts.get(5..7)?.parse().ok()?;
+    let day: u32 = ts.get(8..10)?.parse().ok()?;
+    let hour: i64 = ts.get(11..13)?.parse().ok()?;
+    let minute: i64 = ts.get(14..16)?.parse().ok()?;
+    let second: i64 = ts.get(17..19)?.parse().ok()?;
+    let days = ymd_to_days(year, month, day)?;
+    Some(days * 86_400 + hour * 3_600 + minute * 60 + second)
+}
+
+/// Contiguous time buckets `[edges[i], edges[i+1])` covering `[anchor, end)`,
+/// each `bucket_secs` wide. There are `edges.len() - 1` buckets; the final
+/// edge is the first multiple of `bucket_secs` at or after `end`.
+pub(crate) struct Buckets {
+    pub(crate) bucket_secs: u64,
+    edges: Vec<i64>,
+}
+
+impl Buckets {
+    pub(crate) fn new(anchor_secs: i64, end_secs: i64, bucket_secs: u64) -> Self {
+        let step = bucket_secs.max(1) as i64;
+        let end = end_secs.max(anchor_secs + step); // always at least one bucket
+        let mut edges = Vec::new();
+        let mut e = anchor_secs;
+        while e < end {
+            edges.push(e);
+            e += step;
+        }
+        edges.push(e);
+        Self { bucket_secs, edges }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.edges.len().saturating_sub(1)
+    }
+
+    pub(crate) fn start_iso(&self, i: usize) -> String {
+        format_iso_z_ms(self.edges[i], 0)
+    }
+
+    pub(crate) fn end_iso(&self, i: usize) -> String {
+        format_iso_z_ms(self.edges[i + 1], 0)
+    }
+
+    /// Bucket index for a `ts` epoch, or `None` if it falls outside
+    /// `[anchor, last_edge)`.
+    pub(crate) fn index_for(&self, ts_epoch: i64) -> Option<usize> {
+        let anchor = *self.edges.first()?;
+        let last = *self.edges.last()?;
+        if ts_epoch < anchor || ts_epoch >= last {
+            return None;
+        }
+        let idx = ((ts_epoch - anchor) / self.bucket_secs.max(1) as i64) as usize;
+        Some(idx.min(self.len().saturating_sub(1)))
+    }
+}
+
+/// Pick the bucket anchor: the normalized `--since` epoch when present, else
+/// the earliest turn `ts` seen in `turn_ts`.
+pub(crate) fn bucket_anchor_secs(
+    since_norm: Option<&str>,
+    turn_ts: impl Iterator<Item = i64>,
+) -> Option<i64> {
+    if let Some(secs) = since_norm.and_then(iso_z_to_epoch_secs) {
+        return Some(secs);
+    }
+    turn_ts.min()
+}
+
+/// Upper bound on bucket count, so a tiny `--bucket` over an ancient `--since`
+/// can't allocate millions of windows. When the natural span would exceed it,
+/// the anchor moves forward to keep the most-recent `MAX_BUCKETS` windows.
+pub(crate) const MAX_BUCKETS: i64 = 10_000;
+
+/// Clamp the anchor so `[anchor, end)` spans at most [`MAX_BUCKETS`] buckets.
+pub(crate) fn clamp_bucket_anchor(anchor: i64, end: i64, bucket_secs: u64) -> i64 {
+    let max_span = MAX_BUCKETS.saturating_mul(bucket_secs.max(1) as i64);
+    if end.saturating_sub(anchor) > max_span {
+        end - max_span
+    } else {
+        anchor
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Shared helpers — query construction + hotspots coverage gate
 // ---------------------------------------------------------------------------
 

--- a/crates/relayburn-sdk/src/query_verbs/summary.rs
+++ b/crates/relayburn-sdk/src/query_verbs/summary.rs
@@ -581,6 +581,9 @@ impl LedgerHandle {
         if opts.group_by_tag.is_some() {
             anyhow::bail!("--bucket is not supported with --group-by-tag");
         }
+        if opts.include_quality {
+            anyhow::bail!("--bucket is not supported with --quality metrics yet");
+        }
 
         let q = build_summary_report_query(&opts)?;
         let provider_filter = normalize_summary_provider_filter(opts.providers.as_deref());
@@ -611,7 +614,7 @@ impl LedgerHandle {
             });
         };
         let now = super::system_now_secs() as i64;
-        let anchor = super::clamp_bucket_anchor(anchor, now, bucket_secs);
+        super::ensure_bucket_span(anchor, now, bucket_secs)?;
         let buckets = super::Buckets::new(anchor, now, bucket_secs);
         let n = buckets.len();
 

--- a/crates/relayburn-sdk/src/query_verbs/summary.rs
+++ b/crates/relayburn-sdk/src/query_verbs/summary.rs
@@ -534,7 +534,134 @@ pub struct SummarySubagentTreeReport {
     pub root: Option<SubagentTreeNode>,
 }
 
+/// One time bucket of a [`SummaryTimeseries`]: the grouped summary totals for
+/// turns whose `ts` falls in `[start, end)`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SummaryBucket {
+    pub start: String,
+    pub end: String,
+    pub turn_count: u64,
+    pub total_tokens: u64,
+    pub total_cost: CostBreakdown,
+    pub group_by: SummaryGroupBy,
+    pub rows: Vec<UsageCostAggregateRow>,
+}
+
+/// A time-series of grouped summary totals — one [`SummaryBucket`] per
+/// `bucket_secs`-wide window across the `--since` range. Produced by
+/// [`LedgerHandle::summary_timeseries`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SummaryTimeseries {
+    #[serde(rename = "bucketSeconds")]
+    pub bucket_secs: u64,
+    pub buckets: Vec<SummaryBucket>,
+}
+
 impl LedgerHandle {
+    /// Time-bucketed cost/usage totals (the `--bucket` form of the default
+    /// grouped summary). Fetches the `--since` window once, then partitions the
+    /// turns by `ts` into `bucket_secs`-wide buckets and aggregates each — a
+    /// pure per-turn fold, so per-bucket totals sum back to the un-bucketed
+    /// total. Supported only for the default grouped (`byModel`/`byProvider`)
+    /// summary; the tool/subagent/relationship attribution modes are rejected.
+    pub fn summary_timeseries(
+        &self,
+        opts: SummaryReportOptions,
+        bucket_secs: u64,
+    ) -> Result<SummaryTimeseries> {
+        let by_provider = match &opts.mode {
+            SummaryReportMode::Grouped { by_provider } => *by_provider,
+            _ => anyhow::bail!(
+                "--bucket is only supported with the default grouped summary, not \
+                 --by-tool/--by-subagent-type/--by-relationship/--subagent-tree"
+            ),
+        };
+        if opts.group_by_tag.is_some() {
+            anyhow::bail!("--bucket is not supported with --group-by-tag");
+        }
+
+        let q = build_summary_report_query(&opts)?;
+        let provider_filter = normalize_summary_provider_filter(opts.providers.as_deref());
+        let pricing = load_pricing(None);
+        let agent_session_ids = match opts.agent.as_deref() {
+            Some(agent_id) => Some(resolve_summary_agent_session_tree(&self.inner, agent_id)?),
+            None => None,
+        };
+
+        let enriched = self.inner.query_turns(&q)?;
+        let enriched = filter_summary_enriched_turns(
+            enriched,
+            opts.agent.as_deref(),
+            agent_session_ids.as_ref(),
+            provider_filter.as_ref(),
+        );
+        let turns = summary_turns_from_enriched(&enriched);
+
+        let Some(anchor) = super::bucket_anchor_secs(
+            q.since.as_deref(),
+            turns
+                .iter()
+                .filter_map(|t| super::iso_z_to_epoch_secs(&t.ts)),
+        ) else {
+            return Ok(SummaryTimeseries {
+                bucket_secs,
+                buckets: Vec::new(),
+            });
+        };
+        let now = super::system_now_secs() as i64;
+        let anchor = super::clamp_bucket_anchor(anchor, now, bucket_secs);
+        let buckets = super::Buckets::new(anchor, now, bucket_secs);
+        let n = buckets.len();
+
+        let mut per_bucket: Vec<Vec<TurnRecord>> = (0..n).map(|_| Vec::new()).collect();
+        for t in turns {
+            let Some(ep) = super::iso_z_to_epoch_secs(&t.ts) else {
+                continue;
+            };
+            if let Some(i) = buckets.index_for(ep) {
+                per_bucket[i].push(t);
+            }
+        }
+
+        let group_by = if by_provider {
+            SummaryGroupBy::Provider
+        } else {
+            SummaryGroupBy::Model
+        };
+        let out = per_bucket
+            .into_iter()
+            .enumerate()
+            .map(|(i, bturns)| {
+                let rows = if by_provider {
+                    aggregate_by_provider(&bturns, AggregateByProviderOptions::new(&pricing))
+                        .into_iter()
+                        .map(summary_provider_to_aggregate_row)
+                        .collect::<Vec<_>>()
+                } else {
+                    summary_aggregate_by_model(&bturns, &pricing)
+                };
+                let total_cost = sum_costs(rows.iter().map(|r| &r.cost));
+                let total_tokens: u64 = bturns.iter().map(total_tokens_for_turn).sum();
+                SummaryBucket {
+                    start: buckets.start_iso(i),
+                    end: buckets.end_iso(i),
+                    turn_count: bturns.len() as u64,
+                    total_tokens,
+                    total_cost,
+                    group_by,
+                    rows,
+                }
+            })
+            .collect();
+
+        Ok(SummaryTimeseries {
+            bucket_secs,
+            buckets: out,
+        })
+    }
+
     pub fn summary_report(&self, opts: SummaryReportOptions) -> Result<SummaryReport> {
         let q = build_summary_report_query(&opts)?;
         let provider_filter = normalize_summary_provider_filter(opts.providers.as_deref());

--- a/crates/relayburn-sdk/src/query_verbs/tests.rs
+++ b/crates/relayburn-sdk/src/query_verbs/tests.rs
@@ -2633,3 +2633,147 @@ mod fingerprint_bench {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// `--bucket` time-series
+// ---------------------------------------------------------------------------
+
+fn bucket_test_turn(session: &str, message: &str, ts: &str, input: u64) -> TurnRecord {
+    TurnRecord {
+        v: 1,
+        source: SourceKind::ClaudeCode,
+        session_id: session.into(),
+        session_path: None,
+        message_id: message.into(),
+        turn_index: 0,
+        ts: ts.into(),
+        model: "claude-sonnet-4-6".into(),
+        project: Some("/tmp/proj".into()),
+        project_key: None,
+        usage: Usage {
+            input,
+            output: 0,
+            reasoning: 0,
+            cache_read: 0,
+            cache_create_5m: 0,
+            cache_create_1h: 0,
+        },
+        tool_calls: vec![],
+        files_touched: None,
+        subagent: None,
+        stop_reason: None,
+        activity: None,
+        retries: None,
+        has_edits: None,
+        fidelity: None,
+    }
+}
+
+#[test]
+fn parse_bucket_uses_minute_grammar_and_rejects_garbage() {
+    assert_eq!(super::parse_bucket("30s").unwrap(), 30);
+    assert_eq!(super::parse_bucket("5m").unwrap(), 300); // minutes, not months
+    assert_eq!(super::parse_bucket("1h").unwrap(), 3_600);
+    assert_eq!(super::parse_bucket("12h").unwrap(), 43_200);
+    assert_eq!(super::parse_bucket("1d").unwrap(), 86_400);
+    assert_eq!(super::parse_bucket("7d").unwrap(), 604_800);
+    assert_eq!(super::parse_bucket("1w").unwrap(), 604_800);
+    for bad in ["", "5", "5x", "0m", "abc", "h", "-5m", "m"] {
+        assert!(
+            super::parse_bucket(bad).is_err(),
+            "{bad:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn iso_z_to_epoch_secs_roundtrips_with_formatter() {
+    for secs in [0_i64, 1_700_000_000, super::system_now_secs() as i64] {
+        let iso = super::format_iso_z_ms(secs, 0);
+        assert_eq!(
+            super::iso_z_to_epoch_secs(&iso),
+            Some(secs),
+            "roundtrip {iso}"
+        );
+    }
+    // sub-second precision is floored, not rejected.
+    assert_eq!(
+        super::iso_z_to_epoch_secs("2026-04-23T00:00:00.500Z"),
+        super::iso_z_to_epoch_secs("2026-04-23T00:00:00.000Z")
+    );
+    assert_eq!(super::iso_z_to_epoch_secs("garbage"), None);
+}
+
+#[test]
+fn buckets_partition_edges_and_indices() {
+    let b = super::Buckets::new(0, 1000, 300); // edges 0,300,600,900,1200 -> 4 buckets
+    assert_eq!(b.len(), 4);
+    assert_eq!(b.index_for(0), Some(0));
+    assert_eq!(b.index_for(299), Some(0));
+    assert_eq!(b.index_for(300), Some(1));
+    assert_eq!(b.index_for(899), Some(2));
+    assert_eq!(b.index_for(950), Some(3));
+    assert_eq!(b.index_for(-1), None); // before anchor
+    assert_eq!(b.index_for(1200), None); // last edge is exclusive
+}
+
+#[test]
+fn summary_timeseries_places_turns_in_buckets_and_sums_to_total() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut handle = Ledger::open(LedgerOpenOptions::with_home(dir.path())).expect("open");
+
+    // Two turns inside the last hour, ~9 minutes apart, so they land in
+    // different 5-minute buckets. Timestamps are anchored to `now` so the
+    // `--since 1h` window (which ends at `now`) actually contains them.
+    let now = super::system_now_secs() as i64;
+    let ts_recent = super::format_iso_z_ms(now - 180, 0); // 3m ago
+    let ts_older = super::format_iso_z_ms(now - 720, 0); // 12m ago
+    handle
+        .raw_mut()
+        .append_turns(&[
+            bucket_test_turn("s1", "m1", &ts_recent, 1_000),
+            bucket_test_turn("s1", "m2", &ts_older, 2_000),
+        ])
+        .expect("append");
+
+    let series = handle
+        .summary_timeseries(
+            SummaryReportOptions {
+                since: Some("1h".into()),
+                mode: SummaryReportMode::Grouped { by_provider: false },
+                ..SummaryReportOptions::default()
+            },
+            300, // 5-minute buckets
+        )
+        .expect("timeseries");
+
+    assert_eq!(series.bucket_secs, 300);
+    let nonempty: Vec<_> = series.buckets.iter().filter(|b| b.turn_count > 0).collect();
+    assert_eq!(
+        nonempty.len(),
+        2,
+        "two turns 9m apart -> two distinct 5m buckets"
+    );
+    assert!(nonempty.iter().all(|b| b.turn_count == 1));
+
+    // Per-bucket totals reconcile with the un-bucketed total.
+    let total_tokens: u64 = series.buckets.iter().map(|b| b.total_tokens).sum();
+    assert_eq!(total_tokens, 3_000);
+    let total_turns: u64 = series.buckets.iter().map(|b| b.turn_count).sum();
+    assert_eq!(total_turns, 2);
+}
+
+#[test]
+fn summary_timeseries_rejects_attribution_modes() {
+    let (_dir, handle) = fixture_handle();
+    let err = handle
+        .summary_timeseries(
+            SummaryReportOptions {
+                mode: SummaryReportMode::ByTool,
+                ..SummaryReportOptions::default()
+            },
+            300,
+        )
+        .expect_err("--bucket must reject --by-tool");
+    assert!(err.to_string().contains("--bucket"));
+}

--- a/crates/relayburn-sdk/src/query_verbs/tests.rs
+++ b/crates/relayburn-sdk/src/query_verbs/tests.rs
@@ -2678,7 +2678,9 @@ fn parse_bucket_uses_minute_grammar_and_rejects_garbage() {
     assert_eq!(super::parse_bucket("1d").unwrap(), 86_400);
     assert_eq!(super::parse_bucket("7d").unwrap(), 604_800);
     assert_eq!(super::parse_bucket("1w").unwrap(), 604_800);
-    for bad in ["", "5", "5x", "0m", "abc", "h", "-5m", "m"] {
+    // A trailing multi-byte unit must be rejected, not panic on a byte-index
+    // slice that lands mid-codepoint.
+    for bad in ["", "5", "5x", "0m", "abc", "h", "-5m", "m", "5€", "5м"] {
         assert!(
             super::parse_bucket(bad).is_err(),
             "{bad:?} should be rejected"
@@ -2776,4 +2778,48 @@ fn summary_timeseries_rejects_attribution_modes() {
         )
         .expect_err("--bucket must reject --by-tool");
     assert!(err.to_string().contains("--bucket"));
+}
+
+#[test]
+fn summary_timeseries_rejects_quality() {
+    let (_dir, handle) = fixture_handle();
+    let err = handle
+        .summary_timeseries(
+            SummaryReportOptions {
+                mode: SummaryReportMode::Grouped { by_provider: false },
+                include_quality: true,
+                ..SummaryReportOptions::default()
+            },
+            300,
+        )
+        .expect_err("--bucket must reject --quality");
+    assert!(err.to_string().contains("--quality"));
+}
+
+#[test]
+fn summary_timeseries_rejects_oversized_window() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut handle = Ledger::open(LedgerOpenOptions::with_home(dir.path())).expect("open");
+
+    // A turn ~24h ago with a 1s bucket would demand ~86k buckets (> MAX_BUCKETS),
+    // which previously truncated the anchor and silently dropped older turns.
+    // We now fail fast so per-bucket totals can't drift from the window total.
+    let now = super::system_now_secs() as i64;
+    let ts_old = super::format_iso_z_ms(now - 86_400, 0);
+    handle
+        .raw_mut()
+        .append_turns(&[bucket_test_turn("s1", "m1", &ts_old, 1_000)])
+        .expect("append");
+
+    let err = handle
+        .summary_timeseries(
+            SummaryReportOptions {
+                since: Some("24h".into()),
+                mode: SummaryReportMode::Grouped { by_provider: false },
+                ..SummaryReportOptions::default()
+            },
+            1, // 1-second buckets over 24h -> far more than MAX_BUCKETS
+        )
+        .expect_err("oversized bucket window must be rejected");
+    assert!(err.to_string().contains("buckets"));
 }

--- a/packages/relayburn/CHANGELOG.md
+++ b/packages/relayburn/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `relayburn`.
 
 ## [Unreleased]
 
+- Added `--bucket <DURATION>` to `burn summary` and `burn compare` for a per-bucket time-series across the `--since` window (`{ bucketSeconds, buckets: [...] }` in `--json`). Grammar: `30s`/`5m`(minutes)/`1h`/`12h`/`1d`/`7d`.
+
 ## [3.1.0] - 2026-05-29
 
 - `burn update` now upgrades npm installs through `npm install -g relayburn@latest`: the launcher tags the install channel so the binary picks the right package manager.


### PR DESCRIPTION
## Summary

Adds `--bucket <DURATION>` to the read verbs that take `--since`, turning a single windowed total into a **time-series**: the verb's report computed per fixed-width time bucket. Built for a live spend chart that needs selectable ranges (last 5m / 1h / 12h / 1d / 7d) sourced from one indexed query rather than N client-side round-trips.

**JSON shape** (both verbs): `{ "bucketSeconds": N, "buckets": [ { "start": ISO, "end": ISO, ...the verb's normal report... } ] }`.

## What's included

- **Shared primitive** (`query_verbs/mod.rs`): `parse_bucket` (grammar `30s`/`5m`/`1h`/`12h`/`1d`/`7d`), `iso_z_to_epoch_secs`, and a `Buckets` partition anchored on the normalized `--since` (or the earliest turn), with a `MAX_BUCKETS` guard. Reuses the existing fetch (`query_turns` + `idx_turns_ts`), `cost_for_turn`, `load_pricing`, and `provider_for`.
- **summary**: `summary_timeseries` — turn-level partition (the grouped model/provider/tag path is a pure per-turn fold). Rejected with a clear error for the `--by-tool`/subagent/relationship attribution modes.
- **compare**: `compare_timeseries` — per-bucket compare table.
- **CLI**: `--bucket` on `summary` and `compare`; JSON emits the series, human output prints a per-bucket line.
- **Tests** (5): parser grammar, ISO↔epoch round-trip, `Buckets` edges/indices, `summary_timeseries` placement reconciling exactly to the un-bucketed total, attribution-mode rejection.

### Note: `m` = minutes for `--bucket`
`--since` treats `m` as *month*, but month-sized buckets are meaningless and the consumer wants *minute* buckets ("last 5 minutes"). So `--bucket` uses `m` = minutes and adds `s` = seconds. Documented in the flag help and code.

## Deferred: hotspots / overhead

Both also take `--since`, but their aggregation isn't a pure per-turn fold — `hotspots` attributes turn *N*'s cost to turn *N−1*'s `tool_use` (ordering/cross-turn + session-scoped side queries) and `overhead` computes window-amortized per-session denominators (and does filesystem work). Correct bucketing for these needs **session-granular** partitioning (assign whole sessions to a bucket by earliest `ts`). Rather than ship incorrect attribution, `--bucket` is simply absent on those two; it's a clean follow-up.

## Verification

`cargo build --workspace` ✅ · `cargo test --workspace` ✅ (all suites pass; 5 new). Smoke vs a real ledger: `summary --provider anthropic --since 1h --bucket 5m --json` → `bucketSeconds=300`, 12 buckets, and bucket-sum tokens == the plain `--since 1h` total exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/burn/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

