### PR TITLE
test(macos): restructure BurnOSX for testability, add BurnRunner seam and CI

### DIFF
--- a/.github/workflows/macos-app-tests.yml
+++ b/.github/workflows/macos-app-tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build
         run: swift build --package-path apps/macos

--- a/.github/workflows/macos-app-tests.yml
+++ b/.github/workflows/macos-app-tests.yml
@@ -1,0 +1,33 @@
+name: macOS app tests
+
+# Build + unit-test the apps/macos menu bar app (BurnOSX) on a macOS runner.
+# Only the Rust CLI is exercised on Linux in ci.yml; the Swift package needs
+# AppKit/SwiftUI, so it can only build and test on macOS.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/macos/**'
+      - '.github/workflows/macos-app-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-app-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build
+        run: swift build --package-path apps/macos
+
+      - name: Test
+        run: swift test --package-path apps/macos

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -7,12 +7,27 @@ let package = Package(
         .macOS(.v13)
     ],
     targets: [
-        .executableTarget(
-            name: "Burn",
+        // All app logic lives here as a library so it can be unit-tested via
+        // `@testable import BurnCore`. Resources move with it, so `Bundle.module`
+        // references keep resolving.
+        .target(
+            name: "BurnCore",
             path: "Sources/Burn",
             resources: [
                 .process("Resources")
             ]
+        ),
+        // Thin `@main` entry point. Keeps the executable product named `Burn`
+        // (build.sh/release.sh copy `$BIN_PATH/Burn`).
+        .executableTarget(
+            name: "Burn",
+            dependencies: ["BurnCore"],
+            path: "Sources/Main"
+        ),
+        .testTarget(
+            name: "BurnTests",
+            dependencies: ["BurnCore"],
+            path: "Tests/BurnTests"
         )
     ]
 )

--- a/apps/macos/Sources/Burn/AppDelegate.swift
+++ b/apps/macos/Sources/Burn/AppDelegate.swift
@@ -2,33 +2,26 @@ import SwiftUI
 import AppKit
 import Combine
 
-@main
-struct BurnApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
-
-    var body: some Scene {
-        // No SwiftUI scene drives the menu bar. The status item is created once,
-        // imperatively, by AppDelegate. SwiftUI's `MenuBarExtra` can duplicate
-        // its status item when the app's scene body re-evaluates — that runaway
-        // ("endless menu bar flames") panicked the machine. An AppKit
-        // NSStatusItem created a single time cannot be duplicated.
-        Settings { EmptyView() }
-    }
-}
-
 /// Owns the single menu bar status item and its popover. Created once in
 /// `applicationDidFinishLaunching`; the flame image is mirrored from the view
 /// model's cached icon. No SwiftUI rendering touches the status item, so there
 /// is no render path that can storm or duplicate it.
+///
+/// `public` so the thin `Burn` executable target's `@main` can adopt it via
+/// `@NSApplicationDelegateAdaptor`.
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+public final class AppDelegate: NSObject, NSApplicationDelegate {
     private let viewModel = UsageViewModel()
     private var statusItem: NSStatusItem?
     private let popover = NSPopover()
     private var iconObserver: AnyCancellable?
     private var appearanceObserver: NSObjectProtocol?
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
+    public override init() {
+        super.init()
+    }
+
+    public func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory) // menu-bar-only, no Dock icon
 
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)

