### PR TITLE
feat(macos): in-app updates from the macos-v* GitHub Releases

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -101,9 +101,13 @@ jobs:
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           DMG="dist/BurnOSX-arm64.dmg"
+          # The zip is the in-app updater's download artifact (AppUpdater reads
+          # the releases feed and fetches BurnOSX-arm64.zip from the macos-v*
+          # release it picks).
+          ZIP="dist/BurnOSX-arm64.zip"
           # Versioned release (history). Not marked --latest: burn's own v* CLI
           # releases own the repo's "latest" pointer.
-          gh release create "${TAG}" "${DMG}" \
+          gh release create "${TAG}" "${DMG}" "${ZIP}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${GITHUB_SHA}" \
             --title "Burn for Mac ${{ steps.version.outputs.version }}" \
@@ -111,7 +115,7 @@ jobs:
           # Moving pointer for a stable download URL:
           #   releases/download/macos-latest/BurnOSX-arm64.dmg
           gh release delete macos-latest --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || true
-          gh release create macos-latest "${DMG}" \
+          gh release create macos-latest "${DMG}" "${ZIP}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${GITHUB_SHA}" \
             --title "Burn for Mac (latest)" \
@@ -122,6 +126,8 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: agentlimit-macos-${{ github.run_id }}
-          path: apps/macos/dist/*.dmg
+          path: |
+            apps/macos/dist/*.dmg
+            apps/macos/dist/*.zip
           if-no-files-found: warn
           retention-days: 30

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -24,6 +24,10 @@ you're ahead of or behind your usage pace before you hit a wall — and pulls
   rate-limits (it keeps showing your last reading instead of erroring out).
 - Under each window, shows **spend this period vs. last period** ($), read from
   the burn ledger via the `burn` CLI. Hidden if `burn` isn't installed.
+- **Updates itself**: installed builds silently check GitHub Releases every 6
+  hours; when a new build is out, Settings (⚙) shows an **Update Now** button
+  that downloads it, verifies the signature, and offers **Restart Now**. A
+  manual **Check for Updates** button lives in the same place.
 
 ## How it reads your usage
 
@@ -105,6 +109,7 @@ Sources/Burn/
   Burndown.swift              Turns samples into chart data
   Models.swift                Shared types
   BurnLedger.swift            Reads spend from the bundled/PATH `burn` binary
+  AppUpdater.swift            In-app updates from the macos-v* GitHub Releases
   Resources/                  claude.svg, openai.svg (lobe-icons, MIT)
 ```
 
@@ -123,10 +128,18 @@ To cut a release, go to **Actions → "Release (macOS app)" → Run workflow**. 
 2. generates release notes from commits since the last `macos-v*` tag;
 3. builds the app **and the native `burn` helper** (`cargo build -p
    relayburn-cli`), bundles + signs both with a hardened runtime, notarizes via
-   the App Store Connect API key, staples, and packages `BurnOSX-arm64.dmg`;
+   the App Store Connect API key, staples, and packages `BurnOSX-arm64.dmg`
+   plus `BurnOSX-arm64.zip` (the in-app updater's download artifact);
 4. publishes a versioned release (history) and moves a `macos-latest` pointer so
    `releases/download/macos-latest/BurnOSX-arm64.dmg` is a stable link. It is
    **not** marked the repo's "latest" — that belongs to burn's CLI releases.
+
+Cutting a release is also what feeds the **in-app updater**: `AppUpdater` polls
+the releases feed for the newest `macos-v*` tag, compares it against the stamped
+`CFBundleShortVersionString`, downloads the zip, verifies the payload's
+Developer ID signature matches the running app's team, swaps the bundle, and
+relaunches. Unsigned dev builds skip the silent checks and refuse the install
+step (there's no team to pin the download against).
 
 `release.sh` runs the same build/sign/notarize/package steps locally (set
 `VERSION` and the Apple env vars listed at the top of the script). It needs both

--- a/apps/macos/Sources/Burn/AppDelegate.swift
+++ b/apps/macos/Sources/Burn/AppDelegate.swift
@@ -12,6 +12,7 @@ import Combine
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate {
     private let viewModel = UsageViewModel()
+    private let updater = AppUpdater()
     private var statusItem: NSStatusItem?
     private let popover = NSPopover()
     private var iconObserver: AnyCancellable?
@@ -32,7 +33,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(
-            rootView: ContentView(viewModel: viewModel))
+            rootView: ContentView(viewModel: viewModel, updater: updater))
+
+        // Silent update checks (signed installs only); the Settings tab's
+        // "Check for Updates" button works regardless.
+        updater.startPeriodicChecks()
 
         // Mirror the cached flame onto the status button whenever it changes.
         iconObserver = viewModel.$menuBarIcon.sink { [weak item] image in

--- a/apps/macos/Sources/Burn/AppUpdater.swift
+++ b/apps/macos/Sources/Burn/AppUpdater.swift
@@ -40,11 +40,6 @@ final class AppUpdater: ObservableObject {
     /// placeholder, which is why scheduled checks are gated on a signed install.
     let currentVersion: String
 
-    /// GitHub releases feed for this repo. `per_page=100` comfortably covers
-    /// the newest `macos-v*` release even with CLI releases interleaved.
-    static let releasesURL = URL(
-        string: "https://api.github.com/repos/AgentWorkforce/burn/releases?per_page=100")!
-
     /// The zip asset release.sh publishes for this machine's architecture.
     static var assetName: String {
         #if arch(x86_64)
@@ -86,7 +81,11 @@ final class AppUpdater: ObservableObject {
             self.timerBox.timer = Timer.scheduledTimer(
                 withTimeInterval: Self.checkInterval, repeats: true
             ) { [weak self] _ in
-                Task { @MainActor in await self?.check(silently: true) }
+                // Rebind strongly before hopping into the task: capturing the
+                // weak `self` var inside the concurrent closure is a Swift 6
+                // isolation error.
+                guard let self else { return }
+                Task { @MainActor in await self.check(silently: true) }
             }
             await self.check(silently: true)
         }
@@ -263,6 +262,12 @@ final class AppUpdater: ObservableObject {
     }
 
     nonisolated private static func fetchLatestUpdate(assetName: String) async throws -> AppUpdate? {
+        // GitHub releases feed for this repo. `per_page=100` comfortably covers
+        // the newest `macos-v*` release even with CLI releases interleaved.
+        // (Local so it stays off the @MainActor class — a nonisolated context
+        // can't read the class's isolated statics.)
+        let releasesURL = URL(
+            string: "https://api.github.com/repos/AgentWorkforce/burn/releases?per_page=100")!
         var request = URLRequest(url: releasesURL)
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
         let (data, response) = try await URLSession.shared.data(for: request)

--- a/apps/macos/Sources/Burn/AppUpdater.swift
+++ b/apps/macos/Sources/Burn/AppUpdater.swift
@@ -1,0 +1,407 @@
+import AppKit
+import SwiftUI
+
+/// A newer app build discovered on GitHub Releases: the version to advertise
+/// and the notarized zip asset the updater downloads.
+struct AppUpdate: Equatable {
+    let version: String
+    let downloadURL: URL
+}
+
+/// In-app updates for the menu bar app, backed by the `macos-v*` GitHub
+/// Releases that `release-macos.yml` publishes (mirroring Pear's updater UX:
+/// silent periodic checks, then "Update Now" → download → "Restart Now").
+///
+/// There is no Sparkle dependency — the release pipeline already gives us a
+/// signed, notarized, stapled zip at a predictable URL, so the updater is:
+/// check the releases feed, download the zip, verify its Developer ID
+/// signature matches the running app's team, swap the installed bundle, and
+/// relaunch. All state is surfaced through `phase` for the Settings tab.
+@MainActor
+final class AppUpdater: ObservableObject {
+
+    /// The updater's lifecycle, rendered by the Settings tab. `upToDate` and
+    /// `failed` only appear after a user-initiated check — silent scheduled
+    /// checks either surface `available` or leave the phase alone.
+    enum Phase: Equatable {
+        case idle
+        case checking
+        case upToDate
+        case available(AppUpdate)
+        case downloading
+        case readyToRestart(AppUpdate)
+        case failed(String)
+    }
+
+    @Published private(set) var phase: Phase = .idle
+
+    /// The running build's version (`CFBundleShortVersionString`), stamped by
+    /// release.sh at release time. Dev builds carry the committed `1.0.0`
+    /// placeholder, which is why scheduled checks are gated on a signed install.
+    let currentVersion: String
+
+    /// GitHub releases feed for this repo. `per_page=100` comfortably covers
+    /// the newest `macos-v*` release even with CLI releases interleaved.
+    static let releasesURL = URL(
+        string: "https://api.github.com/repos/AgentWorkforce/burn/releases?per_page=100")!
+
+    /// The zip asset release.sh publishes for this machine's architecture.
+    static var assetName: String {
+        #if arch(x86_64)
+        return "BurnOSX-x86_64.zip"
+        #else
+        return "BurnOSX-arm64.zip"
+        #endif
+    }
+
+    private static let checkInterval: TimeInterval = 6 * 60 * 60
+
+    /// Held outside the actor so `deinit` can tear it down (see `TimerBox`).
+    private let timerBox = TimerBox()
+
+    /// The verified, extracted .app staged by `beginDownload()`, consumed by
+    /// `restart()`.
+    private var stagedAppURL: URL?
+
+    init(currentVersion: String? = nil) {
+        self.currentVersion = currentVersion
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? "0"
+    }
+
+    // MARK: Scheduling
+
+    /// Launch-time entry point: one silent check shortly after startup, then
+    /// every 6 hours. Skipped entirely for unsigned builds (`swift run`, local
+    /// build.sh output) so dev builds don't nag about "updates" the placeholder
+    /// version can never install; the Settings button still allows a manual
+    /// check anywhere.
+    func startPeriodicChecks() {
+        guard !timerBox.isActive else { return }
+        Task { [weak self] in
+            let bundleURL = Bundle.main.bundleURL
+            guard bundleURL.pathExtension == "app" else { return }
+            let team = await Self.teamIdentifier(ofCodeAt: bundleURL)
+            guard team != nil, let self else { return }
+            self.timerBox.timer = Timer.scheduledTimer(
+                withTimeInterval: Self.checkInterval, repeats: true
+            ) { [weak self] _ in
+                Task { @MainActor in await self?.check(silently: true) }
+            }
+            await self.check(silently: true)
+        }
+    }
+
+    // MARK: Checking
+
+    /// Non-async wrapper for SwiftUI buttons.
+    func checkNow() {
+        Task { await check() }
+    }
+
+    /// Fetches the releases feed and compares the newest published `macos-v*`
+    /// build against the running version. Silent checks (the scheduled path)
+    /// only ever surface a new `available` phase; interactive checks also
+    /// report `upToDate` / `failed`.
+    func check(silently: Bool = false) async {
+        switch phase {
+        case .checking, .downloading, .readyToRestart:
+            return
+        default:
+            break
+        }
+        if !silently { phase = .checking }
+        do {
+            let latest = try await Self.fetchLatestUpdate(assetName: Self.assetName)
+            if let latest, Self.isVersion(latest.version, newerThan: currentVersion) {
+                phase = .available(latest)
+            } else if !silently {
+                phase = .upToDate
+            }
+        } catch {
+            if !silently {
+                phase = .failed("Update check failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: Download & install
+
+    /// "Update Now": downloads the zip, extracts it, and verifies the payload's
+    /// Developer ID signature before offering the restart. The installed bundle
+    /// is not touched until the user confirms the restart.
+    func beginDownload() {
+        guard case .available(let update) = phase else { return }
+        phase = .downloading
+        Task { [weak self] in
+            do {
+                let staged = try await Self.downloadAndStage(update)
+                self?.stagedAppURL = staged
+                self?.phase = .readyToRestart(update)
+            } catch {
+                self?.phase = .failed("Update failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// "Restart Now": swaps the staged bundle over the installed one, spawns a
+    /// relauncher that waits for this process to exit, and terminates the app.
+    func restart() {
+        guard case .readyToRestart = phase, let staged = stagedAppURL else { return }
+        do {
+            let installed = Bundle.main.bundleURL
+            try Self.install(staged: staged, over: installed)
+            Self.relaunch(appAt: installed)
+            NSApp.terminate(nil)
+        } catch {
+            stagedAppURL = nil
+            phase = .failed("Update failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: Feed parsing (pure — unit-tested)
+
+    /// One entry of the GitHub releases list; only the fields the updater reads.
+    struct Release: Decodable {
+        struct Asset: Decodable {
+            let name: String
+            let browserDownloadUrl: URL
+        }
+
+        let tagName: String
+        let draft: Bool
+        let prerelease: Bool
+        let assets: [Asset]
+    }
+
+    /// `"macos-v2026.7.2"` → `[2026, 7, 2]`; nil for CLI tags (`relayburn-v*`,
+    /// `v*`), the `macos-latest` pointer, and anything non-numeric.
+    nonisolated static func versionComponents(ofTag tag: String) -> [Int]? {
+        guard tag.hasPrefix("macos-v") else { return nil }
+        return versionComponents(of: String(tag.dropFirst("macos-v".count)))
+    }
+
+    /// `"2026.7.2"` → `[2026, 7, 2]`; nil unless every dot component is numeric.
+    nonisolated static func versionComponents(of version: String) -> [Int]? {
+        let parts = version.split(separator: ".", omittingEmptySubsequences: false)
+        guard !parts.isEmpty else { return nil }
+        var components: [Int] = []
+        for part in parts {
+            guard let value = Int(part), value >= 0 else { return nil }
+            components.append(value)
+        }
+        return components
+    }
+
+    /// Numeric component-wise comparison (so `2026.10.1` beats `2026.9.9`),
+    /// padding the shorter version with zeros. Unparseable versions never win.
+    nonisolated static func isVersion(_ candidate: String, newerThan current: String) -> Bool {
+        guard let a = versionComponents(of: candidate) else { return false }
+        guard let b = versionComponents(of: current) else { return true }
+        for i in 0..<max(a.count, b.count) {
+            let x = i < a.count ? a[i] : 0
+            let y = i < b.count ? b[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+
+    /// Picks the highest-versioned published (non-draft, non-prerelease)
+    /// `macos-v*` release that carries the named zip asset.
+    nonisolated static func latestUpdate(inReleasesJSON data: Data, assetName: String) -> AppUpdate? {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        guard let releases = try? decoder.decode([Release].self, from: data) else { return nil }
+
+        var best: (components: [Int], update: AppUpdate)?
+        for release in releases where !release.draft && !release.prerelease {
+            guard let components = versionComponents(ofTag: release.tagName),
+                  let asset = release.assets.first(where: { $0.name == assetName })
+            else { continue }
+            if let current = best, !componentsAreOrderedBefore(current.components, components) {
+                continue
+            }
+            let version = String(release.tagName.dropFirst("macos-v".count))
+            best = (components, AppUpdate(version: version, downloadURL: asset.browserDownloadUrl))
+        }
+        return best?.update
+    }
+
+    /// Component-wise `<` with zero-padding, mirroring `isVersion(_:newerThan:)`.
+    nonisolated private static func componentsAreOrderedBefore(_ a: [Int], _ b: [Int]) -> Bool {
+        for i in 0..<max(a.count, b.count) {
+            let x = i < a.count ? a[i] : 0
+            let y = i < b.count ? b[i] : 0
+            if x != y { return x < y }
+        }
+        return false
+    }
+
+    // MARK: Networking
+
+    enum UpdateError: LocalizedError {
+        case badStatus(Int)
+        case noAppInArchive
+        case unsignedDownload(String)
+        case unsignedInstall
+        case notInstalledAsApp
+
+        var errorDescription: String? {
+            switch self {
+            case .badStatus(let code):
+                return "GitHub returned HTTP \(code)."
+            case .noAppInArchive:
+                return "the downloaded archive did not contain an app."
+            case .unsignedDownload(let detail):
+                return "the downloaded app failed signature verification (\(detail))."
+            case .unsignedInstall:
+                return "this build is unsigned, so in-app updates are disabled. Download the DMG instead."
+            case .notInstalledAsApp:
+                return "the app is not running from an installed bundle."
+            }
+        }
+    }
+
+    nonisolated private static func fetchLatestUpdate(assetName: String) async throws -> AppUpdate? {
+        var request = URLRequest(url: releasesURL)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw UpdateError.badStatus(http.statusCode)
+        }
+        return latestUpdate(inReleasesJSON: data, assetName: assetName)
+    }
+
+    /// Downloads and extracts the update zip, then verifies the payload:
+    /// `codesign --verify` must pass and the archive's team identifier must
+    /// match the running app's. Refuses to proceed from an unsigned build —
+    /// there is no team to pin the download against.
+    nonisolated private static func downloadAndStage(_ update: AppUpdate) async throws -> URL {
+        guard let expectedTeam = await teamIdentifier(ofCodeAt: Bundle.main.bundleURL) else {
+            throw UpdateError.unsignedInstall
+        }
+
+        let (zipURL, response) = try await URLSession.shared.download(from: update.downloadURL)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw UpdateError.badStatus(http.statusCode)
+        }
+
+        let extractDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burn-update-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: extractDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: zipURL) }
+
+        let unzip = await run("/usr/bin/ditto", ["-x", "-k", zipURL.path, extractDir.path])
+        guard unzip.status == 0 else { throw UpdateError.noAppInArchive }
+
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: extractDir, includingPropertiesForKeys: nil)
+        guard let app = contents.first(where: { $0.pathExtension == "app" }) else {
+            throw UpdateError.noAppInArchive
+        }
+
+        // Belt and braces: the zip is notarized and stapled, but strip any
+        // quarantine attribute so the relaunch can't trip over translocation.
+        _ = await run("/usr/bin/xattr", ["-dr", "com.apple.quarantine", app.path])
+
+        let verify = await run("/usr/bin/codesign", ["--verify", "--deep", "--strict", app.path])
+        guard verify.status == 0 else {
+            throw UpdateError.unsignedDownload(verify.output.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        let downloadedTeam = await teamIdentifier(ofCodeAt: app)
+        guard downloadedTeam == expectedTeam else {
+            throw UpdateError.unsignedDownload("unexpected signing team")
+        }
+        return app
+    }
+
+    // MARK: Bundle swap & relaunch
+
+    /// Moves the installed bundle aside and puts the staged one in its place,
+    /// rolling the old bundle back if the swap fails halfway.
+    nonisolated private static func install(staged: URL, over installed: URL) throws {
+        guard installed.pathExtension == "app" else { throw UpdateError.notInstalledAsApp }
+        let fm = FileManager.default
+        let aside = fm.temporaryDirectory
+            .appendingPathComponent("burn-previous-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent(installed.lastPathComponent)
+        try fm.createDirectory(
+            at: aside.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fm.moveItem(at: installed, to: aside)
+        do {
+            // moveItem fails across volumes (temp vs. /Applications on some
+            // setups); fall back to a copy, which preserves the signature.
+            do {
+                try fm.moveItem(at: staged, to: installed)
+            } catch {
+                try fm.copyItem(at: staged, to: installed)
+            }
+        } catch {
+            try? fm.moveItem(at: aside, to: installed)
+            throw error
+        }
+        try? fm.removeItem(at: aside.deletingLastPathComponent())
+    }
+
+    /// Spawns a detached shell that waits for this process to exit, then opens
+    /// the (now updated) bundle. The path travels as `$1`, so no quoting games.
+    nonisolated private static func relaunch(appAt url: URL) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "while /bin/kill -0 \(ProcessInfo.processInfo.processIdentifier) 2>/dev/null; do /bin/sleep 0.2; done; /usr/bin/open \"$1\"",
+            "burn-relaunch",
+            url.path,
+        ]
+        try? process.run()
+    }
+
+    // MARK: Subprocess helpers
+
+    /// `codesign -dvv`'s `TeamIdentifier=` line, or nil for unsigned/ad-hoc
+    /// code. Used both to gate scheduled checks (dev builds are unsigned) and
+    /// to pin downloads to the running app's signing team.
+    nonisolated static func teamIdentifier(ofCodeAt url: URL) async -> String? {
+        let result = await run("/usr/bin/codesign", ["-dvv", url.path])
+        guard result.status == 0 else { return nil }
+        for line in result.output.split(separator: "\n") {
+            if line.hasPrefix("TeamIdentifier=") {
+                let team = String(line.dropFirst("TeamIdentifier=".count))
+                return (team.isEmpty || team == "not set") ? nil : team
+            }
+        }
+        return nil
+    }
+
+    /// Runs a tool to completion off the cooperative pool, returning its exit
+    /// status and combined stdout+stderr (one shared pipe — codesign reports on
+    /// stderr; outputs here are tiny, far below the 64KB pipe buffer).
+    nonisolated private static func run(
+        _ tool: String, _ arguments: [String]
+    ) async -> (status: Int32, output: String) {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                autoreleasepool {
+                    let process = Process()
+                    process.executableURL = URL(fileURLWithPath: tool)
+                    process.arguments = arguments
+                    let pipe = Pipe()
+                    process.standardOutput = pipe
+                    process.standardError = pipe
+                    do {
+                        try process.run()
+                    } catch {
+                        continuation.resume(returning: (-1, ""))
+                        return
+                    }
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    try? pipe.fileHandleForReading.close()
+                    process.waitUntilExit()
+                    let output = String(data: data, encoding: .utf8) ?? ""
+                    continuation.resume(returning: (process.terminationStatus, output))
+                }
+            }
+        }
+    }
+}

--- a/apps/macos/Sources/Burn/ContentView.swift
+++ b/apps/macos/Sources/Burn/ContentView.swift
@@ -23,13 +23,15 @@ private enum AppearanceMode: String, CaseIterable, Identifiable {
 /// The popover shown when the menu bar item is clicked.
 struct ContentView: View {
     @ObservedObject var viewModel: UsageViewModel
+    @ObservedObject var updater: AppUpdater
     @StateObject private var liveViewModel: LiveBurnViewModel
     @State private var tab: BurnTab = .usage
     @State private var showingSettings = false
     @AppStorage("appearance") private var appearanceRaw = AppearanceMode.system.rawValue
 
-    init(viewModel: UsageViewModel) {
+    init(viewModel: UsageViewModel, updater: AppUpdater) {
         self.viewModel = viewModel
+        self.updater = updater
         // The live view shows all providers at once (its own per-provider
         // toggles), independent of the Usage tab's single-select provider.
         _liveViewModel = StateObject(wrappedValue: LiveBurnViewModel())
@@ -71,7 +73,7 @@ struct ContentView: View {
         .fixedSize()
     }
 
-    /// Settings tab: appearance + quit.
+    /// Settings tab: appearance + updates + quit.
     private var settingsView: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 6) {
@@ -84,6 +86,15 @@ struct ContentView: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Updates")
+                    .font(.subheadline.weight(.medium))
+                updateControl
+                Text("Burn for Mac \(updater.currentVersion)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
             }
 
             Divider()
@@ -99,6 +110,79 @@ struct ContentView: View {
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, minHeight: 96, alignment: .leading)
+    }
+
+    /// The Updates row of Settings, keyed off the updater's phase: a check
+    /// button at rest, progress while checking/downloading, and Pear-style
+    /// "Update Now" / "Restart Now" actions when a new build is found.
+    @ViewBuilder
+    private var updateControl: some View {
+        switch updater.phase {
+        case .idle:
+            updateActionButton("Check for Updates", systemImage: "arrow.triangle.2.circlepath") {
+                updater.checkNow()
+            }
+        case .checking:
+            updateProgressRow("Checking for updates…")
+        case .upToDate:
+            VStack(alignment: .leading, spacing: 4) {
+                Text("You're up to date.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                updateActionButton("Check Again", systemImage: "arrow.triangle.2.circlepath") {
+                    updater.checkNow()
+                }
+            }
+        case .available(let update):
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Version \(update.version) is available.")
+                    .font(.caption)
+                updateActionButton("Update Now", systemImage: "arrow.down.circle") {
+                    updater.beginDownload()
+                }
+            }
+        case .downloading:
+            updateProgressRow("Downloading update…")
+        case .readyToRestart(let update):
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Version \(update.version) is ready to install.")
+                    .font(.caption)
+                updateActionButton("Restart Now", systemImage: "arrow.clockwise.circle") {
+                    updater.restart()
+                }
+            }
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 4) {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                updateActionButton("Try Again", systemImage: "arrow.triangle.2.circlepath") {
+                    updater.checkNow()
+                }
+            }
+        }
+    }
+
+    private func updateActionButton(
+        _ title: String, systemImage: String, action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.callout)
+                .foregroundStyle(Color.accentColor)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func updateProgressRow(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 
     /// Header cog that toggles the Settings tab.

--- a/apps/macos/Tests/BurnTests/AppUpdaterTests.swift
+++ b/apps/macos/Tests/BurnTests/AppUpdaterTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import BurnCore
+
+/// Exercises the pure feed-parsing and version-comparison half of
+/// `AppUpdater` — the network/install half shells out to codesign/ditto and is
+/// exercised on real releases.
+final class AppUpdaterTests: XCTestCase {
+
+    // MARK: - Version parsing
+
+    func testVersionComponentsParsesMacosTags() {
+        XCTAssertEqual(AppUpdater.versionComponents(ofTag: "macos-v2026.7.2"), [2026, 7, 2])
+        XCTAssertEqual(AppUpdater.versionComponents(ofTag: "macos-v2026.12.10"), [2026, 12, 10])
+    }
+
+    func testVersionComponentsRejectsOtherTags() {
+        // CLI releases, the moving pointer, and malformed versions must never
+        // be treated as app updates.
+        XCTAssertNil(AppUpdater.versionComponents(ofTag: "relayburn-v4.0.0"))
+        XCTAssertNil(AppUpdater.versionComponents(ofTag: "v2.3.0"))
+        XCTAssertNil(AppUpdater.versionComponents(ofTag: "macos-latest"))
+        XCTAssertNil(AppUpdater.versionComponents(ofTag: "macos-v2026.7.beta"))
+        XCTAssertNil(AppUpdater.versionComponents(ofTag: "macos-v"))
+    }
+
+    func testIsVersionNewerComparesNumerically() {
+        // Numeric, not lexicographic: month 10 beats month 9.
+        XCTAssertTrue(AppUpdater.isVersion("2026.10.1", newerThan: "2026.9.9"))
+        XCTAssertFalse(AppUpdater.isVersion("2026.9.9", newerThan: "2026.10.1"))
+        XCTAssertTrue(AppUpdater.isVersion("2026.7.2", newerThan: "2026.7.1"))
+        XCTAssertFalse(AppUpdater.isVersion("2026.7.2", newerThan: "2026.7.2"))
+        // Shorter versions are zero-padded.
+        XCTAssertFalse(AppUpdater.isVersion("2026.7", newerThan: "2026.7.0"))
+        XCTAssertTrue(AppUpdater.isVersion("2026.7.1", newerThan: "2026.7"))
+        // The dev placeholder version always loses to a real release…
+        XCTAssertTrue(AppUpdater.isVersion("2026.1.1", newerThan: "1.0.0"))
+        // …and an unparseable candidate never wins.
+        XCTAssertFalse(AppUpdater.isVersion("garbage", newerThan: "1.0.0"))
+    }
+
+    // MARK: - Feed selection
+
+    private func release(
+        tag: String, draft: Bool = false, prerelease: Bool = false, assets: [String] = []
+    ) -> String {
+        let assetJSON = assets.map {
+            """
+            {"name": "\($0)", "browser_download_url": "https://example.com/\(tag)/\($0)"}
+            """
+        }.joined(separator: ",")
+        return """
+        {"tag_name": "\(tag)", "draft": \(draft), "prerelease": \(prerelease), "assets": [\(assetJSON)]}
+        """
+    }
+
+    private func feed(_ releases: [String]) -> Data {
+        Data("[\(releases.joined(separator: ","))]".utf8)
+    }
+
+    func testLatestUpdatePicksNewestPublishedMacosRelease() {
+        // Newest by version, not by list position, with CLI releases mixed in.
+        let data = feed([
+            release(tag: "relayburn-v4.0.0", assets: ["burn-aarch64-apple-darwin.tar.gz"]),
+            release(tag: "macos-v2026.6.3", assets: ["BurnOSX-arm64.dmg", "BurnOSX-arm64.zip"]),
+            release(tag: "macos-v2026.7.1", assets: ["BurnOSX-arm64.dmg", "BurnOSX-arm64.zip"]),
+            release(tag: "macos-latest", assets: ["BurnOSX-arm64.dmg", "BurnOSX-arm64.zip"]),
+        ])
+        let update = AppUpdater.latestUpdate(inReleasesJSON: data, assetName: "BurnOSX-arm64.zip")
+        XCTAssertEqual(update?.version, "2026.7.1")
+        XCTAssertEqual(
+            update?.downloadURL.absoluteString,
+            "https://example.com/macos-v2026.7.1/BurnOSX-arm64.zip")
+    }
+
+    func testLatestUpdateSkipsDraftsAndPrereleases() {
+        let data = feed([
+            release(tag: "macos-v2026.8.1", draft: true, assets: ["BurnOSX-arm64.zip"]),
+            release(tag: "macos-v2026.7.9", prerelease: true, assets: ["BurnOSX-arm64.zip"]),
+            release(tag: "macos-v2026.7.1", assets: ["BurnOSX-arm64.zip"]),
+        ])
+        let update = AppUpdater.latestUpdate(inReleasesJSON: data, assetName: "BurnOSX-arm64.zip")
+        XCTAssertEqual(update?.version, "2026.7.1")
+    }
+
+    func testLatestUpdateRequiresTheMatchingAsset() {
+        // A release without the updater's zip (e.g. DMG-only builds published
+        // before the updater existed) can't be offered.
+        let data = feed([
+            release(tag: "macos-v2026.7.2", assets: ["BurnOSX-arm64.dmg"]),
+            release(tag: "macos-v2026.7.1", assets: ["BurnOSX-arm64.dmg", "BurnOSX-arm64.zip"]),
+        ])
+        let update = AppUpdater.latestUpdate(inReleasesJSON: data, assetName: "BurnOSX-arm64.zip")
+        XCTAssertEqual(update?.version, "2026.7.1")
+    }
+
+    func testLatestUpdateEmptyOrMalformedFeed() {
+        XCTAssertNil(AppUpdater.latestUpdate(inReleasesJSON: feed([]), assetName: "BurnOSX-arm64.zip"))
+        XCTAssertNil(AppUpdater.latestUpdate(
+            inReleasesJSON: Data("not json".utf8), assetName: "BurnOSX-arm64.zip"))
+    }
+}

--- a/apps/macos/release.sh
+++ b/apps/macos/release.sh
@@ -90,7 +90,14 @@ rm -f "${ZIP}"
 # 5. Staple the ticket onto the .app so Gatekeeper passes it offline.
 xcrun stapler staple "${APP_DIR}"
 
-# 6. Package a DMG (app + /Applications drop target) from the stapled app.
+# 6. Package a stapled zip — the in-app updater's download artifact. (The
+#    notarization zip above predates the staple, so re-archive here.)
+UPDATE_ZIP="dist/${APP_NAME}-${ARCH}.zip"
+echo "Building ${UPDATE_ZIP}…"
+rm -f "${UPDATE_ZIP}"
+/usr/bin/ditto -c -k --keepParent "${APP_DIR}" "${UPDATE_ZIP}"
+
+# 7. Package a DMG (app + /Applications drop target) from the stapled app.
 echo "Building ${DMG}…"
 rm -f "${DMG}"
 STAGING="dist/dmg-staging"
@@ -101,4 +108,4 @@ hdiutil create -volname "${APP_NAME}" -srcfolder "${STAGING}" -ov -format UDZO "
 rm -rf "${STAGING}"
 
 echo
-echo "Built ${DMG}"
+echo "Built ${DMG} and ${UPDATE_ZIP}"


### PR DESCRIPTION
Gives Burn for Mac the same release + auto-update experience as Pear. The release half already existed (`release-macos.yml` mirrors Pear's signing/notarization flow); this adds the in-app updater and its button.

## What's new

**`AppUpdater.swift`** — a native, dependency-free equivalent of Pear's `electron-updater` flow:
- Silent update checks at launch and every 6 hours (signed installs only, so dev builds don't nag), plus a manual check.
- Reads the GitHub releases feed and picks the newest published `macos-v*` release carrying the zip asset — numeric version compare (`2026.10.x` beats `2026.9.x`), drafts/prereleases/CLI `relayburn-v*` tags skipped.
- "Update Now" downloads the notarized zip, extracts it, verifies with `codesign --verify`, and pins the payload's team identifier to the running app's before install.
- "Restart Now" swaps the installed bundle (with rollback on failure) and relaunches via a detached shell that waits for the old process to exit. Unsigned builds refuse the install step — there's no team to pin against.

**Settings tab** — new "Updates" section under Appearance: current version plus a phase-driven control (Check for Updates → Checking… → "Version X is available. Update Now" → Downloading… → Restart Now, with error + Try Again).

**Release pipeline** — `release.sh` now packages a stapled `BurnOSX-arm64.zip` (the updater's download artifact) alongside the DMG, and `release-macos.yml` attaches it to both the versioned `macos-v*` release and the `macos-latest` pointer.

**Tests** — `AppUpdaterTests.swift` covers the feed-selection and version-comparison logic.

## Notes

- Existing installs predate the updater, so users need one last manual DMG download; every release after that is one click.
- Updates need write access to the install location (the normal drag-to-/Applications case is fine); no privilege-escalation path.
- Authored on a Linux box, so the Swift build/tests run in `macos-app-tests.yml` CI here rather than locally; worth a manual smoke test of the download → restart path on the first release cut after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9WvBQecNXTrjL6vCgT8dh

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9WvBQecNXTrjL6vCgT8dh)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/burn/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

