### PR TITLE
test(macos): subprocess soak + perf baselines, signpost instrumentation, chart identity fix

### DIFF
--- a/apps/macos/Sources/Burn/BurnLedger.swift
+++ b/apps/macos/Sources/Burn/BurnLedger.swift
@@ -41,6 +41,15 @@ actor SystemBurnRunner: BurnRunner {
     /// the timeout/reap path without waiting the production 30s.
     private let captureTimeout: TimeInterval
 
+    /// Serial queue the blocking subprocess work runs on. `capture` awaits a
+    /// continuation resumed from here instead of blocking inside the actor, so
+    /// the cooperative-pool thread is released for the (up to `captureTimeout`)
+    /// duration of the child's run. Because the queue is serial, only one
+    /// `burn` subprocess is ever alive at a time — the same invariant the
+    /// blocking actor used to provide — even though the actor is reentrant at
+    /// the await.
+    private let execQueue = DispatchQueue(label: "com.agentworkforce.burn.subprocess", qos: .utility)
+
     /// - Parameters:
     ///   - explicitBinaryURL: a `burn`-compatible executable to run directly,
     ///     bypassing resolution (default `nil` → normal resolution).
@@ -52,26 +61,26 @@ actor SystemBurnRunner: BurnRunner {
 
     func run(_ args: [String]) async -> String? {
         let label = args.first ?? "burn"
-        switch resolveTool() {
+        switch await resolveTool() {
         case .bundled(let url):
             // Self-contained Rust binary — exec directly, no shell needed.
-            return capture(label: label) { $0.executableURL = url; $0.arguments = args }
+            return await capture(label: label) { $0.executableURL = url; $0.arguments = args }
         case .path:
             // Run through a login shell so nvm/Homebrew PATH (and the `node` the
             // npm `burn` shim needs) resolve even when launched from Finder.
             let command = "burn " + args.map(shellQuote).joined(separator: " ")
-            return loginShell(command, label: label)
+            return await loginShell(command, label: label)
         case .missing, .unknown:
             return nil
         }
     }
 
     func bundledBinaryURL() async -> URL? {
-        if case .bundled(let url) = resolveTool() { return url }
+        if case .bundled(let url) = await resolveTool() { return url }
         return nil
     }
 
-    private func resolveTool() -> Tool {
+    private func resolveTool() async -> Tool {
         // Explicit binary short-circuits resolution: run it directly like a
         // bundled helper. Preserves normal resolution when unset.
         if let explicit = explicitBinaryURL {
@@ -81,75 +90,108 @@ actor SystemBurnRunner: BurnRunner {
             if let url = Bundle.main.url(forAuxiliaryExecutable: "burn"),
                FileManager.default.isExecutableFile(atPath: url.path) {
                 tool = .bundled(url)
-            } else if !(loginShell("command -v burn")?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? "").isEmpty {
-                tool = .path
             } else {
-                tool = .missing
+                // The actor is reentrant across this await, so two concurrent
+                // first calls may both run the PATH probe. That's benign: both
+                // converge on the same value and the probe is idempotent.
+                let probe = (await loginShell("command -v burn"))?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                tool = probe.isEmpty ? .missing : .path
             }
         }
         return tool
     }
 
-    private func loginShell(_ command: String, label: String = "shell") -> String? {
-        capture(label: label) {
+    private func loginShell(_ command: String, label: String = "shell") async -> String? {
+        await capture(label: label) {
             $0.executableURL = URL(fileURLWithPath: "/bin/zsh")
             $0.arguments = ["-lc", command]
         }
     }
 
-    /// Runs a configured process and returns stdout, or `nil` on failure /
-    /// nonzero exit / timeout. The timeout (`captureTimeout`) stops a hung
-    /// `burn` from wedging the actor and queuing follow-up spend requests behind
-    /// it. `label` names the subprocess in the Instruments signpost interval.
-    private func capture(label: String, _ configure: (Process) -> Void) -> String? {
+    /// Runs a configured process on the serial exec queue and returns stdout,
+    /// or `nil` on failure / nonzero exit / timeout. The timeout
+    /// (`captureTimeout`) stops a hung `burn` from wedging the queue and piling
+    /// follow-up spend requests behind it. Awaiting the queue keeps the
+    /// cooperative pool free while the child runs. `label` names the subprocess
+    /// in the Instruments signpost interval, which spans queue wait + run.
+    private func capture(label: String, _ configure: @escaping @Sendable (Process) -> Void) async -> String? {
         let signpostID = Signposts.subprocess.makeSignpostID()
         let interval = Signposts.subprocess.beginInterval(
             "capture", id: signpostID, "\(label, privacy: .public)"
         )
         defer { Signposts.subprocess.endInterval("capture", interval) }
 
-        let process = Process()
-        configure(process)
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        // Read stdout to EOF (which arrives when the process exits) and reap it
-        // on a background queue; bound the wait with a timeout. This blocks the
-        // runner actor until the process truly finishes or is killed — which,
-        // because the actor serializes calls, guarantees only one `burn`
-        // subprocess can ever be alive at a time (no pile-up). Avoids the
-        // `terminationHandler` race that could let capture() return while the
-        // child kept running.
-        let group = DispatchGroup()
-        group.enter()
-        let output = DataBox()
-        DispatchQueue.global(qos: .utility).async {
-            output.data = stdout.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-            group.leave()
-        }
-        // Drain stderr separately: an undrained pipe fills at ~64KB and blocks
-        // the child's writes, turning a chatty failure into a timeout.
-        DispatchQueue.global(qos: .utility).async {
-            _ = stderr.fileHandleForReading.readDataToEndOfFile()
-        }
-        if group.wait(timeout: .now() + captureTimeout) == .timedOut {
-            process.terminate()                       // SIGTERM…
-            usleep(200_000)
-            if process.isRunning {                    // …then SIGKILL if it ignores it
-                kill(process.processIdentifier, SIGKILL)
+        let timeout = captureTimeout
+        return await withCheckedContinuation { continuation in
+            execQueue.async {
+                continuation.resume(returning: Self.blockingCapture(timeout: timeout, configure))
             }
-            return nil
         }
-        guard process.terminationStatus == 0 else { return nil }
-        return String(data: output.data, encoding: .utf8)
+    }
+
+    /// The synchronous Process/Pipe body. Pure — touches no actor state — so it
+    /// runs on the exec queue, off the cooperative pool.
+    ///
+    /// Descriptor hygiene matters here: the parent-side `Pipe`/`FileHandle`
+    /// objects are Obj-C autoreleased, and on GCD threads the pool drains
+    /// lazily — without the explicit `close()`s and per-call `autoreleasepool`
+    /// each spawn leaked ~2 fds long after the child exited (caught by
+    /// `SubprocessSoakTests`; with a spawn every 3s on the live tab this is a
+    /// real production leak, not test noise).
+    private static func blockingCapture(timeout: TimeInterval, _ configure: (Process) -> Void) -> String? {
+        autoreleasepool { () -> String? in
+            let process = Process()
+            configure(process)
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+            do {
+                try process.run()
+            } catch {
+                return nil
+            }
+            // Read stdout to EOF (which arrives when the process exits) and reap
+            // it on a background queue; bound the wait with a timeout. This
+            // blocks the exec queue until the process truly finishes or is
+            // killed — which, because that queue is serial, guarantees only one
+            // `burn` subprocess can ever be alive at a time (no pile-up). Avoids
+            // the `terminationHandler` race that could let capture() return
+            // while the child kept running.
+            let group = DispatchGroup()
+            group.enter()
+            let output = DataBox()
+            DispatchQueue.global(qos: .utility).async {
+                output.data = stdout.fileHandleForReading.readDataToEndOfFile()
+                try? stdout.fileHandleForReading.close()
+                process.waitUntilExit()
+                group.leave()
+            }
+            // Drain stderr separately: an undrained pipe fills at ~64KB and
+            // blocks the child's writes, turning a chatty failure into a timeout.
+            DispatchQueue.global(qos: .utility).async {
+                _ = stderr.fileHandleForReading.readDataToEndOfFile()
+                try? stderr.fileHandleForReading.close()
+            }
+            if group.wait(timeout: .now() + timeout) == .timedOut {
+                process.terminate()                       // SIGTERM…
+                usleep(200_000)
+                if process.isRunning {                    // …then SIGKILL if it ignores it
+                    kill(process.processIdentifier, SIGKILL)
+                }
+                // The kill closes the child's write ends, so the background
+                // readers hit EOF, return, and close their handles. Give them a
+                // bounded beat (avoids closing under an in-flight legacy read),
+                // then close defensively — double-closes throw and are swallowed.
+                _ = group.wait(timeout: .now() + 1)
+                try? stdout.fileHandleForReading.close()
+                try? stderr.fileHandleForReading.close()
+                return nil
+            }
+            guard process.terminationStatus == 0 else { return nil }
+            return String(data: output.data, encoding: .utf8)
+        }
     }
 
     /// Mutable holder the background reader fills in; capturing a `var` for

--- a/apps/macos/Sources/Burn/BurnLedger.swift
+++ b/apps/macos/Sources/Burn/BurnLedger.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Runs the `burn` CLI and returns its stdout. A seam so tests can inject a fake
 /// that returns canned JSON without spawning a subprocess.
@@ -31,16 +32,35 @@ actor SystemBurnRunner: BurnRunner {
     }
     private var tool: Tool = .unknown
 
+    /// When set, resolution is skipped and this URL is executed directly (no
+    /// login shell), exactly like the bundled case. Lets tests drive the real
+    /// Process/Pipe/timeout machinery against a fake `burn` script. `nil`
+    /// preserves the normal bundled→PATH→missing resolution.
+    private let explicitBinaryURL: URL?
+    /// The `capture` timeout (see `capture`). Injectable so tests can exercise
+    /// the timeout/reap path without waiting the production 30s.
+    private let captureTimeout: TimeInterval
+
+    /// - Parameters:
+    ///   - explicitBinaryURL: a `burn`-compatible executable to run directly,
+    ///     bypassing resolution (default `nil` → normal resolution).
+    ///   - timeout: per-invocation capture timeout in seconds (default `30`).
+    init(explicitBinaryURL: URL? = nil, timeout: TimeInterval = 30) {
+        self.explicitBinaryURL = explicitBinaryURL
+        self.captureTimeout = timeout
+    }
+
     func run(_ args: [String]) async -> String? {
+        let label = args.first ?? "burn"
         switch resolveTool() {
         case .bundled(let url):
             // Self-contained Rust binary — exec directly, no shell needed.
-            return capture { $0.executableURL = url; $0.arguments = args }
+            return capture(label: label) { $0.executableURL = url; $0.arguments = args }
         case .path:
             // Run through a login shell so nvm/Homebrew PATH (and the `node` the
             // npm `burn` shim needs) resolve even when launched from Finder.
             let command = "burn " + args.map(shellQuote).joined(separator: " ")
-            return loginShell(command)
+            return loginShell(command, label: label)
         case .missing, .unknown:
             return nil
         }
@@ -52,6 +72,11 @@ actor SystemBurnRunner: BurnRunner {
     }
 
     private func resolveTool() -> Tool {
+        // Explicit binary short-circuits resolution: run it directly like a
+        // bundled helper. Preserves normal resolution when unset.
+        if let explicit = explicitBinaryURL {
+            return .bundled(explicit)
+        }
         if case .unknown = tool {
             if let url = Bundle.main.url(forAuxiliaryExecutable: "burn"),
                FileManager.default.isExecutableFile(atPath: url.path) {
@@ -66,17 +91,24 @@ actor SystemBurnRunner: BurnRunner {
         return tool
     }
 
-    private func loginShell(_ command: String) -> String? {
-        capture {
+    private func loginShell(_ command: String, label: String = "shell") -> String? {
+        capture(label: label) {
             $0.executableURL = URL(fileURLWithPath: "/bin/zsh")
             $0.arguments = ["-lc", command]
         }
     }
 
     /// Runs a configured process and returns stdout, or `nil` on failure /
-    /// nonzero exit / timeout. The timeout stops a hung `burn` from wedging the
-    /// actor and queuing follow-up spend requests behind it.
-    private func capture(_ configure: (Process) -> Void, timeout: TimeInterval = 30) -> String? {
+    /// nonzero exit / timeout. The timeout (`captureTimeout`) stops a hung
+    /// `burn` from wedging the actor and queuing follow-up spend requests behind
+    /// it. `label` names the subprocess in the Instruments signpost interval.
+    private func capture(label: String, _ configure: (Process) -> Void) -> String? {
+        let signpostID = Signposts.subprocess.makeSignpostID()
+        let interval = Signposts.subprocess.beginInterval(
+            "capture", id: signpostID, "\(label, privacy: .public)"
+        )
+        defer { Signposts.subprocess.endInterval("capture", interval) }
+
         let process = Process()
         configure(process)
         let stdout = Pipe()
@@ -102,7 +134,7 @@ actor SystemBurnRunner: BurnRunner {
             process.waitUntilExit()
             group.leave()
         }
-        if group.wait(timeout: .now() + timeout) == .timedOut {
+        if group.wait(timeout: .now() + captureTimeout) == .timedOut {
             process.terminate()                       // SIGTERM…
             usleep(200_000)
             if process.isRunning {                    // …then SIGKILL if it ignores it

--- a/apps/macos/Sources/Burn/LiveBurnViewModel.swift
+++ b/apps/macos/Sources/Burn/LiveBurnViewModel.swift
@@ -1,9 +1,15 @@
 import SwiftUI
+import os
 
 /// One bucket of the burn series for a provider: the per-bucket burn rate plus
 /// the running cumulative totals across the selected range.
 struct LiveBurnSample: Identifiable {
-    let id = UUID()
+    /// Identity is the bucket's date, not a fresh `UUID` per refresh. Series are
+    /// stored per-provider and each chart `ForEach` iterates a single provider's
+    /// array, where bucket dates are unique — so this is stable across the ~3s
+    /// refresh. A per-refresh `UUID` forced Swift Charts to rebuild every mark
+    /// instead of diffing, which showed up as churn/flicker on the live tab.
+    var id: Date { date }
     let date: Date
     /// Cumulative cost (USD) across the range up to and including this bucket.
     let cost: Double
@@ -164,6 +170,9 @@ final class LiveBurnViewModel: ObservableObject {
         }
         refreshing = true
         defer { refreshing = false }
+
+        let interval = Signposts.refresh.beginInterval("liveRefresh")
+        defer { Signposts.refresh.endInterval("liveRefresh", interval) }
 
         repeat {
             refreshAgain = false

--- a/apps/macos/Sources/Burn/Signposts.swift
+++ b/apps/macos/Sources/Burn/Signposts.swift
@@ -1,0 +1,17 @@
+import os
+
+/// Lightweight `os_signpost` instrumentation so the app's hot paths can be
+/// profiled in Instruments (Time Profiler / os_signpost lane). Filter by
+/// subsystem `com.agentworkforce.burn` and pick a category:
+///
+/// - `refresh`    — the view-model refresh loops and spend load.
+/// - `subprocess` — each `burn` process execution (the interval message carries
+///   the first CLI argument, e.g. `summary`).
+///
+/// Signposters are cheap and safe to leave compiled in; they emit nothing unless
+/// a tool is recording. `OSSignpostIntervalState` is `Sendable`, so an interval
+/// begun before an `await` can be ended after it.
+enum Signposts {
+    static let refresh = OSSignposter(subsystem: "com.agentworkforce.burn", category: "refresh")
+    static let subprocess = OSSignposter(subsystem: "com.agentworkforce.burn", category: "subprocess")
+}

--- a/apps/macos/Sources/Burn/UsageViewModel.swift
+++ b/apps/macos/Sources/Burn/UsageViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 /// This-period and previous-period spend (USD) for one usage window, from the
 /// burn ledger.
@@ -103,6 +104,8 @@ final class UsageViewModel: ObservableObject {
     func refresh(force: Bool = false) async {
         guard let provider = providers[selectedProvider] else { return }
         if !force, let until = backoffUntil, Date() < until { return }
+        let refreshSignpost = Signposts.refresh.beginInterval("usageRefresh")
+        defer { Signposts.refresh.endInterval("usageRefresh", refreshSignpost) }
         isLoading = true
         let result = await provider.fetch()
         let now = Date()
@@ -168,6 +171,8 @@ final class UsageViewModel: ObservableObject {
         if let last = lastSpendAt, Date().timeIntervalSince(last) < spendInterval {
             return
         }
+        let spendSignpost = Signposts.refresh.beginInterval("loadSpend")
+        defer { Signposts.refresh.endInterval("loadSpend", spendSignpost) }
         lastSpendAt = Date()
         let burnProvider = BurnLedger.burnProvider(for: provider)
         var result: [String: PeriodSpend] = [:]

--- a/apps/macos/Tests/BurnTests/PerformanceTests.swift
+++ b/apps/macos/Tests/BurnTests/PerformanceTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import BurnCore
+
+/// XCTest performance baselines for the app's hot paths. These have no stored
+/// baselines, so they never fail CI on timing — they establish measurements
+/// (visible in the test report), catch crashes/regressions in the measured
+/// code, and give a place to attach a baseline later. Each uses the clock and
+/// memory metrics.
+final class PerformanceTests: XCTestCase {
+
+    /// Building a burndown from a large sample series (the per-refresh cost that
+    /// feeds the popover chart). 10,000 samples across the window.
+    func testBurndownBuildPerformance() {
+        let now = Date()
+        let periodSeconds: Double = 5 * 3600
+        let resetsAt = now.addingTimeInterval(periodSeconds / 2)
+        let windowStart = resetsAt.addingTimeInterval(-periodSeconds) // == now - period/2
+        let metric = UsageMetric(
+            name: "5-hour",
+            percentage: 42,
+            resetsAt: resetsAt,
+            periodSeconds: periodSeconds
+        )
+
+        let count = 10_000
+        // Spread samples over [windowStart, now] so they all fall inside the
+        // builder's `windowStart < date < now` filter.
+        let span = now.timeIntervalSince(windowStart)
+        let samples: [UsageSample] = (0..<count).map { i in
+            let fraction = Double(i) / Double(count)
+            return UsageSample(
+                date: windowStart.addingTimeInterval(fraction * span),
+                percentage: fraction * 90
+            )
+        }
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            _ = BurndownBuilder.build(metric: metric, samples: samples, now: now)
+        }
+    }
+
+    /// Parsing a large `burn summary --bucket` payload (JSONSerialization + the
+    /// per-bucket compactMap) — the live-burn chart's per-refresh parse cost.
+    /// 5,000 buckets, fed through a FakeRunner so no subprocess is spawned.
+    func testTimeseriesParsePerformance() {
+        var entries: [String] = []
+        entries.reserveCapacity(5_000)
+        for i in 0..<5_000 {
+            entries.append(#"{"start":"2026-01-01T00:00:00Z","totalTokens":\#(i),"totalCost":{"total":0.01}}"#)
+        }
+        let json = #"{"buckets":["# + entries.joined(separator: ",") + "]}"
+        let ledger = BurnLedger(runner: FakeRunner(output: json))
+        let since = Date(timeIntervalSince1970: 0)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let done = expectation(description: "parse")
+            Task {
+                _ = await ledger.timeseries(provider: "anthropic", since: since, bucket: "1h")
+                done.fulfill()
+            }
+            wait(for: [done], timeout: 30)
+        }
+    }
+
+    /// `UsageHistoryStore.record` against a store pre-seeded with 50 series ×
+    /// 1,000 samples. record() rewrites the whole cache to disk, so this
+    /// measures the known full-rewrite cost — a candidate for incremental
+    /// persistence — and surfaces regressions/improvements.
+    func testHistoryRecordFullRewritePerformance() throws {
+        let seedFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burn-history-perf-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: seedFile) }
+
+        // Future reset so the store's stale-window pruning keeps every series.
+        let reset = Int(Date().addingTimeInterval(3_600).timeIntervalSince1970)
+        let base = Date().addingTimeInterval(-3_000)
+        var seed: [String: [UsageSample]] = [:]
+        for series in 0..<50 {
+            // Key shape mirrors UsageHistoryStore.key: provider|name|resetEpoch.
+            let key = "codex|window\(series)|\(reset)"
+            seed[key] = (0..<1_000).map { i in
+                UsageSample(date: base.addingTimeInterval(Double(i)), percentage: Double(i % 100))
+            }
+        }
+        try JSONEncoder().encode(seed).write(to: seedFile)
+
+        let store = UsageHistoryStore(fileURL: seedFile)
+        // Matches the "codex|window0|<reset>" series so record() appends to it.
+        let metric = UsageMetric(
+            name: "window0",
+            percentage: 55,
+            resetsAt: Date(timeIntervalSince1970: Double(reset)),
+            periodSeconds: 18_000
+        )
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            _ = store.record(provider: .codex, metric: metric, at: Date())
+        }
+    }
+}

--- a/apps/macos/Tests/BurnTests/PerformanceTests.swift
+++ b/apps/macos/Tests/BurnTests/PerformanceTests.swift
@@ -71,8 +71,9 @@ final class PerformanceTests: XCTestCase {
             .appendingPathComponent("burn-history-perf-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: seedFile) }
 
-        // Future reset so the store's stale-window pruning keeps every series.
-        let reset = Int(Date().addingTimeInterval(3_600).timeIntervalSince1970)
+        // Far-future reset so the store's stale-window pruning keeps every
+        // series across all measured iterations (which advance the clock below).
+        let reset = Int(Date().addingTimeInterval(86_400).timeIntervalSince1970)
         let base = Date().addingTimeInterval(-3_000)
         var seed: [String: [UsageSample]] = [:]
         for series in 0..<50 {
@@ -93,8 +94,13 @@ final class PerformanceTests: XCTestCase {
             periodSeconds: 18_000
         )
 
+        // Deterministic advancing clock: each iteration records 61s after the
+        // previous one, so no iteration hits the store's <1s duplicate-collapse
+        // path — every measured call does the same append + full-rewrite work.
+        var recordAt = Date()
         measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
-            _ = store.record(provider: .codex, metric: metric, at: Date())
+            recordAt = recordAt.addingTimeInterval(61)
+            _ = store.record(provider: .codex, metric: metric, at: recordAt)
         }
     }
 }

--- a/apps/macos/Tests/BurnTests/SubprocessSoakTests.swift
+++ b/apps/macos/Tests/BurnTests/SubprocessSoakTests.swift
@@ -115,15 +115,16 @@ final class SubprocessSoakTests: XCTestCase {
 
         // The child is SIGTERM'd (then SIGKILL'd); give the background reader a
         // beat to hit EOF and release the pipe fds.
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(for: .seconds(1))
 
         let fdDelta = openFDCount() - fdBaseline
         XCTAssertLessThan(fdDelta, 10, "fds not reclaimed after a timeout kill: delta \(fdDelta)")
     }
 
-    /// 10 concurrent callers hitting the actor must all complete without a
-    /// subprocess pile-up (the actor serializes capture, so only one child is
-    /// ever live). fd/memory deltas stay bounded afterward.
+    /// 10 concurrent callers hitting the runner must all complete without a
+    /// subprocess pile-up (captures are serialized on the runner's serial exec
+    /// queue, so only one child is ever live). fd/memory deltas stay bounded
+    /// afterward.
     func testConcurrentCallersSerializeWithoutPileup() async throws {
         let script = try makeEchoScript()
         defer { try? FileManager.default.removeItem(at: script) }
@@ -147,7 +148,7 @@ final class SubprocessSoakTests: XCTestCase {
         XCTAssertTrue(results.allSatisfy { $0 != nil }, "every concurrent run should complete with output")
 
         // Let any just-finished captures release their pipes before snapshotting.
-        try await Task.sleep(nanoseconds: 300_000_000)
+        try await Task.sleep(for: .milliseconds(300))
 
         let fdDelta = openFDCount() - fdBaseline
         let memDeltaMB = footprintDeltaMB(memBaseline)

--- a/apps/macos/Tests/BurnTests/SubprocessSoakTests.swift
+++ b/apps/macos/Tests/BurnTests/SubprocessSoakTests.swift
@@ -68,7 +68,7 @@ final class SubprocessSoakTests: XCTestCase {
         try makeScript(
             """
             #!/bin/sh
-            sleep 60
+            exec sleep 60
             """
         )
     }

--- a/apps/macos/Tests/BurnTests/SubprocessSoakTests.swift
+++ b/apps/macos/Tests/BurnTests/SubprocessSoakTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+import Darwin
+@testable import BurnCore
+
+/// Soak tests that drive the *real* `SystemBurnRunner` Process/Pipe/timeout
+/// machinery (via `explicitBinaryURL`, which execs a fake `burn` script
+/// directly) and assert the process doesn't leak file descriptors or memory
+/// across many spawns. These guard the subprocess plumbing behind the live
+/// spend/burn-rate polling, which runs indefinitely while the app is open.
+///
+/// Thresholds are deliberately loose: the assertions catch *unbounded growth*
+/// (an fd left open per spawn, a retained Pipe/Data per call), not small,
+/// bounded allocator noise.
+final class SubprocessSoakTests: XCTestCase {
+
+    // MARK: - Measurement helpers
+
+    /// Count of open file descriptors for this process, via `/dev/fd`.
+    private func openFDCount() -> Int {
+        (try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count) ?? 0
+    }
+
+    /// This process's physical memory footprint in bytes (`phys_footprint` from
+    /// `TASK_VM_INFO`) — the same figure Xcode's memory gauge reports.
+    private func physFootprint() -> UInt64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size
+        )
+        let kr = withUnsafeMutablePointer(to: &info) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), intPtr, &count)
+            }
+        }
+        return kr == KERN_SUCCESS ? UInt64(info.phys_footprint) : 0
+    }
+
+    private func footprintDeltaMB(_ baseline: UInt64) -> Double {
+        Double(Int64(bitPattern: physFootprint()) - Int64(bitPattern: baseline)) / (1024 * 1024)
+    }
+
+    // MARK: - Fixtures
+
+    /// Writes an executable shell script and returns its URL. Callers delete it.
+    private func makeScript(_ body: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burn-fake-\(UUID().uuidString).sh")
+        try body.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    /// A fake `burn` that ignores its args and prints a small canned
+    /// `summary --json` payload, then exits 0.
+    private func makeEchoScript() throws -> URL {
+        try makeScript(
+            """
+            #!/bin/sh
+            echo '{"totalCost":{"total":1.5},"byModel":[],"buckets":[{"start":"2026-07-03T00:00:00Z","totalTokens":100,"totalCost":{"total":0.1}}]}'
+            """
+        )
+    }
+
+    /// A fake `burn` that hangs, to exercise the capture timeout/kill path.
+    private func makeSleepScript() throws -> URL {
+        try makeScript(
+            """
+            #!/bin/sh
+            sleep 60
+            """
+        )
+    }
+
+    // MARK: - Tests
+
+    /// 200 back-to-back real subprocess spawns must not grow the open-fd count
+    /// or the memory footprint without bound. A leaked Pipe read-end (the
+    /// classic Process/Pipe bug) would show up as steadily climbing fds.
+    ///
+    /// 200 trivial spawns run in well under the CI budget (tens of seconds worst
+    /// case); drop to 100 if this ever proves flaky on a slow runner.
+    func testRepeatedRunsDoNotLeakFDsOrMemory() async throws {
+        let script = try makeEchoScript()
+        defer { try? FileManager.default.removeItem(at: script) }
+        let runner = SystemBurnRunner(explicitBinaryURL: script)
+
+        // Warm up so first-call allocations (formatters, thread pool) don't count.
+        for _ in 0..<10 { _ = await runner.run(["summary", "--json"]) }
+
+        let fdBaseline = openFDCount()
+        let memBaseline = physFootprint()
+
+        for _ in 0..<200 { _ = await runner.run(["summary", "--json"]) }
+
+        let fdDelta = openFDCount() - fdBaseline
+        let memDeltaMB = footprintDeltaMB(memBaseline)
+        XCTAssertLessThan(fdDelta, 10, "open fd count grew by \(fdDelta) over 200 runs — a Process/Pipe leak")
+        XCTAssertLessThan(memDeltaMB, 20, "phys footprint grew by \(memDeltaMB) MB over 200 runs")
+    }
+
+    /// A hung child must be reaped by the capture timeout: `run` returns nil and
+    /// the descriptors it held are reclaimed. Uses an injected 1s timeout so CI
+    /// doesn't wait the production 30s.
+    func testTimeoutPathReapsProcessAndFDs() async throws {
+        let script = try makeSleepScript()
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        let fdBaseline = openFDCount()
+        let runner = SystemBurnRunner(explicitBinaryURL: script, timeout: 1)
+
+        let output = await runner.run(["summary", "--json"])
+        XCTAssertNil(output, "a timed-out run must return nil")
+
+        // The child is SIGTERM'd (then SIGKILL'd); give the background reader a
+        // beat to hit EOF and release the pipe fds.
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let fdDelta = openFDCount() - fdBaseline
+        XCTAssertLessThan(fdDelta, 10, "fds not reclaimed after a timeout kill: delta \(fdDelta)")
+    }
+
+    /// 10 concurrent callers hitting the actor must all complete without a
+    /// subprocess pile-up (the actor serializes capture, so only one child is
+    /// ever live). fd/memory deltas stay bounded afterward.
+    func testConcurrentCallersSerializeWithoutPileup() async throws {
+        let script = try makeEchoScript()
+        defer { try? FileManager.default.removeItem(at: script) }
+        let runner = SystemBurnRunner(explicitBinaryURL: script)
+
+        _ = await runner.run(["summary", "--json"]) // warm
+
+        let fdBaseline = openFDCount()
+        let memBaseline = physFootprint()
+
+        let results = await withTaskGroup(of: String?.self) { group -> [String?] in
+            for _ in 0..<10 {
+                group.addTask { await runner.run(["summary", "--json"]) }
+            }
+            var collected: [String?] = []
+            for await result in group { collected.append(result) }
+            return collected
+        }
+
+        XCTAssertEqual(results.count, 10)
+        XCTAssertTrue(results.allSatisfy { $0 != nil }, "every concurrent run should complete with output")
+
+        // Let any just-finished captures release their pipes before snapshotting.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let fdDelta = openFDCount() - fdBaseline
+        let memDeltaMB = footprintDeltaMB(memBaseline)
+        XCTAssertLessThan(fdDelta, 10, "fd count grew by \(fdDelta) under concurrent load")
+        XCTAssertLessThan(memDeltaMB, 20, "phys footprint grew by \(memDeltaMB) MB under concurrent load")
+    }
+}


### PR DESCRIPTION
Targets the reported BurnOSX slowness + memory leaks with empirical leak/perf tests, profiling hooks, and perf fixes. Originally stacked on #491; retargeted to `main` after that merged.

No Swift toolchain in the authoring environment — Swift here is written conservatively and verified by the `macos-app-tests` workflow (macos-14 runner).

## The soak test caught a real leak

The first CI run of `testRepeatedRunsDoNotLeakFDsOrMemory` failed with **"open fd count grew by 398 over 200 runs"** — ~2 fds leaked per subprocess spawn. Parent-side `Pipe`/`FileHandle` objects are Obj-C autoreleased, and on GCD/cooperative threads the pool drains lazily, so each run's descriptors lingered long after the child exited. With a spawn every ~3s on the live tab, this is a real production leak mechanism, not test noise.

**Fix (in `blockingCapture`):** explicitly `close()` the parent-side read handles after each drain (and defensively on the timeout path, after a bounded re-wait so we never close under an in-flight legacy read), and wrap the whole blocking body in `autoreleasepool` so remaining autoreleased objects drain per call. The test thresholds were left untouched (<10 fds, <20 MB) — the production code must be leak-free without the caller's help.

## Cooperative-pool fix (review finding)

`capture` used to run `DispatchGroup.wait` + `usleep` inside the actor method — i.e. on a Swift Concurrency cooperative-pool thread, blocking it for up to `captureTimeout` (30s prod). With the live tab polling every 3s across providers plus spend queries, that can starve the pool (a plausible slowness cause). Now:

- The blocking Process/Pipe body is a pure `static blockingCapture(timeout:_:)` (no actor state).
- It runs on a **serial** `DispatchQueue("com.agentworkforce.burn.subprocess", qos: .utility)`; `capture` is `async` and awaits a checked continuation resumed from that queue. The serial queue preserves the one-subprocess-at-a-time invariant (guarded by `testConcurrentCallersSerializeWithoutPileup`) while the cooperative thread is released for the child's whole run.
- `loginShell`/`resolveTool` became `async`; the actor is reentrant at the await, so two concurrent first calls may both run the PATH probe — benign, both converge on the same cached value (commented in code).

## What each test guards

### `SubprocessSoakTests.swift` — leaks in the subprocess machinery
Drives the **real** `SystemBurnRunner` Process/Pipe/timeout code against a temp fake-`burn` shell script; measures open fds via `/dev/fd` and memory via `phys_footprint` (`TASK_VM_INFO`).

- **`testRepeatedRunsDoNotLeakFDsOrMemory`** — 10 warmup runs, then **200** measured `run(["summary","--json"])`. Asserts fd delta < 10 and footprint delta < 20 MB. (Already earned its keep — see above.)
- **`testTimeoutPathReapsProcessAndFDs`** — a `sleep 60` script with an **injected 1s timeout** (production 30s is too slow for CI). Asserts `run()` returns `nil` and fds return to baseline after the SIGTERM→SIGKILL reap.
- **`testConcurrentCallersSerializeWithoutPileup`** — 10 concurrent `run` calls via a task group; all must complete with output and fd/footprint deltas stay bounded (guards the serialization invariant that prevents subprocess pile-up).

### `PerformanceTests.swift` — hot-path baselines
`measure(metrics: [XCTClockMetric(), XCTMemoryMetric()])` over:
- `BurndownBuilder.build` with a 10,000-sample series.
- `BurnLedger.timeseries` parsing a 5,000-bucket payload via a `FakeRunner`.
- `UsageHistoryStore.record` against a store pre-seeded with 50 series × 1,000 samples (the known full-cache-rewrite-per-record cost). Each iteration advances a deterministic clock by 61s so no iteration hits the store's <1s duplicate-collapse path — every measured call does the same append + full-rewrite work.

No stored baselines, so these **never fail CI on timing** — they establish measurements in the test report and catch crashes/regressions.

## Signposts — profiling slowness in Instruments
`Sources/Burn/Signposts.swift` exposes one `OSSignposter` per category under subsystem **`com.agentworkforce.burn`**:
- `refresh` — intervals around `LiveBurnViewModel.refresh()`, `UsageViewModel.refresh(force:)`, and `loadSpend`.
- `subprocess` — an interval around every capture (queue wait + child run), with the first CLI arg (e.g. `summary`) as the interval message.

To profile:
```
xctrace record --template 'Time Profiler' --attach BurnOSX
```
then filter the os_signpost lane by subsystem `com.agentworkforce.burn` (categories `refresh`, `subprocess`).

## Chart identity fix
`LiveBurnSample` was `Identifiable` via `let id = UUID()`, so every ~3s refresh minted brand-new identities for all samples, forcing Swift Charts to rebuild the entire chart instead of diffing. Changed to `var id: Date { date }`. Series are stored per-provider and each chart `ForEach` iterates a single provider's array (verified in `LiveBurnView.swift`), where bucket dates are unique, so per-series date identity suffices.

## Production changes
- `SystemBurnRunner.init(explicitBinaryURL: URL? = nil, timeout: TimeInterval = 30)` — explicit URL short-circuits resolution to direct exec (like the bundled case, no login shell); injectable timeout. Defaults reproduce prior behavior.
- `capture` async on a serial exec queue + static `blockingCapture` (above); explicit handle closes + per-call `autoreleasepool` (the fd-leak fix).
- Signpost begin/end around the two refresh loops, `loadSpend`, and `capture`.
- `LiveBurnSample` identity change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJPzcAQdxufCWMnap8vTTL