### PR TITLE
fix(macos): bound usage history growth + debounced persistence

### DIFF
--- a/apps/macos/Sources/Burn/BurnLedger.swift
+++ b/apps/macos/Sources/Burn/BurnLedger.swift
@@ -233,19 +233,13 @@ actor BurnLedger {
     /// keeps the ledger fresh incrementally (FS-event driven, ~1s poll), so the
     /// live view's summary polls stay fast.
     private var watchProcess: Process?
-    /// True between start and stop requests. Actor methods are reentrant across
-    /// awaits, so a stop can interleave while start is suspended resolving the
-    /// binary; start rechecks this before spawning so the stop wins.
-    private var watchDesired = false
 
     /// Starts a background `burn ingest --watch` if one isn't already running.
     /// Only runs with the bundled native helper (a login-shell child can't be
     /// cleanly managed); the live chart still polls either way.
     func startIngestWatch() async {
         guard watchProcess == nil else { return }
-        watchDesired = true
         guard let url = await runner.bundledBinaryURL() else { return }
-        guard watchDesired, watchProcess == nil else { return }
         let process = Process()
         process.executableURL = url
         process.arguments = ["ingest", "--watch", "--quiet"]
@@ -259,10 +253,8 @@ actor BurnLedger {
         }
     }
 
-    /// Terminates the background watch process, if running, and cancels any
-    /// start that is still resolving the binary.
+    /// Terminates the background watch process, if running.
     func stopIngestWatch() {
-        watchDesired = false
         watchProcess?.terminate()
         watchProcess = nil
     }

--- a/apps/macos/Sources/Burn/UsageHistory.swift
+++ b/apps/macos/Sources/Burn/UsageHistory.swift
@@ -14,9 +14,20 @@ struct UsageSample: Codable {
 final class UsageHistoryStore {
     static let shared = UsageHistoryStore()
 
+    /// Upper bound on samples retained per series. A weekly window sampled every
+    /// ~60s would otherwise accumulate ~10k samples; once a series crosses this
+    /// bound it is decimated (see `decimated(_:)`) to stay bounded while keeping
+    /// the newest data at full resolution.
+    static let maxSamplesPerSeries = 2_000
+
     private let queue = DispatchQueue(label: "com.agentworkforce.burn.history")
     private var cache: [String: [UsageSample]] = [:]
     private let fileURL: URL
+
+    /// Debounce window for disk writes. Bursts of `record()` calls coalesce into
+    /// a single async write instead of re-encoding the whole cache each time.
+    private let persistDebounce: TimeInterval = 2
+    private var pendingWrite: DispatchWorkItem?
 
     private convenience init() {
         let dir = FileManager.default
@@ -55,19 +66,69 @@ final class UsageHistoryStore {
                 samples.append(UsageSample(date: date, percentage: metric.percentage))
             }
 
+            // Keep each series bounded so long-lived windows can't grow forever.
+            if samples.count > Self.maxSamplesPerSeries {
+                samples = decimated(samples)
+            }
+
             cache[k] = samples
             pruneStaleWindows(reference: date)
-            persist()
+            schedulePersist()
             return samples
         }
     }
 
-    /// Drops series for windows that reset more than an hour ago.
+    /// Synchronously flushes any pending debounced write. Exposed for tests that
+    /// need deterministic on-disk state without waiting for the debounce timer.
+    func flushForTesting() {
+        queue.sync {
+            pendingWrite?.cancel()
+            pendingWrite = nil
+            persist()
+        }
+    }
+
+    /// Reduces an over-long series while preserving its shape: the first sample
+    /// (the window's origin) is always kept, the newest half is kept at full
+    /// resolution, and the older half is thinned by dropping every second sample.
+    /// Deterministic, and structured so repeated appends keep the series bounded
+    /// without discarding recent, high-value data.
+    private func decimated(_ samples: [UsageSample]) -> [UsageSample] {
+        guard samples.count > 2 else { return samples }
+        let mid = samples.count / 2
+        var result: [UsageSample] = []
+        result.reserveCapacity(samples.count)
+        // Older half: keep the first sample, then keep every second sample.
+        for (offset, sample) in samples[0..<mid].enumerated() where offset % 2 == 0 {
+            result.append(sample)
+        }
+        // Newer half: kept intact.
+        result.append(contentsOf: samples[mid...])
+        return result
+    }
+
+    /// Drops series whose window has aged out.
+    ///
+    /// - Timestamped keys are dropped once their reset time is more than an hour
+    ///   in the past.
+    /// - Nil-reset keys (`…|none`) have no reset time to age out on, so they are
+    ///   dropped once their newest sample is older than 24h; otherwise they would
+    ///   accumulate forever.
     private func pruneStaleWindows(reference: Date) {
-        for k in cache.keys {
-            // The reset timestamp is always the final segment and never contains
+        for k in Array(cache.keys) {
+            // The reset segment is always the final segment and never contains
             // "|", so read it from the end — robust to a "|" in a metric name.
-            guard let last = k.split(separator: "|").last, let ts = Double(last), ts != 0 else { continue }
+            guard let last = k.split(separator: "|").last else { continue }
+
+            if last == "none" {
+                if let newest = cache[k]?.last?.date,
+                   newest < reference.addingTimeInterval(-86_400) {
+                    cache.removeValue(forKey: k)
+                }
+                continue
+            }
+
+            guard let ts = Double(last), ts != 0 else { continue }
             let resetDate = Date(timeIntervalSince1970: ts)
             if resetDate < reference.addingTimeInterval(-3600) {
                 cache.removeValue(forKey: k)
@@ -75,8 +136,24 @@ final class UsageHistoryStore {
         }
     }
 
+    /// Coalesces disk writes: cancels any pending write and schedules a fresh one
+    /// `persistDebounce` seconds out on the private queue, so a burst of records
+    /// results in a single encode+write off the caller's (main-actor) path.
+    private func schedulePersist() {
+        pendingWrite?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingWrite = nil
+            self.persist()
+        }
+        pendingWrite = item
+        queue.asyncAfter(deadline: .now() + persistDebounce, execute: item)
+    }
+
+    /// Encodes and writes the cache. Always invoked on `queue`. Writes atomically
+    /// so a crash mid-write can't corrupt the existing history file.
     private func persist() {
         guard let data = try? JSONEncoder().encode(cache) else { return }
-        try? data.write(to: fileURL)
+        try? data.write(to: fileURL, options: .atomic)
     }
 }

--- a/apps/macos/Sources/Burn/UsageHistory.swift
+++ b/apps/macos/Sources/Burn/UsageHistory.swift
@@ -21,6 +21,11 @@ final class UsageHistoryStore {
     static let maxSamplesPerSeries = 2_000
 
     private let queue = DispatchQueue(label: "com.agentworkforce.burn.history")
+    /// Dedicated serial I/O queue for the actual disk writes. Writes must not
+    /// run on `queue`: `record()` enters `queue` synchronously from the main
+    /// actor, so a slow write there would block the next refresh.
+    private static let writeQueue = DispatchQueue(
+        label: "com.agentworkforce.burn.history.write", qos: .utility)
     private var cache: [String: [UsageSample]] = [:]
     private let fileURL: URL
 
@@ -67,7 +72,11 @@ final class UsageHistoryStore {
             }
 
             // Keep each series bounded so long-lived windows can't grow forever.
-            if samples.count > Self.maxSamplesPerSeries {
+            // One decimation pass only trims to ~75%, so loop until under the
+            // cap — an oversized legacy history must be bounded immediately, not
+            // over many future appends. Each pass strictly shrinks the series,
+            // so this terminates.
+            while samples.count > Self.maxSamplesPerSeries {
                 samples = decimated(samples)
             }
 
@@ -78,13 +87,14 @@ final class UsageHistoryStore {
         }
     }
 
-    /// Synchronously flushes any pending debounced write. Exposed for tests that
-    /// need deterministic on-disk state without waiting for the debounce timer.
+    /// Synchronously flushes any pending debounced write; the file is guaranteed
+    /// to be on disk when this returns. Exposed for tests that need deterministic
+    /// on-disk state without waiting for the debounce timer.
     func flushForTesting() {
         queue.sync {
             pendingWrite?.cancel()
             pendingWrite = nil
-            persist()
+            persist(synchronously: true)
         }
     }
 
@@ -121,7 +131,9 @@ final class UsageHistoryStore {
             guard let last = k.split(separator: "|").last else { continue }
 
             if last == "none" {
-                if let newest = cache[k]?.last?.date,
+                // Use the max date, not `.last`, so pruning stays correct even
+                // if a series is ever not strictly chronological.
+                if let newest = cache[k]?.map(\.date).max(),
                    newest < reference.addingTimeInterval(-86_400) {
                     cache.removeValue(forKey: k)
                 }
@@ -137,8 +149,8 @@ final class UsageHistoryStore {
     }
 
     /// Coalesces disk writes: cancels any pending write and schedules a fresh one
-    /// `persistDebounce` seconds out on the private queue, so a burst of records
-    /// results in a single encode+write off the caller's (main-actor) path.
+    /// `persistDebounce` seconds out, so a burst of records results in a single
+    /// encode (on `queue`) whose write is handed off to `writeQueue`.
     private func schedulePersist() {
         pendingWrite?.cancel()
         let item = DispatchWorkItem { [weak self] in
@@ -150,10 +162,26 @@ final class UsageHistoryStore {
         queue.asyncAfter(deadline: .now() + persistDebounce, execute: item)
     }
 
-    /// Encodes and writes the cache. Always invoked on `queue`. Writes atomically
-    /// so a crash mid-write can't corrupt the existing history file.
-    private func persist() {
+    /// Encodes the cache (on `queue`, for thread safety) and hands the bytes to
+    /// the dedicated I/O queue so the disk write never blocks `record()`'s
+    /// `queue.sync`. Writes atomically so a crash mid-write can't corrupt the
+    /// existing history file.
+    ///
+    /// Always invoked on `queue`. `writeQueue` is serial, so writes land in the
+    /// order they were encoded and a `synchronously: true` flush both waits for
+    /// any in-flight async write and then supersedes it with the newest data
+    /// before returning.
+    private func persist(synchronously: Bool = false) {
         guard let data = try? JSONEncoder().encode(cache) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        let url = fileURL
+        if synchronously {
+            Self.writeQueue.sync {
+                try? data.write(to: url, options: .atomic)
+            }
+        } else {
+            Self.writeQueue.async {
+                try? data.write(to: url, options: .atomic)
+            }
+        }
     }
 }

--- a/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
+++ b/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
@@ -34,8 +34,7 @@ final class BurnLedgerParsingTests: XCTestCase {
 
     func testCostParsesTotal() async throws {
         let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 1.23}}"#))
-        let maybeCost = await ledger.cost(provider: "anthropic", since: epoch)
-        let cost = try XCTUnwrap(maybeCost)
+        let cost = try XCTUnwrap(await ledger.cost(provider: "anthropic", since: epoch))
         XCTAssertEqual(cost, 1.23, accuracy: 0.0001)
     }
 
@@ -77,8 +76,7 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let maybeSummary = await ledger.summary(provider: "anthropic", since: epoch)
-        let summary = try XCTUnwrap(maybeSummary)
+        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
         XCTAssertEqual(summary.cost, 2.5, accuracy: 0.0001)
         // 10+20+5+1+2+3 = 41 in the first row, 100 in the second → 141.
         XCTAssertEqual(summary.tokens, 141)
@@ -86,8 +84,7 @@ final class BurnLedgerParsingTests: XCTestCase {
 
     func testSummaryZeroTokensWhenNoModelRows() async throws {
         let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 0.5}}"#))
-        let maybeSummary = await ledger.summary(provider: "anthropic", since: epoch)
-        let summary = try XCTUnwrap(maybeSummary)
+        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
         XCTAssertEqual(summary.cost, 0.5, accuracy: 0.0001)
         XCTAssertEqual(summary.tokens, 0)
     }
@@ -110,8 +107,7 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let maybePoints = await ledger.timeseries(provider: "anthropic", since: epoch, bucket: "1h")
-        let points = try XCTUnwrap(maybePoints)
+        let points = try XCTUnwrap(await ledger.timeseries(provider: "anthropic", since: epoch, bucket: "1h"))
         XCTAssertEqual(points.count, 2)
         // Fractional-second timestamp parsed by the .withFractionalSeconds formatter.
         XCTAssertEqual(points[0].tokens, 42)
@@ -132,8 +128,7 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let maybePoints = await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s")
-        let points = try XCTUnwrap(maybePoints)
+        let points = try XCTUnwrap(await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s"))
         XCTAssertEqual(points.count, 1)
         XCTAssertEqual(points[0].tokens, 9)
     }

--- a/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
+++ b/apps/macos/Tests/BurnTests/BurnLedgerParsingTests.swift
@@ -39,7 +39,8 @@ final class BurnLedgerParsingTests: XCTestCase {
 
     func testCostParsesTotal() async throws {
         let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 1.23}}"#))
-        let cost = try XCTUnwrap(await ledger.cost(provider: "anthropic", since: epoch))
+        let maybeCost = await ledger.cost(provider: "anthropic", since: epoch)
+        let cost = try XCTUnwrap(maybeCost)
         XCTAssertEqual(cost, 1.23, accuracy: 0.0001)
     }
 
@@ -81,7 +82,8 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
+        let maybeSummary = await ledger.summary(provider: "anthropic", since: epoch)
+        let summary = try XCTUnwrap(maybeSummary)
         XCTAssertEqual(summary.cost, 2.5, accuracy: 0.0001)
         // 10+20+5+1+2+3 = 41 in the first row, 100 in the second → 141.
         XCTAssertEqual(summary.tokens, 141)
@@ -89,7 +91,8 @@ final class BurnLedgerParsingTests: XCTestCase {
 
     func testSummaryZeroTokensWhenNoModelRows() async throws {
         let ledger = BurnLedger(runner: FakeRunner(output: #"{"totalCost": {"total": 0.5}}"#))
-        let summary = try XCTUnwrap(await ledger.summary(provider: "anthropic", since: epoch))
+        let maybeSummary = await ledger.summary(provider: "anthropic", since: epoch)
+        let summary = try XCTUnwrap(maybeSummary)
         XCTAssertEqual(summary.cost, 0.5, accuracy: 0.0001)
         XCTAssertEqual(summary.tokens, 0)
     }
@@ -112,7 +115,8 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let points = try XCTUnwrap(await ledger.timeseries(provider: "anthropic", since: epoch, bucket: "1h"))
+        let maybePoints = await ledger.timeseries(provider: "anthropic", since: epoch, bucket: "1h")
+        let points = try XCTUnwrap(maybePoints)
         XCTAssertEqual(points.count, 2)
         // Fractional-second timestamp parsed by the .withFractionalSeconds formatter.
         XCTAssertEqual(points[0].tokens, 42)
@@ -133,7 +137,8 @@ final class BurnLedgerParsingTests: XCTestCase {
         }
         """
         let ledger = BurnLedger(runner: FakeRunner(output: json))
-        let points = try XCTUnwrap(await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s"))
+        let maybePoints = await ledger.timeseries(provider: "openai", since: epoch, bucket: "30s")
+        let points = try XCTUnwrap(maybePoints)
         XCTAssertEqual(points.count, 1)
         XCTAssertEqual(points[0].tokens, 9)
     }

--- a/apps/macos/Tests/BurnTests/UsageHistoryStoreTests.swift
+++ b/apps/macos/Tests/BurnTests/UsageHistoryStoreTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import BurnCore
+
+/// Pins the memory-growth and persistence behavior of `UsageHistoryStore`.
+///
+/// Every test points the store at a unique temp file via `init(fileURL:)` and
+/// drives it with explicit dates, so no wall-clock time or sleeps are needed
+/// (the one debounce assertion checks "not yet written" and then flushes).
+final class UsageHistoryStoreTests: XCTestCase {
+    private var fileURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".json")
+    }
+
+    override func tearDown() {
+        if let fileURL { try? FileManager.default.removeItem(at: fileURL) }
+        fileURL = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func metric(_ name: String, _ percentage: Double, resetsAt: Date?) -> UsageMetric {
+        UsageMetric(name: name, percentage: percentage, resetsAt: resetsAt, periodSeconds: 0)
+    }
+
+    private func loadDict() throws -> [String: [UsageSample]] {
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode([String: [UsageSample]].self, from: data)
+    }
+
+    private func timestampedKey(_ provider: ProviderName, _ name: String, reset: Date) -> String {
+        "\(provider.rawValue)|\(name)|\(Int(reset.timeIntervalSince1970))"
+    }
+
+    private func nilKey(_ provider: ProviderName, _ name: String) -> String {
+        "\(provider.rawValue)|\(name)|none"
+    }
+
+    /// A fixed base instant with an integer `timeIntervalSince1970` so keys built
+    /// in the test match the store's `Int(...)` truncation exactly.
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - 1. Nil-reset series are pruned by staleness
+
+    func testNilResetSeriesPrunedByStaleness() throws {
+        let store = UsageHistoryStore(fileURL: fileURL)
+
+        // Stale nil-reset series: newest sample at `base`.
+        store.record(provider: .claude, metric: metric("StaleWeekly", 10, resetsAt: nil), at: base)
+
+        // Recording a fresh nil-reset metric 25h later drives pruneStaleWindows.
+        let later = base.addingTimeInterval(25 * 3600)
+        store.record(provider: .claude, metric: metric("RecentWeekly", 20, resetsAt: nil), at: later)
+
+        store.flushForTesting()
+        let dict = try loadDict()
+
+        XCTAssertNil(dict[nilKey(.claude, "StaleWeekly")],
+                     "nil-reset series older than 24h should be pruned")
+        XCTAssertNotNil(dict[nilKey(.claude, "RecentWeekly")],
+                        "nil-reset series with a recent sample should survive")
+    }
+
+    // MARK: - 2. Timestamped windows pruned once reset > 1h ago (existing behavior)
+
+    func testTimestampedWindowPruning() throws {
+        let store = UsageHistoryStore(fileURL: fileURL)
+        let reference = base
+
+        let staleReset = reference.addingTimeInterval(-2 * 3600)   // reset 2h ago -> drop
+        let freshReset = reference.addingTimeInterval(-30 * 60)    // reset 30m ago -> keep
+        let futureReset = reference.addingTimeInterval(24 * 3600)  // driver, never stale
+
+        let recordAt = reference.addingTimeInterval(-3 * 3600)
+        store.record(provider: .claude, metric: metric("Stale", 10, resetsAt: staleReset), at: recordAt)
+        store.record(provider: .claude, metric: metric("Fresh", 20, resetsAt: freshReset), at: recordAt)
+
+        // Driver record at `reference` triggers the prune pass.
+        store.record(provider: .claude, metric: metric("Driver", 30, resetsAt: futureReset), at: reference)
+
+        store.flushForTesting()
+        let dict = try loadDict()
+
+        XCTAssertNil(dict[timestampedKey(.claude, "Stale", reset: staleReset)],
+                     "window whose reset is >1h old should be dropped")
+        XCTAssertNotNil(dict[timestampedKey(.claude, "Fresh", reset: freshReset)],
+                        "window whose reset is 30m ago should survive")
+    }
+
+    // MARK: - 3. Per-series cap enforcement + decimation
+
+    func testCapEnforcementDecimatesOldWhileKeepingNewest() {
+        let store = UsageHistoryStore(fileURL: fileURL)
+        let cap = UsageHistoryStore.maxSamplesPerSeries
+        let total = cap + 500
+        let futureReset = base.addingTimeInterval(10 * 365 * 24 * 3600) // never prunes
+
+        var series: [UsageSample] = []
+        for i in 0..<total {
+            let at = base.addingTimeInterval(Double(i) * 60) // one minute apart, no collapse
+            series = store.record(provider: .claude,
+                                  metric: metric("Cap", Double(i), resetsAt: futureReset),
+                                  at: at)
+        }
+
+        XCTAssertLessThanOrEqual(series.count, cap, "series must stay within the cap")
+
+        // First-ever sample retained.
+        XCTAssertEqual(series.first?.percentage, 0)
+        XCTAssertEqual(series.first?.date, base)
+
+        // Newest samples intact at full resolution / precision.
+        let lastDate = base.addingTimeInterval(Double(total - 1) * 60)
+        XCTAssertEqual(series.last?.percentage, Double(total - 1))
+        XCTAssertEqual(series.last?.date, lastDate)
+
+        // Dates strictly ascending.
+        for i in 1..<series.count {
+            XCTAssertLessThan(series[i - 1].date, series[i].date,
+                              "dates must remain strictly ascending after decimation")
+        }
+    }
+
+    // MARK: - 4. Duplicate collapse within 1s (existing behavior)
+
+    func testDuplicateCollapse() {
+        let store = UsageHistoryStore(fileURL: fileURL)
+        let reset = base.addingTimeInterval(3600)
+
+        store.record(provider: .claude, metric: metric("W", 10, resetsAt: reset), at: base)
+        let series = store.record(provider: .claude,
+                                  metric: metric("W", 20, resetsAt: reset),
+                                  at: base.addingTimeInterval(0.5))
+
+        XCTAssertEqual(series.count, 1, "records <1s apart should collapse into one sample")
+        XCTAssertEqual(series.first?.percentage, 20, "collapsed sample should hold the newer value")
+    }
+
+    // MARK: - 5. Debounced persistence + roundtrip
+
+    func testPersistenceIsDebouncedAndRoundtrips() throws {
+        let store = UsageHistoryStore(fileURL: fileURL)
+        let reset = base.addingTimeInterval(24 * 3600)
+
+        store.record(provider: .claude, metric: metric("Week", 10, resetsAt: reset), at: base)
+        store.record(provider: .claude, metric: metric("Week", 20, resetsAt: reset),
+                     at: base.addingTimeInterval(60))
+
+        // Debounced: nothing should be on disk yet.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path),
+                       "record() should defer the disk write behind a debounce")
+
+        store.flushForTesting()
+
+        let dict = try loadDict()
+        let key = timestampedKey(.claude, "Week", reset: reset)
+        XCTAssertEqual(dict[key]?.count, 2)
+        XCTAssertEqual(dict[key]?.last?.percentage, 20)
+
+        // A new store on the same file loads the persisted series.
+        let reopened = UsageHistoryStore(fileURL: fileURL)
+        let series = reopened.record(provider: .claude, metric: metric("Week", 30, resetsAt: reset),
+                                     at: base.addingTimeInterval(120))
+        XCTAssertEqual(series.count, 3, "reopened store should have loaded the persisted samples")
+        XCTAssertEqual(series.first?.percentage, 10)
+        XCTAssertEqual(series.last?.percentage, 30)
+    }
+
+    // MARK: - 6. Loads an on-disk dict written in the current shape
+
+    func testLoadsPersistedDictShape() throws {
+        let reset = base.addingTimeInterval(3600)
+        let key = timestampedKey(.claude, "Legacy", reset: reset)
+        let fixture: [String: [UsageSample]] = [
+            key: [UsageSample(date: base, percentage: 42)]
+        ]
+        let data = try JSONEncoder().encode(fixture)
+        try data.write(to: fileURL)
+
+        let store = UsageHistoryStore(fileURL: fileURL)
+        let series = store.record(provider: .claude, metric: metric("Legacy", 55, resetsAt: reset),
+                                  at: base.addingTimeInterval(60))
+
+        XCTAssertEqual(series.count, 2, "store should load the on-disk sample then append")
+        XCTAssertEqual(series.first?.percentage, 42, "the persisted sample should be preserved")
+        XCTAssertEqual(series.last?.percentage, 55)
+    }
+}

--- a/apps/macos/Tests/BurnTests/UsageHistoryStoreTests.swift
+++ b/apps/macos/Tests/BurnTests/UsageHistoryStoreTests.swift
@@ -125,6 +125,39 @@ final class UsageHistoryStoreTests: XCTestCase {
         }
     }
 
+    func testOversizedLegacySeriesIsCappedOnFirstRecord() throws {
+        // Seed the file with a legacy series far above the cap (a weekly window
+        // sampled every 60s ≈ 10k samples). A single record() must bound it —
+        // one decimation pass only trims to ~75%, so the cap requires looping.
+        let cap = UsageHistoryStore.maxSamplesPerSeries
+        let legacyCount = 10_000
+        let futureReset = base.addingTimeInterval(10 * 365 * 24 * 3600)
+        let key = timestampedKey(.claude, "Legacy", reset: futureReset)
+
+        var legacy: [UsageSample] = []
+        legacy.reserveCapacity(legacyCount)
+        for i in 0..<legacyCount {
+            legacy.append(UsageSample(date: base.addingTimeInterval(Double(i) * 60),
+                                      percentage: Double(i)))
+        }
+        try JSONEncoder().encode([key: legacy]).write(to: fileURL)
+
+        let store = UsageHistoryStore(fileURL: fileURL)
+        let newDate = base.addingTimeInterval(Double(legacyCount) * 60)
+        let series = store.record(provider: .claude,
+                                  metric: metric("Legacy", 99, resetsAt: futureReset),
+                                  at: newDate)
+
+        XCTAssertLessThanOrEqual(series.count, cap,
+                                 "one record() must bound an oversized legacy series")
+        XCTAssertEqual(series.first?.date, base, "first-ever sample must be retained")
+        XCTAssertEqual(series.last?.date, newDate)
+        XCTAssertEqual(series.last?.percentage, 99)
+        for i in 1..<series.count {
+            XCTAssertLessThan(series[i - 1].date, series[i].date)
+        }
+    }
+
     // MARK: - 4. Duplicate collapse within 1s (existing behavior)
 
     func testDuplicateCollapse() {


### PR DESCRIPTION
Stacked on #491.

`UsageHistoryStore` (`apps/macos/Sources/Burn/UsageHistory.swift`) keeps every usage sample in an in-memory dict mirrored to `history.json`, recording one sample per metric roughly every 60s. Three unbounded-growth / hot-path problems contributed to the reported BurnOSX memory growth and per-minute slowness.

## Bugs

**1. Nil-reset series were never pruned.** `key(provider:metric:)` uses `"none"` as the trailing segment when `metric.resetsAt == nil`. `pruneStaleWindows` only handled numeric reset timestamps (`Double(last)`), so `Double("none")` failed the guard and those series accumulated samples forever.

**2. Within-window series were unbounded.** A weekly window sampled every ~60s is roughly `7 * 24 * 60 ≈ 10,080` samples with nothing thinning them — one series per window, kept for the whole window.

**3. Persistence ran on the hot path.** Every `record()` re-encoded the *entire* cache to JSON and wrote it to disk synchronously inside `queue.sync`, and `record` is called from the main actor during refresh. A full-file rewrite per minute whose cost grows with total history size — a main-thread hitch that gets worse over time.

## Fixes

**1. Prune nil-reset series by staleness.** In `pruneStaleWindows`, `…|none` keys are dropped once their newest sample is older than 24h relative to `reference`. Timestamped keys keep the existing "reset > 1h ago" rule.

**2. Cap samples per series.** New internal constant `maxSamplesPerSeries = 2_000`. On append past the cap the series is decimated: the first sample (window origin) is always kept, the newest half is kept at full resolution, and the older half is thinned by dropping every second sample. Deterministic, and structured so repeated appends stay bounded without discarding recent, high-value data.

**3. Move persistence off the hot path.** Cache mutation stays synchronous (the `queue.sync` in `record` still returns the updated series), but the disk write is now a debounced, coalesced `DispatchWorkItem` scheduled ~2s out on the private queue — a burst of records produces one write. Writes are now atomic (`.atomic`) so a crash mid-write can't corrupt `history.json`. New internal `flushForTesting()` performs a pending write synchronously for deterministic tests. (Silent decode-failure fallback on init is unchanged — acceptable behavior.)

Burndown consumption (`Burndown.swift`) is unaffected: it reads samples by `date`/`percentage`, both preserved.

## Tests

New `apps/macos/Tests/BurnTests/UsageHistoryStoreTests.swift`, each using `init(fileURL:)` on a unique temp file with injected dates (no sleeps):

- nil-reset pruning (stale dropped after 25h, recent survives)
- timestamped-window pruning (reset >1h ago dropped, 30m ago survives)
- cap enforcement + decimation (count ≤ cap, first sample retained, newest date/percentage intact, dates strictly ascending)
- duplicate collapse (<1s apart → one sample holding the newer value)
- debounced persistence: file not written until `flushForTesting()`, then decode matches in-memory series, and a new store on the same file loads the roundtripped samples
- loads an on-disk dict written in the current shape (guards against schema breakage)

No Swift toolchain in the authoring environment; the `macos-app-tests` workflow verifies on macos-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJPzcAQdxufCWMnap8vTTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJPzcAQdxufCWMnap8vTTL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/burn/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