--- a/apps/macos/Sources/Burn/BurnLedger.swift
+++ b/apps/macos/Sources/Burn/BurnLedger.swift
@@ -80,8 +80,9 @@ actor SystemBurnRunner: BurnRunner {
         let process = Process()
         configure(process)
         let stdout = Pipe()
+        let stderr = Pipe()
         process.standardOutput = stdout
-        process.standardError = Pipe()
+        process.standardError = stderr
         do {
             try process.run()
         } catch {
@@ -96,11 +97,16 @@ actor SystemBurnRunner: BurnRunner {
         // child kept running.
         let group = DispatchGroup()
         group.enter()
-        var output = Data()
+        let output = DataBox()
         DispatchQueue.global(qos: .utility).async {
-            output = stdout.fileHandleForReading.readDataToEndOfFile()
+            output.data = stdout.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
             group.leave()
+        }
+        // Drain stderr separately: an undrained pipe fills at ~64KB and blocks
+        // the child's writes, turning a chatty failure into a timeout.
+        DispatchQueue.global(qos: .utility).async {
+            _ = stderr.fileHandleForReading.readDataToEndOfFile()
         }
         if group.wait(timeout: .now() + timeout) == .timedOut {
             process.terminate()                       // SIGTERM…
@@ -111,7 +117,13 @@ actor SystemBurnRunner: BurnRunner {
             return nil
         }
         guard process.terminationStatus == 0 else { return nil }
-        return String(data: output, encoding: .utf8)
+        return String(data: output.data, encoding: .utf8)
+    }
+
+    /// Mutable holder the background reader fills in; capturing a `var` for
+    /// mutation in concurrently-executing code is an error under Swift 6.
+    private final class DataBox: @unchecked Sendable {
+        var data = Data()
     }
 
     private func shellQuote(_ value: String) -> String {

--- a/apps/macos/Sources/Burn/BurnLedger.swift
+++ b/apps/macos/Sources/Burn/BurnLedger.swift
@@ -1,15 +1,137 @@
 import Foundation
 
+/// Runs the `burn` CLI and returns its stdout. A seam so tests can inject a fake
+/// that returns canned JSON without spawning a subprocess.
+protocol BurnRunner: Sendable {
+    /// Runs `burn` with the given arguments, returning stdout on success or nil
+    /// on failure/timeout/missing binary.
+    func run(_ args: [String]) async -> String?
+
+    /// URL of the bundled native `burn` helper, when this runner is backed by a
+    /// real app bundle. The long-lived ingest watch needs a directly spawnable
+    /// binary (a login-shell child can't be cleanly managed), so it only starts
+    /// when this is non-nil. Defaults to `nil` for fakes / PATH-only setups.
+    func bundledBinaryURL() async -> URL?
+}
+
+extension BurnRunner {
+    func bundledBinaryURL() async -> URL? { nil }
+}
+
+/// Production `BurnRunner`: resolves and spawns the real `burn` binary. Prefers
+/// the native helper bundled inside the app (so spend works with no separate
+/// install), and falls back to a `burn` on `PATH` for dev builds run via
+/// `swift run`. An actor because it caches the resolved `Tool`.
+actor SystemBurnRunner: BurnRunner {
+    private enum Tool {
+        case unknown
+        case bundled(URL) // self-contained native binary in the app bundle
+        case path         // a `burn` on PATH (resolved via a login shell)
+        case missing
+    }
+    private var tool: Tool = .unknown
+
+    func run(_ args: [String]) async -> String? {
+        switch resolveTool() {
+        case .bundled(let url):
+            // Self-contained Rust binary — exec directly, no shell needed.
+            return capture { $0.executableURL = url; $0.arguments = args }
+        case .path:
+            // Run through a login shell so nvm/Homebrew PATH (and the `node` the
+            // npm `burn` shim needs) resolve even when launched from Finder.
+            let command = "burn " + args.map(shellQuote).joined(separator: " ")
+            return loginShell(command)
+        case .missing, .unknown:
+            return nil
+        }
+    }
+
+    func bundledBinaryURL() async -> URL? {
+        if case .bundled(let url) = resolveTool() { return url }
+        return nil
+    }
+
+    private func resolveTool() -> Tool {
+        if case .unknown = tool {
+            if let url = Bundle.main.url(forAuxiliaryExecutable: "burn"),
+               FileManager.default.isExecutableFile(atPath: url.path) {
+                tool = .bundled(url)
+            } else if !(loginShell("command -v burn")?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? "").isEmpty {
+                tool = .path
+            } else {
+                tool = .missing
+            }
+        }
+        return tool
+    }
+
+    private func loginShell(_ command: String) -> String? {
+        capture {
+            $0.executableURL = URL(fileURLWithPath: "/bin/zsh")
+            $0.arguments = ["-lc", command]
+        }
+    }
+
+    /// Runs a configured process and returns stdout, or `nil` on failure /
+    /// nonzero exit / timeout. The timeout stops a hung `burn` from wedging the
+    /// actor and queuing follow-up spend requests behind it.
+    private func capture(_ configure: (Process) -> Void, timeout: TimeInterval = 30) -> String? {
+        let process = Process()
+        configure(process)
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        // Read stdout to EOF (which arrives when the process exits) and reap it
+        // on a background queue; bound the wait with a timeout. This blocks the
+        // runner actor until the process truly finishes or is killed — which,
+        // because the actor serializes calls, guarantees only one `burn`
+        // subprocess can ever be alive at a time (no pile-up). Avoids the
+        // `terminationHandler` race that could let capture() return while the
+        // child kept running.
+        let group = DispatchGroup()
+        group.enter()
+        var output = Data()
+        DispatchQueue.global(qos: .utility).async {
+            output = stdout.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            group.leave()
+        }
+        if group.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()                       // SIGTERM…
+            usleep(200_000)
+            if process.isRunning {                    // …then SIGKILL if it ignores it
+                kill(process.processIdentifier, SIGKILL)
+            }
+            return nil
+        }
+        guard process.terminationStatus == 0 else { return nil }
+        return String(data: output, encoding: .utf8)
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
 /// Reads authoritative spend figures from the burn ledger. Cost is *not* stored
 /// in the ledger — burn computes it from its pricing table — so we invoke the
-/// `burn` binary rather than re-derive pricing here.
+/// `burn` binary (via a `BurnRunner`) rather than re-derive pricing here.
 ///
-/// Prefers the native `burn` helper bundled inside the app (so spend works with
-/// no separate install), and falls back to a `burn` on `PATH` for dev builds
-/// run via `swift run`. Returns `nil` when neither is available, letting the UI
-/// hide the spend line.
+/// Returns `nil` when burn is unavailable, letting the UI hide the spend line.
 actor BurnLedger {
     static let shared = BurnLedger()
+
+    private let runner: BurnRunner
+
+    init(runner: BurnRunner = SystemBurnRunner()) {
+        self.runner = runner
+    }
 
     /// burn's provider name for one of our providers.
     static func burnProvider(for name: ProviderName) -> String {
@@ -19,20 +141,12 @@ actor BurnLedger {
         }
     }
 
-    private enum Tool {
-        case unknown
-        case bundled(URL) // self-contained native binary in the app bundle
-        case path         // a `burn` on PATH (resolved via a login shell)
-        case missing
-    }
-    private var tool: Tool = .unknown
-
     /// Total USD spend for `provider` since `since`, or `nil` if burn is
     /// unavailable or the query fails.
     func cost(provider: String, since: Date) async -> Double? {
         let iso = ISO8601DateFormatter().string(from: since)
         let args = ["summary", "--provider", provider, "--since", iso, "--json"]
-        guard let output = runBurn(args),
+        guard let output = await runner.run(args),
               let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let totalCost = json["totalCost"] as? [String: Any],
@@ -56,7 +170,7 @@ actor BurnLedger {
     func summary(provider: String, since: Date) async -> Summary? {
         let iso = ISO8601DateFormatter().string(from: since)
         let args = ["summary", "--provider", provider, "--since", iso, "--json"]
-        guard let output = runBurn(args),
+        guard let output = await runner.run(args),
               let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return nil }
@@ -91,7 +205,7 @@ actor BurnLedger {
     func timeseries(provider: String, since: Date, bucket: String) async -> [TimeseriesPoint]? {
         let iso = ISO8601DateFormatter().string(from: since)
         let args = ["summary", "--provider", provider, "--since", iso, "--bucket", bucket, "--json"]
-        guard let output = runBurn(args),
+        guard let output = await runner.run(args),
               let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let buckets = json["buckets"] as? [[String: Any]]
@@ -123,9 +237,9 @@ actor BurnLedger {
     /// Starts a background `burn ingest --watch` if one isn't already running.
     /// Only runs with the bundled native helper (a login-shell child can't be
     /// cleanly managed); the live chart still polls either way.
-    func startIngestWatch() {
+    func startIngestWatch() async {
         guard watchProcess == nil else { return }
-        guard case .bundled(let url) = resolveTool() else { return }
+        guard let url = await runner.bundledBinaryURL() else { return }
         let process = Process()
         process.executableURL = url
         process.arguments = ["ingest", "--watch", "--quiet"]
@@ -143,89 +257,5 @@ actor BurnLedger {
     func stopIngestWatch() {
         watchProcess?.terminate()
         watchProcess = nil
-    }
-
-    // MARK: - Resolution & invocation
-
-    private func resolveTool() -> Tool {
-        if case .unknown = tool {
-            if let url = Bundle.main.url(forAuxiliaryExecutable: "burn"),
-               FileManager.default.isExecutableFile(atPath: url.path) {
-                tool = .bundled(url)
-            } else if !(loginShell("command -v burn")?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? "").isEmpty {
-                tool = .path
-            } else {
-                tool = .missing
-            }
-        }
-        return tool
-    }
-
-    private func runBurn(_ args: [String]) -> String? {
-        switch resolveTool() {
-        case .bundled(let url):
-            // Self-contained Rust binary — exec directly, no shell needed.
-            return capture { $0.executableURL = url; $0.arguments = args }
-        case .path:
-            // Run through a login shell so nvm/Homebrew PATH (and the `node` the
-            // npm `burn` shim needs) resolve even when launched from Finder.
-            let command = "burn " + args.map(shellQuote).joined(separator: " ")
-            return loginShell(command)
-        case .missing, .unknown:
-            return nil
-        }
-    }
-
-    private func loginShell(_ command: String) -> String? {
-        capture {
-            $0.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            $0.arguments = ["-lc", command]
-        }
-    }
-
-    /// Runs a configured process and returns stdout, or `nil` on failure /
-    /// nonzero exit / timeout. The timeout stops a hung `burn` from wedging the
-    /// actor and queuing follow-up spend requests behind it.
-    private func capture(_ configure: (Process) -> Void, timeout: TimeInterval = 30) -> String? {
-        let process = Process()
-        configure(process)
-        let stdout = Pipe()
-        process.standardOutput = stdout
-        process.standardError = Pipe()
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        // Read stdout to EOF (which arrives when the process exits) and reap it
-        // on a background queue; bound the wait with a timeout. This blocks the
-        // BurnLedger actor until the process truly finishes or is killed — which,
-        // because the actor serializes calls, guarantees only one `burn`
-        // subprocess can ever be alive at a time (no pile-up). Avoids the
-        // `terminationHandler` race that could let capture() return while the
-        // child kept running.
-        let group = DispatchGroup()
-        group.enter()
-        var output = Data()
-        DispatchQueue.global(qos: .utility).async {
-            output = stdout.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-            group.leave()
-        }
-        if group.wait(timeout: .now() + timeout) == .timedOut {
-            process.terminate()                       // SIGTERM…
-            usleep(200_000)
-            if process.isRunning {                    // …then SIGKILL if it ignores it
-                kill(process.processIdentifier, SIGKILL)
-            }
-            return nil
-        }
-        guard process.terminationStatus == 0 else { return nil }
-        return String(data: output, encoding: .utf8)
-    }
-
-    private func shellQuote(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/apps/macos/Sources/Burn/BurnLedger.swift
+++ b/apps/macos/Sources/Burn/BurnLedger.swift
@@ -233,13 +233,19 @@ actor BurnLedger {
     /// keeps the ledger fresh incrementally (FS-event driven, ~1s poll), so the
     /// live view's summary polls stay fast.
     private var watchProcess: Process?
+    /// True between start and stop requests. Actor methods are reentrant across
+    /// awaits, so a stop can interleave while start is suspended resolving the
+    /// binary; start rechecks this before spawning so the stop wins.
+    private var watchDesired = false
 
     /// Starts a background `burn ingest --watch` if one isn't already running.
     /// Only runs with the bundled native helper (a login-shell child can't be
     /// cleanly managed); the live chart still polls either way.
     func startIngestWatch() async {
         guard watchProcess == nil else { return }
+        watchDesired = true
         guard let url = await runner.bundledBinaryURL() else { return }
+        guard watchDesired, watchProcess == nil else { return }
         let process = Process()
         process.executableURL = url
         process.arguments = ["ingest", "--watch", "--quiet"]
@@ -253,8 +259,10 @@ actor BurnLedger {
         }
     }
 
-    /// Terminates the background watch process, if running.
+    /// Terminates the background watch process, if running, and cancels any
+    /// start that is still resolving the binary.
     func stopIngestWatch() {
+        watchDesired = false
         watchProcess?.terminate()
         watchProcess = nil
     }

--- a/apps/macos/Sources/Burn/LiveBurnViewModel.swift
+++ b/apps/macos/Sources/Burn/LiveBurnViewModel.swift
@@ -95,16 +95,23 @@ final class LiveBurnViewModel: ObservableObject {
     @Published private(set) var unavailable = false
 
     private let providers = ProviderName.allCases
+    private let ledger: BurnLedger
     private var timer: Timer?
     private var refreshing = false
     /// Set when a refresh is requested while one is in flight, so the running
     /// one does another pass (for the latest range) instead of being dropped.
     private var refreshAgain = false
 
+    /// - Parameter ledger: the burn ledger to query (default `.shared`). Tests
+    ///   inject a ledger backed by a fake runner.
+    init(ledger: BurnLedger = .shared) {
+        self.ledger = ledger
+    }
+
     /// Begins the refresh loop and the background ingest watch. Idempotent.
     func start() {
         guard timer == nil else { return }
-        Task { await BurnLedger.shared.startIngestWatch() }
+        Task { await ledger.startIngestWatch() }
         Task { await refresh() }
         scheduleTimer()
     }
@@ -113,7 +120,7 @@ final class LiveBurnViewModel: ObservableObject {
     func stop() {
         timer?.invalidate()
         timer = nil
-        Task { await BurnLedger.shared.stopIngestWatch() }
+        Task { await ledger.stopIngestWatch() }
     }
 
     func isEnabled(_ provider: ProviderName) -> Bool { enabled.contains(provider) }
@@ -167,7 +174,7 @@ final class LiveBurnViewModel: ObservableObject {
 
             for provider in providers {
                 let burnProvider = BurnLedger.burnProvider(for: provider)
-                guard let points = await BurnLedger.shared.timeseries(
+                guard let points = await ledger.timeseries(
                     provider: burnProvider, since: since, bucket: range.bucketArg
                 ) else { continue }
                 gotAny = true

--- a/apps/macos/Sources/Burn/UsageHistory.swift
+++ b/apps/macos/Sources/Burn/UsageHistory.swift
@@ -18,13 +18,17 @@ final class UsageHistoryStore {
     private var cache: [String: [UsageSample]] = [:]
     private let fileURL: URL
 
-    private init() {
+    private convenience init() {
         let dir = FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("Burn", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        fileURL = dir.appendingPathComponent("history.json")
+        self.init(fileURL: dir.appendingPathComponent("history.json"))
+    }
 
+    /// Backs the store with an explicit file (tests point this at a temp file).
+    init(fileURL: URL) {
+        self.fileURL = fileURL
         if let data = try? Data(contentsOf: fileURL),
            let decoded = try? JSONDecoder().decode([String: [UsageSample]].self, from: data) {
             cache = decoded

--- a/apps/macos/Sources/Burn/UsageViewModel.swift
+++ b/apps/macos/Sources/Burn/UsageViewModel.swift
@@ -47,24 +47,27 @@ final class UsageViewModel: ObservableObject {
          history: UsageHistoryStore = .shared,
          ledger: BurnLedger = .shared,
          autostart: Bool = true) {
-        self.providers = providers ?? [
+        let resolvedProviders = providers ?? [
             .claude: ClaudeProvider(),
             .codex: CodexProvider(),
         ]
+        self.providers = resolvedProviders
         self.history = history
         self.ledger = ledger
+        var selected: ProviderName = .codex
         if let raw = UserDefaults.standard.string(forKey: "selectedProvider"),
            let provider = ProviderName(rawValue: raw) {
-            selectedProvider = provider
-        } else {
-            selectedProvider = .codex
+            selected = provider
         }
         // The saved (or default) selection may not exist in an injected provider
         // map; normalize to an available provider so refresh() isn't a no-op.
-        if self.providers[selectedProvider] == nil,
-           let fallback = ProviderName.allCases.first(where: { self.providers[$0] != nil }) {
-            selectedProvider = fallback
+        // (Computed on locals: `self` is off-limits until all stored properties
+        // are initialized.)
+        if resolvedProviders[selected] == nil,
+           let fallback = ProviderName.allCases.first(where: { resolvedProviders[$0] != nil }) {
+            selected = fallback
         }
+        selectedProvider = selected
         menuBarIcon = MenuBarIcon.render(usage: nil, offTarget: false)
         if autostart { start() }
     }

--- a/apps/macos/Sources/Burn/UsageViewModel.swift
+++ b/apps/macos/Sources/Burn/UsageViewModel.swift
@@ -32,12 +32,27 @@ final class UsageViewModel: ObservableObject {
     /// While set, scheduled (non-forced) refreshes are skipped to let a 429 clear.
     private var backoffUntil: Date?
     private var consecutiveRateLimits = 0
-    private let providers: [ProviderName: UsageProvider] = [
-        .claude: ClaudeProvider(),
-        .codex: CodexProvider(),
-    ]
+    private let providers: [ProviderName: UsageProvider]
+    private let history: UsageHistoryStore
+    private let ledger: BurnLedger
 
-    init() {
+    /// - Parameters:
+    ///   - providers: usage providers to poll (default: the real Claude/Codex
+    ///     providers). Tests inject fakes.
+    ///   - history: the sample store to record into (default `.shared`).
+    ///   - ledger: the burn ledger for spend (default `.shared`).
+    ///   - autostart: when `false`, skips `start()` so tests can construct the
+    ///     model without kicking off timers/network.
+    init(providers: [ProviderName: UsageProvider]? = nil,
+         history: UsageHistoryStore = .shared,
+         ledger: BurnLedger = .shared,
+         autostart: Bool = true) {
+        self.providers = providers ?? [
+            .claude: ClaudeProvider(),
+            .codex: CodexProvider(),
+        ]
+        self.history = history
+        self.ledger = ledger
         if let raw = UserDefaults.standard.string(forKey: "selectedProvider"),
            let provider = ProviderName(rawValue: raw) {
             selectedProvider = provider
@@ -45,7 +60,7 @@ final class UsageViewModel: ObservableObject {
             selectedProvider = .codex
         }
         menuBarIcon = MenuBarIcon.render(usage: nil, offTarget: false)
-        start()
+        if autostart { start() }
     }
 
     /// Recomputes the cached menu bar flame from the current headline state, but
@@ -121,7 +136,7 @@ final class UsageViewModel: ObservableObject {
         var built: [(metric: UsageMetric, data: BurndownData?)] = []
         if result.status == .ok || result.status == .warning {
             for metric in result.metrics {
-                let samples = UsageHistoryStore.shared.record(provider: result.provider, metric: metric, at: now)
+                let samples = history.record(provider: result.provider, metric: metric, at: now)
                 let data = BurndownBuilder.build(metric: metric, samples: samples, now: now)
                 built.append((metric, data))
             }
@@ -160,12 +175,12 @@ final class UsageViewModel: ObservableObject {
             guard let resetsAt = metric.resetsAt, metric.periodSeconds > 0 else { continue }
             let thisStart = resetsAt.addingTimeInterval(-metric.periodSeconds)
             let lastStart = resetsAt.addingTimeInterval(-2 * metric.periodSeconds)
-            guard let thisCost = await BurnLedger.shared.cost(provider: burnProvider, since: thisStart) else {
+            guard let thisCost = await ledger.cost(provider: burnProvider, since: thisStart) else {
                 return // burn unavailable — keep whatever we had
             }
             // "Last period" = [lastStart, thisStart): spend since lastStart minus
             // spend since thisStart (burn has no --until).
-            let lastCost = await BurnLedger.shared.cost(provider: burnProvider, since: lastStart)
+            let lastCost = await ledger.cost(provider: burnProvider, since: lastStart)
                 .map { max(0, $0 - thisCost) }
             result[metric.name] = PeriodSpend(thisPeriod: thisCost, lastPeriod: lastCost)
         }

--- a/apps/macos/Sources/Burn/UsageViewModel.swift
+++ b/apps/macos/Sources/Burn/UsageViewModel.swift
@@ -59,6 +59,12 @@ final class UsageViewModel: ObservableObject {
         } else {
             selectedProvider = .codex
         }
+        // The saved (or default) selection may not exist in an injected provider
+        // map; normalize to an available provider so refresh() isn't a no-op.
+        if self.providers[selectedProvider] == nil,
+           let fallback = ProviderName.allCases.first(where: { self.providers[$0] != nil }) {
+            selectedProvider = fallback
+        }
         menuBarIcon = MenuBarIcon.render(usage: nil, offTarget: false)
         if autostart { start() }
     }

--- a/apps/macos/Sources/Main/BurnApp.swift
+++ b/apps/macos/Sources/Main/BurnApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import BurnCore
+
+@main
+struct BurnApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
+
+    var body: some Scene {
+        // No SwiftUI scene drives the menu bar. The status item is created once,
+        // imperatively, by AppDelegate. SwiftUI's `MenuBarExtra` can duplicate
+        // its status item when the app's scene body re-evaluates — that runaway
+        // ("endless menu bar flames") panicked the machine. An AppKit
+        // NSStatusItem created a single time cannot be duplicated.
+        Settings { EmptyView() }
+    }
+}

--- a/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
+++ b/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
@@ -11,8 +11,7 @@ final class FakeRunner: BurnRunner, @unchecked Sendable {
 
     /// Every arg vector passed to `run(_:)`, in call order.
     var capturedArgs: [[String]] {
-        lock.lock(); defer { lock.unlock() }
-        return recorded
+        withLock { recorded }
     }
 
     init(output: String?) {
@@ -20,10 +19,16 @@ final class FakeRunner: BurnRunner, @unchecked Sendable {
     }
 
     func run(_ args: [String]) async -> String? {
-        lock.lock()
-        recorded.append(args)
-        lock.unlock()
+        withLock { recorded.append(args) }
         return output
+    }
+
+    /// NSLock's lock()/unlock() are `noasync`; scope them inside a synchronous
+    /// helper so `run` stays callable from async contexts under Swift 6.
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
     }
 }
 

--- a/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
+++ b/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
@@ -34,7 +34,8 @@ final class BurnLedgerParsingTests: XCTestCase {
 
     func testCostParsesTotal() async throws {
         let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 1.23}}"#))
-        let cost = try XCTUnwrap(await ledger.cost(provider: "anthropic", since: epoch))
+        let maybeCost = await ledger.cost(provider: "anthropic", since: epoch)
+        let cost = try XCTUnwrap(maybeCost)
         XCTAssertEqual(cost, 1.23, accuracy: 0.0001)
     }
 
@@ -76,7 +77,8 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
+        let maybeSummary = await ledger.summary(provider: "anthropic", since: epoch)
+        let summary = try XCTUnwrap(maybeSummary)
         XCTAssertEqual(summary.cost, 2.5, accuracy: 0.0001)
         // 10+20+5+1+2+3 = 41 in the first row, 100 in the second → 141.
         XCTAssertEqual(summary.tokens, 141)
@@ -84,7 +86,8 @@ final class BurnLedgerParsingTests: XCTestCase {
 
     func testSummaryZeroTokensWhenNoModelRows() async throws {
         let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 0.5}}"#))
-        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
+        let maybeSummary = await ledger.summary(provider: "anthropic", since: epoch)
+        let summary = try XCTUnwrap(maybeSummary)
         XCTAssertEqual(summary.cost, 0.5, accuracy: 0.0001)
         XCTAssertEqual(summary.tokens, 0)
     }
@@ -107,7 +110,8 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let points = try XCTUnwrap(await ledger.timeseries(provider: "anthropic", since: epoch, bucket: "1h"))
+        let maybePoints = await ledger.timeseries(provider: "anthropic", since: epoch, bucket: "1h")
+        let points = try XCTUnwrap(maybePoints)
         XCTAssertEqual(points.count, 2)
         // Fractional-second timestamp parsed by the .withFractionalSeconds formatter.
         XCTAssertEqual(points[0].tokens, 42)
@@ -128,7 +132,8 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let points = try XCTUnwrap(await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s"))
+        let maybePoints = await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s")
+        let points = try XCTUnwrap(maybePoints)
         XCTAssertEqual(points.count, 1)
         XCTAssertEqual(points[0].tokens, 9)
     }

--- a/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
+++ b/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import BurnCore
+
+/// A `BurnRunner` that returns canned stdout and records the args it was asked
+/// to run, so `BurnLedger`'s JSON parsing can be exercised without spawning the
+/// real `burn` binary.
+final class FakeRunner: BurnRunner, @unchecked Sendable {
+    private let output: String?
+    private let lock = NSLock()
+    private var recorded: [[String]] = []
+
+    /// Every arg vector passed to `run(_:)`, in call order.
+    var capturedArgs: [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return recorded
+    }
+
+    init(output: String?) {
+        self.output = output
+    }
+
+    func run(_ args: [String]) async -> String? {
+        lock.lock()
+        recorded.append(args)
+        lock.unlock()
+        return output
+    }
+}
+
+final class BurnLedgerParsingTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 0)
+
+    // MARK: - cost
+
+    func testCostParsesTotal() async throws {
+        let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 1.23}}"#))
+        let cost = try XCTUnwrap(await ledger.cost(provider: "anthropic", since: epoch))
+        XCTAssertEqual(cost, 1.23, accuracy: 0.0001)
+    }
+
+    func testCostNilOnGarbage() async {
+        let ledger = BurnLedger(runner: FakeRunner(output: "not json at all"))
+        let cost = await ledger.cost(provider: "anthropic", since: epoch)
+        XCTAssertNil(cost)
+    }
+
+    func testCostNilOnNilOutput() async {
+        let ledger = BurnLedger(runner: FakeRunner(output: nil))
+        let cost = await ledger.cost(provider: "anthropic", since: epoch)
+        XCTAssertNil(cost)
+    }
+
+    func testCostSendsExpectedArgs() async {
+        let runner = FakeRunner(output: #"{"totalCost": {"total": 0}}"#)
+        let ledger = BurnLedger(runner: runner)
+        _ = await ledger.cost(provider: "anthropic", since: epoch)
+        let iso = ISO8601DateFormatter().string(from: epoch)
+        XCTAssertEqual(
+            runner.capturedArgs.first,
+            ["summary", "--provider", "anthropic", "--since", iso, "--json"]
+        )
+    }
+
+    // MARK: - summary
+
+    func testSummarySumsTokenFieldsAcrossModelRows() async throws {
+        let json = """
+        {
+          "totalCost": {"total": 2.5},
+          "byModel": [
+            {"usage": {"input": 10, "output": 20, "reasoning": 5,
+                       "cacheRead": 1, "cacheCreate5m": 2, "cacheCreate1h": 3}},
+            {"usage": {"input": 100, "output": 0, "reasoning": 0,
+                       "cacheRead": 0, "cacheCreate5m": 0, "cacheCreate1h": 0}}
+          ]
+        }
+        """
+        let ledger = BurnLedger(runner: FakeRunner(output: json))
+        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
+        XCTAssertEqual(summary.cost, 2.5, accuracy: 0.0001)
+        // 10+20+5+1+2+3 = 41 in the first row, 100 in the second → 141.
+        XCTAssertEqual(summary.tokens, 141)
+    }
+
+    func testSummaryZeroTokensWhenNoModelRows() async throws {
+        let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 0.5}}"#))
+        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
+        XCTAssertEqual(summary.cost, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(summary.tokens, 0)
+    }
+
+    func testSummaryNilOnGarbage() async {
+        let ledger = BurnLedger(runner: FakeRunner(output: "garbage"))
+        let summary = await ledger.summary(provider: "anthropic", since: epoch)
+        XCTAssertNil(summary)
+    }
+
+    // MARK: - timeseries
+
+    func testTimeseriesParsesFractionalAndPlainTimestamps() async throws {
+        let json = """
+        {
+          "buckets": [
+            {"start": "2026-01-01T00:00:00.500Z", "totalTokens": 42, "totalCost": {"total": 0.5}},
+            {"start": "2026-01-01T01:00:00Z", "totalTokens": 7, "totalCost": {"total": 0.1}}
+          ]
+        }
+        """
+        let ledger = BurnLedger(runner: FakeRunner(output: json))
+        let points = try XCTUnwrap(await ledger.timeseries(provider: "anthropic", since: epoch, bucket: "1h"))
+        XCTAssertEqual(points.count, 2)
+        // Fractional-second timestamp parsed by the .withFractionalSeconds formatter.
+        XCTAssertEqual(points[0].tokens, 42)
+        XCTAssertEqual(points[0].cost, 0.5, accuracy: 0.0001)
+        // Plain timestamp parsed by the fallback formatter.
+        XCTAssertEqual(points[1].tokens, 7)
+        XCTAssertEqual(points[1].cost, 0.1, accuracy: 0.0001)
+        XCTAssertLessThan(points[0].date, points[1].date)
+    }
+
+    func testTimeseriesSkipsBucketsWithUnparseableStart() async throws {
+        let json = """
+        {
+          "buckets": [
+            {"start": "not-a-date", "totalTokens": 1, "totalCost": {"total": 0.1}},
+            {"start": "2026-01-01T00:00:00Z", "totalTokens": 9, "totalCost": {"total": 0.2}}
+          ]
+        }
+        """
+        let ledger = BurnLedger(runner: FakeRunner(output: json))
+        let points = try XCTUnwrap(await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s"))
+        XCTAssertEqual(points.count, 1)
+        XCTAssertEqual(points[0].tokens, 9)
+    }
+
+    func testTimeseriesNilOnGarbage() async {
+        let ledger = BurnLedger(runner: FakeRunner(output: "garbage"))
+        let points = await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s")
+        XCTAssertNil(points)
+    }
+
+    func testTimeseriesSendsExpectedArgs() async {
+        let runner = FakeRunner(output: #"{"buckets": []}"#)
+        let ledger = BurnLedger(runner: runner)
+        _ = await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s")
+        let iso = ISO8601DateFormatter().string(from: epoch)
+        XCTAssertEqual(
+            runner.capturedArgs.first,
+            ["summary", "--provider", "openai", "--since", iso, "--bucket", "30s", "--json"]
+        )
+    }
+}


### PR DESCRIPTION
## Motivation

The macOS menu bar app (`apps/macos`, BurnOSX) has zero test infrastructure. Recent reports of slowness and memory-leak-shaped behavior need tests to reproduce and guard against regressions, but the package is a single executable target with no seams for injecting fakes and no CI running on macOS. This is the **foundation PR**: it makes the app testable and adds the CI that will run those tests. Follow-up PRs (lifecycle/leak tests, history-store tests, soak tests) stack on top of this branch.

## What changed

**Package restructure** (`apps/macos/Package.swift`) — split the single `Burn` executable target into three:
- `BurnCore` (`.target`, `path: Sources/Burn`) — all existing app logic + `Resources` (so `Bundle.module` keeps resolving).
- `Burn` (`.executableTarget`, depends on `BurnCore`, `path: Sources/Main`) — a thin `@main` entry point only. Executable **product name is unchanged**, so `build.sh`/`release.sh` (which copy `$BIN_PATH/Burn` and glob `*.bundle`) keep working with no edits.
- `BurnTests` (`.testTarget`, depends on `BurnCore`).

The `@main struct BurnApp` moved to `Sources/Main/BurnApp.swift`; `AppDelegate` + `MenuBarIcon` stayed in `BurnCore` (old `BurnApp.swift` renamed to `AppDelegate.swift`). `AppDelegate` was made `public` with a `public override init()` so the executable's `@NSApplicationDelegateAdaptor` can adopt it. Nothing else was made public — tests use `@testable import BurnCore`.

**BurnRunner seam** (`BurnLedger.swift`) — introduced `protocol BurnRunner: Sendable` and moved the Process/Pipe/timeout resolution machinery into `actor SystemBurnRunner: BurnRunner`. `BurnLedger` now takes an injectable runner (`init(runner: BurnRunner = SystemBurnRunner())`) and its `cost`/`summary`/`timeseries` call `await runner.run(args)`. The ingest watch resolves the bundled binary via `runner.bundledBinaryURL()`. Production behavior is identical.

**Injectability** for stores/view models:
- `UsageHistoryStore` — added `init(fileURL:)` (default init now delegates to it).
- `UsageViewModel` — `init(providers:history:ledger:autostart:)`, all defaulted; `autostart: false` lets tests skip timers/network.
- `LiveBurnViewModel` — `init(ledger:)`.

**Smoke tests** (`Tests/BurnTests/BurnLedgerParsingTests.swift`) — a `FakeRunner` returning canned JSON drives `cost`/`summary`/`timeseries` parsing (token-field summation, fractional + plain ISO8601 timestamps, nil-on-garbage) and asserts the emitted `burn summary --provider … --since … --json` arg shape.

**CI** (`.github/workflows/macos-app-tests.yml`) — `pull_request` (paths-filtered to `apps/macos/**` + the workflow) and `workflow_dispatch`, runs `swift build` + `swift test` on `macos-14`. The Swift package imports AppKit/SwiftUI so it can't build on the Linux `ci.yml` job.

> Note: written without a local Swift toolchain (Linux container, AppKit imports) — CI is the first real compile.

## Follow-ups

Three PRs will stack on this branch: lifecycle/leak tests, history-store tests, and soak tests. The public/internal seams above are the shape they build on.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJPzcAQdxufCWMnap8vTTL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/burn/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

